### PR TITLE
salvage: wire-world-bank-data-loader (reopen after PR #41 closed)

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -613,6 +613,7 @@ export class App {
  { name: 'tropicalCyclones', fn: () => this.dataLoader.loadTropicalCyclones(), intervalMs: 30 * 60 * 1000, condition: () => SITE_VARIANT === 'full' },
  { name: 'savedPlaceWeather', fn: () => this.dataLoader.loadSavedPlaceWeather(), intervalMs: 30 * 60 * 1000, condition: () => SITE_VARIANT === 'full' },
  { name: 'foodInsecurity', fn: () => this.dataLoader.loadFoodInsecurity(), intervalMs: 4 * 60 * 60 * 1000, condition: () => SITE_VARIANT === 'full' },
+      { name: 'worldBankBaselines', fn: () => this.dataLoader.loadWorldBankBaselines(), intervalMs: 6 * 60 * 60 * 1000, condition: () => SITE_VARIANT === 'full' },
  { name: 'globalWeather', fn: () => this.dataLoader.loadGlobalWeather(), intervalMs: 30 * 60 * 1000, condition: () => SITE_VARIANT === 'full' },
  { name: 'openSanctions', fn: () => this.dataLoader.loadOpenSanctions(), intervalMs: 60 * 60 * 1000, condition: () => SITE_VARIANT === 'full' },
  { name: 'edgarFilings', fn: () => this.dataLoader.loadEdgarFilings(), intervalMs: 30 * 60 * 1000, condition: () => SITE_VARIANT === 'full' },

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -308,6 +308,7 @@ import { fetchPowerGridAlerts } from '@/services/power-grid-alerts';
 import { fetchGreyNoise, fetchOtxPulses, fetchAbuseIpDb, fetchUrlscanFeed } from '@/services/osint';
 import { fetchAcledEvents, fetchAdsbMilitary } from '@/services/osint';
 import { fetchHibpBreaches, fetchTorMetrics } from '@/services/osint';
+import { fetchWorldBankProfile } from '@/services/world-bank';
 import type { ThreatIntelHubPanel } from '@/components/ThreatIntelHubPanel';
 import type { GeoIntelPanel } from '@/components/GeoIntelPanel';
 import type { DarkWebPanel } from '@/components/DarkWebPanel';
@@ -3551,6 +3552,15 @@ export class DataLoaderManager implements AppModule {
  } catch (error) {
  console.warn('[satellites] fetch failed', error);
  }
+  }
+
+  async loadWorldBankBaselines(): Promise<void> {
+    try {
+      const keyCodes = ['USA', 'CHN', 'RUS', 'IND', 'DEU', 'GBR', 'FRA', 'JPN', 'BRA', 'SAU', 'IRN', 'UKR', 'ISR', 'TWN', 'KOR'];
+      await Promise.allSettled(keyCodes.map(iso => fetchWorldBankProfile(iso)));
+    } catch (error) {
+      console.error('[App] World Bank baselines fetch failed:', error);
+    }
   }
 
   async loadDarkWeb(): Promise<void> {

--- a/tests/data-sources-wiring.test.mjs
+++ b/tests/data-sources-wiring.test.mjs
@@ -1,0 +1,26 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+const dataLoaderSrc = readFileSync(resolve(root, 'src/app/data-loader.ts'), 'utf8');
+const appSrc = readFileSync(resolve(root, 'src/App.ts'), 'utf8');
+
+describe('World Bank data-loader wiring', () => {
+  it('data-loader imports fetchWorldBankProfile', () => {
+    assert.match(dataLoaderSrc, /fetchWorldBankProfile/);
+  });
+
+  it('data-loader has loadWorldBankBaselines method', () => {
+    assert.match(dataLoaderSrc, /async loadWorldBankBaselines\(\): Promise<void>/);
+  });
+
+  it('App.ts scheduler includes worldBankBaselines', () => {
+    assert.match(appSrc, /worldBankBaselines/);
+    assert.match(appSrc, /loadWorldBankBaselines/);
+  });
+});


### PR DESCRIPTION
## Summary

Preserves `claude/wire-world-bank-data-loader` (1 commit, 3 files).

### Note — previously closed as part of PR #41

PR #41 (`claude/high-impact-data-sources`) bundled World Bank + other data sources and was closed unmerged. This salvage PR isolates just the World Bank wiring so you can decide on that piece alone.

### Single commit

`feat: wire World Bank service into periodic data-loader`

Touches:
- `src/App.ts` (scheduleRefresh registration)
- `src/app/data-loader.ts`
- `tests/data-sources-wiring.test.mjs`

### Test plan

- [ ] Rebase onto main after PR #52 merges
- [ ] ⚠️ `data-loader.ts` was restructured in PR #52 (~250 lines extracted to loaders/). The World Bank integration may need to move into a new `loaders/economic.ts` module rather than being added inline.
- [ ] Run `npm run test:data` to verify the data-sources-wiring test still works