### PR TITLE
ci: fix workflow_dispatch trigger recognition

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -1,4 +1,4 @@
-name: 'Build Desktop App'
+name: Build Desktop App
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Force GitHub to re-parse build-desktop workflow triggers. Created release environment for publish job.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>