### PR TITLE
salvage: fix-sidecar-crash (sidecar crash + auth bypass + sitrep filter/severity + Groq fallback)

### DIFF
--- a/api/_api-key.js
+++ b/api/_api-key.js
@@ -10,8 +10,8 @@ const BROWSER_ORIGIN_PATTERNS = [
   /^https:\/\/(tech|finance|happy|api)\.crystalball\.app$/,
   /^https:\/\/crystalball-[a-z0-9-]+\.vercel\.app$/,
   ...(process.env.NODE_ENV === 'production' ? [] : [
- /^https?:\/\/localhost(:\d+)?$/,
- /^https?:\/\/127\.0\.0\.1(:\d+)?$/,
+	/^https?:\/\/localhost(:\d+)?$/,
+	/^https?:\/\/127\.0\.0\.1(:\d+)?$/,
   ]),
 ];
 
@@ -34,8 +34,6 @@ function hasTrustedBrowserFetchMetadata(req) {
 
 function isTrustedBrowserRequest(req, origin) {
   if (!hasTrustedBrowserFetchMetadata(req)) return false;
-  // Require an explicit trusted Origin for browser no-key access.
-  // Referer can be forged by non-browser clients and is therefore insufficient.
   return isTrustedBrowserOrigin(origin);
 }
 
@@ -44,35 +42,37 @@ function isReadRequest(req) {
   return method === 'GET' || method === 'HEAD' || method === 'OPTIONS';
 }
 
+// Sidecar mode: the sidecar already authenticates via LOCAL_API_TOKEN,
+// so skip the API-key check entirely for requests it proxies.
+const IS_SIDECAR = (process.env.LOCAL_API_MODE || '').includes('sidecar');
+const SIDECAR_PASS = { valid: true, required: false };
+
+function requireKey(key, validKeys, errorMsg) {
+  if (!key) return { valid: false, required: true, error: errorMsg };
+  if (!validKeys.has(key)) return { valid: false, required: true, error: 'Invalid API key' };
+  return { valid: true, required: true };
+}
+
 export function validateApiKey(req) {
+  if (IS_SIDECAR) return SIDECAR_PASS;
+
   const key = req.headers.get('X-CrystalBall-Key');
   const origin = req.headers.get('Origin') || '';
   const validKeys = new Set((process.env.CRYSTALBALL_VALID_KEYS || '').split(',').filter(Boolean));
 
-  // Desktop app — always require API key
   if (isDesktopOrigin(origin)) {
- if (!key) return { valid: false, required: true, error: 'API key required for desktop access' };
- if (!validKeys.has(key)) return { valid: false, required: true, error: 'Invalid API key' };
- return { valid: true, required: true };
+	return requireKey(key, validKeys, 'API key required for desktop access');
   }
 
-  // Trusted browser requests must look like real browser fetches, not just spoofed headers.
   if (isTrustedBrowserRequest(req, origin)) {
- if (!isReadRequest(req)) {
- if (!key) return { valid: false, required: true, error: 'API key required for trusted browser non-read requests' };
- if (!validKeys.has(key)) return { valid: false, required: true, error: 'Invalid API key' };
- return { valid: true, required: true };
- }
- if (key && !validKeys.has(key)) return { valid: false, required: true, error: 'Invalid API key' };
- return { valid: true, required: false };
+	if (!isReadRequest(req)) {
+	  return requireKey(key, validKeys, 'API key required for trusted browser non-read requests');
+	}
+	if (key && !validKeys.has(key)) return { valid: false, required: true, error: 'Invalid API key' };
+	return { valid: true, required: false };
   }
 
-  // Explicit key provided from unknown origin — validate it
-  if (key) {
- if (!validKeys.has(key)) return { valid: false, required: true, error: 'Invalid API key' };
- return { valid: true, required: true };
-  }
+  if (key) return requireKey(key, validKeys, 'API key required');
 
-  // No origin, no key — require API key (blocks unauthenticated curl/scripts)
   return { valid: false, required: true, error: 'API key required' };
 }

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -1613,7 +1613,7 @@ async function handleIntelGenerate(req, res, context) {
         resp.on('error', reject);
       });
       r.on('error', reject);
-      r.setTimeout(10_000, () => { r.destroy(new Error('timeout')); });
+      r.setTimeout(60_000, () => { r.destroy(new Error('timeout')); });
       r.write(requestBody);
       r.end();
     });

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -1551,6 +1551,35 @@ let intelCooldownUntil = 0;
 // Generic non-streaming intel generation. Accepts { prompt, system?, maxTokens?,
 // temperature? } and returns { response, model } from OLLAMA_API_URL (any
 // OpenAI-compatible local endpoint, e.g. LM Studio at http://localhost:1234).
+async function callChatCompletion(apiUrl, model, messages, maxTokens, temperature, authHeader, timeoutMs) {
+  const u = new URL(apiUrl);
+  const mod = u.protocol === 'https:' ? https : http;
+  const requestBody = JSON.stringify({ model, messages, temperature, max_tokens: maxTokens, stream: false });
+  const reqHeaders = { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(requestBody) };
+  if (authHeader) reqHeaders['Authorization'] = authHeader;
+  const reqOptions = {
+    hostname: u.hostname, port: u.port || (u.protocol === 'https:' ? 443 : 80),
+    path: u.pathname + u.search, method: 'POST', headers: reqHeaders, family: 4,
+  };
+  const result = await new Promise((resolve, reject) => {
+    const r = mod.request(reqOptions, (resp) => {
+      const chunks = [];
+      resp.on('data', c => chunks.push(c));
+      resp.on('end', () => {
+        const text = Buffer.concat(chunks).toString();
+        if (resp.statusCode !== 200) return reject(new Error(`upstream ${resp.statusCode}: ${text.slice(0, 200)}`));
+        try { resolve(JSON.parse(text)); } catch (error) { reject(error); }
+      });
+      resp.on('error', reject);
+    });
+    r.on('error', reject);
+    r.setTimeout(timeoutMs, () => { r.destroy(new Error('timeout')); });
+    r.write(requestBody);
+    r.end();
+  });
+  return result?.choices?.[0]?.message?.content ?? '';
+}
+
 async function handleIntelGenerate(req, res, context) {
   const cors = getSidecarCorsOrigin(req);
   const headers = { 'content-type': 'application/json', 'access-control-allow-origin': cors, 'vary': 'Origin' };
@@ -1566,70 +1595,58 @@ async function handleIntelGenerate(req, res, context) {
   try { parsed = JSON.parse(body.toString()); }
   catch { res.writeHead(400, headers); res.end(JSON.stringify({ error: 'invalid JSON' })); return; }
 
-  const baseUrl = process.env.OLLAMA_API_URL || 'http://localhost:1234';
-  const rawModel = process.env.OLLAMA_MODEL || 'local-model';
-  const model = /^[a-zA-Z0-9._:/-]{1,80}$/.test(rawModel) ? rawModel : 'local-model';
   const prompt = typeof parsed.prompt === 'string' ? parsed.prompt.slice(0, 8000) : '';
   const system = typeof parsed.system === 'string' ? parsed.system.slice(0, 2000) : 'You are a concise intelligence analyst. Be factual, direct, no preamble.';
   const maxTokens = Math.min(2048, Math.max(16, Number(parsed.maxTokens) || 400));
   const temperature = Math.min(1, Math.max(0, Number(parsed.temperature) || 0.3));
   if (!prompt) { res.writeHead(400, headers); res.end(JSON.stringify({ error: 'prompt required' })); return; }
 
-  let apiUrl;
-  try { apiUrl = new URL('/v1/chat/completions', baseUrl).toString(); }
-  catch { res.writeHead(400, headers); res.end(JSON.stringify({ error: 'invalid OLLAMA_API_URL' })); return; }
+  const messages = [{ role: 'system', content: system }, { role: 'user', content: prompt }];
 
-  const requestBody = JSON.stringify({
-    model,
-    messages: [
-      { role: 'system', content: system },
-      { role: 'user', content: prompt },
-    ],
-    temperature,
-    max_tokens: maxTokens,
-    stream: false,
-  });
+  // Try local Ollama first, fall back to Groq
+  const baseUrl = process.env.OLLAMA_API_URL || 'http://localhost:1234';
+  const rawModel = process.env.OLLAMA_MODEL || 'local-model';
+  const localModel = /^[a-zA-Z0-9._:/-]{1,80}$/.test(rawModel) ? rawModel : 'local-model';
+  let localUrl;
+  try { localUrl = new URL('/v1/chat/completions', baseUrl).toString(); } catch { /* invalid URL */ }
 
-  try {
-    const u = new URL(apiUrl);
-    const mod = u.protocol === 'https:' ? https : http;
-    const reqOptions = {
-      hostname: u.hostname,
-      port: u.port || (u.protocol === 'https:' ? 443 : 80),
-      path: u.pathname + u.search,
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(requestBody) },
-      family: 4,
-    };
-    const result = await new Promise((resolve, reject) => {
-      const r = mod.request(reqOptions, (resp) => {
-        const chunks = [];
-        resp.on('data', c => chunks.push(c));
-        resp.on('end', () => {
-          const text = Buffer.concat(chunks).toString();
-          if (resp.statusCode !== 200) return reject(new Error(`upstream ${resp.statusCode}: ${text.slice(0, 200)}`));
-          try { resolve(JSON.parse(text)); } catch (error) { reject(error); }
-        });
-        resp.on('error', reject);
-      });
-      r.on('error', reject);
-      r.setTimeout(60_000, () => { r.destroy(new Error('timeout')); });
-      r.write(requestBody);
-      r.end();
-    });
-    const response = result?.choices?.[0]?.message?.content ?? '';
+  let response, model;
+  if (localUrl) {
+    try {
+      response = await callChatCompletion(localUrl, localModel, messages, maxTokens, temperature, null, 60_000);
+      model = localModel;
+    } catch (localError) {
+      context.logger.warn('[intel-generate] local failed:', localError.message);
+    }
+  }
+
+  // Groq fallback
+  if (response == null && process.env.GROQ_API_KEY) {
+    try {
+      response = await callChatCompletion(
+        'https://api.groq.com/openai/v1/chat/completions',
+        'llama-3.1-8b-instant', messages, maxTokens, temperature,
+        `Bearer ${process.env.GROQ_API_KEY}`, 30_000,
+      );
+      model = 'groq:llama-3.1-8b-instant';
+      context.logger.warn('[intel-generate] used Groq fallback');
+    } catch (groqError) {
+      context.logger.warn('[intel-generate] Groq fallback failed:', groqError.message);
+    }
+  }
+
+  if (response != null) {
     intelFailures = 0;
     res.writeHead(200, headers);
     res.end(JSON.stringify({ response, model }));
-  } catch (error) {
+  } else {
     intelFailures++;
     if (intelFailures >= 2) {
       intelCooldownUntil = Date.now() + 120_000;
       context.logger.warn(`[intel-generate] circuit breaker open after ${intelFailures} failures — cooling down 120s`);
     }
-    context.logger.warn('[intel-generate] error:', error.message);
     res.writeHead(502, headers);
-    res.end(JSON.stringify({ error: error.message }));
+    res.end(JSON.stringify({ error: 'all LLM providers failed' }));
   }
 }
 

--- a/src-tauri/sidecar/sitrep-filter.mjs
+++ b/src-tauri/sidecar/sitrep-filter.mjs
@@ -1,0 +1,104 @@
+// src-tauri/sidecar/sitrep-filter.mjs
+
+const MILITARY_CALLSIGN_PREFIXES = [
+  'RCH', 'ZEUS', 'KYOTE', 'BOMR', 'ENT', 'OTIS', 'MUSEL', 'WATTS',
+  'CARGO', 'VVHK', 'SCHNR', 'DOOM', 'EVAC', 'TOPCAT', 'JAKE', 'NCHO',
+  'TEAL', 'GORDO', 'RAIDR', 'HAVOC', 'KNIFE',
+];
+
+function itemLimit(severity) {
+  if (severity <= 1) return 0;
+  if (severity <= 3) return 5;
+  return 20;
+}
+
+function stripGeometry(alert) {
+  const copy = { ...alert };
+  delete copy.geometry;
+  return copy;
+}
+
+function isMilitaryCallsign(callsign) {
+  if (!callsign) return false;
+  return MILITARY_CALLSIGN_PREFIXES.some(p => callsign.startsWith(p));
+}
+
+const extractors = {
+  conflicts(raw) { return raw?.events ?? (Array.isArray(raw) ? raw : []); },
+  markets(raw) { return raw?.quotes ?? (Array.isArray(raw) ? raw : []); },
+  weather(raw) { return Array.isArray(raw) ? raw : raw?.alerts ?? []; },
+  seismic(raw) { return raw?.earthquakes ?? raw?.features ?? (Array.isArray(raw) ? raw : []); },
+  health(raw) { return raw?.outbreaks ?? (Array.isArray(raw) ? raw : []); },
+  sanctions(raw) { return raw?.results ?? (Array.isArray(raw) ? raw : []); },
+  news(raw) { return raw?.articles ?? (Array.isArray(raw) ? raw : []); },
+  cyber(raw) { return { iocs: raw?.iocs ?? [], kevs: raw?.kevs ?? raw?.vulnerabilities ?? [] }; },
+  military(raw) {
+    const aircraft = raw?.aircraft ?? (Array.isArray(raw?.militaryFlights) ? raw.militaryFlights : []);
+    const milAircraft = aircraft.filter(a => a.military === true || isMilitaryCallsign(a.callsign));
+    return { aircraft: milAircraft, vessels: raw?.vessels ?? raw?.navalVessels ?? [], posture: raw?.posture ?? raw?.theaterPosture ?? {} };
+  },
+  infrastructure(raw) { return raw?.gridAlerts ?? []; },
+  economic(raw) { return raw; },
+};
+
+export function filterDomain(domain, severity, raw) {
+  const limit = itemLimit(severity);
+  const extracted = (extractors[domain] ?? (r => r))(raw);
+
+  if (domain === 'military') {
+    const { aircraft, vessels, posture } = extracted;
+    const count = aircraft.length + vessels.length;
+    if (limit === 0) {
+      return { summary: `${aircraft.length} military aircraft, ${vessels.length} vessels tracked`, count };
+    }
+    return {
+      summary: `${aircraft.length} military aircraft, ${vessels.length} vessels tracked`,
+      count,
+      items: aircraft.slice(0, limit),
+      vessels: vessels.slice(0, limit),
+      posture,
+    };
+  }
+
+  if (domain === 'cyber') {
+    const { iocs, kevs } = extracted;
+    const count = iocs.length + kevs.length;
+    if (limit === 0) {
+      return { summary: `${iocs.length} IOCs, ${kevs.length} KEVs`, count };
+    }
+    return {
+      summary: `${iocs.length} IOCs, ${kevs.length} KEVs`,
+      count,
+      iocs: iocs.slice(0, limit),
+      kevs: kevs.slice(0, limit),
+    };
+  }
+
+  if (domain === 'economic') {
+    return { summary: extracted?.error ? 'unavailable' : 'available', data: limit > 0 ? extracted : undefined };
+  }
+
+  const items = Array.isArray(extracted) ? extracted : [];
+  const count = items.length;
+
+  if (limit === 0) {
+    return { summary: `${count} items`, count };
+  }
+
+  let sliced = items.slice(0, limit);
+  if (domain === 'weather') {
+    sliced = sliced.map(a => stripGeometry(a));
+  }
+
+  return { summary: `${count} items`, count, items: sliced };
+}
+
+export function filterAllDomains(severity, raw) {
+  const result = {};
+  for (const [domain, score] of Object.entries(severity)) {
+    if (raw[domain] !== undefined) {
+      result[domain] = filterDomain(domain, score, raw[domain]);
+    }
+  }
+  return result;
+}

--- a/src-tauri/sidecar/sitrep-filter.test.mjs
+++ b/src-tauri/sidecar/sitrep-filter.test.mjs
@@ -1,0 +1,63 @@
+// src-tauri/sidecar/sitrep-filter.test.mjs
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { filterDomain, filterAllDomains } from './sitrep-filter.mjs';
+
+test('filterDomain: severity 1 strips items, returns summary only', () => {
+  const result = filterDomain('conflicts', 1, {
+    events: Array.from({ length: 3 }, () => ({ country: 'X' })),
+  });
+  assert.equal(result.items, undefined);
+  assert.equal(typeof result.summary, 'string');
+  assert.equal(result.count, 3);
+});
+
+test('filterDomain: severity 2 returns top 5 items', () => {
+  const events = Array.from({ length: 20 }, (_, i) => ({ id: i }));
+  const result = filterDomain('conflicts', 2, { events });
+  assert.equal(result.items.length, 5);
+});
+
+test('filterDomain: severity 4 returns up to 20 items', () => {
+  const events = Array.from({ length: 50 }, (_, i) => ({ id: i }));
+  const result = filterDomain('conflicts', 4, { events });
+  assert.equal(result.items.length, 20);
+});
+
+test('filterDomain: weather severity 1 strips polygon geometry', () => {
+  const result = filterDomain('weather', 1, [
+    { event: 'Flood', severity: 'Moderate', geometry: { type: 'Polygon', coordinates: [[[1,2],[3,4]]] } },
+  ]);
+  assert.equal(result.items, undefined);
+});
+
+test('filterDomain: weather severity 3 strips polygon geometry from items', () => {
+  const result = filterDomain('weather', 3, [
+    { event: 'Flood', severity: 'Severe', geometry: { type: 'Polygon', coordinates: [[[1,2],[3,4]]] } },
+  ]);
+  assert.ok(result.items.length > 0);
+  assert.equal(result.items[0].geometry, undefined);
+});
+
+test('filterDomain: military strips non-military aircraft', () => {
+  const aircraft = [
+    { callsign: 'RCH001', military: true },
+    { callsign: 'THY123', military: false },
+    { callsign: 'ZEUS22', military: true },
+  ];
+  const result = filterDomain('military', 3, { aircraft, vessels: [], posture: {} });
+  const milOnly = result.items.filter(a => a.callsign);
+  assert.ok(milOnly.every(a => a.military === true || /^(RCH|ZEUS|KYOTE|BOMR|ENT|OTIS|MUSEL|WATTS|CARGO|VVHK|SCHNR)/.test(a.callsign)));
+});
+
+test('filterAllDomains: applies correct filter per domain', () => {
+  const severity = { conflicts: 1, weather: 3, seismic: 1 };
+  const raw = {
+    conflicts: { events: [{ country: 'X' }] },
+    weather: [{ event: 'Flood', severity: 'Severe', geometry: {} }],
+    seismic: { earthquakes: [] },
+  };
+  const result = filterAllDomains(severity, raw);
+  assert.equal(result.conflicts.items, undefined);
+  assert.ok(result.weather.items.length > 0);
+});

--- a/src-tauri/sidecar/sitrep-severity.mjs
+++ b/src-tauri/sidecar/sitrep-severity.mjs
@@ -1,0 +1,117 @@
+export function scoreConflicts(events) {
+  const n = events?.length ?? 0;
+  if (n === 0) return 1;
+  const hasFatalities = events.some(e => (e.fatalities ?? 0) > 0);
+  if (n >= 30) return hasFatalities ? 5 : 4;
+  if (n >= 15 && hasFatalities) return 3;
+  if (n >= 5) return 2;
+  return 1;
+}
+
+export function scoreMarkets(quotes) {
+  if (!quotes?.length) return 1;
+  const thresholds = { SPY: 2.5, 'BTC-USD': 5, 'CL=F': 4, 'GC=F': 2 };
+  let triggers = 0;
+  for (const q of quotes) {
+    const thresh = thresholds[q.symbol];
+    if (thresh && Math.abs(q.changePercent ?? 0) >= thresh) triggers++;
+  }
+  return Math.min(1 + triggers, 5);
+}
+
+export function scoreCyber(iocs, kevs) {
+  const iocCount = iocs?.length ?? 0;
+  const today = new Date().toISOString().slice(0, 10);
+  const newKevs = (kevs ?? []).filter(k => k.firstSeen === today).length;
+  if (iocCount >= 50 || newKevs >= 5) return 4;
+  if (iocCount >= 20 || newKevs >= 1) return 3;
+  if (iocCount >= 5) return 2;
+  return 1;
+}
+
+export function scoreMilitary({ aircraft = [], vessels = [], posture = {} } = {}) {
+  const theaters = Object.values(posture?.theaters ?? posture ?? {});
+  const elevated = theaters.filter(t => t.status && t.status !== 'normal').length;
+  if (elevated >= 2) return 5;
+  if (elevated >= 1) return 4;
+  const acCount = aircraft.length;
+  const vesCount = vessels.length;
+  if (acCount > 50 || vesCount > 20) return 3;
+  if (acCount > 20 || vesCount > 5) return 2;
+  return 1;
+}
+
+export function scoreWeather(alerts) {
+  if (!alerts?.length) return 1;
+  const hasExtreme = alerts.some(a => a.severity === 'Extreme');
+  if (hasExtreme) return 5;
+  const severeCount = alerts.filter(a => a.severity === 'Severe').length;
+  if (severeCount >= 5) return 4;
+  if (severeCount >= 1) return 3;
+  const modCount = alerts.filter(a => a.severity === 'Moderate').length;
+  if (modCount >= 5) return 2;
+  return 1;
+}
+
+export function scoreInfrastructure(gridAlerts) {
+  const n = gridAlerts?.length ?? 0;
+  if (n === 0) return 1;
+  if (n >= 10) return 4;
+  if (n >= 5) return 3;
+  if (n >= 1) return 2;
+  return 1;
+}
+
+export function scoreSeismic(quakes) {
+  if (!quakes?.length) return 1;
+  const maxMag = Math.max(...quakes.map(q => q.magnitude ?? q.mag ?? 0));
+  if (maxMag >= 7.5) return 5;
+  if (maxMag >= 6.5) return 4;
+  if (maxMag >= 5.5) return 3;
+  if (maxMag >= 4) return 2;
+  return 1;
+}
+
+export function scoreHealth(outbreaks) {
+  const n = outbreaks?.length ?? 0;
+  if (n === 0) return 1;
+  if (n >= 5) return 4;
+  if (n >= 3) return 3;
+  if (n >= 1) return 2;
+  return 1;
+}
+
+export function scoreEconomic(data) {
+  if (!data || data.error) return 1;
+  const series = data.series ?? [];
+  if (series.length === 0) return 1;
+  const yieldCurve = series.find(s => s.id === 'T10Y2Y');
+  if (yieldCurve?.observations?.length) {
+    const latest = yieldCurve.observations[yieldCurve.observations.length - 1];
+    if (Number.parseFloat(latest?.value) < 0) return 3;
+  }
+  return 1;
+}
+
+export function scoreSanctions(entries) {
+  const n = entries?.length ?? 0;
+  if (n === 0) return 1;
+  if (n >= 10) return 3;
+  if (n >= 1) return 2;
+  return 1;
+}
+
+export function scoreAllDomains(raw) {
+  return {
+    conflicts: scoreConflicts(raw.conflicts),
+    markets: scoreMarkets(raw.markets),
+    cyber: scoreCyber(raw.cyber?.iocs, raw.cyber?.kevs),
+    military: scoreMilitary(raw.military),
+    weather: scoreWeather(raw.weather),
+    infrastructure: scoreInfrastructure(raw.infrastructure?.gridAlerts),
+    seismic: scoreSeismic(raw.seismic),
+    health: scoreHealth(raw.health),
+    economic: scoreEconomic(raw.economic),
+    sanctions: scoreSanctions(raw.sanctions),
+  };
+}

--- a/src-tauri/sidecar/sitrep-severity.test.mjs
+++ b/src-tauri/sidecar/sitrep-severity.test.mjs
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  scoreConflicts,
+  scoreMarkets,
+  scoreCyber,
+  scoreMilitary,
+  scoreWeather,
+  scoreSeismic,
+  scoreHealth,
+  scoreEconomic,
+  scoreSanctions,
+  scoreAllDomains,
+} from './sitrep-severity.mjs';
+
+test('scoreConflicts: empty events = 1', () => {
+  assert.equal(scoreConflicts([]), 1);
+});
+
+test('scoreConflicts: 10 events = 2', () => {
+  const events = Array.from({ length: 10 }, () => ({ event_type: 'Protests', country: 'X' }));
+  assert.equal(scoreConflicts(events), 2);
+});
+
+test('scoreConflicts: 20 events with fatalities = 3', () => {
+  const events = Array.from({ length: 20 }, () => ({ event_type: 'Battles', fatalities: 1 }));
+  assert.equal(scoreConflicts(events), 3);
+});
+
+test('scoreConflicts: 35 events = 4', () => {
+  const events = Array.from({ length: 35 }, () => ({ event_type: 'Battles' }));
+  assert.equal(scoreConflicts(events), 4);
+});
+
+test('scoreMarkets: no quotes = 1', () => {
+  assert.equal(scoreMarkets([]), 1);
+});
+
+test('scoreMarkets: SPY down 3% = 2 (one threshold)', () => {
+  assert.equal(scoreMarkets([{ symbol: 'SPY', changePercent: -3 }]), 2);
+});
+
+test('scoreMarkets: SPY -3% + BTC -6% = 3 (two thresholds)', () => {
+  assert.equal(scoreMarkets([
+    { symbol: 'SPY', changePercent: -3 },
+    { symbol: 'BTC-USD', changePercent: -6 },
+  ]), 3);
+});
+
+test('scoreWeather: no alerts = 1', () => {
+  assert.equal(scoreWeather([]), 1);
+});
+
+test('scoreWeather: severe alerts = 3', () => {
+  const alerts = [{ severity: 'Severe', event: 'Flood Warning' }];
+  assert.equal(scoreWeather(alerts), 3);
+});
+
+test('scoreWeather: extreme alerts = 5', () => {
+  const alerts = [{ severity: 'Extreme', event: 'Hurricane Warning' }];
+  assert.equal(scoreWeather(alerts), 5);
+});
+
+test('scoreCyber: no KEVs no IOCs = 1', () => {
+  assert.equal(scoreCyber([], []), 1);
+});
+
+test('scoreCyber: 30 IOCs + new KEV = 3', () => {
+  const iocs = Array.from({ length: 30 }, () => ({ indicator: 'test-ioc' }));
+  const kevs = [{ indicator: 'CVE-2026-1234', firstSeen: new Date().toISOString().slice(0, 10) }];
+  assert.equal(scoreCyber(iocs, kevs), 3);
+});
+
+test('scoreSeismic: no quakes = 1', () => {
+  assert.equal(scoreSeismic([]), 1);
+});
+
+test('scoreSeismic: M6.5 = 4', () => {
+  assert.equal(scoreSeismic([{ magnitude: 6.5 }]), 4);
+});
+
+test('scoreSeismic: M7.5 = 5', () => {
+  assert.equal(scoreSeismic([{ magnitude: 7.5 }]), 5);
+});
+
+test('scoreMilitary: baseline = 1', () => {
+  assert.equal(scoreMilitary({ aircraft: [], vessels: [], posture: {} }), 1);
+});
+
+test('scoreHealth: no outbreaks = 1', () => {
+  assert.equal(scoreHealth([]), 1);
+});
+
+test('scoreEconomic: empty = 1', () => {
+  assert.equal(scoreEconomic({}), 1);
+});
+
+test('scoreSanctions: empty = 1', () => {
+  assert.equal(scoreSanctions([]), 1);
+});
+
+test('scoreAllDomains: returns all domain scores', () => {
+  const scores = scoreAllDomains({
+    conflicts: [],
+    markets: [],
+    cyber: { iocs: [], kevs: [] },
+    military: { aircraft: [], vessels: [], posture: {} },
+    weather: [],
+    infrastructure: { gridAlerts: [] },
+    seismic: [],
+    health: [],
+    economic: {},
+    sanctions: [],
+  });
+  assert.equal(typeof scores.conflicts, 'number');
+  assert.equal(typeof scores.markets, 'number');
+  assert.equal(typeof scores.cyber, 'number');
+  assert.equal(typeof scores.military, 'number');
+  assert.equal(typeof scores.weather, 'number');
+  assert.equal(typeof scores.seismic, 'number');
+  assert.equal(typeof scores.health, 'number');
+  assert.equal(typeof scores.economic, 'number');
+  assert.equal(typeof scores.sanctions, 'number');
+});

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -56,6 +56,8 @@
     "resources": [
       "../api",
       "sidecar/local-api-server.mjs",
+      "sidecar/sitrep-severity.mjs",
+      "sidecar/sitrep-filter.mjs",
       "sidecar/package.json",
       "sidecar/node",
       "../data",


### PR DESCRIPTION
## Closing — superseded by PR #71

Re-cherry-picked onto current main as PR #71 (now merged). The sidecar fixes from this branch's other commits (`fix: sidecar crash + auth bypass for bundled API routes`, `feat: Groq fallback for intel-generate`) still need their own PR — opening that next.

Branch can be deleted.