### PR TITLE
docs: comprehensive README rewrite + MCP pipeline docs + sitrep enhancement

### DIFF
--- a/.claude/commands/sitrep.md
+++ b/.claude/commands/sitrep.md
@@ -117,7 +117,8 @@ BOTTOM LINE UP FRONT
    seasonal outlook.]
 
   SEISMIC
-  [Significant earthquakes (M5+), tsunami alerts, volcanic activity.]
+  [Significant earthquakes — M5.5+ noted, M6.5+ highlighted.
+   Tsunami alerts, volcanic activity. Proximity to home location noted.]
 
   INFRASTRUCTURE
   [Power grid, internet, transport disruptions, NOTAM clusters.]
@@ -148,10 +149,17 @@ Follow these rules strictly when writing the brief:
 2. **Signal-proportional density.** Quiet sections compress to one line (e.g., "Sanctions: no new designations or enforcement actions."). Never omit a section.
 3. **Inline cross-references.** Use `↳ Note:` or `— see SECTION` when domains connect (e.g., a cyber campaign targeting energy infrastructure cross-references both CYBER and INFRASTRUCTURE).
 4. **Degraded feeds.** Mark affected sections with `⚠ DATA DEGRADED — [feed name]` inline. Do not silently omit data.
-5. **Personal relevance.** Prefix items matching the user profile with `★ PERSONAL:` — Apple CVEs, watchlist ticker filings, Midwest severe weather, home-area items. Elevate these even in otherwise quiet sections.
+5. **Personal relevance.** Prefix items matching the user profile with `★ PERSONAL:`. Elevate these even in otherwise quiet sections. Per-section personalization:
+   - **LOCAL CONDITIONS**: Home location weather, grid (MISO), nearby seismic/conflicts
+   - **CYBER**: Flag CVEs/KEVs/IOCs targeting Apple, macOS, iOS, WebKit
+   - **MARKETS & ECONOMY**: Surface AAPL 8-Ks, Apple supply chain disruptions (TSMC, Foxconn, rare earths)
+   - **INFRASTRUCTURE**: Note Apple service outages if detected, Midwest grid and water status
+   - **WEATHER**: Great Lakes / Midwest severe weather highlighted
+   - **NEXUS**: Correlations involving Apple ecosystem or La Porte area get priority
 6. **SOURCE STATUS.** Count operational vs degraded feeds from `check_feed_health`. List any missing API keys.
 7. **LOCAL CONDITIONS.** Filter weather, grid (use MISO for La Porte, IN), seismic (within ~500km), NWS alerts, local cyber/health relevance for the home location. Compress to "All local indicators nominal." on quiet days.
 8. **BLUF.** Exactly 2-3 sentences: the single most important development, the overnight shift direction, and one forward watch item.
-9. **NEXUS.** Only surface genuine cross-domain correlations. Do not force connections. State "No significant cross-domain convergence detected." when nothing links.
-10. **No emojis.** Only `⚠` for warnings and `★` for personal flags.
-11. **Timestamps.** Use the user's local timezone throughout.
+9. **Honest uncertainty.** If data is degraded or a correlation is speculative, say so. Never invent connections.
+10. **NEXUS.** Only surface genuine cross-domain correlations. Do not force connections. State "No significant cross-domain convergence detected." when nothing links.
+11. **No emojis.** Only `⚠` for warnings and `★` for personal flags.
+12. **Timestamps.** Use the user's local timezone throughout.

--- a/.claude/commands/sitrep.md
+++ b/.claude/commands/sitrep.md
@@ -1,4 +1,157 @@
-Use the Crystal Ball MCP tools to generate a comprehensive situational report.
-Call get_sitrep, get_threat_landscape, and get_military_posture.
-Synthesize into a brief with sections: Conflicts, Markets, Cyber, Military, Weather.
-Flag anything at elevated or critical levels. Be concise — this is a daily brief.
+Generate a full-spectrum presidential-style daily intelligence brief using all Crystal Ball MCP tools, personalized to the user's profile.
+
+---
+
+## Phase 0 — User Profile
+
+Read `~/.claude/projects/-Users-bradleybond-Developer-crystalball/memory/user_sitrep_profile.md` to load:
+
+- **home_location** (e.g., "La Porte, Indiana")
+- **platforms** (e.g., Apple macOS/iOS/iPadOS/watchOS, WebKit/Safari)
+- **watchlist_tickers** (e.g., AAPL)
+- **interests** (e.g., Apple supply chain, Great Lakes weather, Midwest severe weather)
+
+If the file does not exist, skip personalization and run as a generic global brief.
+
+---
+
+## Phase 1 — Collection
+
+Call all 16 aggregate MCP tools **in parallel**, using `summary_only: true` where supported:
+
+| Tool | Parameters |
+|------|------------|
+| `check_feed_health` | _(none)_ |
+| `get_sitrep` | `summary_only: true` |
+| `get_threat_landscape` | `summary_only: true` |
+| `get_military_posture` | `summary_only: true` |
+| `get_cyber_intel` | `summary_only: true` |
+| `get_market_overview` | `summary_only: true` |
+| `get_economic_data` | `series: fed_funds, yield_curve, unemployment` |
+| `get_weather_environment` | `summary_only: true` |
+| `get_earthquakes` | `summary_only: true` |
+| `get_infrastructure_status` | `summary_only: true` |
+| `get_disease_outbreaks` | `summary_only: true` |
+| `get_sanctions` | `summary_only: true` |
+| `search_conflicts` | `summary_only: true` |
+| `get_region_brief` | `place_name:` _(from user profile home_location)_ |
+| `search_news` | `limit: 10` |
+| `get_sec_filings` | `limit: 5` |
+
+---
+
+## Phase 2 — Triage & Enrichment
+
+### Layer 1 — Escalation Drill-Down
+
+For any aggregate tool that returned **elevated or critical** indicators in Phase 1, re-call that tool with `limit: 20` and **without** `summary_only` to get full detail. Quiet domains skip this layer entirely.
+
+### Layer 2 — Entity Enrichment
+
+When Phase 1 or Layer 1 names specific entities, enrich with granular lookup tools:
+
+| Signal | Tool | Key Parameter |
+|--------|------|---------------|
+| Military aircraft | `lookup_flight` | callsign or hex |
+| Naval vessels | `lookup_vessel` | MMSI or name |
+| CVEs | `lookup_cve` | CVE ID |
+| Suspicious IPs | `lookup_ip` | IP address |
+| Sanctions entities | `get_sanctions` | entity search |
+| Regional conflict escalation | `search_conflicts` | country/date filter |
+| Market-moving company | `get_sec_filings` | filtered search |
+
+Only enrich entities that are actually named in the data. Do not fabricate lookups.
+
+---
+
+## Phase 3 — Synthesis
+
+Write the brief using this exact fixed structure. Never omit a section — compress quiet sections to one line instead.
+
+```
+╔══════════════════════════════════════════════════════╗
+║  CRYSTAL BALL — DAILY SITUATIONAL REPORT             ║
+║  [date] [time] [timezone]                            ║
+╚══════════════════════════════════════════════════════╝
+
+SOURCE STATUS
+  [count] feeds operational, [count] degraded, [count] missing API keys
+  Degraded: [list if any]
+
+LOCAL CONDITIONS — [home city from profile]
+  [Weather, grid status (MISO for La Porte IN), seismic within ~500km,
+   NWS alerts, local cyber/health relevance. Compress to
+   "All local indicators nominal." on quiet days.]
+
+BOTTOM LINE UP FRONT
+  [2-3 sentences: most important development, overnight shift direction,
+   forward watch item.]
+
+── SECURITY ───────────────────────────────────────────
+  CONFLICTS & SECURITY
+  [Active conflicts, escalation/de-escalation, casualty events,
+   peace talks, territorial changes.]
+
+  MILITARY POSTURE
+  [Force movements, exercises, deployments, strategic signaling.
+   Include lookup_flight / lookup_vessel results if enriched.]
+
+  THREAT LANDSCAPE
+  [Terrorism, WMD, hybrid warfare, state-sponsored activity.]
+
+  CYBER
+  [Active campaigns, CVEs, IOCs, ransomware, APT activity.
+   Include lookup_cve / lookup_ip results if enriched.]
+
+── ECONOMY ────────────────────────────────────────────
+  MARKETS & ECONOMY
+  [Indices, commodities, crypto, FX, yield curve, fed funds,
+   unemployment, SEC filings. Watchlist tickers called out.]
+
+  SANCTIONS
+  [New designations, enforcement actions, evasion patterns.]
+
+── ENVIRONMENT ────────────────────────────────────────
+  WEATHER & SPACE WEATHER
+  [Severe weather, tropical systems, space weather (Kp, solar flares),
+   seasonal outlook.]
+
+  SEISMIC
+  [Significant earthquakes (M5+), tsunami alerts, volcanic activity.]
+
+  INFRASTRUCTURE
+  [Power grid, internet, transport disruptions, NOTAM clusters.]
+
+  HEALTH
+  [Disease outbreaks, WHO alerts, pandemic indicators.]
+
+── SIGNALS ────────────────────────────────────────────
+  NEWS WIRE
+  [Top stories from search_news not covered above.
+   Brief bullets, source attributed.]
+
+── SYNTHESIS ──────────────────────────────────────────
+  NEXUS
+  [Explicit cross-domain correlations where genuine connections exist.
+   Examples: oil spike + Gulf military movement = supply chain risk;
+   cyber IOCs targeting energy + grid alerts = infrastructure convergence.
+   "No significant cross-domain convergence detected." when quiet.]
+```
+
+---
+
+## Narrative Rules
+
+Follow these rules strictly when writing the brief:
+
+1. **Analyst voice.** Declarative sentences. Connect dots. No hedging, no filler, no "it remains to be seen."
+2. **Signal-proportional density.** Quiet sections compress to one line (e.g., "Sanctions: no new designations or enforcement actions."). Never omit a section.
+3. **Inline cross-references.** Use `↳ Note:` or `— see SECTION` when domains connect (e.g., a cyber campaign targeting energy infrastructure cross-references both CYBER and INFRASTRUCTURE).
+4. **Degraded feeds.** Mark affected sections with `⚠ DATA DEGRADED — [feed name]` inline. Do not silently omit data.
+5. **Personal relevance.** Prefix items matching the user profile with `★ PERSONAL:` — Apple CVEs, watchlist ticker filings, Midwest severe weather, home-area items. Elevate these even in otherwise quiet sections.
+6. **SOURCE STATUS.** Count operational vs degraded feeds from `check_feed_health`. List any missing API keys.
+7. **LOCAL CONDITIONS.** Filter weather, grid (use MISO for La Porte, IN), seismic (within ~500km), NWS alerts, local cyber/health relevance for the home location. Compress to "All local indicators nominal." on quiet days.
+8. **BLUF.** Exactly 2-3 sentences: the single most important development, the overnight shift direction, and one forward watch item.
+9. **NEXUS.** Only surface genuine cross-domain correlations. Do not force connections. State "No significant cross-domain convergence detected." when nothing links.
+10. **No emojis.** Only `⚠` for warnings and `★` for personal flags.
+11. **Timestamps.** Use the user's local timezone throughout.

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -16,5 +16,5 @@
  "MD039": true,
  "MD047": true
   },
-  "ignores": ["node_modules/**", "dist/**", "src-tauri/target/**", ".planning/**", ".worktrees/**"]
+  "ignores": ["node_modules/**", "dist/**", "src-tauri/target/**", ".planning/**", ".worktrees/**", "tools/**", "docs/archive/**"]
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Crystal Ball
 
-Tauri 2 + TypeScript + Rust desktop app: 170+ live data panels across 4 product variants, a Cesium.js/DeckGL 3D globe with 74 geospatial layers, SGP4 orbital propagation in a Web Worker, AI summarization with Ollama/Groq/Claude/OpenRouter fallback chain, Protobuf/Buf contract-driven API layer, OS keychain secret storage, Node.js sidecar proxy on a bearer-authenticated local port, and a PostHog-instrumented Ghost Mode with analytics suppression.
+Real-time global intelligence platform. Desktop app and web dashboard that aggregates 50+ live data feeds into 183 interactive panels, a 3D Cesium globe with 70 geospatial layers, AI-powered analysis, and an MCP server that lets Claude Code query it all from the terminal.
 
 [![Version](https://img.shields.io/github/v/release/bradleybond512/crystal-ball?label=version)](https://github.com/bradleybond512/crystal-ball/releases/latest)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
@@ -11,61 +11,175 @@ Tauri 2 + TypeScript + Rust desktop app: 170+ live data panels across 4 product 
 
 <!-- screenshot: full-app overview -- 2D map with active panels -->
 
-## God's Eye
+---
 
-Full-viewport Cesium.js 3D globe mode. Activate with `G` or the sidebar.
+## What It Does
 
-**74 live data layers:** military bases, nuclear facilities, earthquakes, active conflicts, airstrikes, cyclones, fires, vessels, flights, cyber threats, submarines, cables, ports, satellites, ISS, and more.
+Crystal Ball pulls data from ACLED, GDACS, NWS, USGS, CISA, ThreatFox, FRED, ADS-B, AIS, CelesTrak, and dozens of other sources, then presents it across a 2D MapLibre map, a 3D Cesium globe, 183 live panels, a unified alert inbox, and a correlation engine that connects events across domains. You can ask Claude Code `/sitrep` and get a synthesized intelligence brief from all active feeds without opening the app.
 
-**HUD overlay:** threat assessment card, mode badge, HOTSPOTS/ALT/CONFLICT/DISASTER stat pills, nearest hotspot (haversine), sun-phase badge (DAY/GOLDEN/CIVIL/NAUTICAL/ASTRO/NIGHT), local clock at camera longitude, scrolling LIVE alert ticker, top-5 alert list, layer-toggle bar.
+Four product variants share one codebase:
 
-**Fly Mode:** game-style WASD/mouse first-person flight over the globe. Right-click drag for look, scroll for speed.
+| Variant | Panels | Focus |
+|---------|--------|-------|
+| `full` | 183 | Geopolitics, conflict, cyber, infrastructure, disasters, markets |
+| `tech` | 35 | AI, startups, cloud, service health, developer ecosystems |
+| `finance` | 31 | Markets, forex, bonds, commodities, crypto, central banks |
+| `happy` | 10 | Positive news, progress, science, conservation |
 
-**Time Machine:** scrub historical data across a configurable time window.
+---
 
-**Satellite tracking:** SGP4 orbital propagation in a Web Worker -- ISS, Starlink, weather satellites. No API key required, TLE data from CelesTrak.
+## God's Vision
 
-**3D buildings:** 5-tier fallback -- Google Photorealistic > Cesium OSM Buildings > 2D extrusions > flat. Photorealistic requires `GOOGLE_MAPS_API_KEY`.
+Full-viewport Cesium.js 3D globe. Press `G` or click the sidebar to enter.
 
-**Imagery:** Bing satellite (Cesium Ion token) > ArcGIS World Imagery fallback.
+**70 data layers** -- military bases, nuclear facilities, earthquakes, active conflicts, airstrikes, cyclones, fires, vessels, flights, cyber threats, submarine cables, ports, satellites, ISS, weather radar, lightning, GPS jamming, trade routes, day/night terminator, and more. 26 enabled by default; toggle the rest from the layer bar.
+
+**HUD overlay** -- real-time UTC clock, threat level assessment (NOMINAL through CRITICAL), camera altitude and coordinates, sun phase (DAY/GOLDEN/CIVIL/NAUTICAL/ASTRO/NIGHT), local time at camera longitude, nearest hotspot with haversine distance, scrolling alert ticker, top-5 active alerts, and layer toggle controls.
+
+**Fly Mode** -- 5 submodes: free fly (WASD + mouse), cinema (smooth auto-orbit), autopilot (waypoint tour), targeted (fly-to-entity), and chase (track a moving target). Right-click drag to look, scroll for speed, `C` to toggle cockpit view.
+
+**Time Machine** -- scrub historical data across a configurable time window. Space bar to play/pause.
+
+**Satellite tracking** -- SGP4 orbital propagation in a Web Worker for ISS, Starlink, and weather satellites. TLE data from CelesTrak, no API key required.
+
+**3D buildings** -- 5-tier fallback: Google Photorealistic Tiles > Cesium OSM Buildings > 2D extrusions > flat terrain. Photorealistic requires `GOOGLE_MAPS_API_KEY`.
+
+**Navigation** -- turn-by-turn routing integrated into the globe. 4-tier routing engine (OSRM > GraphHopper > Valhalla > straight-line), street-level tiles, and a Navigation HUD with ETA. Press `N` to toggle.
+
+**Theater presets** -- press `1`-`6` to fly to Middle East, Pacific, Europe, Arctic, Africa, or Americas. `Cmd+1`-`5` to save/recall custom camera bookmarks. `W` to drop waypoints, `Shift+W` to start a tour.
+
+**Spatial audio** -- procedural Web Audio that responds to what's on screen. Sub-bass drone during conflict, teletype clicks during market activity, sonar pings for map events, geiger ticks on the radiation layer. All independently toggleable.
 
 <!-- screenshot: God's Eye 3D globe with HUD overlay and active layers -->
 
+---
+
+## Unified Alert System
+
+A single inbox that ingests from every alert source -- NWS, GDACS, OREF (Israel sirens), ACLED, ThreatFox, CISA KEV, power grid, cyber, breaking news, and internal correlation signals.
+
+**What you can do with it:**
+
+- **Triage** -- alerts scored by `severity * proximity * freshness * novelty * source_trust`. Highest-relevance items surface first.
+- **Situations** -- related alerts auto-cluster by geography (<100km), time (<6hr), and category. A hurricane touching down generates one situation card, not 15 separate items.
+- **Geofencing** -- set watched locations (home, office, family). Alerts within your radius get promoted automatically.
+- **Reactions** -- acknowledge, pin, snooze, annotate, or bookmark any alert. Snooze re-escalates if the situation worsens.
+- **Correlation** -- the engine detects patterns across domains: market-news divergence, prediction-leads-news, keyword velocity spikes, compound threats, temporal chains, and silence anomalies.
+- **History** -- alerts persist in IndexedDB for 30 days. Search, filter, export. Activity log tracks every action for shift handoff.
+- **Custom rules** -- define your own alert triggers with condition/action pairs, or use built-in presets (earthquake watcher, storm chaser, conflict monitor).
+
+**Keyboard shortcuts:** `J/K` navigate, `A` acknowledge, `P` pin, `1`-`5` filter by severity.
+
+---
+
+## MCP Server -- Claude Code Integration
+
+Crystal Ball ships an MCP server that gives Claude Code direct access to all intelligence feeds. 19 tools registered automatically when you open a session in this repo.
+
+**Aggregate tools** (broad awareness):
+
+| Command | What you get |
+|---------|-------------|
+| `get_sitrep` | Top conflicts, market moves, weather alerts, service health |
+| `get_threat_landscape` | ACLED conflicts, ThreatFox IOCs, CISA KEVs, crisis alerts |
+| `get_market_overview` | Indices, crypto, ETF flows, Fear & Greed, FRED macro signals |
+| `get_cyber_intel` | IOCs, KEVs, phishing URLs, malware feeds, OTX threat pulses |
+| `get_weather_environment` | Conditions for 28 global cities, NWS alerts, space weather |
+| `get_infrastructure_status` | Power grid, water quality, radiation, outage alerts |
+| `get_military_posture` | Tracked aircraft (ADS-B), naval vessels (AIS), theater posture, ISW |
+
+**Granular tools** (targeted lookups): `search_conflicts`, `search_news`, `lookup_ip`, `lookup_cve`, `lookup_vessel`, `lookup_flight`, `get_sanctions`, `get_economic_data`, `get_sec_filings`, `get_earthquakes`, `get_disease_outbreaks`, `get_region_brief`.
+
+**Slash commands** built on top of MCP tools:
+
+- `/sitrep` -- daily intelligence brief across all domains
+- `/watch Strait of Hormuz` -- regional brief for any location
+- `/threat-brief` -- top 5 threats with trajectory and recommended watches
+- `/market-pulse` -- markets snapshot with yield curve and Fed balance sheet
+
+The MCP server talks to the Crystal Ball sidecar over a bearer-authenticated localhost port. Crystal Ball must be running. See [docs/MCP_PIPELINE.md](docs/MCP_PIPELINE.md) for the full pipeline architecture.
+
+---
+
 ## Intelligence Coverage
 
-| Domain | What's included |
-|--------|----------------|
-| **Conflict & Geopolitics** | Live conflict zones, airstrike tracking, ACLED events, military bases, nuclear facilities, theater polygons, kill chain, ORBAT, STIX/TAXII feeds |
-| **Weather** | 7-day forecasts, RainViewer global radar, Blitzortung lightning, NOAA GOES/Himawari satellite imagery, tide predictions, pollen tracking, NWS severe alerts, SPC convective outlooks, tropical cyclone tracking, red flag fire warnings |
-| **Cyber & Threats** | ThreatFox IOCs, OpenPhish feeds, Spamhaus blocklists, CISA KEV, ICS/OT threats, network topology, 24-session EMA threat forecast, Palantir/Dragos-inspired intel panels |
-| **Markets & Finance** | S&P 500, BTC, oil, gold, commodities, macro signals, central bank feeds, sector heatmap (requires Finnhub key) |
-| **Space & Satellites** | ISS + Starlink + weather satellite tracking, SGP4 propagation, real-time orbital positions, satellite ISR intelligence |
-| **Infrastructure** | Submarine cables, maritime vessels, flight tracking, port status, datacenter outages, internet exchange points, CCTV & webcams |
-| **Disasters** | GDACS Red/Orange events, M6.5+ earthquakes, wildfire perimeters (NASA FIRMS), cyclone paths |
-| **Cross-Domain Correlation** | 40+ directional causal rules (earthquake→tsunami, NWS→grid, cyclone→maritime, etc.), region×domain correlation matrix with drill-down UI, compound threat detection across 20+ hazard patterns, weather-threat convergence scoring, sentiment divergence signals, anomaly detection with Z-score statistical monitoring, OODA-loop situation engine |
+| Domain | Sources and capabilities |
+|--------|------------------------|
+| **Conflict & Geopolitics** | ACLED events, airstrike tracking, military bases, nuclear facilities, STIX/TAXII feeds, kill chain tracker, ORBAT, ISW reports, theater posture, multi-theater coordination detection, OpenSanctions, OREF sirens, Ukraine frontline, DSCA arms transfers, UN Security Council |
+| **Cyber & Threats** | ThreatFox IOCs, CISA KEV, OpenPhish, URLhaus, Vulners CVE, Pulsedive, VirusTotal, HIBP breach exposure, OTX threat pulses, ICS/OT dashboard, IOC manager, STIX/TAXII feeds, network topology, Bitcoin abuse |
+| **Markets & Finance** | S&P 500, BTC, oil, gold, commodities, FRED macro signals, Fear & Greed index, central bank calendar, BTC ETF flows, SEC EDGAR filings, supply chain tracking, financial contagion modeling, stablecoin monitoring, WSB sentiment |
+| **Weather & Environment** | 7-day forecasts, RainViewer global radar, Blitzortung lightning, NOAA satellite imagery, NWS alerts, SPC mesoscale, tropical cyclones, tide predictions, pollen tracking, red flag fire warnings, air quality, wildfire smoke |
+| **Space & Satellites** | ISS + Starlink + weather satellite tracking, SGP4 propagation, space weather (NASA DONKI), NOAA SWPC, space launches, aerospace reentry tracker |
+| **Infrastructure** | Submarine cables, maritime vessels (AIS), flight tracking (ADS-B), port status, power grid monitoring, internet disruptions, RIPE NCC BGP, datacenter outages, communications health |
+| **Disasters & Health** | GDACS Red/Orange events, USGS earthquakes, NASA FIRMS wildfires, cyclone paths, volcano alerts, tsunami alerts, WHO disease outbreaks, UNHCR displacement, humanitarian crises, food insecurity, hazmat incidents |
+
+---
+
+## Ghost Mode
+
+Press `Cmd+Shift+G`. Polling intervals multiply by 5x, PostHog analytics are suppressed, notifications go silent, and the sidebar switches to dark crimson chrome. For when you want to monitor without being monitored.
+
+---
+
+## AI Summarization
+
+Every panel has a summarize button (sparkle icon). The AI fallback chain resolves at runtime:
+
+1. **Ollama** -- local, no data leaves the machine
+2. **Groq** -- fast cloud inference
+3. **Claude** -- Anthropic API
+4. **OpenRouter** -- routes to 100+ models
+
+Works in air-gapped environments with just Ollama. Each hop is an explicit boundary, not a catch-all.
+
+---
+
+## Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `G` | Toggle God's Vision 3D globe |
+| `Cmd+K` | Command palette |
+| `Cmd+Shift+G` | Toggle Ghost Mode |
+| `Cmd+Shift+T` | Toggle Today view |
+| `Cmd+Shift+W` | Toggle Watchlist editor |
+| `Cmd+S` | Copy shareable URL to clipboard |
+| `Cmd+,` | Open Settings |
+| `Cmd+\` | Toggle sidebar |
+| `F` | Enter Fly Mode (in God's Vision) |
+| `N` | Toggle Navigation (in God's Vision) |
+| `Space` | Play/pause Time Machine (in God's Vision) |
+| `L` | Toggle day/night terminator |
+| `1`-`6` | Fly to theater presets |
+| `Cmd+1`-`5` | Save/recall camera bookmarks |
+| `ESC` | Exit God's Vision or Fly Mode |
+
+---
+
+## Procedural Audio
+
+All sounds are synthesized with Web Audio API -- no audio files in the repo:
+
+- **Mode transitions** -- military two-tone pulse, Bloomberg-style chime, EAS attention signal, electronic sweep
+- **Spatial layers** -- sub-bass drone (conflict-driven), bandpass noise (news density), sonar sweep, teletype tick, 28Hz ghost hum
+- **Feedback** -- panel open/close clicks, data ingestion pulses, sonar pings, geiger ticks
+- **Controls** -- master mute, per-layer volume, spatial volume slider (0-100%)
+
+---
 
 ## What Makes This Hard
 
-**Local-first desktop security boundary**
-The renderer never touches API keys directly. Keys are stored in the OS keychain via Tauri's secret store, injected into a Node.js sidecar at startup, and proxied through a bearer-authenticated localhost port. The renderer resolves the sidecar port dynamically -- no hardcoded assumptions about the runtime environment.
+**Local-first security boundary** -- the renderer never sees API keys. Keys live in the macOS keychain, get injected into a Node.js sidecar at startup, and are proxied through a bearer-authenticated localhost port. The MCP server discovers the port and token from disk files with `0o600` permissions.
 
-**CSP under real constraints**
-`script-src` requires `'unsafe-eval'` because Cesium compiles GLSL shaders dynamically. Removing it silently breaks God's Eye (dynamic import failure > reload loop, no visible error). Compensating controls: trusted-window IPC gating, sidecar bearer auth, no `'unsafe-inline'` on script-src, devtools disabled in production builds.
+**CSP under real constraints** -- `script-src` requires `'unsafe-eval'` because Cesium compiles GLSL shaders dynamically. Removing it silently breaks God's Vision. Compensating controls: trusted-window IPC gating, sidecar bearer auth, no `'unsafe-inline'` on script-src, devtools disabled in production.
 
-**Variant architecture without forking**
-Four product variants (Full, Tech, Finance, Happy) share one application shell. Panel inventory, map layer defaults, and feed configuration swap through `src/config/panels.ts` and `src/config/variant.ts` -- not separate builds or conditional compilation.
+**Variant architecture without forking** -- four product variants share one shell. Panel inventory, map layer defaults, and feed configuration swap through `src/config/panels.ts` and `src/config/variant.ts` at build time.
 
-**AI fallback chain**
-Summarization resolves at runtime: Ollama (local) > Groq > Claude > OpenRouter > browser inference. Each hop is an explicit boundary, not a catch-all try/catch. Works in air-gapped and privacy-sensitive environments.
+**Native location via CoreLocation IPC** -- WKWebView blocks `navigator.geolocation`. Crystal Ball bypasses this with native CLLocationManager via ObjC FFI from Rust, exposed as a Tauri IPC command.
 
-**App mode state machine**
-Five modes (Peace/Finance/War/Disaster/Ghost) trigger on live signal thresholds -- S&P >=2.5%, >=2 war signals above confidence 0.6 normalized by conflict baselines, GDACS Red events. Ghost Mode suppresses analytics, multiplies poll intervals x5, and changes UI chrome. Mode transitions are deterministic and testable.
+**WKWebView constraints** -- CSS `-webkit-app-region: drag` is silently ignored. All local iframes must use `http://127.0.0.1:{port}` not `localhost`. Window dragging requires JS `mousedown` into Tauri's `start_dragging` command.
 
-**Native location via CoreLocation IPC**
-WKWebView blocks `navigator.geolocation` entirely. Crystal Ball bypasses this with native CLLocationManager via ObjC FFI from Rust, exposed as a Tauri IPC command. Requires hardened runtime entitlements for location access.
-
-**WKWebView constraints**
-CSS `-webkit-app-region: drag` is silently ignored. Window dragging requires JS `mousedown` > `tryInvokeTauri('plugin:window|start_dragging')`. All local iframes must use `http://127.0.0.1:{port}` not `localhost` -- WKWebView treats them as distinct origins and the CSP only allows `127.0.0.1`.
+---
 
 ## Architecture
 
@@ -73,54 +187,64 @@ CSS `-webkit-app-region: drag` is silently ignored. Window dragging requires JS 
 |-------|-------|
 | Frontend | TypeScript, Vite, MapLibre GL, deck.gl, Cesium.js, D3, i18next |
 | Contracts | Buf, Protobuf, generated TypeScript clients + OpenAPI output |
-| Desktop shell | Tauri v2, Rust, OS keychain, Node.js sidecar (port 46123) |
-| AI layer | Ollama > Groq > Claude > OpenRouter > browser inference |
+| Desktop shell | Tauri v2, Rust, macOS keychain, CoreLocation IPC, Node.js sidecar (port 46123) |
+| AI layer | Ollama > Groq > Claude > OpenRouter |
+| MCP server | @modelcontextprotocol/sdk, 19 tools, sidecar port/token discovery |
+| Correlation | Unified event schema, directional rules, temporal chains, situation clustering |
+| Alerts | Unified inbox, composite relevance scoring, IndexedDB persistence, custom rules |
+| Audio | Procedural Web Audio synthesis, per-layer spatial mixing |
 | Verification | TypeScript strict, Playwright e2e + visual, sidecar unit tests |
-| CI/CD | Tag-driven desktop publish, release manifest verification, CodeQL |
+| CI/CD | Tag-driven desktop publish, release manifest verification, CodeQL, secret scan |
+
+---
 
 ## By The Numbers
 
 | Metric | Value | Source |
 |--------|-------|--------|
+| Panels (full variant) | 183 | `src/config/panels.ts` |
+| God's Vision map layers | 70 (26 on by default) | `src/types/index.ts` MapLayers |
+| Panel categories | 19 | `src/config/panels.ts` PANEL_CATEGORY_MAP |
 | Product variants | 4 | `src/config/variant.ts` |
-| Desktop build targets | 3 | `package.json` |
-| Default panel inventory | 170 full / 35 tech / 31 finance / 10 happy | `src/config/panels.ts` |
-| God's Eye data layers | 74 | `src/config/panels.ts` |
-| Supported secret keys | 47 | `src-tauri/src/main.rs` |
+| MCP tools | 19 | `tools/mcp-server/index.mjs` |
+| Supported secret keys | 49 | `src-tauri/src/main.rs` |
 | Locales | 19 | `src/locales/` |
 | Generated OpenAPI specs | 21 | `docs/api/` |
+| Desktop build targets | 3 | `package.json` |
+| CI/CD workflows | 12 | `.github/workflows/` |
 
-## Variants
-
-| Variant | Web | Desktop | Focus |
-|---------|-----|---------|-------|
-| `full` | Yes | Yes | Geopolitics, infrastructure, cyber, conflict, disasters |
-| `tech` | Yes | Yes | AI, startups, cloud, service health, developer ecosystems |
-| `finance` | Yes | Yes | Markets, commodities, macro signals, central banks |
-| `happy` | Yes | No | Positive news, progress, science, conservation |
+---
 
 ## Quick Start
 
 ```bash
-npm ci && npm run dev          # web, default variant
+npm ci && npm run dev          # web, full variant (default)
 npm run dev:tech               # tech variant
 npm run dev:finance            # finance variant
-npm run desktop:dev            # Tauri dev build
-npm run desktop:build:full     # production desktop
+npm run desktop:dev            # Tauri desktop with devtools
+npm run desktop:build:full     # production desktop build
 npm run typecheck:all          # zero-error type check
 ```
 
-The `happy` variant shares the default dev server (`npm run dev`). See [docs/API_KEYS.md](docs/API_KEYS.md) for key setup and [docs/DESKTOP_CONFIGURATION.md](docs/DESKTOP_CONFIGURATION.md) for sidecar config.
+The `happy` variant shares the default dev server. Set `SITE_VARIANT=happy` in your environment.
+
+API keys are optional -- most panels degrade gracefully without them. Configure keys in Settings (gear icon) > API Keys tab. See [docs/API_KEYS.md](docs/API_KEYS.md) for the full list.
+
+---
 
 ## Documentation
 
 | Guide | Purpose |
 |-------|---------|
-| [docs/API_KEYS.md](docs/API_KEYS.md) | All 47 API keys -- categories, signup URLs, free/paid |
-| [docs/DESKTOP_CONFIGURATION.md](docs/DESKTOP_CONFIGURATION.md) | Desktop secret keys, feature availability, fallback |
+| [docs/MCP_PIPELINE.md](docs/MCP_PIPELINE.md) | How Claude Code gathers intelligence via MCP -- pipeline, auth, tools |
+| [docs/API_KEYS.md](docs/API_KEYS.md) | All 49 API keys -- categories, signup URLs, free/paid |
+| [docs/DESKTOP_CONFIGURATION.md](docs/DESKTOP_CONFIGURATION.md) | Desktop secret keys, feature availability, fallback behavior |
 | [docs/RELEASE_PACKAGING.md](docs/RELEASE_PACKAGING.md) | Desktop packaging and signing workflow |
+| [docs/ALERTS_ENHANCEMENT_ROADMAP.md](docs/ALERTS_ENHANCEMENT_ROADMAP.md) | Alert system architecture and enhancement roadmap |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Contributor workflow, checks, PR expectations |
 | [SECURITY.md](SECURITY.md) | Vulnerability reporting and scope |
+
+---
 
 ## Contributing
 


### PR DESCRIPTION
Full documentation overhaul with verified numbers and new feature coverage.

**README.md** — complete rewrite with:
- Verified counts: 183 panels, 70 map layers, 49 secrets, 19 locales
- New sections: Unified Alert System, MCP Server, Ghost Mode, AI Summarization, Keyboard Shortcuts, Procedural Audio
- Expanded God's Vision: 5 fly submodes, theater presets, bookmarks, navigation, spatial audio
- Removed stale Peace/Finance/War/Disaster mode references
- Updated Intelligence Coverage with all current data sources

**docs/MCP_PIPELINE.md** — new doc explaining the full Claude Code -> MCP -> Sidecar -> APIs pipeline

**Sitrep enhancement** — presidential-style daily brief format