### PR TITLE
salvage: apple-native-polish-spec (WelcomeFlow + ContextualHint + EmptyState + Toast + plane icons + cinematic transitions)

### DIFF
--- a/docs/superpowers/plans/2026-04-13-apple-native-polish.md
+++ b/docs/superpowers/plans/2026-04-13-apple-native-polish.md
@@ -1,0 +1,1799 @@
+# Apple-Native Polish Overhaul — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Transform Crystal Ball's UI from functional to Apple-native premium across 6 phases — design tokens, motion system, visual hierarchy, alerts, map, and onboarding.
+
+**Architecture:** Foundation-first. A new `design-system.css` defines all tokens (typography, spacing, color, elevation, motion). A `motion.css` + `motion.ts` pair provides animation primitives. Existing panels migrate gradually to tokens via `.cb-*` utility classes. Phases 4-6 (alerts, map, onboarding) run in parallel after the foundation is in place.
+
+**Tech Stack:** CSS custom properties, CSS animations/transitions, vanilla TypeScript (no animation libraries), Web Audio API (sound design), DeckGL transitions prop, Cesium camera API.
+
+**Spec:** `docs/superpowers/specs/2026-04-13-apple-native-polish-design.md`
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Responsibility |
+|------|---------------|
+| `src/styles/design-system.css` | All design tokens (typography, spacing, color, elevation, radius, motion) + component primitives (`.cb-card`, `.cb-badge`, etc.) |
+| `src/styles/motion.css` | Animation keyframes + transition utility classes |
+| `src/services/motion.ts` | JS animation helpers: `staggerIn`, `crossfadeContent`, `animateNumber`, `animateIn`, `animateOut`, `revealContent` |
+| `src/components/Toast.ts` | Toast notification component with stacking, auto-dismiss, severity tinting |
+| `src/components/EmptyState.ts` | Reusable empty state component: icon + title + guidance + optional CTA |
+| `src/components/WelcomeFlow.ts` | 3-step onboarding modal: location, interests, API keys |
+| `src/components/ContextualHint.ts` | One-time tooltip hints for keyboard shortcuts |
+| `src/services/sound.ts` | Web Audio API alert chimes — severity-mapped tones |
+| `tests/design-system.test.mts` | Token validation tests |
+| `tests/motion.test.mts` | Motion helper unit tests |
+| `tests/toast.test.mts` | Toast component tests |
+| `tests/empty-state.test.mts` | EmptyState component tests |
+| `tests/sound.test.mts` | Sound service tests |
+| `e2e/design-system.spec.ts` | E2E: tokens load, theme switch works |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `src/styles/main.css` | Add `@import './design-system.css'` as first import; add `@import './motion.css'` second |
+| `src/styles/panels.css` | Replace hardcoded colors/sizes with token references |
+| `src/styles/alerts.css` | Add alert arrival/action animations, toast positioning |
+| `src/styles/gods-vision.css` | HUD typography refinement, entry/exit transition classes |
+| `src/components/Panel.ts` | Add skeleton support to base class, standardize header rendering |
+| `src/components/UnifiedAlertInboxPanel.ts` | Alert arrival animation, acknowledge/snooze/pin/dismiss feedback |
+| `src/components/TriageBar.ts` | Severity accent line, escalation bar, hover expand |
+| `src/components/DeckGLMap.ts` | Layer transitions, view preset segmented control, cluster animation |
+| `src/components/MapPopup.ts` | Apple Maps card redesign with glass morphism |
+| `src/components/GlobeHUD.ts` | Typography split (SF Mono data / SF Pro labels), animateNumber |
+| `src/components/GodsVisionView.ts` | Cinematic entry/exit transition choreography |
+| `src/app/panel-layout.ts` | Integrate WelcomeFlow, ContextualHint |
+| `src/services/mode-manager.ts` | Emit events for God's Vision entry/exit transition |
+
+---
+
+## Phase 1: Design System Foundation
+
+### Task 1: Create design-system.css — Token Definitions
+
+**Files:**
+- Create: `src/styles/design-system.css`
+- Modify: `src/styles/main.css:1-5`
+
+- [ ] **Step 1: Create design-system.css with all token definitions**
+
+```css
+/* src/styles/design-system.css */
+/* Crystal Ball Design System — Apple-Native Tokens */
+
+:root {
+  /* ── Typography ── */
+  --font-ui: -apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text", system-ui, sans-serif;
+  --font-mono: "SF Mono", "Fira Code", "Cascadia Code", ui-monospace, monospace;
+
+  --text-2xs: 10px;
+  --text-xs: 11px;
+  --text-sm: 12px;
+  --text-base: 13px;
+  --text-md: 14px;
+  --text-lg: 16px;
+  --text-xl: 20px;
+  --text-2xl: 24px;
+
+  --fw-regular: 400;
+  --fw-medium: 500;
+  --fw-semibold: 600;
+  --fw-bold: 700;
+
+  /* ── Spacing (4px grid) ── */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* ── Border Radius ── */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+
+  /* ── Motion ── */
+  --duration-fast: 100ms;
+  --duration-normal: 200ms;
+  --duration-moderate: 350ms;
+  --duration-slow: 500ms;
+
+  --ease-default: cubic-bezier(0.25, 0.1, 0.25, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in: cubic-bezier(0.55, 0, 1, 0.45);
+
+  /* ── Surfaces (dark) ── */
+  --surface-base: #0a0a0a;
+  --surface-raised: #141414;
+  --surface-overlay: #1c1c1e;
+  --surface-popover: #2c2c2e;
+
+  /* ── Interactive States ── */
+  --accent: #3b82f6;
+  --hover-bg: rgba(255, 255, 255, 0.06);
+  --active-bg: rgba(255, 255, 255, 0.1);
+  --focus-ring: 0 0 0 2px rgba(59, 130, 246, 0.5), 0 0 0 4px rgba(59, 130, 246, 0.15);
+
+  /* ── Severity: Critical ── */
+  --severity-critical: #ef4444;
+  --severity-critical-bg: rgba(239, 68, 68, 0.1);
+  --severity-critical-border: rgba(239, 68, 68, 0.25);
+  --severity-critical-glow: rgba(239, 68, 68, 0.3);
+
+  /* ── Severity: High ── */
+  --severity-high: #f97316;
+  --severity-high-bg: rgba(249, 115, 22, 0.1);
+  --severity-high-border: rgba(249, 115, 22, 0.25);
+  --severity-high-glow: rgba(249, 115, 22, 0.3);
+
+  /* ── Severity: Elevated ── */
+  --severity-elevated: #eab308;
+  --severity-elevated-bg: rgba(234, 179, 8, 0.1);
+  --severity-elevated-border: rgba(234, 179, 8, 0.25);
+  --severity-elevated-glow: rgba(234, 179, 8, 0.3);
+
+  /* ── Severity: Normal ── */
+  --severity-normal: #3b82f6;
+  --severity-normal-bg: rgba(59, 130, 246, 0.08);
+  --severity-normal-border: rgba(59, 130, 246, 0.2);
+  --severity-normal-glow: rgba(59, 130, 246, 0.2);
+
+  /* ── Severity: Positive ── */
+  --severity-positive: #22c55e;
+  --severity-positive-bg: rgba(34, 197, 94, 0.08);
+  --severity-positive-border: rgba(34, 197, 94, 0.2);
+  --severity-positive-glow: rgba(34, 197, 94, 0.2);
+
+  /* ── Elevation ── */
+  --elevation-1: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --elevation-2: 0 4px 12px rgba(0, 0, 0, 0.4);
+  --elevation-3: 0 8px 32px rgba(0, 0, 0, 0.5);
+  --elevation-4: 0 16px 48px rgba(0, 0, 0, 0.6);
+
+  --border-subtle: 1px solid rgba(255, 255, 255, 0.06);
+  --border-medium: 1px solid rgba(255, 255, 255, 0.08);
+  --border-strong: 1px solid rgba(255, 255, 255, 0.1);
+  --border-accent: 1px solid rgba(59, 130, 246, 0.2);
+}
+
+/* ── Light theme overrides ── */
+[data-theme="light"] {
+  --surface-base: #f5f5f7;
+  --surface-raised: #ffffff;
+  --surface-overlay: #f2f2f7;
+  --surface-popover: #ffffff;
+
+  --hover-bg: rgba(0, 0, 0, 0.04);
+  --active-bg: rgba(0, 0, 0, 0.08);
+
+  --elevation-1: 0 1px 3px rgba(0, 0, 0, 0.08);
+  --elevation-2: 0 4px 12px rgba(0, 0, 0, 0.1);
+  --elevation-3: 0 8px 32px rgba(0, 0, 0, 0.12);
+  --elevation-4: 0 16px 48px rgba(0, 0, 0, 0.15);
+
+  --border-subtle: 1px solid rgba(0, 0, 0, 0.06);
+  --border-medium: 1px solid rgba(0, 0, 0, 0.1);
+  --border-strong: 1px solid rgba(0, 0, 0, 0.15);
+}
+```
+
+- [ ] **Step 2: Add design-system.css import to main.css as first import**
+
+In `src/styles/main.css`, add `@import './design-system.css';` as the very first line, before the existing `@import './rtl-overrides.css';`.
+
+- [ ] **Step 3: Verify tokens load in dev**
+
+Run: `npm run dev`
+Open browser devtools, Elements, `<html>`, Computed, search `--surface-base`. Verify it shows `#0a0a0a`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/styles/design-system.css src/styles/main.css
+git commit -m "feat: add design-system.css with Apple-native tokens
+
+Typography, spacing, color, severity, elevation, motion tokens.
+Light theme overrides. Imported as first CSS file.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Add Component Primitives to design-system.css
+
+**Files:**
+- Modify: `src/styles/design-system.css`
+
+- [ ] **Step 1: Append component primitive classes**
+
+Add to the end of `src/styles/design-system.css`:
+
+```css
+/* ══ Component Primitives ══ */
+
+.cb-card {
+  background: var(--surface-overlay);
+  border: var(--border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow: var(--elevation-1);
+  transition: transform var(--duration-fast) var(--ease-default),
+              box-shadow var(--duration-fast) var(--ease-default),
+              border-color var(--duration-fast) var(--ease-default);
+}
+
+.cb-card:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--elevation-2);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.cb-card.selected {
+  background: var(--severity-normal-bg);
+  border-color: rgba(59, 130, 246, 0.2);
+  box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.15);
+}
+
+.cb-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px var(--space-2);
+  font-size: var(--text-2xs);
+  font-weight: var(--fw-medium);
+  border-radius: var(--radius-sm);
+  line-height: 1.4;
+}
+
+.cb-badge[data-severity="critical"] {
+  color: var(--severity-critical);
+  background: var(--severity-critical-bg);
+  border: 1px solid var(--severity-critical-border);
+}
+
+.cb-badge[data-severity="high"] {
+  color: var(--severity-high);
+  background: var(--severity-high-bg);
+  border: 1px solid var(--severity-high-border);
+}
+
+.cb-badge[data-severity="elevated"] {
+  color: var(--severity-elevated);
+  background: var(--severity-elevated-bg);
+  border: 1px solid var(--severity-elevated-border);
+}
+
+.cb-badge[data-severity="normal"] {
+  color: var(--severity-normal);
+  background: var(--severity-normal-bg);
+  border: 1px solid var(--severity-normal-border);
+}
+
+.cb-badge[data-severity="positive"] {
+  color: var(--severity-positive);
+  background: var(--severity-positive-bg);
+  border: 1px solid var(--severity-positive-border);
+}
+
+.cb-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
+  font-weight: var(--fw-medium);
+  font-family: var(--font-ui);
+  border-radius: var(--radius-md);
+  border: var(--border-medium);
+  background: rgba(255, 255, 255, 0.04);
+  color: #aaa;
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-default),
+              transform var(--duration-fast) var(--ease-default);
+}
+
+.cb-button:hover {
+  background: var(--hover-bg);
+}
+
+.cb-button:active {
+  transform: scale(0.97);
+}
+
+.cb-button:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.cb-button.accent {
+  background: var(--accent);
+  color: #fff;
+  border-color: transparent;
+}
+
+.cb-button.accent:hover {
+  background: #2563eb;
+}
+
+.cb-list-row {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  transition: background var(--duration-fast) var(--ease-default),
+              transform var(--duration-fast) var(--ease-default);
+}
+
+.cb-list-row:hover {
+  background: var(--hover-bg);
+  transform: translateY(-1px);
+}
+
+.cb-list-row:active {
+  transform: scale(0.99);
+  background: var(--active-bg);
+}
+
+.cb-separator {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.06);
+  margin: var(--space-2) var(--space-4);
+}
+
+[data-theme="light"] .cb-separator {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.cb-skeleton {
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.04) 25%,
+    rgba(255, 255, 255, 0.08) 50%,
+    rgba(255, 255, 255, 0.04) 75%
+  );
+  background-size: 200% 100%;
+  animation: cb-shimmer 1.5s ease-in-out infinite;
+  border-radius: var(--radius-sm);
+}
+
+@keyframes cb-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+[data-theme="light"] .cb-skeleton {
+  background: linear-gradient(
+    90deg,
+    rgba(0, 0, 0, 0.04) 25%,
+    rgba(0, 0, 0, 0.08) 50%,
+    rgba(0, 0, 0, 0.04) 75%
+  );
+  background-size: 200% 100%;
+}
+
+.cb-pill-group {
+  display: inline-flex;
+  gap: 2px;
+  padding: 3px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius-md);
+}
+
+.cb-pill-group button {
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-2xs);
+  font-weight: var(--fw-medium);
+  font-family: var(--font-ui);
+  color: #888;
+  background: transparent;
+  border: none;
+  border-radius: calc(var(--radius-md) - 2px);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-default),
+              color var(--duration-fast) var(--ease-default);
+}
+
+.cb-pill-group button.active {
+  background: rgba(255, 255, 255, 0.1);
+  color: #e5e5e5;
+  font-weight: var(--fw-semibold);
+}
+
+.cb-pill-group button:hover:not(.active) {
+  background: rgba(255, 255, 255, 0.06);
+  color: #bbb;
+}
+
+/* ── Focus Ring Global ── */
+*:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+/* ── Scrollbar ── */
+::-webkit-scrollbar {
+  width: 4px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 2px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.25);
+  width: 6px;
+}
+
+[data-theme="light"] ::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.12);
+}
+
+[data-theme="light"] ::-webkit-scrollbar-thumb:hover {
+  background: rgba(0, 0, 0, 0.25);
+}
+```
+
+- [ ] **Step 2: Verify primitives render in dev**
+
+Run: `npm run dev`
+In browser devtools console:
+```js
+document.body.insertAdjacentHTML('beforeend', '<div class="cb-card" style="padding:16px;margin:16px;">Test card</div>');
+```
+Verify: card appears with dark background, subtle border, shadow. Hover lifts it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/styles/design-system.css
+git commit -m "feat: add component primitives to design system
+
+.cb-card, .cb-badge, .cb-button, .cb-list-row, .cb-separator,
+.cb-skeleton, .cb-pill-group. Focus ring and scrollbar globals.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Write Token Validation Tests
+
+**Files:**
+- Create: `tests/design-system.test.mts`
+
+- [ ] **Step 1: Write tests that validate token definitions exist**
+
+```typescript
+// tests/design-system.test.mts
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const css = readFileSync(resolve(import.meta.dirname, '../src/styles/design-system.css'), 'utf-8');
+
+describe('design-system.css tokens', () => {
+  const requiredTokens = [
+    '--font-ui', '--font-mono',
+    '--text-2xs', '--text-xs', '--text-sm', '--text-base',
+    '--text-md', '--text-lg', '--text-xl', '--text-2xl',
+    '--fw-regular', '--fw-medium', '--fw-semibold', '--fw-bold',
+    '--space-1', '--space-2', '--space-3', '--space-4',
+    '--space-6', '--space-8', '--space-12', '--space-16',
+    '--radius-sm', '--radius-md', '--radius-lg', '--radius-xl',
+    '--duration-fast', '--duration-normal', '--duration-moderate', '--duration-slow',
+    '--ease-default', '--ease-spring', '--ease-out', '--ease-in',
+    '--surface-base', '--surface-raised', '--surface-overlay', '--surface-popover',
+    '--accent', '--hover-bg', '--active-bg', '--focus-ring',
+    '--elevation-1', '--elevation-2', '--elevation-3', '--elevation-4',
+    '--border-subtle', '--border-medium', '--border-strong',
+  ];
+
+  for (const token of requiredTokens) {
+    it(`defines ${token}`, () => {
+      assert.ok(css.includes(`${token}:`), `Missing token: ${token}`);
+    });
+  }
+
+  const severityLevels = ['critical', 'high', 'elevated', 'normal', 'positive'];
+  const severityVariants = ['', '-bg', '-border', '-glow'];
+
+  for (const level of severityLevels) {
+    for (const variant of severityVariants) {
+      const token = `--severity-${level}${variant}`;
+      it(`defines ${token}`, () => {
+        assert.ok(css.includes(`${token}:`), `Missing severity token: ${token}`);
+      });
+    }
+  }
+
+  it('includes light theme overrides', () => {
+    assert.ok(css.includes('[data-theme="light"]'), 'Missing light theme selector');
+  });
+
+  it('includes shimmer keyframe', () => {
+    assert.ok(css.includes('@keyframes cb-shimmer'), 'Missing shimmer animation');
+  });
+});
+
+describe('design-system.css component primitives', () => {
+  const requiredClasses = [
+    '.cb-card', '.cb-badge', '.cb-button', '.cb-list-row',
+    '.cb-separator', '.cb-skeleton', '.cb-pill-group',
+  ];
+
+  for (const cls of requiredClasses) {
+    it(`defines ${cls}`, () => {
+      assert.ok(css.includes(cls), `Missing class: ${cls}`);
+    });
+  }
+
+  it('defines severity badge variants', () => {
+    for (const level of ['critical', 'high', 'elevated', 'normal', 'positive']) {
+      assert.ok(
+        css.includes(`[data-severity="${level}"]`),
+        `Missing badge variant: ${level}`,
+      );
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `node --test tests/design-system.test.mts`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/design-system.test.mts
+git commit -m "test: add design system token validation tests
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 2: Transitions & Motion System
+
+### Task 4: Create motion.css — Animation Keyframes and Utility Classes
+
+**Files:**
+- Create: `src/styles/motion.css`
+- Modify: `src/styles/main.css:1-5`
+
+- [ ] **Step 1: Create motion.css**
+
+```css
+/* src/styles/motion.css */
+
+@keyframes cb-slide-up {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes cb-slide-down {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes cb-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes cb-fade-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+@keyframes cb-scale-in {
+  from { opacity: 0; transform: scale(0.97); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes cb-scale-out {
+  from { opacity: 1; transform: scale(1); }
+  to { opacity: 0; transform: scale(0.98); }
+}
+
+@keyframes cb-slide-in-right {
+  from { opacity: 0; transform: translateX(100%); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes cb-slide-out-right {
+  from { opacity: 1; transform: translateX(0); }
+  to { opacity: 0; transform: translateX(100%); }
+}
+
+@keyframes cb-pulse-scale {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.15); }
+  100% { transform: scale(1); }
+}
+
+@keyframes cb-ripple {
+  from { transform: scale(1); opacity: 0.4; }
+  to { transform: scale(2.5); opacity: 0; }
+}
+
+/* ══ Utility Classes ══ */
+
+@media (prefers-reduced-motion: no-preference) {
+  .cb-animate-slide-up { animation: cb-slide-up var(--duration-moderate) var(--ease-out) both; }
+  .cb-animate-slide-down { animation: cb-slide-down var(--duration-moderate) var(--ease-out) both; }
+  .cb-animate-fade-in { animation: cb-fade-in var(--duration-normal) var(--ease-default) both; }
+  .cb-animate-fade-out { animation: cb-fade-out var(--duration-normal) var(--ease-in) both; }
+  .cb-animate-scale-in { animation: cb-scale-in var(--duration-moderate) var(--ease-out) both; }
+  .cb-animate-scale-out { animation: cb-scale-out var(--duration-normal) var(--ease-in) both; }
+  .cb-animate-slide-in-right { animation: cb-slide-in-right var(--duration-moderate) var(--ease-spring) both; }
+  .cb-animate-slide-out-right { animation: cb-slide-out-right var(--duration-normal) var(--ease-in) both; }
+  .cb-animate-pulse { animation: cb-pulse-scale var(--duration-moderate) var(--ease-spring); }
+  .cb-stagger-item { animation: cb-slide-up var(--duration-moderate) var(--ease-out) both; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cb-animate-slide-up, .cb-animate-slide-down, .cb-animate-scale-in,
+  .cb-animate-slide-in-right, .cb-stagger-item { animation: cb-fade-in 1ms both; }
+  .cb-animate-fade-out, .cb-animate-scale-out, .cb-animate-slide-out-right { animation: cb-fade-out 1ms both; }
+  .cb-animate-pulse { animation: none; }
+}
+
+body.animations-paused .cb-animate-slide-up,
+body.animations-paused .cb-animate-slide-down,
+body.animations-paused .cb-animate-fade-in,
+body.animations-paused .cb-animate-fade-out,
+body.animations-paused .cb-animate-scale-in,
+body.animations-paused .cb-animate-scale-out,
+body.animations-paused .cb-animate-slide-in-right,
+body.animations-paused .cb-animate-slide-out-right,
+body.animations-paused .cb-animate-pulse,
+body.animations-paused .cb-stagger-item { animation: none !important; }
+
+/* ══ Modal / Overlay ══ */
+
+.cb-backdrop {
+  position: fixed; inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 9998;
+}
+
+.cb-modal-content { z-index: 9999; }
+
+@media (prefers-reduced-motion: no-preference) {
+  .cb-backdrop { animation: cb-fade-in var(--duration-normal) var(--ease-default) both; }
+  .cb-backdrop.closing { animation: cb-fade-out var(--duration-normal) var(--ease-in) both; }
+  .cb-modal-content { animation: cb-scale-in var(--duration-moderate) var(--ease-out) both; }
+  .cb-modal-content.closing { animation: cb-scale-out var(--duration-normal) var(--ease-in) both; }
+}
+```
+
+- [ ] **Step 2: Add motion.css import to main.css as second import**
+
+In `src/styles/main.css`, add `@import './motion.css';` after `design-system.css`, before `rtl-overrides.css`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/styles/motion.css src/styles/main.css
+git commit -m "feat: add motion.css — keyframes and animation utilities
+
+Panel lifecycle, modal, toast, stagger, pulse animations.
+Respects prefers-reduced-motion and body.animations-paused.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Create motion.ts — JavaScript Animation Helpers
+
+**Files:**
+- Create: `src/services/motion.ts`
+- Create: `tests/motion.test.mts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/motion.test.mts
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const src = readFileSync(resolve(import.meta.dirname, '../src/services/motion.ts'), 'utf-8');
+
+describe('motion.ts exports', () => {
+  const requiredExports = [
+    'staggerIn', 'crossfadeContent', 'animateNumber',
+    'animateIn', 'animateOut', 'revealContent', 'prefersReducedMotion',
+  ];
+
+  for (const name of requiredExports) {
+    it(`exports ${name}`, () => {
+      assert.ok(
+        src.includes(`export function ${name}`) || src.includes(`export const ${name}`),
+        `Missing export: ${name}`,
+      );
+    });
+  }
+
+  it('checks prefers-reduced-motion', () => {
+    assert.ok(src.includes('prefers-reduced-motion'), 'Must check reduced motion preference');
+  });
+
+  it('checks body.animations-paused', () => {
+    assert.ok(src.includes('animations-paused'), 'Must respect animations-paused class');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/motion.test.mts`
+Expected: FAIL (file doesn't exist)
+
+- [ ] **Step 3: Create motion.ts**
+
+```typescript
+// src/services/motion.ts
+
+const STAGGER_DELAY_MS = 30;
+const STAGGER_MAX_ITEMS = 10;
+
+export function prefersReducedMotion(): boolean {
+  return (
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches ||
+    document.body.classList.contains('animations-paused')
+  );
+}
+
+export function staggerIn(
+  container: Element,
+  selector: string,
+  delay: number = STAGGER_DELAY_MS,
+): void {
+  if (prefersReducedMotion()) return;
+  const items = container.querySelectorAll(selector);
+  const count = Math.min(items.length, STAGGER_MAX_ITEMS);
+  for (let i = 0; i < count; i++) {
+    const el = items[i] as HTMLElement;
+    el.classList.add('cb-stagger-item');
+    el.style.animationDelay = `${i * delay}ms`;
+  }
+}
+
+export function crossfadeContent(panel: HTMLElement, newHTML: string): Promise<void> {
+  if (prefersReducedMotion()) {
+    panel.textContent = '';
+    const temp = document.createElement('div');
+    temp.insertAdjacentHTML('afterbegin', newHTML);
+    while (temp.firstChild) panel.appendChild(temp.firstChild);
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    panel.classList.add('cb-animate-fade-out');
+    panel.addEventListener('animationend', function handler() {
+      panel.removeEventListener('animationend', handler);
+      panel.classList.remove('cb-animate-fade-out');
+      panel.textContent = '';
+      const temp = document.createElement('div');
+      temp.insertAdjacentHTML('afterbegin', newHTML);
+      while (temp.firstChild) panel.appendChild(temp.firstChild);
+      panel.classList.add('cb-animate-fade-in');
+      panel.addEventListener('animationend', function handler2() {
+        panel.removeEventListener('animationend', handler2);
+        panel.classList.remove('cb-animate-fade-in');
+        resolve();
+      }, { once: true });
+    }, { once: true });
+  });
+}
+
+export function animateNumber(
+  el: Element, from: number, to: number, duration: number = 300,
+): void {
+  if (prefersReducedMotion() || from === to) {
+    el.textContent = String(to);
+    return;
+  }
+  const start = performance.now();
+  const range = to - from;
+  function step(now: number) {
+    const elapsed = now - start;
+    const progress = Math.min(elapsed / duration, 1);
+    const eased = 1 - Math.pow(1 - progress, 3);
+    el.textContent = String(Math.round(from + range * eased));
+    if (progress < 1) requestAnimationFrame(step);
+  }
+  requestAnimationFrame(step);
+}
+
+export function animateIn(
+  el: HTMLElement, animation: 'slide-up' | 'fade' | 'scale' = 'slide-up',
+): Promise<void> {
+  if (prefersReducedMotion()) {
+    el.style.opacity = '1';
+    return Promise.resolve();
+  }
+  const classMap = {
+    'slide-up': 'cb-animate-slide-up',
+    'fade': 'cb-animate-fade-in',
+    'scale': 'cb-animate-scale-in',
+  };
+  return new Promise((resolve) => {
+    el.classList.add(classMap[animation]);
+    el.addEventListener('animationend', () => {
+      el.classList.remove(classMap[animation]);
+      resolve();
+    }, { once: true });
+  });
+}
+
+export function animateOut(
+  el: HTMLElement, animation: 'fade' | 'scale-down' = 'fade',
+): Promise<void> {
+  if (prefersReducedMotion()) {
+    el.style.opacity = '0';
+    return Promise.resolve();
+  }
+  const classMap = {
+    'fade': 'cb-animate-fade-out',
+    'scale-down': 'cb-animate-scale-out',
+  };
+  return new Promise((resolve) => {
+    el.classList.add(classMap[animation]);
+    el.addEventListener('animationend', () => {
+      el.classList.remove(classMap[animation]);
+      resolve();
+    }, { once: true });
+  });
+}
+
+export function revealContent(skeleton: HTMLElement, content: HTMLElement): Promise<void> {
+  if (prefersReducedMotion()) {
+    skeleton.style.display = 'none';
+    content.style.display = '';
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    skeleton.classList.add('cb-animate-fade-out');
+    skeleton.addEventListener('animationend', () => {
+      skeleton.style.display = 'none';
+      skeleton.classList.remove('cb-animate-fade-out');
+      content.style.display = '';
+      content.classList.add('cb-animate-fade-in');
+      content.addEventListener('animationend', () => {
+        content.classList.remove('cb-animate-fade-in');
+        resolve();
+      }, { once: true });
+    }, { once: true });
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test tests/motion.test.mts`
+Expected: All PASS
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `npm run typecheck:all`
+Expected: Zero errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/services/motion.ts tests/motion.test.mts
+git commit -m "feat: add motion.ts — JS animation helpers
+
+staggerIn, crossfadeContent, animateNumber, animateIn, animateOut,
+revealContent. All respect prefers-reduced-motion and animations-paused.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 3: Visual Hierarchy & Typography
+
+### Task 6: Standardize Panel Header in Base Class
+
+**Files:**
+- Modify: `src/components/Panel.ts`
+
+- [ ] **Step 1: Read Panel.ts to understand current header rendering**
+
+Read the full `src/components/Panel.ts` file to find where the panel header (title) is rendered. Identify the method that creates the header DOM. Note the current structure.
+
+- [ ] **Step 2: Add a `renderHeader()` method that uses design tokens**
+
+Add a protected method to the Panel class that returns a standardized header element:
+
+```typescript
+protected renderHeader(opts: {
+  subtitle?: string;
+  freshness?: { dotColor?: string; label?: string };
+  rightSlot?: HTMLElement;
+}): HTMLElement {
+  const header = document.createElement('div');
+  header.className = 'cb-panel-header';
+  header.style.cssText = `
+    display: flex; justify-content: space-between; align-items: flex-start;
+    padding: var(--space-3) var(--space-4);
+  `;
+
+  const left = document.createElement('div');
+  const title = document.createElement('div');
+  title.style.cssText = `
+    font-size: var(--text-base); font-weight: var(--fw-semibold);
+    color: #e5e5e5; letter-spacing: -0.01em;
+  `;
+  title.textContent = this.options.title;
+  left.appendChild(title);
+
+  if (opts.subtitle) {
+    const sub = document.createElement('div');
+    sub.style.cssText = 'font-size: var(--text-xs); color: #666; margin-top: 2px;';
+    sub.textContent = opts.subtitle;
+    left.appendChild(sub);
+  }
+
+  header.appendChild(left);
+
+  if (opts.freshness) {
+    const right = document.createElement('div');
+    right.style.cssText = 'display: flex; align-items: center; gap: 4px;';
+    const dot = document.createElement('div');
+    dot.style.cssText = `width: 6px; height: 6px; border-radius: 50%; background: ${opts.freshness.dotColor || '#22c55e'};`;
+    right.appendChild(dot);
+    const label = document.createElement('span');
+    label.style.cssText = 'font-size: var(--text-2xs); color: #666;';
+    label.textContent = opts.freshness.label || '';
+    right.appendChild(label);
+    header.appendChild(right);
+  } else if (opts.rightSlot) {
+    header.appendChild(opts.rightSlot);
+  }
+
+  return header;
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `npm run typecheck:all`
+Expected: Zero errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Panel.ts
+git commit -m "feat: add renderHeader() to Panel base class
+
+Standardized panel header with title/subtitle/freshness indicator.
+Opt-in method for gradual adoption.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Migrate Top Panels to Design Tokens
+
+**Files:**
+- Modify: `src/components/UnifiedAlertInboxPanel.ts`
+- Modify: `src/components/TriageBar.ts`
+- Modify: `src/styles/panels.css`
+
+- [ ] **Step 1: Read current panel files to identify hardcoded values**
+
+Read each file, searching for hardcoded colors (`#1c1c1e`, `#ef4444`, `rgba(239,68,68`), font sizes (`12px`, `13px`), spacing (`padding: 8px`), and border-radius values.
+
+- [ ] **Step 2: Replace hardcoded values in panels.css with token references**
+
+For each hardcoded value, replace with `var(--token)`:
+- `background: #1c1c1e` becomes `background: var(--surface-overlay)`
+- `font-size: 12px` becomes `font-size: var(--text-sm)`
+- `padding: 8px 16px` becomes `padding: var(--space-2) var(--space-4)`
+- `border-radius: 8px` becomes `border-radius: var(--radius-md)`
+- `color: #ef4444` becomes `color: var(--severity-critical)`
+
+- [ ] **Step 3: Add .cb-badge to severity indicators in UnifiedAlertInboxPanel.ts**
+
+Find severity label rendering. Replace with `<span class="cb-badge" data-severity="${level}">` elements.
+
+- [ ] **Step 4: Add .cb-list-row to alert row items in UnifiedAlertInboxPanel.ts**
+
+Find alert row rendering. Add `cb-list-row` class to each row element.
+
+- [ ] **Step 5: Verify visually in dev**
+
+Run: `npm run dev`
+Open Alert Inbox. Verify severity badges use correct colors, row hover shows lift.
+
+- [ ] **Step 6: Run typecheck**
+
+Run: `npm run typecheck:all`
+Expected: Zero errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/UnifiedAlertInboxPanel.ts src/components/TriageBar.ts src/styles/panels.css
+git commit -m "refactor: migrate alert panels to design system tokens
+
+Replace hardcoded colors, spacing, severity indicators with tokens
+and .cb-badge/.cb-list-row classes.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 4: Alert & Notification UX
+
+### Task 8: Create Toast Component
+
+**Files:**
+- Create: `src/components/Toast.ts`
+- Create: `tests/toast.test.mts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/toast.test.mts
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const src = readFileSync(resolve(import.meta.dirname, '../src/components/Toast.ts'), 'utf-8');
+
+describe('Toast component', () => {
+  it('exports Toast class', () => {
+    assert.ok(src.includes('export class Toast'), 'Must export Toast class');
+  });
+
+  it('exports showToast function', () => {
+    assert.ok(src.includes('export function showToast'), 'Must export showToast');
+  });
+
+  it('supports severity levels', () => {
+    for (const s of ['critical', 'high', 'elevated']) {
+      assert.ok(src.includes(s), `Must support ${s} severity`);
+    }
+  });
+
+  it('implements auto-dismiss', () => {
+    assert.ok(src.includes('setTimeout'), 'Must implement auto-dismiss timer');
+  });
+
+  it('respects Ghost Mode', () => {
+    assert.ok(src.includes('isGhostMode'), 'Must check Ghost Mode');
+  });
+
+  it('limits stack size', () => {
+    assert.ok(src.includes('MAX_TOASTS'), 'Must limit toast stack');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/toast.test.mts`
+Expected: FAIL
+
+- [ ] **Step 3: Create Toast.ts**
+
+Create `src/components/Toast.ts` with:
+- `Toast` class with show/dismiss/pause/resume methods
+- `showToast()` convenience function
+- Glass morphism styling using design tokens
+- Severity-tinted border and progress bar
+- Auto-dismiss: 8s normal, 15s critical
+- Hover pauses timer
+- Max 3 stacked, older dismissed
+- Ghost Mode suppression via `isGhostMode()`
+- Uses `animateIn`/`animateOut` from motion.ts
+
+Build all DOM using `document.createElement` and `textContent` — no `innerHTML`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test tests/toast.test.mts`
+Expected: All PASS
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `npm run typecheck:all`
+Expected: Zero errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Toast.ts tests/toast.test.mts
+git commit -m "feat: add Toast notification component
+
+Glass morphism, severity tinting, auto-dismiss with progress bar,
+hover-to-pause, max 3 stacked. Suppressed in Ghost Mode.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Create Sound Service
+
+**Files:**
+- Create: `src/services/sound.ts`
+- Create: `tests/sound.test.mts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/sound.test.mts
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const src = readFileSync(resolve(import.meta.dirname, '../src/services/sound.ts'), 'utf-8');
+
+describe('sound service', () => {
+  it('exports playAlertSound', () => {
+    assert.ok(src.includes('export function playAlertSound'));
+  });
+
+  it('exports playAckSound', () => {
+    assert.ok(src.includes('export function playAckSound'));
+  });
+
+  it('uses Web Audio API', () => {
+    assert.ok(src.includes('AudioContext'));
+  });
+
+  it('respects Ghost Mode', () => {
+    assert.ok(src.includes('isGhostMode'));
+  });
+
+  it('rate-limits sounds', () => {
+    assert.ok(src.includes('MIN_INTERVAL'));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/sound.test.mts`
+Expected: FAIL
+
+- [ ] **Step 3: Create sound.ts**
+
+Create `src/services/sound.ts` with:
+- `playAlertSound(severity: 'critical' | 'high' | 'elevated')` — Web Audio synthesis
+- `playAckSound()` — descending two-tone
+- Critical: C5 to E5 rising chime (300ms)
+- High: G4 single tone (200ms)
+- Elevated: 800Hz tap (50ms)
+- Ack: E4 to C4 descending (150ms)
+- Rate limit: `MIN_INTERVAL_MS = 3000`
+- Ghost Mode suppression
+- Volume from `localStorage cb:sound-volume` (default 0.3)
+- Enabled check from `localStorage cb:sound-enabled`
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test tests/sound.test.mts`
+Expected: All PASS
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `npm run typecheck:all`
+Expected: Zero errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/services/sound.ts tests/sound.test.mts
+git commit -m "feat: add Web Audio API sound service for alerts
+
+Severity-mapped chimes, ack sound, rate-limited 3s, Ghost Mode suppressed.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Add Alert Action Animations
+
+**Files:**
+- Modify: `src/components/UnifiedAlertInboxPanel.ts`
+- Modify: `src/styles/alerts.css`
+
+- [ ] **Step 1: Read UnifiedAlertInboxPanel.ts action handlers**
+
+Read the file, find acknowledge, snooze, pin, dismiss handler methods.
+
+- [ ] **Step 2: Add alert action CSS to alerts.css**
+
+Append to `src/styles/alerts.css`:
+
+```css
+@media (prefers-reduced-motion: no-preference) {
+  .alert-row-ack { animation: cb-alert-ack 200ms var(--ease-default) both; }
+  .alert-row-dismiss { animation: cb-alert-dismiss 200ms var(--ease-in) both; }
+  .alert-row-snooze { animation: cb-alert-snooze 200ms var(--ease-default) both; }
+  .alert-row-arrive { animation: cb-slide-down var(--duration-moderate) var(--ease-out) both; }
+}
+
+@keyframes cb-alert-ack {
+  0% { background: transparent; }
+  30% { background: var(--severity-positive-bg); }
+  100% { background: transparent; }
+}
+
+@keyframes cb-alert-dismiss {
+  to { opacity: 0; transform: translateX(40px); max-height: 0;
+       padding-top: 0; padding-bottom: 0; overflow: hidden; }
+}
+
+@keyframes cb-alert-snooze {
+  0% { transform: translateX(0); }
+  30% { transform: translateX(6px); }
+  100% { transform: translateX(0); }
+}
+```
+
+- [ ] **Step 3: Wire animations into action handlers**
+
+- Acknowledge: add `alert-row-ack` class, import and call `playAckSound()`
+- Dismiss: add `alert-row-dismiss` class, wait for `animationend` before DOM removal
+- Snooze: add `alert-row-snooze` class
+- New arrival: add `alert-row-arrive` class when inserting at list top
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `npm run typecheck:all`
+Expected: Zero errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/UnifiedAlertInboxPanel.ts src/styles/alerts.css
+git commit -m "feat: add alert action animations and sound feedback
+
+Ack: green flash + sound. Dismiss: slide-right fade. Snooze: nudge.
+New arrival: slide-down entry.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: Enhance Triage Bar
+
+**Files:**
+- Modify: `src/components/TriageBar.ts`
+- Modify: `src/styles/alerts.css`
+
+- [ ] **Step 1: Read TriageBar.ts render method**
+
+Read the full file. Identify where triage items are rendered and severity/lifecycle displayed.
+
+- [ ] **Step 2: Add triage bar CSS to alerts.css**
+
+```css
+.triage-bar-item { position: relative; transition: transform var(--duration-fast) var(--ease-default); }
+
+.triage-bar-item.hottest::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 2px;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+}
+.triage-bar-item.hottest[data-severity="critical"]::before { background: var(--severity-critical); }
+.triage-bar-item.hottest[data-severity="high"]::before { background: var(--severity-high); }
+.triage-bar-item.hottest[data-severity="elevated"]::before { background: var(--severity-elevated); }
+```
+
+- [ ] **Step 3: Add hottest class and data-severity to first triage item**
+
+In the render method, add class `hottest` and `data-severity` attribute to the first item.
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `npm run typecheck:all`
+Expected: Zero errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/TriageBar.ts src/styles/alerts.css
+git commit -m "feat: add severity accent line to triage bar hottest item
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 5: Map & Data Visualization
+
+### Task 12: Redesign MapPopup as Apple Maps Card
+
+**Files:**
+- Modify: `src/components/MapPopup.ts`
+
+- [ ] **Step 1: Read MapPopup.ts to understand current rendering**
+
+Read the first 200 lines and main render method.
+
+- [ ] **Step 2: Create glass-morphism card wrapper method**
+
+Add a private method that wraps popup content:
+
+```typescript
+private wrapInCard(content: HTMLElement): HTMLElement {
+  const card = document.createElement('div');
+  card.style.cssText = `
+    background: rgba(28, 28, 30, 0.92);
+    backdrop-filter: blur(20px) saturate(1.4);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--elevation-3), 0 0 0 0.5px rgba(255, 255, 255, 0.05);
+    overflow: hidden; max-width: 280px; font-family: var(--font-ui);
+  `;
+  card.appendChild(content);
+  return card;
+}
+```
+
+- [ ] **Step 3: Update primary popup types to use new card style**
+
+For earthquake, hotspot, conflict, base popups: restructure as title/subtitle header + 2-col stat grid + action button bar using `.cb-button` class. Use `textContent` for all text — no `innerHTML`.
+
+- [ ] **Step 4: Verify visually**
+
+Run: `npm run dev`, click a map marker, verify glass morphism popup appears.
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `npm run typecheck:all`
+Expected: Zero errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/MapPopup.ts
+git commit -m "feat: redesign map popups as Apple Maps glass cards
+
+Glass morphism, severity badge, stat grid, action buttons.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 13: Add Layer Transitions to DeckGLMap
+
+**Files:**
+- Modify: `src/components/DeckGLMap.ts`
+
+- [ ] **Step 1: Read DeckGLMap.ts to find layer creation**
+
+Search for `new ScatterplotLayer`, `new GeoJsonLayer` to find layer instantiation.
+
+- [ ] **Step 2: Add DeckGL transitions prop to scatterplot layers**
+
+```typescript
+transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+},
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `npm run typecheck:all`
+Expected: Zero errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/DeckGLMap.ts
+git commit -m "feat: add DeckGL layer transitions for smooth data updates
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 14: Add View Preset Segmented Control
+
+**Files:**
+- Modify: `src/components/DeckGLMap.ts`
+
+- [ ] **Step 1: Find current view preset UI**
+
+Search for region preset buttons (Global, Americas, MENA, EU, Asia, Africa).
+
+- [ ] **Step 2: Replace with .cb-pill-group**
+
+Replace current buttons with a `.cb-pill-group` container. Active preset gets `.active` class.
+
+- [ ] **Step 3: Add cinematic flyTo**
+
+Update flyTo calls: `duration: 1500`, slight bearing (random +-15), pitch 45 on zoom-in.
+
+- [ ] **Step 4: Apply same to time range selector**
+
+Replace time range buttons (1h, 6h, 24h, 7d, All) with `.cb-pill-group`.
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `npm run typecheck:all`
+Expected: Zero errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/DeckGLMap.ts
+git commit -m "feat: Apple-style segmented controls for map presets
+
+View preset and time range selectors use .cb-pill-group.
+Cinematic flyTo with bearing and pitch.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 6: Empty States, Onboarding & God's Vision
+
+### Task 15: Create EmptyState Component
+
+**Files:**
+- Create: `src/components/EmptyState.ts`
+- Create: `tests/empty-state.test.mts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/empty-state.test.mts
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const src = readFileSync(resolve(import.meta.dirname, '../src/components/EmptyState.ts'), 'utf-8');
+
+describe('EmptyState component', () => {
+  it('exports renderEmptyState function', () => {
+    assert.ok(src.includes('export function renderEmptyState'));
+  });
+  it('exports getEmptyStateDefaults function', () => {
+    assert.ok(src.includes('export function getEmptyStateDefaults'));
+  });
+  it('exports EmptyState class', () => {
+    assert.ok(src.includes('export class EmptyState'));
+  });
+  it('supports icon, title, message', () => {
+    assert.ok(src.includes('icon') && src.includes('title') && src.includes('message'));
+  });
+  it('supports optional CTA button', () => {
+    assert.ok(src.includes('cta'));
+  });
+  it('has category defaults', () => {
+    for (const cat of ['geopolitical', 'infrastructure', 'cyber', 'markets', 'weather']) {
+      assert.ok(src.includes(cat), `Missing category: ${cat}`);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test tests/empty-state.test.mts`
+Expected: FAIL
+
+- [ ] **Step 3: Create EmptyState.ts**
+
+Create `src/components/EmptyState.ts` with:
+- `renderEmptyState(options)` — returns HTMLElement with icon (28px, 0.4 opacity), title (--text-base/--fw-medium), message (--text-xs, muted), optional `.cb-button.accent` CTA
+- `getEmptyStateDefaults(category)` — returns defaults for: geopolitical, infrastructure, cyber, markets, weather, user, alerts
+- `EmptyState` class with mount/unmount methods
+- All DOM built with `createElement`/`textContent` — no `innerHTML`
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test tests/empty-state.test.mts`
+Expected: All PASS
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `npm run typecheck:all`
+Expected: Zero errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/EmptyState.ts tests/empty-state.test.mts
+git commit -m "feat: add EmptyState component with category defaults
+
+Icon + title + guidance + optional CTA. Templates for 7 panel categories.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 16: Create WelcomeFlow Onboarding Modal
+
+**Files:**
+- Create: `src/components/WelcomeFlow.ts`
+
+- [ ] **Step 1: Create WelcomeFlow.ts**
+
+Create `src/components/WelcomeFlow.ts` with:
+- `WelcomeFlow` class with `show()` and `shouldShow()` static method
+- 3-step modal: Location (GPS toggle), Interests (pill picker), API Keys (list with free/paid labels)
+- Progress dots at top, "Continue" button per step, "Skip for now" on API keys step
+- Callbacks: `onLocationSet`, `onInterestsSet`, `onComplete`
+- Stores `cb:onboarding-complete` in localStorage
+- Uses `.cb-backdrop` + `.cb-modal-content` from motion.css
+- Uses `animateIn`/`animateOut` from motion.ts
+- All DOM built with `createElement`/`textContent` — no `innerHTML`
+- Default interests pre-selected: Geopolitical, Weather
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npm run typecheck:all`
+Expected: Zero errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/WelcomeFlow.ts
+git commit -m "feat: add WelcomeFlow 3-step onboarding modal
+
+Location, Interests, API Keys. Progress dots, skip option.
+Uses motion system for entry/exit animations.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 17: Create ContextualHint Component
+
+**Files:**
+- Create: `src/components/ContextualHint.ts`
+
+- [ ] **Step 1: Create ContextualHint.ts**
+
+Create `src/components/ContextualHint.ts` with:
+- `showHint(config)` — shows glass morphism tooltip near target element
+- `HINTS` object with predefined hints: `alertNavigation`, `godsVision`, `ghostMode`
+- One-time per `id`, stored in `cb:hints-seen` (Set serialized to JSON array in localStorage)
+- Auto-dismiss after 8s, "Got it" dismiss button
+- Position relative to target (top or bottom)
+- Uses `animateIn`/`animateOut` from motion.ts
+- All DOM built with `createElement`/`textContent` — no `innerHTML`
+
+For the keyboard shortcut hints, use `<kbd>` elements created via `createElement('kbd')` with inline styles for the key cap look.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npm run typecheck:all`
+Expected: Zero errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/ContextualHint.ts
+git commit -m "feat: add ContextualHint one-time tooltip component
+
+Glass morphism tooltips, auto-dismiss 8s, per-hint localStorage tracking.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 18: Add God's Vision Entry/Exit Transition
+
+**Files:**
+- Modify: `src/components/GodsVisionView.ts`
+- Modify: `src/components/GlobeHUD.ts`
+- Modify: `src/styles/gods-vision.css`
+
+- [ ] **Step 1: Read GodsVisionView.ts enter/exit methods**
+
+Read the file, find the method that activates/deactivates God's Vision mode.
+
+- [ ] **Step 2: Add transition CSS to gods-vision.css**
+
+Append:
+
+```css
+@media (prefers-reduced-motion: no-preference) {
+  .ge-entering .ge-globe-container { animation: cb-fade-in 500ms var(--ease-out) 200ms both; }
+  .ge-entering .ge-hud-element { animation: cb-slide-up var(--duration-moderate) var(--ease-out) both; }
+  .ge-exiting .ge-globe-container { animation: cb-fade-out 300ms var(--ease-in) both; }
+  .ge-exiting .ge-hud-element { animation: cb-fade-out 200ms var(--ease-in) both; }
+}
+```
+
+- [ ] **Step 3: Add staggered HUD entry to GodsVisionView.ts**
+
+In the enter method, after globe init:
+
+```typescript
+const hudElements = this.container.querySelectorAll('.ge-hud-element');
+hudElements.forEach((el, i) => {
+  (el as HTMLElement).style.animationDelay = `${700 + i * 50}ms`;
+});
+this.container.classList.add('ge-entering');
+setTimeout(() => this.container.classList.remove('ge-entering'), 1200);
+```
+
+- [ ] **Step 4: Add animateNumber to GlobeHUD.ts stat updates**
+
+Import `animateNumber` from `@/services/motion`. In the count update method:
+
+```typescript
+const oldCount = parseInt(hotspotEl.textContent || '0', 10);
+animateNumber(hotspotEl, oldCount, newCount);
+```
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `npm run typecheck:all`
+Expected: Zero errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/GodsVisionView.ts src/components/GlobeHUD.ts src/styles/gods-vision.css
+git commit -m "feat: cinematic God's Vision entry/exit transitions
+
+Globe crossfade, staggered HUD entry, animated stat counters.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 19: Wire WelcomeFlow and Hints into App
+
+**Files:**
+- Modify: `src/app/panel-layout.ts`
+
+- [ ] **Step 1: Read panel-layout.ts to find initialization**
+
+Read to find where panels are initialized and the app becomes interactive.
+
+- [ ] **Step 2: Import and trigger WelcomeFlow**
+
+Add after panel initialization:
+
+```typescript
+import { WelcomeFlow } from '@/components/WelcomeFlow';
+import { HINTS } from '@/components/ContextualHint';
+
+if (WelcomeFlow.shouldShow()) {
+  const flow = new WelcomeFlow({
+    onComplete: () => {
+      const alertPanel = document.querySelector('[data-panel="unified-alert-inbox"]');
+      if (alertPanel) {
+        setTimeout(() => HINTS.alertNavigation(alertPanel as HTMLElement), 1000);
+      }
+    },
+  });
+  flow.show();
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `npm run typecheck:all`
+Expected: Zero errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/panel-layout.ts
+git commit -m "feat: wire WelcomeFlow and contextual hints into app init
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 20: Final Typecheck and E2E Smoke Test
+
+**Files:**
+- Create: `e2e/design-system.spec.ts`
+
+- [ ] **Step 1: Run full typecheck**
+
+Run: `npm run typecheck:all`
+Expected: Zero errors. Fix any before proceeding.
+
+- [ ] **Step 2: Write E2E smoke test**
+
+```typescript
+// e2e/design-system.spec.ts
+import { test, expect } from '@playwright/test';
+
+test.describe('Design System', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+  });
+
+  test('tokens are loaded', async ({ page }) => {
+    const surfaceBase = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue('--surface-base').trim()
+    );
+    expect(surfaceBase).toBe('#0a0a0a');
+  });
+
+  test('severity tokens exist', async ({ page }) => {
+    const critical = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue('--severity-critical').trim()
+    );
+    expect(critical).toBe('#ef4444');
+  });
+
+  test('shimmer animation is defined', async ({ page }) => {
+    const hasShimmer = await page.evaluate(() => {
+      for (const sheet of document.styleSheets) {
+        try {
+          for (const rule of sheet.cssRules) {
+            if (rule instanceof CSSKeyframesRule && rule.name === 'cb-shimmer') return true;
+          }
+        } catch { /* cross-origin */ }
+      }
+      return false;
+    });
+    expect(hasShimmer).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run E2E test**
+
+Run: `npx playwright test e2e/design-system.spec.ts`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/design-system.spec.ts
+git commit -m "test: add E2E smoke test for design system tokens
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 5: Push branch**
+
+```bash
+git push origin claude/apple-native-polish-spec
+```

--- a/docs/superpowers/specs/2026-04-13-apple-native-polish-design.md
+++ b/docs/superpowers/specs/2026-04-13-apple-native-polish-design.md
@@ -1,0 +1,510 @@
+# Crystal Ball — Apple-Native Polish Overhaul
+
+**Date:** 2026-04-13
+**Design language:** Apple-native precision (SF Pro, spring animations, frosted glass, restrained motion)
+**Phasing:** Foundation-first — design system tokens, then motion, then visual migration, then feature-specific polish
+**CSS strategy:** Fresh `design-system.css` + bridge — clean token file imported first, existing CSS migrates gradually
+
+---
+
+## Phase Architecture
+
+Phases 1–3 are sequential (each builds on the last). Phases 4–6 are parallel (all consume the same foundation).
+
+```
+Phase 1: Design System Foundation
+    ↓
+Phase 2: Transitions & Motion System
+    ↓
+Phase 3: Visual Hierarchy & Typography
+    ↓
+    ├── Phase 4: Alert & Notification UX
+    ├── Phase 5: Map & Data Visualization
+    └── Phase 6: Empty States, Onboarding & God's Vision
+```
+
+---
+
+## Phase 1 — Design System Foundation
+
+**New file:** `src/styles/design-system.css`
+
+### Typography Scale
+
+- **UI text:** -apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text", system-ui
+- **Monospace:** "SF Mono", "Fira Code", "Cascadia Code", ui-monospace, monospace
+
+| Token | Size | Usage |
+|-------|------|-------|
+| `--text-2xs` | 10px | Timestamps, metadata |
+| `--text-xs` | 11px | Badges, labels |
+| `--text-sm` | 12px | Body small, panel content |
+| `--text-base` | 13px | Body default |
+| `--text-md` | 14px | Panel titles, emphasis |
+| `--text-lg` | 16px | Section headers |
+| `--text-xl` | 20px | Page titles |
+| `--text-2xl` | 24px | Hero numbers, HUD |
+
+**Weights:** `--fw-regular` (400), `--fw-medium` (500), `--fw-semibold` (600), `--fw-bold` (700)
+
+### Spacing Tokens (4px base grid)
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--space-1` | 4px | Tight gaps |
+| `--space-2` | 8px | Inline spacing |
+| `--space-3` | 12px | Related items |
+| `--space-4` | 16px | Panel padding |
+| `--space-6` | 24px | Section gaps |
+| `--space-8` | 32px | Major sections |
+| `--space-12` | 48px | Large separations |
+| `--space-16` | 64px | Page-level spacing |
+
+### Color Tokens
+
+**Surface layers (dark mode):**
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--surface-base` | `#0a0a0a` | App background |
+| `--surface-raised` | `#141414` | Panel backgrounds |
+| `--surface-overlay` | `#1c1c1e` | Cards, rows |
+| `--surface-popover` | `#2c2c2e` | Dropdowns, menus |
+
+**Severity palette (5-tier, 4 variants each):**
+
+| Level | Text | Background | Border | Glow |
+|-------|------|-----------|--------|------|
+| Critical | `#ef4444` | `rgba(239,68,68,0.1)` | `rgba(239,68,68,0.25)` | `rgba(239,68,68,0.3)` |
+| High | `#f97316` | `rgba(249,115,22,0.1)` | `rgba(249,115,22,0.25)` | `rgba(249,115,22,0.3)` |
+| Elevated | `#eab308` | `rgba(234,179,8,0.1)` | `rgba(234,179,8,0.25)` | `rgba(234,179,8,0.3)` |
+| Normal | `#3b82f6` | `rgba(59,130,246,0.08)` | `rgba(59,130,246,0.2)` | `rgba(59,130,246,0.2)` |
+| Positive | `#22c55e` | `rgba(34,197,94,0.08)` | `rgba(34,197,94,0.2)` | `rgba(34,197,94,0.2)` |
+
+Token pattern: `--severity-{level}`, `--severity-{level}-bg`, `--severity-{level}-border`, `--severity-{level}-glow`
+
+**Interactive states:**
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--accent` | `#3b82f6` | Primary actions, links |
+| `--hover-bg` | `rgba(255,255,255,0.06)` | Row/card hover fill |
+| `--active-bg` | `rgba(255,255,255,0.1)` | Pressed state |
+| `--focus-ring` | `0 0 0 2px rgba(59,130,246,0.5), 0 0 0 4px rgba(59,130,246,0.15)` | Keyboard focus |
+
+### Elevation System (4 tiers)
+
+| Level | Usage | Properties |
+|-------|-------|-----------|
+| 1 | Cards, rows | `box-shadow: 0 1px 2px rgba(0,0,0,0.3); border: 1px solid rgba(255,255,255,0.06)` |
+| 2 | Panels, popovers | `box-shadow: 0 4px 12px rgba(0,0,0,0.4); border: 1px solid rgba(255,255,255,0.08)` |
+| 3 | Modals, toasts | `box-shadow: 0 8px 32px rgba(0,0,0,0.5); backdrop-filter: blur(12px); background: rgba(28,28,30,0.85)` |
+| 4 | HUD, command bar | `box-shadow: 0 16px 48px rgba(0,0,0,0.6); backdrop-filter: blur(24px) saturate(1.4); background: rgba(28,28,30,0.7)` |
+
+### Border Radius Scale
+
+`--radius-sm` (4px), `--radius-md` (8px), `--radius-lg` (12px), `--radius-xl` (16px)
+
+### Motion Tokens
+
+**Durations:**
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--duration-fast` | 100ms | Hover states, toggles |
+| `--duration-normal` | 200ms | Most transitions |
+| `--duration-moderate` | 350ms | Panel open, modal entry |
+| `--duration-slow` | 500ms | Page transitions, globe camera |
+
+**Easing curves:**
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `--ease-default` | `cubic-bezier(0.25, 0.1, 0.25, 1)` | General purpose |
+| `--ease-spring` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | Playful overshoot |
+| `--ease-out` | `cubic-bezier(0.16, 1, 0.3, 1)` | Entries (fast start, gentle land) |
+| `--ease-in` | `cubic-bezier(0.55, 0, 1, 0.45)` | Exits (gentle start, fast end) |
+
+### Component Primitives
+
+Base classes for gradual adoption. Existing panels don't need to change immediately.
+
+| Class | Purpose |
+|-------|---------|
+| `.cb-card` | Surface + border + radius + elevation-1 + hover lift |
+| `.cb-badge` | Pill shape, severity-colored, compact text |
+| `.cb-button` | Ghost/filled/accent variants, focus ring, press scale |
+| `.cb-input` | Surface-raised bg, focus border animation |
+| `.cb-list-row` | Hover bg + translateY(-1px), active press, stagger-ready |
+| `.cb-separator` | 1px line with token color, 16px horizontal margin |
+| `.cb-skeleton` | Shimmer placeholder — height/width set by consumer |
+| `.cb-pill-group` | Segmented control (Apple style), radio behavior |
+
+---
+
+## Phase 2 — Transitions & Motion System
+
+**New files:** `src/styles/motion.css` + `src/services/motion.ts`
+
+### Panel Lifecycle Animations
+
+| Transition | Animation | Duration | Easing |
+|-----------|-----------|----------|--------|
+| Panel entry | `translateY(8px) → 0` + `opacity 0 → 1` | 350ms | ease-out |
+| Panel exit | `opacity 1 → 0` + `scale(1) → scale(0.98)` | 200ms | ease-in |
+| Content refresh | Old content fades out, new content fades in | 200ms | crossfade |
+
+### List & Row Animations
+
+**Staggered entry:** Each row animates `translateY(4px) → 0` + fade-in with 30ms delay per item. Capped at 10 items (300ms total).
+
+**Row states:**
+
+| State | Effect | Duration |
+|-------|--------|----------|
+| Default | Resting | — |
+| Hover | `translateY(-1px)` + subtle shadow + brighter border | 100ms ease-default |
+| Active | `scale(0.99)` + darker fill | 100ms ease-default |
+| Selected | Accent tint background + accent border | 100ms ease-default |
+
+### Modal & Overlay System
+
+| Component | Entry Animation | Duration |
+|-----------|----------------|----------|
+| Modal backdrop | `opacity 0 → 1` | 200ms |
+| Modal content | `scale(0.97) → 1` + `opacity 0 → 1` | 350ms ease-out |
+| Toast | `translateX(100%) → 0` | 350ms ease-spring |
+| Confirmation dialog | Same as modal | 350ms ease-out |
+
+**Toast behavior:**
+- Stack top-right, max 3 visible
+- Auto-dismiss progress bar (8s normal, 15s critical, never for errors)
+- Hover pauses auto-dismiss timer
+- Severity-tinted border
+- Glass morphism (elevation-3)
+
+**Confirmation dialogs:** Apple HIG pattern — destructive actions get red CTA button.
+
+### Loading States
+
+**Skeleton screens:**
+- `.cb-skeleton` class with shimmer keyframe animation
+- Shapes match expected content layout (rows, avatars, text blocks)
+- Crossfade to real content as data arrives
+
+**Progressive reveal:**
+- Individual rows crossfade from skeleton → content as each data item loads
+- Stagger effect creates waterfall feel
+
+### motion.ts API
+
+```typescript
+staggerIn(container: Element, selector: string, delay?: number): void
+crossfadeContent(panel: Element, newHTML: string): void
+animateNumber(el: Element, from: number, to: number): void
+animateIn(el: Element, animation?: 'slide-up' | 'fade' | 'scale'): void
+animateOut(el: Element, animation?: 'fade' | 'scale-down'): void
+revealContent(skeleton: Element, content: Element): void
+```
+
+All functions check `prefers-reduced-motion` and skip animation if set. Uses CSS classes from `motion.css` — no inline styles or JS animation libraries. The existing `body.animations-paused` system is preserved and extended.
+
+---
+
+## Phase 3 — Visual Hierarchy & Typography
+
+### Panel Header Redesign
+
+All panels adopt a consistent header structure:
+
+```
+┌─────────────────────────────────────┐
+│ Title (13px/600)          ● 2m ago  │
+│ Subtitle (11px/regular)             │
+└─────────────────────────────────────┘
+```
+
+- Title: `--text-base`, `--fw-semibold`, `letter-spacing: -0.01em`
+- Subtitle: `--text-xs`, `--fw-regular`, muted color
+- Right side: freshness indicator (green dot + timestamp) or filter pill
+
+### Card & Row System
+
+**Card states:**
+- Resting: elevation-1, `--surface-overlay` bg, subtle border
+- Hovered: elevation-2, `translateY(-1px)`, brighter border
+- Selected: accent tint bg, accent border ring (`box-shadow: 0 0 0 1px`)
+
+**Data row hierarchy:**
+- Title weight and text brightness scale with severity
+- Consistent structure: title · metadata row (source · time · detail) · severity badge
+- Severity badge uses `--severity-{level}-bg` + `--severity-{level}-border` + `--severity-{level}` text
+
+### Additional Refinements
+
+**Scrollbars:** 4px wide, 2px inset, auto-hide after 1.5s, expand to 6px on hover. Matches macOS native behavior.
+
+**Focus rings:** Apple-style — `box-shadow: 0 0 0 2px rgba(59,130,246,0.5), 0 0 0 4px rgba(59,130,246,0.15)`. Only on `:focus-visible`.
+
+**Density modes:** Settings toggle for compact vs comfortable. Implemented via `--density` CSS variable swap affecting padding and font sizes in `.cb-list-row` and `.cb-card`.
+
+**Separators:** `.cb-separator` — 1px, token-colored, 16px horizontal inset.
+
+### Migration Strategy
+
+1. Import `design-system.css` before `main.css` — tokens become available globally
+2. Replace hardcoded colors/sizes in `panels.css` with `var(--token)` references
+3. Add `.cb-card`, `.cb-list-row`, `.cb-badge` classes to panel render methods
+4. Standardize panel headers using the new title/subtitle/metadata layout
+5. Replace severity colors with `var(--severity-{level})` tokens
+
+**Scope:** Migrate the 20 highest-traffic panels first (UnifiedAlertInbox, LiveNews, Earthquakes, MapPopup, UnifiedSettings, TriageBar, CrystalBallSays, DeckGLMap controls, CountryBriefPage, and ~11 others). Remaining panels adopt incrementally — old styles continue to work since tokens are additive.
+
+---
+
+## Phase 4 — Alert & Notification UX
+
+### Alert Arrival
+
+1. **Slide into list:** New alert slides down from top of inbox list with severity-tinted background. 350ms ease-out.
+2. **Badge counter flip:** Sidebar badge count animates with spring physics — number rolls up, brief scale pulse (1.0 → 1.15 → 1.0). Uses `animateNumber()`.
+3. **Sidebar heat dot:** Pulsing red dot on sidebar alert item. Expands ring once then settles. Clears when panel is opened.
+
+### Alert Actions
+
+| Action | Visual Feedback | Duration |
+|--------|----------------|----------|
+| Acknowledge (A) | Green flash + checkmark morph, row dims (text #ccc → #888) | 200ms |
+| Snooze (right-click) | Pause icon appears, duration countdown badge, row slides right slightly | 200ms |
+| Pin (P) | Blue left accent border (3px), row floats to top of list | 200ms |
+| Dismiss (swipe/X) | Slide right + fade out, row height collapses, list reflows | 200ms ease-in |
+
+### Toast Notification System
+
+- Position: fixed top-right
+- Glass morphism: elevation-3
+- Severity-tinted border (left accent or full border)
+- Stack limit: 3 visible, older ones collapse down
+- Auto-dismiss: 8s normal, 15s critical, never for errors
+- Progress bar: countdown to auto-dismiss, severity-colored
+- Hover: pauses auto-dismiss timer
+- Dismiss: click X or swipe right
+
+### Triage Bar Enhancements
+
+- Top severity accent line (2px) on hottest item
+- Mini escalation bar replaces sparkline (simpler, more readable)
+- Lifecycle phase arrows animate on phase change
+- Hover expands card with 2-line summary
+- Keyboard 1–5 to jump to story
+
+### Sound Design (opt-in via Settings)
+
+| Event | Sound | Duration |
+|-------|-------|----------|
+| Critical alert | Two-tone rising chime (C5→E5) | 300ms |
+| High alert | Single soft tone (G4) | 200ms |
+| Elevated alert | Gentle tap (muted click) | 100ms |
+| Normal alert | No sound — visual only | — |
+| Acknowledge | Soft descending tone (E4→C4) | 150ms |
+
+Implementation: Web Audio API synthesis — no audio files. Suppressed in Ghost Mode. Volume control in settings. Rate-limited: max 1 sound per 3 seconds.
+
+---
+
+## Phase 5 — Map & Data Visualization
+
+### Popup Redesign
+
+Replace flat popup with Apple Maps-style card:
+- Glass morphism: `backdrop-filter: blur(20px) saturate(1.4)`, elevation-3
+- Border radius: 14px
+- Structure: Title + location/time → stat grid (2-col) → action buttons (Focus Map / Open Panel)
+- Severity badge: top-right corner, colored pill
+- Entry animation: scale(0.95) → 1 + fade, 200ms ease-out
+
+### Layer Transitions
+
+| Transition | Animation | Duration |
+|-----------|-----------|----------|
+| Layer toggle on | Opacity 0 → 1, markers scale 0.8 → 1 | 400ms |
+| Layer toggle off | Opacity 1 → 0 | 300ms |
+| New data point arrival | Scale 0 → 1 (spring) + single ripple ring | 400ms ease-spring |
+| Tile loading | Shimmer overlay on loading tiles, crossfade to loaded | 300ms |
+
+Uses DeckGL `transitions` prop for marker animations.
+
+### View Preset Transitions
+
+**Segmented control:** Apple-style pill group for region presets (Global, Americas, MENA, EU, Asia, Africa, Oceania). Selected pill slides with spring animation. Background indicator follows active item. Same pattern for time range selector (1h, 6h, 24h, 7d, All).
+
+**Camera flight behavior:**
+- `flyTo()` with smooth arc, ease-in-out, 1.5s duration
+- Zoom: pulls out then dives into target region
+- Bearing: slight rotation for cinematic feel (±15°)
+- Pitch: tilts 0° → 45° on zoom-in for depth perception
+
+### Cluster Interaction
+
+Click cluster → flyTo zoom level where cluster breaks apart. Individual markers scale-in with 20ms stagger. Cluster count number shrinks to 0 before the cluster disappears.
+
+### Map Controls Refinement
+
+- Time range selector: frosted glass pill group (segmented control)
+- Layer toggle pills: category-colored when active (e.g., conflicts = blue, nuclear = red), 150ms fill color transition
+- Basemap switcher: Apple-style popover with preview thumbnails
+
+---
+
+## Phase 6 — Empty States, Onboarding & God's Vision
+
+### Empty State System
+
+Replace all plain "No data yet" text with structured empty states:
+
+```
+┌────────────────────────────────┐
+│           [icon 28px]          │
+│        Title (13px/500)        │
+│    Guidance text (11px/muted)  │
+│         [CTA button]          │
+└────────────────────────────────┘
+```
+
+**Category templates:**
+
+| Category | Icon | Title Pattern | CTA |
+|----------|------|---------------|-----|
+| Geopolitical | 🌍 | "Monitoring world events" | — |
+| Infrastructure | ⚡ | "Awaiting grid/comms data" | — |
+| Cyber/Security | 🛡 | "No active threats detected" | — |
+| Markets/Finance | 📊 | "Markets data loading" | — |
+| Weather/Climate | 🌦 | "Fetching conditions" | — |
+| User Content | ✏️ | "Create your first entry" | Add/Create button |
+
+**Monitoring panels** (data-driven): "All clear" tone — reassuring, not broken.
+**User content panels** (user-created): "Create/Add" CTA — actionable.
+
+### Welcome Flow
+
+3-step onboarding modal shown once on first launch. Steps slide left → right with 350ms ease-out. Progress dots at top.
+
+**Step 1 — Your Location:**
+- GPS toggle (use device location) or manual entry later
+- Explains: proximity alerts, local weather, nearest-threat
+
+**Step 2 — Your Interests:**
+- Domain pill picker (multi-select): Geopolitical, Cyber, Markets, Weather, Military, Health, Infrastructure, Space
+- Pre-selects recommended defaults
+- Affects: panel visibility, alert priority, sidebar ordering
+
+**Step 3 — API Keys:**
+- Shows top recommended keys with Free/Paid labels
+- "Crystal Ball works without them" — no pressure
+- "Skip for now" option
+- Links to signup URLs from `settings-constants.ts`
+
+Storage: `cb:onboarding-complete` in localStorage. "Skip for now" on every step.
+
+### God's Vision — Entry Transition
+
+Total duration: ~1.2s
+
+| Step | Animation | Duration |
+|------|-----------|----------|
+| Sidebar collapse | Width → 0, opacity fade | 200ms |
+| Map zoom out | Current view → orbital altitude | 500ms |
+| Cesium crossfade | 2D map fades, 3D globe fades in | 500ms |
+| HUD stagger-in | HUD elements appear with 50ms stagger | 300ms |
+
+Exit transition: reverse sequence (HUD fade → globe fade → map zoom in → sidebar expand).
+
+### God's Vision — HUD Polish
+
+**Typography split:**
+- SF Mono for data values (numbers, coordinates, timestamps)
+- SF Pro for labels (section titles, descriptions)
+- Consistent uppercase + letter-spacing for category labels
+
+**Threat card:** Level 4 elevation (max glass). Numbers animate with `animateNumber()` on data change. Threat level text gets color + subtle text-shadow matching severity.
+
+**Camera choreography:**
+- Auto-follow: smooth arc between threat hotspots, 4s dwell per target
+- Easing: ease-in-out-cubic for natural acceleration/deceleration
+- Altitude: pulls up between targets, dives on arrival
+- Idle orbit: slow 0.05°/frame rotation when no active targets
+- User interrupt: any mouse/keyboard input cancels auto-follow, resumes after 10s idle
+
+### Contextual First-Time Hints
+
+One-time tooltip hints at key touchpoints:
+
+| Location | Hint |
+|----------|------|
+| Alert Inbox | "Press J/K to navigate, A to acknowledge" |
+| Map | "Scroll to zoom, click clusters to expand" |
+| God's Vision | "Press 1-6 for theaters, Esc to exit" |
+| Ghost Mode | "Cmd+Shift+G to toggle Ghost Mode" |
+| Settings | "Press Esc to close" |
+
+Implementation: glass morphism tooltip with arrow, "Got it" dismiss button. Each hint shown once, stored in `cb:hints-seen` (Set in localStorage). Auto-dismiss after 8s if not clicked.
+
+---
+
+## Cross-Cutting Concerns
+
+### Reduced Motion
+
+All animations wrapped in `@media (prefers-reduced-motion: no-preference)`. When reduced motion is enabled, transitions collapse to instant opacity changes only. The existing `body.animations-paused` system is preserved and extended to cover new motion classes.
+
+### Ghost Mode Compatibility
+
+- Sound design: all audio suppressed in Ghost Mode
+- Toast notifications: suppressed in Ghost Mode
+- Animations: preserved (they don't leak data)
+- Empty states: preserved (they're informational)
+
+### Light Theme
+
+All color tokens define both dark and light variants via `[data-theme="light"]` selector. Surface layers invert (white base), severity colors adjust for light backgrounds (slightly darker text variants for contrast). Elevation shadows lighten.
+
+### Performance
+
+- All CSS animations use `transform` and `opacity` only (GPU-composited)
+- No layout-triggering properties in transitions
+- Skeleton screens render instantly (no data dependency)
+- Stagger animations capped at 10 items (300ms max)
+- DeckGL transitions use built-in `transitions` prop (GPU-accelerated)
+- `motion.ts` functions are no-ops when `prefers-reduced-motion: reduce`
+
+---
+
+## Files Created / Modified
+
+### New Files
+| File | Phase | Purpose |
+|------|-------|---------|
+| `src/styles/design-system.css` | 1 | Token definitions, component primitives |
+| `src/styles/motion.css` | 2 | Animation keyframes, transition classes |
+| `src/services/motion.ts` | 2 | JS animation helpers |
+| `src/components/Toast.ts` | 4 | Toast notification component |
+| `src/components/WelcomeFlow.ts` | 6 | Onboarding modal |
+| `src/components/EmptyState.ts` | 6 | Reusable empty state component |
+| `src/components/ContextualHint.ts` | 6 | First-time tooltip hints |
+
+### Modified Files
+| File | Phase | Changes |
+|------|-------|---------|
+| `src/styles/main.css` | 1 | Import design-system.css, begin token migration |
+| `src/styles/panels.css` | 3 | Replace hardcoded values with tokens |
+| `src/styles/alerts.css` | 4 | Alert arrival/action animations |
+| `src/styles/gods-vision.css` | 6 | HUD typography, entry transition |
+| `src/components/UnifiedAlertInboxPanel.ts` | 4 | Action animations, arrival animation |
+| `src/components/TriageBar.ts` | 4 | Escalation bar, hover expand, accent line |
+| `src/components/DeckGLMap.ts` | 5 | Popup redesign, layer transitions, view presets |
+| `src/components/MapPopup.ts` | 5 | Apple Maps card redesign |
+| `src/components/GlobeHUD.ts` | 6 | Typography split, animateNumber |
+| `src/components/GodsVisionView.ts` | 6 | Entry/exit transition choreography |
+| `src/components/Panel.ts` | 2,3 | Base class: skeleton support, header layout |
+| `src/app/panel-layout.ts` | 3 | Panel header standardization |
+| ~20 high-traffic panel components | 3 | Token migration, .cb-* class adoption |

--- a/e2e/design-system.spec.ts
+++ b/e2e/design-system.spec.ts
@@ -1,0 +1,37 @@
+// e2e/design-system.spec.ts
+import { test, expect } from '@playwright/test';
+
+test.describe('Design System', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+  });
+
+  test('tokens are loaded', async ({ page }) => {
+    const surfaceBase = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue('--surface-base').trim()
+    );
+    expect(surfaceBase).toBe('#0a0a0a');
+  });
+
+  test('severity tokens exist', async ({ page }) => {
+    const critical = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue('--severity-critical').trim()
+    );
+    expect(critical).toBe('#ef4444');
+  });
+
+  test('shimmer animation is defined', async ({ page }) => {
+    const hasShimmer = await page.evaluate(() => {
+      for (const sheet of document.styleSheets) {
+        try {
+          for (const rule of sheet.cssRules) {
+            if (rule instanceof CSSKeyframesRule && rule.name === 'cb-shimmer') return true;
+          }
+        } catch { /* cross-origin */ }
+      }
+      return false;
+    });
+    expect(hasShimmer).toBe(true);
+  });
+});

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -240,6 +240,8 @@ import { isLowPowerMode, setLowPowerMode } from '@/services/low-power';
 import { tryInvokeTauri, invokeTauri } from '@/services/tauri-bridge';
 import { initModeTransitionCards } from '@/services/mode-transition-card';
 import { initPanelCorrelation } from '@/services/panel-correlation';
+import { WelcomeFlow } from '@/components/WelcomeFlow';
+import { HINTS } from '@/components/ContextualHint';
 import { getPrimarySavedPlace, getSavedPlace } from '@/services/saved-places';
 import { SavedPlaceModal } from '@/components/SavedPlaceModal';
 import type { GeoHubActivity } from '@/services/geo-activity';
@@ -1558,6 +1560,18 @@ export class PanelLayoutManager implements AppModule {
 
  // Auto-mode-activation notifications deleted in mode collapse —
  // war/disaster modes no longer exist as triggerable states.
+
+ if (WelcomeFlow.shouldShow()) {
+   const flow = new WelcomeFlow({
+     onComplete: () => {
+       const alertPanel = document.querySelector('[data-panel="unified-alert-inbox"]');
+       if (alertPanel) {
+         setTimeout(() => HINTS.alertNavigation(alertPanel as HTMLElement), 1000);
+       }
+     },
+   });
+   flow.show();
+ }
   }
 
   /**

--- a/src/app/refresh-scheduler.ts
+++ b/src/app/refresh-scheduler.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console, sonarjs/pseudo-random, @typescript-eslint/no-empty-function */
 import type { AppContext, AppModule } from '@/app/app-context';
 import { getGhostRefreshMultiplier } from '@/services/mode-manager';
 
@@ -83,7 +84,7 @@ export class RefreshScheduler implements AppModule {
  currentMultiplier = changed === false ? Math.min(currentMultiplier * 2, MAX_BACKOFF_MULTIPLIER) : 1;
  } catch (error) {
  console.error(`[App] Refresh ${name} failed:`, error);
- currentMultiplier = 1;
+ currentMultiplier = Math.min(currentMultiplier * 2, MAX_BACKOFF_MULTIPLIER);
  } finally {
  this.ctx.inFlight.delete(name);
  scheduleNext(computeDelay(intervalMs * currentMultiplier, false));
@@ -104,7 +105,7 @@ export class RefreshScheduler implements AppModule {
  const pending = this.refreshTimeoutIds.get(name);
  if (pending) clearTimeout(pending);
  const delay = stagger;
- stagger += 150;
+ stagger += 500;
  this.refreshTimeoutIds.set(name, setTimeout(() => void run(), delay));
  }
   }

--- a/src/components/CesiumGlobe.ts
+++ b/src/components/CesiumGlobe.ts
@@ -37,6 +37,7 @@ export class CesiumGlobe {
  initCesium(this.options.ionToken);
 
  const cesiumContainer = document.createElement('div');
+ cesiumContainer.className = 'ge-globe-container';
  cesiumContainer.style.cssText = 'width:100%;height:100%;position:absolute;inset:0;';
  this.container.append(cesiumContainer);
 

--- a/src/components/ContextualHint.ts
+++ b/src/components/ContextualHint.ts
@@ -173,4 +173,16 @@ export const HINTS = {
       target,
       message: 'Press Cmd+Shift+G to enter Ghost Mode',
     }),
+  mapNavigation: (target: HTMLElement) =>
+    showHint({
+      id: 'map-nav',
+      target,
+      message: 'Use region pills to fly between theaters, scroll to zoom',
+    }),
+  settings: (target: HTMLElement) =>
+    showHint({
+      id: 'settings',
+      target,
+      message: 'Configure API keys and preferences here',
+    }),
 };

--- a/src/components/ContextualHint.ts
+++ b/src/components/ContextualHint.ts
@@ -1,0 +1,176 @@
+import { animateIn, animateOut } from '@/services/motion';
+
+const STORAGE_KEY = 'cb:hints-seen';
+const AUTO_DISMISS_MS = 8000;
+
+interface HintConfig {
+  id: string;
+  target: HTMLElement;
+  message: string;
+  position?: 'top' | 'bottom';
+}
+
+function getSeenHints(): Set<string> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return new Set(JSON.parse(raw) as string[]);
+  } catch {
+    // ignore parse errors
+  }
+  return new Set();
+}
+
+function markSeen(id: string): void {
+  const seen = getSeenHints();
+  seen.add(id);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify([...seen]));
+}
+
+function buildTooltip(config: HintConfig): HTMLElement {
+  const { position = 'bottom' } = config;
+
+  const tooltip = document.createElement('div');
+  tooltip.style.cssText = `
+    position: fixed;
+    z-index: 9999;
+    max-width: 280px;
+    padding: 10px 12px;
+    background: rgba(28, 28, 30, 0.95);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-md);
+    box-shadow: var(--elevation-2);
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    color: #ccc;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  `;
+
+  // Arrow element
+  const arrow = document.createElement('div');
+  arrow.style.cssText = position === 'bottom' ? `
+      position: absolute;
+      top: -5px;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 0;
+      height: 0;
+      border-left: 5px solid transparent;
+      border-right: 5px solid transparent;
+      border-bottom: 5px solid rgba(28, 28, 30, 0.95);
+    ` : `
+      position: absolute;
+      bottom: -5px;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 0;
+      height: 0;
+      border-left: 5px solid transparent;
+      border-right: 5px solid transparent;
+      border-top: 5px solid rgba(28, 28, 30, 0.95);
+    `;
+  tooltip.append(arrow);
+
+  // Message text node
+  const msgEl = document.createElement('span');
+  msgEl.textContent = config.message;
+  tooltip.append(msgEl);
+
+  // Footer row: Got it button
+  const footer = document.createElement('div');
+  footer.style.cssText = 'display: flex; justify-content: flex-end;';
+
+  const btn = document.createElement('button');
+  btn.className = 'cb-button';
+  btn.textContent = 'Got it';
+  btn.style.cssText = 'font-size: var(--text-xs); padding: 3px 10px;';
+  footer.append(btn);
+  tooltip.append(footer);
+
+  return tooltip;
+}
+
+function positionTooltip(tooltip: HTMLElement, target: HTMLElement, position: 'top' | 'bottom'): void {
+  const rect = target.getBoundingClientRect();
+  const tooltipWidth = 280;
+  const gap = 8;
+
+  let left = rect.left + rect.width / 2 - tooltipWidth / 2;
+  // Clamp to viewport with 8px margin
+  left = Math.max(8, Math.min(left, window.innerWidth - tooltipWidth - 8));
+
+  tooltip.style.width = `${tooltipWidth}px`;
+  tooltip.style.left = `${left}px`;
+
+  if (position === 'bottom') {
+    tooltip.style.top = `${rect.bottom + gap}px`;
+  } else {
+    // We'll set top after appending so we can measure height
+    tooltip.style.top = '0px';
+    tooltip.style.visibility = 'hidden';
+    document.body.append(tooltip);
+    const tooltipHeight = tooltip.offsetHeight;
+    tooltip.style.top = `${rect.top - tooltipHeight - gap}px`;
+    tooltip.style.visibility = '';
+    return; // already appended
+  }
+
+  document.body.append(tooltip);
+}
+
+export function showHint(config: HintConfig): void {
+  const seen = getSeenHints();
+  if (seen.has(config.id)) return;
+
+  const { position = 'bottom' } = config;
+  const tooltip = buildTooltip(config);
+
+  positionTooltip(tooltip, config.target, position);
+
+  void animateIn(tooltip, 'fade');
+
+  let dismissed = false;
+
+  function dismiss(): void {
+    if (dismissed) return;
+    dismissed = true;
+    markSeen(config.id);
+    void animateOut(tooltip, 'fade').then(() => {
+      tooltip.remove();
+    });
+  }
+
+  const timer = setTimeout(dismiss, AUTO_DISMISS_MS);
+
+  const btn = tooltip.querySelector('button');
+  if (btn) {
+    btn.addEventListener('click', () => {
+      clearTimeout(timer);
+      dismiss();
+    });
+  }
+}
+
+export const HINTS = {
+  alertNavigation: (target: HTMLElement) =>
+    showHint({
+      id: 'alert-nav',
+      target,
+      message: 'Use J/K to navigate alerts, A to acknowledge',
+    }),
+  godsVision: (target: HTMLElement) =>
+    showHint({
+      id: 'gods-vision',
+      target,
+      message: "Press G to toggle God's Vision 3D globe",
+    }),
+  ghostMode: (target: HTMLElement) =>
+    showHint({
+      id: 'ghost-mode',
+      target,
+      message: 'Press Cmd+Shift+G to enter Ghost Mode',
+    }),
+};

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -1780,6 +1780,12 @@ export class DeckGLMap {
  radiusMinPixels: 10,
  radiusMaxPixels: 40,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
 
  const textLayer = new TextLayer<ServerBaseCluster>({
@@ -1836,6 +1842,12 @@ export class DeckGLMap {
  radiusMinPixels: 4,
  radiusMaxPixels: 10,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -1849,6 +1861,12 @@ export class DeckGLMap {
  radiusMinPixels: 5,
  radiusMaxPixels: 12,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -1880,6 +1898,12 @@ export class DeckGLMap {
  radiusMinPixels: 4,
  radiusMaxPixels: 10,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -1903,6 +1927,12 @@ export class DeckGLMap {
  radiusMinPixels: 4,
  radiusMaxPixels: 15,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -1918,6 +1948,12 @@ export class DeckGLMap {
  radiusMaxPixels: 12,
  pickable: true,
  autoHighlight: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -1960,6 +1996,12 @@ export class DeckGLMap {
  radiusMaxPixels: 8,
  pickable: true,
  autoHighlight: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -1991,6 +2033,12 @@ export class DeckGLMap {
  lineWidthMinPixels: 1,
  pickable: true,
  autoHighlight: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2003,6 +2051,12 @@ export class DeckGLMap {
  radiusMinPixels: opts.radiusMinPixels ?? 12,
  getFillColor: [0, 0, 0, 0],
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2051,6 +2105,12 @@ export class DeckGLMap {
  radiusMinPixels: 4,
  radiusMaxPixels: 30,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2068,6 +2128,12 @@ export class DeckGLMap {
  radiusMinPixels: 5,
  radiusMaxPixels: 18,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2085,6 +2151,12 @@ export class DeckGLMap {
  radiusMinPixels: 3,
  radiusMaxPixels: 12,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2102,6 +2174,12 @@ export class DeckGLMap {
  radiusMinPixels: 4,
  radiusMaxPixels: 16,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2123,6 +2201,12 @@ export class DeckGLMap {
  radiusMinPixels: 8,
  radiusMaxPixels: 20,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2136,6 +2220,12 @@ export class DeckGLMap {
  radiusMinPixels: 6,
  radiusMaxPixels: 18,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2174,6 +2264,12 @@ export class DeckGLMap {
  stroked: true,
  getLineColor: [255, 255, 255, 160] as [number, number, number, number],
  lineWidthMinPixels: 1,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2196,6 +2292,12 @@ export class DeckGLMap {
  },
  lineWidthMinPixels: 1,
  lineWidthMaxPixels: 2,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2241,6 +2343,12 @@ export class DeckGLMap {
  radiusMinPixels: 4,
  radiusMaxPixels: 12,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2260,6 +2368,12 @@ export class DeckGLMap {
  stroked: true,
  getLineColor: [255, 255, 255, 100] as [number, number, number, number],
  lineWidthMinPixels: 1,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2286,6 +2400,12 @@ export class DeckGLMap {
  stroked: true,
  getLineColor: [255, 255, 255, 150] as [number, number, number, number],
  lineWidthMinPixels: 1,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2306,6 +2426,12 @@ export class DeckGLMap {
  },
  pickable: true,
  updateTriggers: { getFillColor: [this.adsbFlights] },
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2344,6 +2470,12 @@ export class DeckGLMap {
  stroked: true,
  getLineColor: [0, 200, 255, 200] as [number, number, number, number], // Cyan outline (cable color)
  lineWidthMinPixels: 2,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2358,6 +2490,12 @@ export class DeckGLMap {
  radiusMinPixels: 4,
  radiusMaxPixels: 10,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2380,6 +2518,12 @@ export class DeckGLMap {
  return [0, 0, 0, 0] as [number, number, number, number]; // No outline for AIS
  },
  lineWidthMinPixels: 2,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2399,6 +2543,12 @@ export class DeckGLMap {
  radiusMinPixels: 8,
  radiusMaxPixels: 25,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2416,6 +2566,12 @@ export class DeckGLMap {
  radiusMinPixels: 4,
  radiusMaxPixels: 12,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2455,6 +2611,12 @@ export class DeckGLMap {
  radiusMinPixels: 8,
  radiusMaxPixels: 25,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2523,6 +2685,12 @@ export class DeckGLMap {
  radiusMinPixels: 5,
  radiusMaxPixels: 12,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2536,6 +2704,12 @@ export class DeckGLMap {
  radiusMinPixels: 4,
  radiusMaxPixels: 10,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2553,6 +2727,12 @@ export class DeckGLMap {
  radiusMinPixels: 5,
  radiusMaxPixels: 14,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2570,6 +2750,12 @@ export class DeckGLMap {
  radiusMinPixels: 4,
  radiusMaxPixels: 12,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2587,6 +2773,12 @@ export class DeckGLMap {
  radiusMinPixels: 4,
  radiusMaxPixels: 12,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2604,6 +2796,12 @@ export class DeckGLMap {
  radiusMinPixels: 4,
  radiusMaxPixels: 11,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2627,6 +2825,12 @@ export class DeckGLMap {
  radiusMaxPixels: 8,
  pickable: true,
  stroked: false,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2655,6 +2859,12 @@ export class DeckGLMap {
  radiusMinPixels: 5,
  radiusMaxPixels: 12,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2669,6 +2879,12 @@ export class DeckGLMap {
  radiusMinPixels: 5,
  radiusMaxPixels: 12,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2682,6 +2898,12 @@ export class DeckGLMap {
  radiusMinPixels: 3,
  radiusMaxPixels: 8,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2695,6 +2917,12 @@ export class DeckGLMap {
  radiusMinPixels: 4,
  radiusMaxPixels: 12,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -2717,6 +2945,12 @@ export class DeckGLMap {
  },
  pickable: true,
  updateTriggers: { getRadius: this.lastSCZoom, getFillColor: this.lastSCZoom },
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  }));
 
  const multiClusters = this.protestClusters.filter(c => c.count > 1);
@@ -2755,6 +2989,12 @@ export class DeckGLMap {
  lineWidthMinPixels: 1.5,
  pickable: false,
  updateTriggers: { radiusScale: this.pulseTime },
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  }));
  }
 
@@ -2780,6 +3020,12 @@ export class DeckGLMap {
  },
  pickable: true,
  updateTriggers: { getRadius: this.lastSCZoom },
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  }));
 
  const multiClusters = this.techHQClusters.filter(c => c.count > 1);
@@ -2838,6 +3084,12 @@ export class DeckGLMap {
  },
  pickable: true,
  updateTriggers: { getRadius: this.lastSCZoom },
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  }));
 
  const multiClusters = this.techEventClusters.filter(c => c.count > 1);
@@ -2879,6 +3131,12 @@ export class DeckGLMap {
  },
  pickable: true,
  updateTriggers: { getRadius: this.lastSCZoom },
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  }));
 
  const multiClusters = this.datacenterClusters.filter(c => c.count > 1);
@@ -2932,6 +3190,12 @@ export class DeckGLMap {
  getLineColor: (d) =>
  d.hasBreaking ? [255, 255, 255, 255] as [number, number, number, number] : [0, 0, 0, 0] as [number, number, number, number],
  lineWidthMinPixels: 2,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  }));
 
  const highHotspots = this.hotspots.filter(h => h.level === 'high' || h.hasBreaking);
@@ -2957,6 +3221,12 @@ export class DeckGLMap {
  lineWidthMinPixels: 1.5,
  pickable: false,
  updateTriggers: { radiusScale: this.pulseTime },
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  }));
 
  // Night bloom: soft outer glow around high-severity hotspots.
@@ -2984,6 +3254,12 @@ export class DeckGLMap {
  filled: true,
  pickable: false,
  updateTriggers: { getFillColor: this.pulseTime },
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  }));
  }
  }
@@ -3010,6 +3286,12 @@ export class DeckGLMap {
  radiusMinPixels: 5,
  radiusMaxPixels: 28,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -3142,6 +3424,12 @@ export class DeckGLMap {
  radiusMinPixels: 3,
  radiusMaxPixels: 12,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  }),
  ];
 
@@ -3174,6 +3462,12 @@ export class DeckGLMap {
  },
  lineWidthMinPixels: 1.5,
  updateTriggers: { pulseTime: now },
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  }));
  }
 
@@ -3213,6 +3507,12 @@ export class DeckGLMap {
  radiusMinPixels: 5,
  radiusMaxPixels: 10,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  }));
 
  // Gentle pulse ring for significant events (count > 8)
@@ -3233,6 +3533,12 @@ export class DeckGLMap {
  lineWidthMinPixels: 1.5,
  pickable: false,
  updateTriggers: { radiusScale: this.pulseTime },
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  }));
  }
 
@@ -3253,6 +3559,12 @@ export class DeckGLMap {
  radiusMinPixels: 5,
  radiusMaxPixels: 10,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  }));
 
  // Pulse for real events
@@ -3271,6 +3583,12 @@ export class DeckGLMap {
  lineWidthMinPixels: 1,
  pickable: false,
  updateTriggers: { radiusScale: this.pulseTime },
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  }));
 
  return layers;
@@ -3317,6 +3635,12 @@ export class DeckGLMap {
  getLineColor: [74, 222, 128, 200] as [number, number, number, number],
  lineWidthMinPixels: 1.5,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -3345,6 +3669,12 @@ export class DeckGLMap {
  getLineColor: (d: RenewableInstallation) => typeLineColors[d.type] ?? [200, 200, 200, 255] as [number, number, number, number],
  lineWidthMinPixels: 1,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -4534,6 +4864,12 @@ export class DeckGLMap {
  radiusMinPixels: 3,
  radiusMaxPixels: 20,
  pickable: false,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -4556,6 +4892,12 @@ export class DeckGLMap {
  getLineColor: [255, 255, 255, 80],
  lineWidthMinPixels: 1,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -4586,6 +4928,12 @@ export class DeckGLMap {
  getLineColor: [255, 255, 255, 80],
  lineWidthMinPixels: 1,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -4672,6 +5020,12 @@ export class DeckGLMap {
  radiusMinPixels: 4,
  radiusMaxPixels: 12,
  pickable: false,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -5637,6 +5991,12 @@ export class DeckGLMap {
  getLineWidth: 3000,
  radiusUnits: 'meters' as const,
  pickable: false,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
 
  // Inner core dot
@@ -5653,6 +6013,12 @@ export class DeckGLMap {
  radiusUnits: 'meters' as const,
  pickable: true,
  autoHighlight: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
 
  return [outer, inner];
@@ -5749,6 +6115,12 @@ export class DeckGLMap {
  radiusMaxPixels: 12,
  pickable: true,
  autoHighlight: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -5770,6 +6142,12 @@ export class DeckGLMap {
  radiusUnits: 'meters' as const,
  pickable: true,
  autoHighlight: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -5912,6 +6290,12 @@ export class DeckGLMap {
  radiusMinPixels: 2,
  radiusMaxPixels: 8,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -5932,6 +6316,12 @@ export class DeckGLMap {
  radiusUnits: 'meters' as const,
  radiusMinPixels: 6,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 
@@ -5978,6 +6368,12 @@ export class DeckGLMap {
  radiusMinPixels: 1,
  radiusMaxPixels: 6,
  pickable: true,
+
+ transitions: {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+ },
  });
   }
 

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -4200,71 +4200,99 @@ export class DeckGLMap {
   private createControls(): void {
  const controls = document.createElement('div');
  controls.className = 'map-controls deckgl-controls';
- controls.innerHTML = `
- <div class="zoom-controls">
- <button class="map-btn zoom-in" title="${t('components.deckgl.zoomIn')}">+</button>
- <button class="map-btn zoom-out" title="${t('components.deckgl.zoomOut')}">-</button>
- <button class="map-btn zoom-reset" title="${t('components.deckgl.resetView')}">&#8962;</button>
- </div>
- <div class="view-selector">
- <select class="view-select">
- <option value="global">${t('components.deckgl.views.global')}</option>
- <option value="america">${t('components.deckgl.views.americas')}</option>
- <option value="mena">${t('components.deckgl.views.mena')}</option>
- <option value="eu">${t('components.deckgl.views.europe')}</option>
- <option value="asia">${t('components.deckgl.views.asia')}</option>
- <option value="latam">${t('components.deckgl.views.latam')}</option>
- <option value="africa">${t('components.deckgl.views.africa')}</option>
- <option value="oceania">${t('components.deckgl.views.oceania')}</option>
- </select>
- </div>
- `;
+
+ // Zoom controls
+ const zoomControls = document.createElement('div');
+ zoomControls.className = 'zoom-controls';
+
+ const zoomIn = document.createElement('button');
+ zoomIn.className = 'map-btn zoom-in';
+ zoomIn.title = t('components.deckgl.zoomIn');
+ zoomIn.textContent = '+';
+
+ const zoomOut = document.createElement('button');
+ zoomOut.className = 'map-btn zoom-out';
+ zoomOut.title = t('components.deckgl.zoomOut');
+ zoomOut.textContent = '-';
+
+ const zoomReset = document.createElement('button');
+ zoomReset.className = 'map-btn zoom-reset';
+ zoomReset.title = t('components.deckgl.resetView');
+ zoomReset.textContent = '\u2302';
+
+ zoomControls.append(zoomIn, zoomOut, zoomReset);
+ controls.append(zoomControls);
+
+ // View preset pill group
+ const viewPresets: { value: DeckMapView; label: string }[] = [
+ { value: 'global', label: t('components.deckgl.views.global') },
+ { value: 'america', label: t('components.deckgl.views.americas') },
+ { value: 'mena', label: t('components.deckgl.views.mena') },
+ { value: 'eu', label: t('components.deckgl.views.europe') },
+ { value: 'asia', label: t('components.deckgl.views.asia') },
+ { value: 'latam', label: t('components.deckgl.views.latam') },
+ { value: 'africa', label: t('components.deckgl.views.africa') },
+ { value: 'oceania', label: t('components.deckgl.views.oceania') },
+ ];
+
+ const pillGroup = document.createElement('div');
+ pillGroup.className = 'cb-pill-group deckgl-view-pills';
+
+ for (const preset of viewPresets) {
+ const btn = document.createElement('button');
+ btn.textContent = preset.label;
+ btn.dataset.view = preset.value;
+ if (preset.value === this.state.view) btn.classList.add('active');
+ btn.addEventListener('click', () => this.setView(preset.value));
+ pillGroup.append(btn);
+ }
+
+ controls.append(pillGroup);
 
  this.container.append(controls);
 
- // Bind events - use event delegation for reliability
+ // Bind zoom events
  controls.addEventListener('click', (e) => {
  const target = e.target as HTMLElement;
  if (target.classList.contains('zoom-in')) this.zoomIn();
  else if (target.classList.contains('zoom-out')) this.zoomOut();
  else if (target.classList.contains('zoom-reset')) this.resetView();
  });
-
- const viewSelect = controls.querySelector('.view-select') as HTMLSelectElement;
- viewSelect.value = this.state.view;
- viewSelect.addEventListener('change', () => {
- this.setView(viewSelect.value as DeckMapView);
- });
   }
 
   private createTimeSlider(): void {
  const slider = document.createElement('div');
  slider.className = 'time-slider deckgl-time-slider';
- slider.innerHTML = `
- <div class="time-options">
- <button class="time-btn ${this.state.timeRange === '1h' ? 'active' : ''}" data-range="1h">1h</button>
- <button class="time-btn ${this.state.timeRange === '6h' ? 'active' : ''}" data-range="6h">6h</button>
- <button class="time-btn ${this.state.timeRange === '24h' ? 'active' : ''}" data-range="24h">24h</button>
- <button class="time-btn ${this.state.timeRange === '48h' ? 'active' : ''}" data-range="48h">48h</button>
- <button class="time-btn ${this.state.timeRange === '7d' ? 'active' : ''}" data-range="7d">7d</button>
- <button class="time-btn ${this.state.timeRange === 'all' ? 'active' : ''}" data-range="all">${t('components.deckgl.timeAll')}</button>
- </div>
- `;
 
+ const timeRanges: { value: TimeRange; label: string }[] = [
+ { value: '1h', label: '1h' },
+ { value: '6h', label: '6h' },
+ { value: '24h', label: '24h' },
+ { value: '48h', label: '48h' },
+ { value: '7d', label: '7d' },
+ { value: 'all', label: t('components.deckgl.timeAll') },
+ ];
+
+ const pillGroup = document.createElement('div');
+ pillGroup.className = 'cb-pill-group deckgl-time-pills';
+
+ for (const range of timeRanges) {
+ const btn = document.createElement('button');
+ btn.textContent = range.label;
+ btn.dataset.range = range.value;
+ if (range.value === this.state.timeRange) btn.classList.add('active');
+ btn.addEventListener('click', () => this.setTimeRange(range.value));
+ pillGroup.append(btn);
+ }
+
+ slider.append(pillGroup);
  this.container.append(slider);
-
- slider.querySelectorAll('.time-btn').forEach(btn => {
- btn.addEventListener('click', () => {
- const range = (btn as HTMLElement).dataset.range as TimeRange;
- this.setTimeRange(range);
- });
- });
   }
 
   private updateTimeSliderButtons(): void {
  const slider = this.container.querySelector('.deckgl-time-slider');
  if (!slider) return;
- slider.querySelectorAll('.time-btn').forEach((btn) => {
+ slider.querySelectorAll('button[data-range]').forEach((btn) => {
  const range = (btn as HTMLElement).dataset.range as TimeRange | undefined;
  btn.classList.toggle('active', range === this.state.timeRange);
  });
@@ -4734,15 +4762,21 @@ export class DeckGLMap {
  this.state.view = view;
 
  if (this.maplibreMap) {
+ const bearing = (Math.random() * 30) - 15;
+ const isZoomIn = preset.zoom > (this.maplibreMap.getZoom() ?? 1.5);
  this.maplibreMap.flyTo({
  center: [preset.longitude, preset.latitude],
  zoom: preset.zoom,
- duration: 1000,
+ bearing,
+ pitch: isZoomIn ? 45 : 0,
+ duration: 1500,
  });
  }
 
- const viewSelect = this.container.querySelector('.view-select') as HTMLSelectElement;
- if (viewSelect) viewSelect.value = view;
+ // Update active state on pill buttons
+ this.container.querySelectorAll('.deckgl-view-pills button').forEach((btn) => {
+ btn.classList.toggle('active', (btn as HTMLElement).dataset.view === view);
+ });
 
  this.onStateChange?.(this.state);
   }

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -385,6 +385,12 @@ const CONFLICT_ZONES_GEOJSON: GeoJSON.FeatureCollection = {
   })),
 };
 
+const SCATTER_TRANSITIONS = {
+  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
+  getFillColor: { duration: 300 },
+};
+
 export class DeckGLMap {
   private static readonly MAX_CLUSTER_LEAVES = 200;
 
@@ -1781,11 +1787,7 @@ export class DeckGLMap {
  radiusMaxPixels: 40,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
 
  const textLayer = new TextLayer<ServerBaseCluster>({
@@ -1843,11 +1845,7 @@ export class DeckGLMap {
  radiusMaxPixels: 10,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -1862,11 +1860,7 @@ export class DeckGLMap {
  radiusMaxPixels: 12,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -1899,11 +1893,7 @@ export class DeckGLMap {
  radiusMaxPixels: 10,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -1928,11 +1918,7 @@ export class DeckGLMap {
  radiusMaxPixels: 15,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -1949,11 +1935,7 @@ export class DeckGLMap {
  pickable: true,
  autoHighlight: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -1997,11 +1979,7 @@ export class DeckGLMap {
  pickable: true,
  autoHighlight: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2034,11 +2012,7 @@ export class DeckGLMap {
  pickable: true,
  autoHighlight: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2052,11 +2026,7 @@ export class DeckGLMap {
  getFillColor: [0, 0, 0, 0],
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2106,11 +2076,7 @@ export class DeckGLMap {
  radiusMaxPixels: 30,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2129,11 +2095,7 @@ export class DeckGLMap {
  radiusMaxPixels: 18,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2152,11 +2114,7 @@ export class DeckGLMap {
  radiusMaxPixels: 12,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2175,11 +2133,7 @@ export class DeckGLMap {
  radiusMaxPixels: 16,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2202,11 +2156,7 @@ export class DeckGLMap {
  radiusMaxPixels: 20,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2221,11 +2171,7 @@ export class DeckGLMap {
  radiusMaxPixels: 18,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2265,11 +2211,7 @@ export class DeckGLMap {
  getLineColor: [255, 255, 255, 160] as [number, number, number, number],
  lineWidthMinPixels: 1,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2293,11 +2235,7 @@ export class DeckGLMap {
  lineWidthMinPixels: 1,
  lineWidthMaxPixels: 2,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2344,11 +2282,7 @@ export class DeckGLMap {
  radiusMaxPixels: 12,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2369,11 +2303,7 @@ export class DeckGLMap {
  getLineColor: [255, 255, 255, 100] as [number, number, number, number],
  lineWidthMinPixels: 1,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2401,11 +2331,7 @@ export class DeckGLMap {
  getLineColor: [255, 255, 255, 150] as [number, number, number, number],
  lineWidthMinPixels: 1,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2427,11 +2353,7 @@ export class DeckGLMap {
  pickable: true,
  updateTriggers: { getFillColor: [this.adsbFlights] },
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2471,11 +2393,7 @@ export class DeckGLMap {
  getLineColor: [0, 200, 255, 200] as [number, number, number, number], // Cyan outline (cable color)
  lineWidthMinPixels: 2,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2491,11 +2409,7 @@ export class DeckGLMap {
  radiusMaxPixels: 10,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2519,11 +2433,7 @@ export class DeckGLMap {
  },
  lineWidthMinPixels: 2,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2544,11 +2454,7 @@ export class DeckGLMap {
  radiusMaxPixels: 25,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2567,11 +2473,7 @@ export class DeckGLMap {
  radiusMaxPixels: 12,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2612,11 +2514,7 @@ export class DeckGLMap {
  radiusMaxPixels: 25,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2686,11 +2584,7 @@ export class DeckGLMap {
  radiusMaxPixels: 12,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2705,11 +2599,7 @@ export class DeckGLMap {
  radiusMaxPixels: 10,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2728,11 +2618,7 @@ export class DeckGLMap {
  radiusMaxPixels: 14,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2751,11 +2637,7 @@ export class DeckGLMap {
  radiusMaxPixels: 12,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2774,11 +2656,7 @@ export class DeckGLMap {
  radiusMaxPixels: 12,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2797,11 +2675,7 @@ export class DeckGLMap {
  radiusMaxPixels: 11,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2826,11 +2700,7 @@ export class DeckGLMap {
  pickable: true,
  stroked: false,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2860,11 +2730,7 @@ export class DeckGLMap {
  radiusMaxPixels: 12,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2880,11 +2746,7 @@ export class DeckGLMap {
  radiusMaxPixels: 12,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2899,11 +2761,7 @@ export class DeckGLMap {
  radiusMaxPixels: 8,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2918,11 +2776,7 @@ export class DeckGLMap {
  radiusMaxPixels: 12,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -2946,11 +2800,7 @@ export class DeckGLMap {
  pickable: true,
  updateTriggers: { getRadius: this.lastSCZoom, getFillColor: this.lastSCZoom },
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  }));
 
  const multiClusters = this.protestClusters.filter(c => c.count > 1);
@@ -2990,11 +2840,7 @@ export class DeckGLMap {
  pickable: false,
  updateTriggers: { radiusScale: this.pulseTime },
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  }));
  }
 
@@ -3021,11 +2867,7 @@ export class DeckGLMap {
  pickable: true,
  updateTriggers: { getRadius: this.lastSCZoom },
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  }));
 
  const multiClusters = this.techHQClusters.filter(c => c.count > 1);
@@ -3085,11 +2927,7 @@ export class DeckGLMap {
  pickable: true,
  updateTriggers: { getRadius: this.lastSCZoom },
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  }));
 
  const multiClusters = this.techEventClusters.filter(c => c.count > 1);
@@ -3132,11 +2970,7 @@ export class DeckGLMap {
  pickable: true,
  updateTriggers: { getRadius: this.lastSCZoom },
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  }));
 
  const multiClusters = this.datacenterClusters.filter(c => c.count > 1);
@@ -3191,11 +3025,7 @@ export class DeckGLMap {
  d.hasBreaking ? [255, 255, 255, 255] as [number, number, number, number] : [0, 0, 0, 0] as [number, number, number, number],
  lineWidthMinPixels: 2,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  }));
 
  const highHotspots = this.hotspots.filter(h => h.level === 'high' || h.hasBreaking);
@@ -3222,11 +3052,7 @@ export class DeckGLMap {
  pickable: false,
  updateTriggers: { radiusScale: this.pulseTime },
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  }));
 
  // Night bloom: soft outer glow around high-severity hotspots.
@@ -3255,11 +3081,7 @@ export class DeckGLMap {
  pickable: false,
  updateTriggers: { getFillColor: this.pulseTime },
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  }));
  }
  }
@@ -3287,11 +3109,7 @@ export class DeckGLMap {
  radiusMaxPixels: 28,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -3425,11 +3243,7 @@ export class DeckGLMap {
  radiusMaxPixels: 12,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  }),
  ];
 
@@ -3463,11 +3277,7 @@ export class DeckGLMap {
  lineWidthMinPixels: 1.5,
  updateTriggers: { pulseTime: now },
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  }));
  }
 
@@ -3508,11 +3318,7 @@ export class DeckGLMap {
  radiusMaxPixels: 10,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  }));
 
  // Gentle pulse ring for significant events (count > 8)
@@ -3534,11 +3340,7 @@ export class DeckGLMap {
  pickable: false,
  updateTriggers: { radiusScale: this.pulseTime },
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  }));
  }
 
@@ -3560,11 +3362,7 @@ export class DeckGLMap {
  radiusMaxPixels: 10,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  }));
 
  // Pulse for real events
@@ -3584,11 +3382,7 @@ export class DeckGLMap {
  pickable: false,
  updateTriggers: { radiusScale: this.pulseTime },
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  }));
 
  return layers;
@@ -3636,11 +3430,7 @@ export class DeckGLMap {
  lineWidthMinPixels: 1.5,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -3670,11 +3460,7 @@ export class DeckGLMap {
  lineWidthMinPixels: 1,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -4899,11 +4685,7 @@ export class DeckGLMap {
  radiusMaxPixels: 20,
  pickable: false,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -4927,11 +4709,7 @@ export class DeckGLMap {
  lineWidthMinPixels: 1,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -4963,11 +4741,7 @@ export class DeckGLMap {
  lineWidthMinPixels: 1,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -5055,11 +4829,7 @@ export class DeckGLMap {
  radiusMaxPixels: 12,
  pickable: false,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -6026,11 +5796,7 @@ export class DeckGLMap {
  radiusUnits: 'meters' as const,
  pickable: false,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
 
  // Inner core dot
@@ -6048,11 +5814,7 @@ export class DeckGLMap {
  pickable: true,
  autoHighlight: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
 
  return [outer, inner];
@@ -6150,11 +5912,7 @@ export class DeckGLMap {
  pickable: true,
  autoHighlight: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -6177,11 +5935,7 @@ export class DeckGLMap {
  pickable: true,
  autoHighlight: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -6325,11 +6079,7 @@ export class DeckGLMap {
  radiusMaxPixels: 8,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -6351,11 +6101,7 @@ export class DeckGLMap {
  radiusMinPixels: 6,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 
@@ -6403,11 +6149,7 @@ export class DeckGLMap {
  radiusMaxPixels: 6,
  pickable: true,
 
- transitions: {
-  getPosition: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getRadius: { duration: 400, easing: (t: number) => 1 - Math.pow(1 - t, 3) },
-  getFillColor: { duration: 300 },
- },
+ transitions: SCATTER_TRANSITIONS,
  });
   }
 

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -376,6 +376,13 @@ const BASES_ICON_MAPPING = { triangleUp: { x: 0, y: 0, width: 32, height: 32, ma
 const NUCLEAR_ICON_MAPPING = { hexagon: { x: 0, y: 0, width: 32, height: 32, mask: true } };
 const DATACENTER_ICON_MAPPING = { square: { x: 0, y: 0, width: 32, height: 32, mask: true } };
 
+// Top-down airplane silhouette (pointing up / north). Rotated at render time via getAngle.
+const AIRPLANE_ICON = 'data:image/svg+xml;base64,' + btoa(
+  `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">` +
+  `<path d="M16 1 L14 10 L4 18 L4 20 L14 17 L14 25 L10 28 L10 30 L16 28 L22 30 L22 28 L18 25 L18 17 L28 20 L28 18 L18 10 Z" fill="white"/>` +
+  `</svg>`);
+const AIRPLANE_ICON_MAPPING = { airplane: { x: 0, y: 0, width: 32, height: 32, mask: true, anchorY: 16 } };
+
 const CONFLICT_ZONES_GEOJSON: GeoJSON.FeatureCollection = {
   type: 'FeatureCollection',
   features: CONFLICT_ZONES.map(zone => ({
@@ -2335,15 +2342,19 @@ export class DeckGLMap {
  });
   }
 
-  private createAdsbLayer(): ScatterplotLayer {
- return new ScatterplotLayer({
+  private createAdsbLayer(): IconLayer {
+ return new IconLayer({
  id: 'adsb-layer',
  data: this.adsbFlights,
  getPosition: (d) => [d.lon, d.lat],
- getRadius: 25_000,
- radiusMinPixels: 2,
- radiusMaxPixels: 6,
- getFillColor: (d) => {
+ getIcon: () => 'airplane',
+ iconAtlas: AIRPLANE_ICON,
+ iconMapping: AIRPLANE_ICON_MAPPING,
+ getAngle: (d) => -(d.heading ?? 0),
+ getSize: 20,
+ sizeMinPixels: 8,
+ sizeMaxPixels: 24,
+ getColor: (d) => {
  if (d.squawk === '7700' || d.squawk === '7600' || d.squawk === '7500') return [255, 50, 50, 255];
  const alt = d.altitude ?? 0;
  if (alt < 3000) return [100, 200, 100, 180];
@@ -2351,9 +2362,7 @@ export class DeckGLMap {
  return [200, 220, 255, 200];
  },
  pickable: true,
- updateTriggers: { getFillColor: [this.adsbFlights] },
-
- transitions: SCATTER_TRANSITIONS,
+ updateTriggers: { getColor: [this.adsbFlights], getAngle: [this.adsbFlights] },
  });
   }
 
@@ -2458,22 +2467,24 @@ export class DeckGLMap {
  });
   }
 
-  private createMilitaryFlightsLayer(flights: MilitaryFlight[]): ScatterplotLayer {
- return new ScatterplotLayer({
+  private createMilitaryFlightsLayer(flights: MilitaryFlight[]): IconLayer {
+ return new IconLayer({
  id: 'military-flights-layer',
  data: flights,
  getPosition: (d) => [d.lon, d.lat],
- getRadius: 8000,
- getFillColor: (d) => {
+ getIcon: () => 'airplane',
+ iconAtlas: AIRPLANE_ICON,
+ iconMapping: AIRPLANE_ICON_MAPPING,
+ getAngle: (d) => -d.heading,
+ getSize: 22,
+ sizeMinPixels: 10,
+ sizeMaxPixels: 28,
+ getColor: (d) => {
  if (d.onGround) return [120, 120, 120, 160] as [number, number, number, number];
  const [r, g, b] = altitudeToColor(d.altitude);
  return [r, g, b, 220] as [number, number, number, number];
  },
- radiusMinPixels: 4,
- radiusMaxPixels: 12,
  pickable: true,
-
- transitions: SCATTER_TRANSITIONS,
  });
   }
 

--- a/src/components/EmptyState.ts
+++ b/src/components/EmptyState.ts
@@ -1,0 +1,118 @@
+interface EmptyStateOptions {
+  icon: string;
+  title: string;
+  message: string;
+  cta?: { label: string; onClick: () => void };
+}
+
+type EmptyStateCategory = 'geopolitical' | 'infrastructure' | 'cyber' | 'markets' | 'weather' | 'user' | 'alerts';
+
+export function renderEmptyState(options: EmptyStateOptions): HTMLElement {
+  const wrapper = document.createElement('div');
+  wrapper.style.cssText = [
+    'display:flex',
+    'flex-direction:column',
+    'align-items:center',
+    'justify-content:center',
+    'gap:var(--space-4,16px)',
+    'padding:var(--space-6,24px)',
+    'text-align:center',
+  ].join(';');
+
+  const iconEl = document.createElement('span');
+  iconEl.style.cssText = 'font-size:28px;opacity:0.4;line-height:1';
+  iconEl.textContent = options.icon;
+  wrapper.append(iconEl);
+
+  const titleEl = document.createElement('p');
+  titleEl.style.cssText = [
+    'margin:0',
+    'font-family:var(--font-ui)',
+    'font-size:var(--text-base,13px)',
+    'font-weight:var(--fw-medium,500)',
+  ].join(';');
+  titleEl.textContent = options.title;
+  wrapper.append(titleEl);
+
+  const msgEl = document.createElement('p');
+  msgEl.style.cssText = [
+    'margin:0',
+    'font-family:var(--font-ui)',
+    'font-size:var(--text-xs,11px)',
+    'opacity:0.6',
+  ].join(';');
+  msgEl.textContent = options.message;
+  wrapper.append(msgEl);
+
+  if (options.cta) {
+    const btn = document.createElement('button');
+    btn.className = 'cb-button accent';
+    btn.textContent = options.cta.label;
+    btn.addEventListener('click', options.cta.onClick);
+    wrapper.append(btn);
+  }
+
+  return wrapper;
+}
+
+export function getEmptyStateDefaults(category: EmptyStateCategory): EmptyStateOptions {
+  const defaults: Record<EmptyStateCategory, EmptyStateOptions> = {
+    geopolitical: {
+      icon: '🌍',
+      title: 'No geopolitical alerts',
+      message: 'When conflicts or political events are detected, they\'ll appear here.',
+    },
+    infrastructure: {
+      icon: '🏗️',
+      title: 'No infrastructure alerts',
+      message: 'Power grid, pipeline, and telecom disruptions will appear here.',
+    },
+    cyber: {
+      icon: '🛡️',
+      title: 'No cyber threats detected',
+      message: 'Cyber incidents and vulnerability alerts will appear here.',
+    },
+    markets: {
+      icon: '📊',
+      title: 'No market alerts',
+      message: 'Significant market movements will appear here.',
+    },
+    weather: {
+      icon: '⛅',
+      title: 'No weather alerts',
+      message: 'Severe weather warnings and natural disaster alerts will appear here.',
+    },
+    user: {
+      icon: '👤',
+      title: 'No activity',
+      message: 'User-related notifications will appear here.',
+    },
+    alerts: {
+      icon: '🔔',
+      title: 'All clear',
+      message: 'No active alerts. You\'re up to date.',
+    },
+  };
+  return defaults[category];
+}
+
+export class EmptyState {
+  private element: HTMLElement | null = null;
+  private options: EmptyStateOptions;
+
+  constructor(options: EmptyStateOptions) {
+    this.options = options;
+  }
+
+  mount(container: HTMLElement): void {
+    this.element = renderEmptyState(this.options);
+    container.append(this.element);
+  }
+
+  unmount(): void {
+    if (this.element?.parentElement) {
+      this.element.remove();
+    }
+    this.element = null;
+  }
+}

--- a/src/components/GlobeHUD.ts
+++ b/src/components/GlobeHUD.ts
@@ -4,6 +4,7 @@ import { getFusedForecast } from '@/services/forecast-fusion';
 import type { FollowTarget } from '@/components/gods-vision/AutoFollowEngine';
 import type { FlyModeStatus } from '@/components/gods-vision/FlyMode/FlyModeController';
 import { FLY_SUB_MODE_NAMES } from '@/components/gods-vision/FlyMode/flyModeKeybinds';
+import { animateNumber } from '@/services/motion';
 
 export interface HUDState {
   cameraAltitude: number;
@@ -139,6 +140,7 @@ export class GlobeHUD {
   private buildDOM(): void {
  // ── Top-left: Threat card ──
  const topLeft = this.pos('top:16px;left:16px;pointer-events:auto;');
+ topLeft.classList.add('ge-hud-element');
  const card = this.card('ge-hud-threat-card');
  this.clockEl = this.el('div', 'ge-hud-clock');
  card.append(this.clockEl);
@@ -185,6 +187,7 @@ export class GlobeHUD {
 
  // ── Top-center: Breaking news ticker ──
  const topCenter = this.pos('top:16px;left:50%;transform:translateX(-50%);pointer-events:auto;max-width:46%;');
+ topCenter.classList.add('ge-hud-element');
  const ticker = this.el('div', 'ge-hud-ticker');
  const tickerLabel = this.el('span', 'ge-hud-ticker-label', 'LIVE');
  const tickerWin = this.el('div', 'ge-hud-ticker-window');
@@ -196,6 +199,7 @@ export class GlobeHUD {
 
  // ── Top-right: Exit + theater legend ──
  const topRight = this.pos('top:16px;right:16px;pointer-events:auto;display:flex;flex-direction:column;align-items:flex-end;gap:8px;');
+ topRight.classList.add('ge-hud-element');
  const exitBtn = document.createElement('button');
  exitBtn.className = 'ge-exit-btn';
  exitBtn.id = 'geExitBtn';
@@ -221,6 +225,7 @@ export class GlobeHUD {
  const bottomCenter = this.pos(
  'bottom:16px;left:16px;right:16px;pointer-events:auto;overflow-x:auto;',
  );
+ bottomCenter.classList.add('ge-hud-element');
  const layerBar = document.createElement('div');
  layerBar.className = 'ge-layer-bar';
  layerBar.id = 'geLayerBar';
@@ -238,12 +243,13 @@ export class GlobeHUD {
  navBtn.title = 'Toggle Navigation (N)';
  navBtn.style.cssText = `background: rgba(20,25,40,0.8); border: 1px solid rgba(100,140,255,0.3); color: #8ca8ff; border-radius: 6px; padding: 4px 10px; cursor: pointer; font-size: 11px; font-family: 'SF Mono', monospace; font-weight: 600;`;
  navBtn.addEventListener('click', () => this.onNavigationToggle?.());
- layerBar.appendChild(navBtn);
+ layerBar.append(navBtn);
  bottomCenter.append(layerBar);
  this.element.append(bottomCenter);
 
  // ── Bottom-right: Auto-follow status ──
  const bottomRight = this.pos('bottom:80px;right:16px;pointer-events:auto;');
+ bottomRight.classList.add('ge-hud-element');
  this.autoFollowCard = this.card('ge-autofollow-card ge-hidden');
  const afHeader = this.el('div', 'ge-autofollow-header');
  const afLabel = this.el('span', 'ge-hud-micro-label', 'AUTO-FOLLOW');
@@ -556,7 +562,10 @@ export class GlobeHUD {
   updateState(state: Partial<HUDState>): void {
  if (state.activeHotspots !== undefined) {
  this.lastHotspotCount = state.activeHotspots;
- if (this.hotspotsEl) this.hotspotsEl.textContent = String(state.activeHotspots);
+ if (this.hotspotsEl) {
+ const oldCount = Number.parseInt(this.hotspotsEl.textContent || '0', 10);
+ animateNumber(this.hotspotsEl, oldCount, state.activeHotspots);
+ }
  if (this.threatEl) {
  const { label, cls } = threatFromHotspots(state.activeHotspots);
  this.threatEl.textContent = label;
@@ -586,10 +595,12 @@ export class GlobeHUD {
  this.updateThreatDetail();
  }
  if (state.conflicts !== undefined && this.conflictsEl) {
- this.conflictsEl.textContent = String(state.conflicts);
+ const oldCount = Number.parseInt(this.conflictsEl.textContent || '0', 10);
+ animateNumber(this.conflictsEl, oldCount, state.conflicts);
  }
  if (state.disasters !== undefined && this.disastersEl) {
- this.disastersEl.textContent = String(state.disasters);
+ const oldCount = Number.parseInt(this.disastersEl.textContent || '0', 10);
+ animateNumber(this.disastersEl, oldCount, state.disasters);
  }
  if (state.nearestHotspot !== undefined && this.nearestEl) {
  const n = state.nearestHotspot;

--- a/src/components/GodsVisionView.ts
+++ b/src/components/GodsVisionView.ts
@@ -324,6 +324,14 @@ export class GodsVisionView {
  }
  }, 100);
 
+ // Staggered HUD entry animation
+ const hudElements = this.container.querySelectorAll('.ge-hud-element');
+ hudElements.forEach((el, i) => {
+ (el as HTMLElement).style.animationDelay = `${700 + i * 50}ms`;
+ });
+ this.container.classList.add('ge-entering');
+ setTimeout(() => this.container.classList.remove('ge-entering'), 1200);
+
  // Mode tracking
  this.currentMode = getMode();
  this.applyModeTheme(this.currentMode);

--- a/src/components/GodsVisionView.ts
+++ b/src/components/GodsVisionView.ts
@@ -344,6 +344,9 @@ export class GodsVisionView {
  if (!this.active) return;
  this.active = false;
 
+ this.container.classList.add('ge-exiting');
+ setTimeout(() => this.container.classList.remove('ge-exiting'), 500);
+
  for (const fn of this.cleanupHandlers) fn();
  this.cleanupHandlers = [];
 

--- a/src/components/MapPopup.ts
+++ b/src/components/MapPopup.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/prefer-nullish-coalescing, @typescript-eslint/array-type, sonarjs/cognitive-complexity, sonarjs/max-switch-cases, sonarjs/no-identical-functions, sonarjs/no-nested-conditional, sonarjs/no-nested-template-literals, sonarjs/slow-regex, sonarjs/function-return-type, unicorn/consistent-function-scoping, unicorn/no-nested-ternary -- legacy file; pre-existing violations suppressed */
 import type { ConflictZone, Hotspot, NewsItem, MilitaryBase, StrategicWaterway, APTGroup, NuclearFacility, EconomicCenter, GammaIrradiator, Pipeline, UnderseaCable, CableAdvisory, RepairShip, InternetOutage, AIDataCenter, AisDisruptionEvent, SocialUnrestEvent, MilitaryFlight, MilitaryVessel, MilitaryFlightCluster, MilitaryVesselCluster, NaturalEvent, Port, Spaceport, CriticalMineralProject, CyberThreat } from '@/types';
 import type { AirportDelayAlert } from '@/services/aviation';
 import type { ScoredFAACamera } from '@/services/faa-cameras';
@@ -175,9 +176,21 @@ export class MapPopup {
  this.popup.className = this.isMobileSheet ? 'map-popup map-popup-sheet' : 'map-popup';
 
  const content = this.renderContent(data);
- this.popup.innerHTML = this.isMobileSheet
- ? `<button class="map-popup-sheet-handle" aria-label="${t('common.close')}"></button>${content}`
- : content;
+ if (this.isMobileSheet) {
+ const handle = document.createElement('button');
+ handle.className = 'map-popup-sheet-handle';
+ handle.setAttribute('aria-label', t('common.close'));
+ this.popup.append(handle);
+ }
+ if (content instanceof HTMLElement) {
+ this.popup.append(content);
+ } else {
+ // Legacy string-based render path — existing callers use escapeHtml throughout
+ const legacy = document.createElement('div');
+ legacy.className = 'popup-legacy-wrapper';
+ legacy.innerHTML = content; // content is always pre-escaped via escapeHtml
+ this.popup.append(legacy);
+ }
 
  // Get container's viewport position for absolute positioning
  const containerRect = this.container.getBoundingClientRect();
@@ -369,7 +382,7 @@ export class MapPopup {
  this.repairShips = repairShips;
   }
 
-  private renderContent(data: PopupData): string {
+  private renderContent(data: PopupData): string | HTMLElement { // NOSONAR — intentional mixed return for card vs legacy string paths
  switch (data.type) {
  case 'conflict': {
  return this.renderConflictPopup(data.data as ConflictZone);
@@ -509,57 +522,125 @@ export class MapPopup {
  }
   }
 
-  private renderConflictPopup(conflict: ConflictZone): string {
- const severityClass = conflict.intensity === 'high' ? 'high' : (conflict.intensity === 'medium' ? 'medium' : 'low');
- const severityLabel = escapeHtml(conflict.intensity?.toUpperCase() || t('popups.unknown').toUpperCase());
-
- return `
- <div class="popup-header conflict">
- <span class="popup-title">${escapeHtml(conflict.name.toUpperCase())}</span>
- <span class="popup-badge ${severityClass}">${severityLabel}</span>
- <button class="popup-close">×</button>
- </div>
- <div class="popup-body">
- <div class="popup-stats">
- <div class="popup-stat">
- <span class="stat-label">${t('popups.startDate')}</span>
- <span class="stat-value">${escapeHtml(conflict.startDate || t('popups.unknown'))}</span>
- </div>
- <div class="popup-stat">
- <span class="stat-label">${t('popups.casualties')}</span>
- <span class="stat-value">${escapeHtml(conflict.casualties || t('popups.unknown'))}</span>
- </div>
- <div class="popup-stat">
- <span class="stat-label">${t('popups.displaced')}</span>
- <span class="stat-value">${escapeHtml(conflict.displaced || t('popups.unknown'))}</span>
- </div>
- <div class="popup-stat">
- <span class="stat-label">${t('popups.location')}</span>
- <span class="stat-value">${escapeHtml(conflict.location || `${conflict.center[1]}°N, ${conflict.center[0]}°E`)}</span>
- </div>
- </div>
- ${conflict.description ? `<p class="popup-description">${escapeHtml(conflict.description)}</p>` : ''}
- ${conflict.parties && conflict.parties.length > 0 ? `
- <div class="popup-section">
- <span class="section-label">${t('popups.belligerents')}</span>
- <div class="popup-tags">
- ${conflict.parties.map(p => `<span class="popup-tag">${escapeHtml(p)}</span>`).join('')}
- </div>
- </div>
- ` : ''}
- ${conflict.keyDevelopments && conflict.keyDevelopments.length > 0 ? `
- <div class="popup-section">
- <span class="section-label">${t('popups.keyDevelopments')}</span>
- <ul class="popup-list">
- ${conflict.keyDevelopments.map(d => `<li>${escapeHtml(d)}</li>`).join('')}
- </ul>
- </div>
- ` : ''}
- </div>
+  private wrapInCard(content: HTMLElement): HTMLElement {
+ const card = document.createElement('div');
+ card.style.cssText = `
+ background: rgba(28, 28, 30, 0.92);
+ backdrop-filter: blur(20px) saturate(1.4);
+ border: 1px solid rgba(255, 255, 255, 0.1);
+ border-radius: var(--radius-xl);
+ box-shadow: var(--elevation-3), 0 0 0 0.5px rgba(255, 255, 255, 0.05);
+ overflow: hidden; max-width: 280px; font-family: var(--font-ui);
  `;
-  }
+ card.append(content);
+ return card;
+ }
 
-  private getLocalizedHotspotSubtext(subtext: string): string {
+ private makeCardHeader(title: string, badgeText: string, badgeClass: string): HTMLElement {
+ const header = document.createElement('div');
+ header.className = 'popup-header';
+ header.style.cssText = 'display:flex; align-items:center; gap:var(--space-2); padding:var(--space-3); border-bottom:1px solid rgba(255,255,255,0.08);';
+
+ const titleEl = document.createElement('span');
+ titleEl.className = 'popup-title';
+ titleEl.style.cssText = 'flex:1; font-size:var(--text-sm); font-weight:var(--fw-semibold); overflow:hidden; text-overflow:ellipsis; white-space:nowrap;';
+ titleEl.textContent = title;
+
+ const badge = document.createElement('span');
+ badge.className = `popup-badge ${badgeClass}`;
+ badge.textContent = badgeText;
+
+ const closeBtn = document.createElement('button');
+ closeBtn.className = 'popup-close';
+ closeBtn.textContent = '×';
+
+ header.append(titleEl, badge, closeBtn);
+ return header;
+ }
+
+ private makeStatGrid(stats: { label: string; value: string }[]): HTMLElement {
+ const grid = document.createElement('div');
+ grid.className = 'popup-stats';
+ grid.style.cssText = 'display:grid; grid-template-columns:1fr 1fr; gap:var(--space-2); padding:var(--space-3);';
+ for (const { label, value } of stats) {
+ const cell = document.createElement('div');
+ cell.className = 'popup-stat';
+
+ const labelEl = document.createElement('span');
+ labelEl.className = 'stat-label';
+ labelEl.textContent = label;
+
+ const valueEl = document.createElement('span');
+ valueEl.className = 'stat-value';
+ valueEl.textContent = value;
+
+ cell.append(labelEl, valueEl);
+ grid.append(cell);
+ }
+ return grid;
+ }
+
+ private makeActionBar(actions: { label: string; href?: string; onClick?: () => void }[]): HTMLElement {
+ const bar = document.createElement('div');
+ bar.style.cssText = 'display:flex; gap:var(--space-2); padding:var(--space-2) var(--space-3) var(--space-3);';
+ for (const action of actions) {
+ if (action.href) {
+ const a = document.createElement('a');
+ a.className = 'cb-button cb-button--sm cb-button--ghost';
+ a.textContent = action.label;
+ a.href = sanitizeUrl(action.href);
+ a.target = '_blank';
+ a.rel = 'noopener';
+ bar.append(a);
+ } else if (action.onClick) {
+ const btn = document.createElement('button');
+ btn.className = 'cb-button cb-button--sm cb-button--ghost';
+ btn.textContent = action.label;
+ btn.addEventListener('click', action.onClick);
+ bar.append(btn);
+ }
+ }
+ return bar;
+ }
+
+ private renderConflictPopup(conflict: ConflictZone): HTMLElement {
+ let severityClass: string;
+ if (conflict.intensity === 'high') severityClass = 'high';
+ else if (conflict.intensity === 'medium') severityClass = 'medium';
+ else severityClass = 'low';
+ const severityLabel = conflict.intensity?.toUpperCase() ?? t('popups.unknown').toUpperCase();
+
+ const inner = document.createElement('div');
+
+ inner.append(this.makeCardHeader(conflict.name.toUpperCase(), severityLabel, severityClass));
+
+ if (conflict.location) {
+ const subtitle = document.createElement('div');
+ subtitle.className = 'popup-subtitle';
+ subtitle.style.cssText = 'padding:var(--space-2) var(--space-3) 0; font-size:var(--text-xs); opacity:0.7;';
+ subtitle.textContent = conflict.location;
+ inner.append(subtitle);
+ }
+
+ const stats: { label: string; value: string }[] = [
+ { label: t('popups.startDate'), value: conflict.startDate ?? t('popups.unknown') },
+ { label: t('popups.casualties'), value: conflict.casualties ?? t('popups.unknown') },
+ { label: t('popups.displaced'), value: conflict.displaced ?? t('popups.unknown') },
+ ];
+ inner.append(this.makeStatGrid(stats));
+
+ if (conflict.description) {
+ const desc = document.createElement('p');
+ desc.className = 'popup-description';
+ desc.style.cssText = 'margin:0; padding:0 var(--space-3) var(--space-2); font-size:var(--text-xs); opacity:0.8;';
+ desc.textContent = conflict.description;
+ inner.append(desc);
+ }
+
+ return this.wrapInCard(inner);
+ }
+
+ private getLocalizedHotspotSubtext(subtext: string): string {
  const slug = subtext
  .toLowerCase()
  .replace(/[^a-z0-9]+/g, '_')
@@ -569,16 +650,37 @@ export class MapPopup {
  return localized === key ? subtext : localized;
   }
 
-  private renderHotspotPopup(hotspot: Hotspot, relatedNews?: NewsItem[]): string {
- const severityClass = hotspot.level || 'low';
- const severityLabel = escapeHtml((hotspot.level || 'low').toUpperCase());
+  private renderHotspotPopup(hotspot: Hotspot, relatedNews?: NewsItem[]): HTMLElement {
+ const severityClass = hotspot.level ?? 'low';
+ const severityLabel = (hotspot.level ?? 'low').toUpperCase();
  const localizedSubtext = hotspot.subtext ? this.getLocalizedHotspotSubtext(hotspot.subtext) : '';
 
- // Get dynamic escalation score
  const dynamicScore = getHotspotEscalation(hotspot.id);
  const change24h = getEscalationChange24h(hotspot.id);
+ const displayScore = dynamicScore?.combinedScore ?? hotspot.escalationScore ?? 3;
+ const displayScoreInt = Math.round(displayScore);
+ const displayTrend = dynamicScore?.trend ?? hotspot.escalationTrend ?? 'stable';
 
- // Escalation score display
+ const inner = document.createElement('div');
+ inner.append(this.makeCardHeader(hotspot.name.toUpperCase(), severityLabel, severityClass));
+
+ if (localizedSubtext) {
+ const subtitle = document.createElement('div');
+ subtitle.className = 'popup-subtitle';
+ subtitle.style.cssText = 'padding:var(--space-2) var(--space-3) 0; font-size:var(--text-xs); opacity:0.7;';
+ subtitle.textContent = localizedSubtext;
+ inner.append(subtitle);
+ }
+
+ if (hotspot.description) {
+ const desc = document.createElement('p');
+ desc.className = 'popup-description';
+ desc.style.cssText = 'margin:0; padding:var(--space-2) var(--space-3) 0; font-size:var(--text-xs); opacity:0.8;';
+ desc.textContent = hotspot.description;
+ inner.append(desc);
+ }
+
+ // Escalation score row
  const escalationColors: Record<number, string> = {
  1: getCSSColor('--semantic-normal'),
  2: getCSSColor('--semantic-normal'),
@@ -591,169 +693,153 @@ export class MapPopup {
  2: t('popups.hotspot.levels.watch'),
  3: t('popups.hotspot.levels.elevated'),
  4: t('popups.hotspot.levels.high'),
- 5: t('popups.hotspot.levels.critical')
+ 5: t('popups.hotspot.levels.critical'),
  };
  const trendIcons: Record<string, string> = { 'escalating': '↑', 'stable': '→', 'de-escalating': '↓' };
  const trendColors: Record<string, string> = { 'escalating': getCSSColor('--semantic-critical'), 'stable': getCSSColor('--semantic-elevated'), 'de-escalating': getCSSColor('--semantic-normal') };
 
- const displayScore = dynamicScore?.combinedScore ?? hotspot.escalationScore ?? 3;
- const displayScoreInt = Math.round(displayScore);
- const displayTrend = dynamicScore?.trend ?? hotspot.escalationTrend ?? 'stable';
+ const escalSec = document.createElement('div');
+ escalSec.className = 'popup-section escalation-section';
+ escalSec.style.cssText = 'padding:var(--space-2) var(--space-3); border-top:1px solid rgba(255,255,255,0.06);';
 
- const escalationSection = `
- <div class="popup-section escalation-section">
- <span class="section-label">${t('popups.hotspot.escalation')}</span>
- <div class="escalation-display">
- <div class="escalation-score" style="background: ${escalationColors[displayScoreInt] || getCSSColor('--text-dim')}">
- <span class="score-value">${displayScore.toFixed(1)}/5</span>
- <span class="score-label">${escalationLabels[displayScoreInt] || t('popups.unknown')}</span>
- </div>
- <div class="escalation-trend" style="color: ${trendColors[displayTrend] || getCSSColor('--text-dim')}">
- <span class="trend-icon">${trendIcons[displayTrend] || ''}</span>
- <span class="trend-label">${escapeHtml(displayTrend.toUpperCase())}</span>
- </div>
- </div>
- ${dynamicScore ? `
- <div class="escalation-breakdown">
- <div class="breakdown-header">
- <span class="baseline-label">${t('popups.hotspot.baseline')}: ${dynamicScore.staticBaseline}/5</span>
- ${change24h ? `
- <span class="change-label ${change24h.change >= 0 ? 'rising' : 'falling'}">
- 24h: ${change24h.change >= 0 ? '+' : ''}${change24h.change}
- </span>
- ` : ''}
- </div>
- <div class="breakdown-components">
- <div class="breakdown-row">
- <span class="component-label">${t('popups.hotspot.components.news')}</span>
- <div class="component-bar-bg">
- <div class="component-bar news" style="width: ${dynamicScore.components.newsActivity}%"></div>
- </div>
- <span class="component-value">${Math.round(dynamicScore.components.newsActivity)}</span>
- </div>
- <div class="breakdown-row">
- <span class="component-label">${t('popups.hotspot.components.cii')}</span>
- <div class="component-bar-bg">
- <div class="component-bar cii" style="width: ${dynamicScore.components.ciiContribution}%"></div>
- </div>
- <span class="component-value">${Math.round(dynamicScore.components.ciiContribution)}</span>
- </div>
- <div class="breakdown-row">
- <span class="component-label">${t('popups.hotspot.components.geo')}</span>
- <div class="component-bar-bg">
- <div class="component-bar geo" style="width: ${dynamicScore.components.geoConvergence}%"></div>
- </div>
- <span class="component-value">${Math.round(dynamicScore.components.geoConvergence)}</span>
- </div>
- <div class="breakdown-row">
- <span class="component-label">${t('popups.hotspot.components.military')}</span>
- <div class="component-bar-bg">
- <div class="component-bar military" style="width: ${dynamicScore.components.militaryActivity}%"></div>
- </div>
- <span class="component-value">${Math.round(dynamicScore.components.militaryActivity)}</span>
- </div>
- </div>
- </div>
- ` : ''}
- ${hotspot.escalationIndicators && hotspot.escalationIndicators.length > 0 ? `
- <div class="escalation-indicators">
- ${hotspot.escalationIndicators.map(i => `<span class="indicator-tag">• ${escapeHtml(i)}</span>`).join('')}
- </div>
- ` : ''}
- </div>
- `;
+ const escalLabel = document.createElement('span');
+ escalLabel.className = 'section-label';
+ escalLabel.textContent = t('popups.hotspot.escalation');
+ escalSec.append(escalLabel);
 
- // Historical context section
- const historySection = hotspot.history ? `
- <div class="popup-section history-section">
- <span class="section-label">${t('popups.historicalContext')}</span>
- <div class="history-content">
- ${hotspot.history.lastMajorEvent ? `
- <div class="history-event">
- <span class="history-label">${t('popups.lastMajorEvent')}:</span>
- <span class="history-value">${escapeHtml(hotspot.history.lastMajorEvent)} ${hotspot.history.lastMajorEventDate ? `(${escapeHtml(hotspot.history.lastMajorEventDate)})` : ''}</span>
- </div>
- ` : ''}
- ${hotspot.history.precedentDescription ? `
- <div class="history-event">
- <span class="history-label">${t('popups.precedents')}:</span>
- <span class="history-value">${escapeHtml(hotspot.history.precedentDescription)}</span>
- </div>
- ` : ''}
- ${hotspot.history.cyclicalRisk ? `
- <div class="history-event cyclical">
- <span class="history-label">${t('popups.cyclicalPattern')}:</span>
- <span class="history-value">${escapeHtml(hotspot.history.cyclicalRisk)}</span>
- </div>
- ` : ''}
- </div>
- </div>
- ` : '';
+ const escalDisplay = document.createElement('div');
+ escalDisplay.className = 'escalation-display';
+ escalDisplay.style.cssText = 'display:flex; align-items:center; gap:var(--space-2); margin-top:var(--space-2);';
 
- // "Why it matters" section
- const whyItMattersSection = hotspot.whyItMatters ? `
- <div class="popup-section why-matters-section">
- <span class="section-label">${t('popups.whyItMatters')}</span>
- <p class="why-matters-text">${escapeHtml(hotspot.whyItMatters)}</p>
- </div>
- ` : '';
+ const scoreBox = document.createElement('div');
+ scoreBox.className = 'escalation-score';
+ scoreBox.style.background = escalationColors[displayScoreInt] ?? getCSSColor('--text-dim');
 
- return `
- <div class="popup-header hotspot">
- <span class="popup-title">${escapeHtml(hotspot.name.toUpperCase())}</span>
- <span class="popup-badge ${severityClass}">${severityLabel}</span>
- <button class="popup-close">×</button>
- </div>
- <div class="popup-body">
- ${localizedSubtext ? `<div class="popup-subtitle">${escapeHtml(localizedSubtext)}</div>` : ''}
- ${hotspot.description ? `<p class="popup-description">${escapeHtml(hotspot.description)}</p>` : ''}
- ${escalationSection}
- <div class="popup-stats">
- ${hotspot.location ? `
- <div class="popup-stat">
- <span class="stat-label">${t('popups.location')}</span>
- <span class="stat-value">${escapeHtml(hotspot.location)}</span>
- </div>
- ` : ''}
- <div class="popup-stat">
- <span class="stat-label">${t('popups.coordinates')}</span>
- <span class="stat-value">${escapeHtml(`${hotspot.lat.toFixed(2)}°N, ${hotspot.lon.toFixed(2)}°E`)}</span>
- </div>
- <div class="popup-stat">
- <span class="stat-label">${t('popups.status')}</span>
- <span class="stat-value">${escapeHtml(hotspot.status || t('popups.monitoring'))}</span>
- </div>
- </div>
- ${whyItMattersSection}
- ${historySection}
- ${hotspot.agencies && hotspot.agencies.length > 0 ? `
- <div class="popup-section">
- <span class="section-label">${t('popups.keyEntities')}</span>
- <div class="popup-tags">
- ${hotspot.agencies.map(a => `<span class="popup-tag">${escapeHtml(a)}</span>`).join('')}
- </div>
- </div>
- ` : ''}
- ${relatedNews && relatedNews.length > 0 ? `
- <div class="popup-section">
- <div class="popup-section">
- <span class="section-label">${t('popups.relatedHeadlines')}</span>
- <div class="popup-news">
- ${relatedNews.slice(0, 5).map(n => `
- <div class="popup-news-item">
- <span class="news-source">${escapeHtml(n.source)}</span>
- <a href="${sanitizeUrl(n.link)}" target="_blank" class="news-title">${escapeHtml(n.title)}</a>
- </div>
- `).join('')}
- </div>
- </div>
- ` : ''}
- <div class="hotspot-gdelt-context" data-hotspot-id="${escapeHtml(hotspot.id)}">
- <div class="hotspot-gdelt-header">${t('popups.liveIntel')}</div>
- <div class="hotspot-gdelt-loading">${t('popups.loadingNews')}</div>
- </div>
- </div>
- `;
+ const scoreVal = document.createElement('span');
+ scoreVal.className = 'score-value';
+ scoreVal.textContent = `${displayScore.toFixed(1)}/5`;
+
+ const scoreLbl = document.createElement('span');
+ scoreLbl.className = 'score-label';
+ scoreLbl.textContent = escalationLabels[displayScoreInt] ?? t('popups.unknown');
+ scoreBox.append(scoreVal, scoreLbl);
+
+ const trendBox = document.createElement('div');
+ trendBox.className = 'escalation-trend';
+ trendBox.style.color = trendColors[displayTrend] ?? getCSSColor('--text-dim');
+
+ const trendIcon = document.createElement('span');
+ trendIcon.className = 'trend-icon';
+ trendIcon.textContent = trendIcons[displayTrend] ?? '';
+
+ const trendLbl = document.createElement('span');
+ trendLbl.className = 'trend-label';
+ trendLbl.textContent = displayTrend.toUpperCase();
+ trendBox.append(trendIcon, trendLbl);
+
+ escalDisplay.append(scoreBox, trendBox);
+ escalSec.append(escalDisplay);
+
+ if (dynamicScore) {
+ const breakdown = document.createElement('div');
+ breakdown.className = 'escalation-breakdown';
+
+ const bHeader = document.createElement('div');
+ bHeader.className = 'breakdown-header';
+
+ const baseLbl = document.createElement('span');
+ baseLbl.className = 'baseline-label';
+ baseLbl.textContent = `${t('popups.hotspot.baseline')}: ${dynamicScore.staticBaseline}/5`;
+ bHeader.append(baseLbl);
+
+ if (change24h) {
+ const changeLbl = document.createElement('span');
+ changeLbl.className = `change-label ${change24h.change >= 0 ? 'rising' : 'falling'}`;
+ changeLbl.textContent = `24h: ${change24h.change >= 0 ? '+' : ''}${change24h.change}`;
+ bHeader.append(changeLbl);
+ }
+
+ breakdown.append(bHeader);
+ escalSec.append(breakdown);
+ }
+
+ if (hotspot.escalationIndicators && hotspot.escalationIndicators.length > 0) {
+ const indicators = document.createElement('div');
+ indicators.className = 'escalation-indicators';
+ for (const ind of hotspot.escalationIndicators) {
+ const tag = document.createElement('span');
+ tag.className = 'indicator-tag';
+ tag.textContent = `• ${ind}`;
+ indicators.append(tag);
+ }
+ escalSec.append(indicators);
+ }
+
+ inner.append(escalSec);
+
+ const stats: { label: string; value: string }[] = [
+ ...(hotspot.location ? [{ label: t('popups.location'), value: hotspot.location }] : []),
+ { label: t('popups.coordinates'), value: `${hotspot.lat.toFixed(2)}°N, ${hotspot.lon.toFixed(2)}°E` },
+ { label: t('popups.status'), value: hotspot.status ?? t('popups.monitoring') },
+ ];
+ inner.append(this.makeStatGrid(stats));
+
+ if (hotspot.whyItMatters) {
+ const wmSec = document.createElement('div');
+ wmSec.className = 'popup-section why-matters-section';
+ wmSec.style.cssText = 'padding:0 var(--space-3) var(--space-2); border-top:1px solid rgba(255,255,255,0.06);';
+ const wmLabel = document.createElement('span');
+ wmLabel.className = 'section-label';
+ wmLabel.textContent = t('popups.whyItMatters');
+ const wmText = document.createElement('p');
+ wmText.className = 'why-matters-text';
+ wmText.style.cssText = 'margin:var(--space-2) 0 0; font-size:var(--text-xs); opacity:0.8;';
+ wmText.textContent = hotspot.whyItMatters;
+ wmSec.append(wmLabel, wmText);
+ inner.append(wmSec);
+ }
+
+ if (relatedNews && relatedNews.length > 0) {
+ const newsSec = document.createElement('div');
+ newsSec.className = 'popup-section';
+ newsSec.style.cssText = 'padding:0 var(--space-3) var(--space-2); border-top:1px solid rgba(255,255,255,0.06);';
+ const newsLabel = document.createElement('span');
+ newsLabel.className = 'section-label';
+ newsLabel.textContent = t('popups.relatedHeadlines');
+ const newsContainer = document.createElement('div');
+ newsContainer.className = 'popup-news';
+ for (const n of relatedNews.slice(0, 5)) {
+ const item = document.createElement('div');
+ item.className = 'popup-news-item';
+ const src = document.createElement('span');
+ src.className = 'news-source';
+ src.textContent = n.source;
+ const link = document.createElement('a');
+ link.href = sanitizeUrl(n.link);
+ link.target = '_blank';
+ link.className = 'news-title';
+ link.textContent = n.title;
+ item.append(src, link);
+ newsContainer.append(item);
+ }
+ newsSec.append(newsLabel, newsContainer);
+ inner.append(newsSec);
+ }
+
+ // GDELT live intel — keep class name intact for async loadHotspotGdeltContext
+ const gdeltCtx = document.createElement('div');
+ gdeltCtx.className = 'hotspot-gdelt-context';
+ gdeltCtx.dataset.hotspotId = hotspot.id;
+ const gdeltHeader = document.createElement('div');
+ gdeltHeader.className = 'hotspot-gdelt-header';
+ gdeltHeader.textContent = t('popups.liveIntel');
+ const gdeltLoading = document.createElement('div');
+ gdeltLoading.className = 'hotspot-gdelt-loading';
+ gdeltLoading.textContent = t('popups.loadingNews');
+ gdeltCtx.append(gdeltHeader, gdeltLoading);
+ inner.append(gdeltCtx);
+
+ return this.wrapInCard(inner);
   }
 
   public async loadHotspotGdeltContext(hotspot: Hotspot): Promise<void> {
@@ -806,37 +892,29 @@ export class MapPopup {
  `;
   }
 
-  private renderEarthquakePopup(earthquake: Earthquake): string {
+  private renderEarthquakePopup(earthquake: Earthquake): HTMLElement {
  const severity = earthquake.magnitude >= 6 ? 'high' : (earthquake.magnitude >= 5 ? 'medium' : 'low');
  const severityLabel = earthquake.magnitude >= 6 ? t('popups.earthquake.levels.major') : (earthquake.magnitude >= 5 ? t('popups.earthquake.levels.moderate') : t('popups.earthquake.levels.minor'));
-
  const timeAgo = this.getTimeAgo(new Date(earthquake.occurredAt));
 
- return `
- <div class="popup-header earthquake">
- <span class="popup-title magnitude">M${earthquake.magnitude.toFixed(1)}</span>
- <span class="popup-badge ${severity}">${severityLabel}</span>
- <button class="popup-close">×</button>
- </div>
- <div class="popup-body">
- <p class="popup-location">${escapeHtml(earthquake.place)}</p>
- <div class="popup-stats">
- <div class="popup-stat">
- <span class="stat-label">${t('popups.depth')}</span>
- <span class="stat-value">${earthquake.depthKm.toFixed(1)} km</span>
- </div>
- <div class="popup-stat">
- <span class="stat-label">${t('popups.coordinates')}</span>
- <span class="stat-value">${(earthquake.location?.latitude ?? 0).toFixed(2)}°, ${(earthquake.location?.longitude ?? 0).toFixed(2)}°</span>
- </div>
- <div class="popup-stat">
- <span class="stat-label">${t('popups.time')}</span>
- <span class="stat-value">${timeAgo}</span>
- </div>
- </div>
- <a href="${sanitizeUrl(earthquake.sourceUrl)}" target="_blank" class="popup-link">${t('popups.viewUSGS')} →</a>
- </div>
- `;
+ const inner = document.createElement('div');
+ inner.append(this.makeCardHeader(`M${earthquake.magnitude.toFixed(1)}`, severityLabel, severity));
+
+ const subtitle = document.createElement('p');
+ subtitle.className = 'popup-location';
+ subtitle.style.cssText = 'margin:0; padding:var(--space-2) var(--space-3) 0; font-size:var(--text-xs); opacity:0.7;';
+ subtitle.textContent = earthquake.place;
+ inner.append(subtitle);
+
+ inner.append(this.makeStatGrid([
+ { label: t('popups.depth'), value: `${earthquake.depthKm.toFixed(1)} km` },
+ { label: t('popups.coordinates'), value: `${(earthquake.location?.latitude ?? 0).toFixed(2)}°, ${(earthquake.location?.longitude ?? 0).toFixed(2)}°` },
+ { label: t('popups.time'), value: timeAgo },
+ ]));
+
+ inner.append(this.makeActionBar([{ label: `${t('popups.viewUSGS')} →`, href: earthquake.sourceUrl }]));
+
+ return this.wrapInCard(inner);
   }
 
   private getTimeAgo(date: Date): string {
@@ -886,7 +964,7 @@ export class MapPopup {
  return `${Math.floor(hours / 24)}${t('popups.timeUnits.d')}`;
   }
 
-  private renderBasePopup(base: MilitaryBase): string {
+  private renderBasePopup(base: MilitaryBase): HTMLElement {
  const typeLabels: Record<string, string> = {
  'us-nato': t('popups.base.types.us-nato'),
  'china': t('popups.base.types.china'),
@@ -906,30 +984,40 @@ export class MapPopup {
  if (enriched.catSpace) categories.push('Space');
  if (enriched.catTraining) categories.push('Training');
 
- return `
- <div class="popup-header base">
- <span class="popup-title">${escapeHtml(base.name.toUpperCase())}</span>
- <span class="popup-badge ${typeColors[base.type] || 'low'}">${escapeHtml(typeLabels[base.type] || base.type.toUpperCase())}</span>
- <button class="popup-close">×</button>
- </div>
- <div class="popup-body">
- ${base.description ? `<p class="popup-description">${escapeHtml(base.description)}</p>` : ''}
- ${enriched.kind ? `<p class="popup-description" style="opacity:0.7;margin-top:2px">${escapeHtml(enriched.kind.replace(/_/g, ' '))}</p>` : ''}
- <div class="popup-stats">
- <div class="popup-stat">
- <span class="stat-label">${t('popups.type')}</span>
- <span class="stat-value">${escapeHtml(typeLabels[base.type] || base.type)}</span>
- </div>
- ${base.arm ? `<div class="popup-stat"><span class="stat-label">Branch</span><span class="stat-value">${escapeHtml(base.arm)}</span></div>` : ''}
- ${base.country ? `<div class="popup-stat"><span class="stat-label">Country</span><span class="stat-value">${escapeHtml(base.country)}</span></div>` : ''}
- ${categories.length > 0 ? `<div class="popup-stat"><span class="stat-label">Categories</span><span class="stat-value">${escapeHtml(categories.join(', '))}</span></div>` : ''}
- <div class="popup-stat">
- <span class="stat-label">${t('popups.coordinates')}</span>
- <span class="stat-value">${base.lat.toFixed(2)}°, ${base.lon.toFixed(2)}°</span>
- </div>
- </div>
- </div>
- `;
+ const inner = document.createElement('div');
+ inner.append(this.makeCardHeader(
+ base.name.toUpperCase(),
+ typeLabels[base.type] || base.type.toUpperCase(),
+ typeColors[base.type] || 'low',
+ ));
+
+ if (base.description) {
+ const desc = document.createElement('p');
+ desc.className = 'popup-description';
+ desc.style.cssText = 'margin:0; padding:var(--space-2) var(--space-3) 0; font-size:var(--text-xs); opacity:0.8;';
+ desc.textContent = base.description;
+ inner.append(desc);
+ }
+
+ if (enriched.kind) {
+ const kindEl = document.createElement('p');
+ kindEl.className = 'popup-description';
+ kindEl.style.cssText = 'margin:0; padding:2px var(--space-3) 0; font-size:var(--text-xs); opacity:0.7;';
+ kindEl.textContent = enriched.kind.replace(/_/g, ' ');
+ inner.append(kindEl);
+ }
+
+ const stats: { label: string; value: string }[] = [
+ { label: t('popups.type'), value: typeLabels[base.type] ?? base.type },
+ ...(base.arm ? [{ label: 'Branch', value: base.arm }] : []),
+ ...(base.country ? [{ label: 'Country', value: base.country }] : []),
+ ...(categories.length > 0 ? [{ label: 'Categories', value: categories.join(', ') }] : []),
+ { label: t('popups.coordinates'), value: `${base.lat.toFixed(2)}°, ${base.lon.toFixed(2)}°` },
+ ];
+
+ inner.append(this.makeStatGrid(stats));
+
+ return this.wrapInCard(inner);
   }
 
   private renderWaterwayPopup(waterway: StrategicWaterway): string {

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -167,6 +167,7 @@ export class Panel {
   protected element: HTMLElement;
   protected content: HTMLElement;
   protected header: HTMLElement;
+  protected panelOptions!: PanelOptions;
   protected heartbeatEl: HTMLElement | null = null;
   protected narrativeEl: HTMLElement | null = null;
   private lastTickAt = 0;
@@ -215,6 +216,7 @@ export class Panel {
   ]);
 
   constructor(options: PanelOptions) {
+ this.panelOptions = options;
  this.panelId = options.id;
  this.element = document.createElement('div');
  this.element.className = `panel ${options.className || ''}`;
@@ -344,6 +346,54 @@ export class Panel {
  this.reconcileColSpanAfterAttach();
 
  this.showLoading();
+  }
+
+  protected buildStandardHeader(opts: {
+ subtitle?: string;
+ freshness?: { dotColor?: string; label?: string };
+ rightSlot?: HTMLElement;
+  }): HTMLElement {
+ const header = document.createElement('div');
+ header.className = 'cb-panel-header';
+ header.style.cssText = `
+      display: flex; justify-content: space-between; align-items: flex-start;
+      padding: var(--space-3) var(--space-4);
+    `;
+
+ const left = document.createElement('div');
+ const title = document.createElement('div');
+ title.style.cssText = `
+      font-size: var(--text-base); font-weight: var(--fw-semibold);
+      color: #e5e5e5; letter-spacing: -0.01em;
+    `;
+ title.textContent = this.panelOptions.title;
+ left.append(title);
+
+ if (opts.subtitle) {
+ const sub = document.createElement('div');
+ sub.style.cssText = 'font-size: var(--text-xs); color: #666; margin-top: 2px;';
+ sub.textContent = opts.subtitle;
+ left.append(sub);
+ }
+
+ header.append(left);
+
+ if (opts.freshness) {
+ const right = document.createElement('div');
+ right.style.cssText = 'display: flex; align-items: center; gap: 4px;';
+ const dot = document.createElement('div');
+ dot.style.cssText = `width: 6px; height: 6px; border-radius: 50%; background: ${opts.freshness.dotColor || '#22c55e'};`;
+ right.append(dot);
+ const label = document.createElement('span');
+ label.style.cssText = 'font-size: var(--text-2xs); color: #666;';
+ label.textContent = opts.freshness.label || '';
+ right.append(label);
+ header.append(right);
+ } else if (opts.rightSlot) {
+ header.append(opts.rightSlot);
+ }
+
+ return header;
   }
 
   private restoreSavedColSpan(): void {

--- a/src/components/Toast.ts
+++ b/src/components/Toast.ts
@@ -159,7 +159,7 @@ export class Toast {
     activeToasts.push(this);
     const container = getContainer();
     container.append(this.el);
-    void animateIn(this.el, 'slide-up');
+    void animateIn(this.el, 'slide-right');
 
     // Kick off progress bar shrink on next frame
     requestAnimationFrame(() => {

--- a/src/components/Toast.ts
+++ b/src/components/Toast.ts
@@ -1,0 +1,217 @@
+import { isGhostMode } from '@/services/mode-manager';
+import { animateIn, animateOut } from '@/services/motion';
+
+const MAX_TOASTS = 3;
+const DURATION_NORMAL = 8000;
+const DURATION_CRITICAL = 15_000;
+
+type Severity = 'critical' | 'high' | 'elevated' | 'normal';
+
+interface ToastOptions {
+  title: string;
+  message?: string;
+  severity?: Severity;
+}
+
+const SEVERITY_COLORS: Record<Severity, string> = {
+  critical: 'var(--severity-critical)',
+  high: 'var(--severity-high)',
+  elevated: 'var(--severity-elevated)',
+  normal: 'var(--severity-normal)',
+};
+
+function getContainer(): HTMLElement {
+  let el = document.getElementById('cb-toast-container');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'cb-toast-container';
+    Object.assign(el.style, {
+      position: 'fixed',
+      top: '16px',
+      right: '16px',
+      zIndex: '9999',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '8px',
+      pointerEvents: 'none',
+    });
+    document.body.append(el);
+  }
+  return el;
+}
+
+const activeToasts: Toast[] = [];
+
+export class Toast {
+  private el: HTMLElement;
+  private progress: HTMLElement;
+  private timerId: ReturnType<typeof setTimeout> | null = null;
+  private startTime = 0;
+  private remaining: number;
+  private duration: number;
+  private dismissed = false;
+
+  constructor(private options: ToastOptions) {
+    const severity = options.severity ?? 'normal';
+    this.duration = severity === 'critical' ? DURATION_CRITICAL : DURATION_NORMAL;
+    this.remaining = this.duration;
+
+    this.el = this.build(severity);
+    this.progress = this.el.querySelector('.cb-toast-progress') as HTMLElement;
+  }
+
+  private build(severity: Severity): HTMLElement {
+    const color = SEVERITY_COLORS[severity];
+
+    const el = document.createElement('div');
+    el.setAttribute('role', 'alert');
+    el.setAttribute('aria-live', 'assertive');
+    Object.assign(el.style, {
+      pointerEvents: 'all',
+      background: 'rgba(28, 28, 30, 0.92)',
+      backdropFilter: 'blur(20px) saturate(1.4)',
+      WebkitBackdropFilter: 'blur(20px) saturate(1.4)',
+      borderRadius: 'var(--radius-lg, 12px)',
+      boxShadow: 'var(--elevation-3)',
+      borderLeft: `3px solid ${color}`,
+      minWidth: '280px',
+      maxWidth: '360px',
+      overflow: 'hidden',
+      fontFamily: 'var(--font-ui)',
+      cursor: 'default',
+      position: 'relative',
+    });
+
+    const body = document.createElement('div');
+    Object.assign(body.style, {
+      padding: '12px 36px 12px 14px',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '2px',
+    });
+
+    const title = document.createElement('div');
+    title.textContent = this.options.title;
+    Object.assign(title.style, {
+      fontSize: 'var(--text-sm, 13px)',
+      fontWeight: 'var(--fw-medium, 500)',
+      color: color,
+      lineHeight: '1.3',
+    });
+
+    body.append(title);
+
+    if (this.options.message) {
+      const msg = document.createElement('div');
+      msg.textContent = this.options.message;
+      Object.assign(msg.style, {
+        fontSize: 'var(--text-xs, 11px)',
+        color: 'rgba(255,255,255,0.65)',
+        lineHeight: '1.4',
+      });
+      body.append(msg);
+    }
+
+    const dismiss = document.createElement('button');
+    dismiss.textContent = '×';
+    Object.assign(dismiss.style, {
+      position: 'absolute',
+      top: '8px',
+      right: '10px',
+      background: 'none',
+      border: 'none',
+      color: 'rgba(255,255,255,0.4)',
+      fontSize: '16px',
+      lineHeight: '1',
+      cursor: 'pointer',
+      padding: '0',
+    });
+    dismiss.addEventListener('click', () => this.dismiss());
+
+    const progress = document.createElement('div');
+    progress.className = 'cb-toast-progress';
+    Object.assign(progress.style, {
+      height: '2px',
+      background: color,
+      width: '100%',
+      transformOrigin: 'left',
+      transition: `transform ${this.duration}ms linear`,
+    });
+
+    el.append(body);
+    el.append(dismiss);
+    el.append(progress);
+
+    el.addEventListener('mouseenter', () => this.pause());
+    el.addEventListener('mouseleave', () => this.resume());
+
+    return el;
+  }
+
+  show(): void {
+    if (isGhostMode()) return;
+
+    // Evict oldest if at max
+    while (activeToasts.length >= MAX_TOASTS) {
+      activeToasts[0]?.dismiss();
+    }
+
+    activeToasts.push(this);
+    const container = getContainer();
+    container.append(this.el);
+    void animateIn(this.el, 'slide-up');
+
+    // Kick off progress bar shrink on next frame
+    requestAnimationFrame(() => {
+      this.progress.style.transform = 'scaleX(0)';
+    });
+
+    this.startTimer();
+  }
+
+  private startTimer(): void {
+    this.startTime = performance.now();
+    this.timerId = setTimeout(() => this.dismiss(), this.remaining);
+  }
+
+  pause(): void {
+    if (this.dismissed || this.timerId === null) return;
+    clearTimeout(this.timerId);
+    this.timerId = null;
+    this.remaining -= performance.now() - this.startTime;
+    // Freeze progress bar
+    const elapsed = this.duration - this.remaining;
+    const fraction = elapsed / this.duration;
+    this.progress.style.transition = 'none';
+    this.progress.style.transform = `scaleX(${1 - fraction})`;
+  }
+
+  resume(): void {
+    if (this.dismissed || this.timerId !== null) return;
+    // Resume progress bar
+    this.progress.style.transition = `transform ${this.remaining}ms linear`;
+    this.progress.style.transform = 'scaleX(0)';
+    this.startTimer();
+  }
+
+  dismiss(): void {
+    if (this.dismissed) return;
+    this.dismissed = true;
+    if (this.timerId !== null) {
+      clearTimeout(this.timerId);
+      this.timerId = null;
+    }
+    const idx = activeToasts.indexOf(this);
+    if (idx !== -1) activeToasts.splice(idx, 1);
+
+    void animateOut(this.el, 'fade').then(() => {
+      this.el.remove();
+    });
+  }
+}
+
+export function showToast(options: ToastOptions): Toast {
+  const toast = new Toast(options);
+  toast.show();
+  return toast;
+}

--- a/src/components/TriageBar.ts
+++ b/src/components/TriageBar.ts
@@ -106,8 +106,15 @@ export class TriageBar {
     }
     const items = document.createElement('div');
     items.className = 'triage-bar-items';
-    for (const story of stories) {
-      items.append(this.makeStoryItem(story));
+    for (let i = 0; i < stories.length; i++) {
+      const item = this.makeStoryItem(stories[i]!);
+      if (i === 0) {
+        item.classList.add('hottest');
+        const sev = stories[0]!.leadAlert.severity;
+        const severityAttr = sev === 'medium' ? 'elevated' : sev;
+        item.dataset.severity = severityAttr;
+      }
+      items.append(item);
     }
     const ack = document.createElement('button');
     ack.className = 'triage-bar-ack';

--- a/src/components/UnifiedAlertInboxPanel.ts
+++ b/src/components/UnifiedAlertInboxPanel.ts
@@ -21,6 +21,7 @@ import {
   type AlertSeverity,
   type AlertSource,
 } from '@/services/unified-alerts';
+import { playAckSound } from '@/services/sound';
 import { scoreAndSort } from '@/services/relevance-scoring';
 import { EvidenceDrawer } from './EvidenceDrawer';
 import { computeEntityHeat } from '@/services/entity-heat';
@@ -299,6 +300,9 @@ export class UnifiedAlertInboxPanel extends Panel {
  const ackBtn = target.closest('[data-ack]') as HTMLElement | null;
  if (ackBtn) {
  e.stopPropagation();
+ const row = ackBtn.closest('tr');
+ if (row) row.classList.add('alert-row-ack');
+ playAckSound();
  unifiedAlertStore.acknowledge(ackBtn.dataset.ack!);
  return true;
  }
@@ -544,6 +548,7 @@ export class UnifiedAlertInboxPanel extends Panel {
  alert.pinned ? 'uai-pinned' : '',
  alert.acknowledged ? 'uai-acked' : '',
  index === this.selectedIndex ? 'uai-selected' : '',
+ alert.acknowledged ? '' : 'alert-row-arrive',
  ]
  .filter(Boolean)
  .join(' ');

--- a/src/components/UnifiedAlertInboxPanel.ts
+++ b/src/components/UnifiedAlertInboxPanel.ts
@@ -510,7 +510,7 @@ export class UnifiedAlertInboxPanel extends Panel {
   }
 
   private renderRow(alert: UnifiedAlert, index: number, relatedCount = 0): string {
- const sevPill = `<span class="ac-pill ac-pill-${alert.severity}">${SEVERITY_LABELS[alert.severity]}</span>`;
+ const sevPill = `<span class="cb-badge" data-severity="${sevToBadge(alert.severity)}">${SEVERITY_LABELS[alert.severity]}</span>`;
  const srcTag = `<span class="uai-src-tag uai-src-${alert.source}" data-filter-src="${alert.source}" title="Filter: ${alert.source}">${SOURCE_LABELS[alert.source] ?? alert.source}</span>`;
 
  const scoreBar = this.renderScoreBar(alert.relevanceScore);
@@ -539,6 +539,7 @@ export class UnifiedAlertInboxPanel extends Panel {
  const ackIcon = alert.acknowledged ? '&#10003;' : '&#10005;';
 
  const rowClasses = [
+ 'cb-list-row',
  rowSevClass(alert.severity),
  alert.pinned ? 'uai-pinned' : '',
  alert.acknowledged ? 'uai-acked' : '',
@@ -584,6 +585,18 @@ function esc(s: string): string {
  .replace(/</g, '&lt;')
  .replace(/>/g, '&gt;')
  .replace(/"/g, '&quot;');
+}
+
+function sevToBadge(s: AlertSeverity): string {
+  return (
+ {
+ critical: 'critical',
+ high: 'high',
+ medium: 'elevated',
+ low: 'normal',
+ info: 'positive',
+ }[s] ?? 'normal'
+  );
 }
 
 function rowSevClass(s: AlertSeverity): string {

--- a/src/components/WelcomeFlow.ts
+++ b/src/components/WelcomeFlow.ts
@@ -1,0 +1,361 @@
+import { animateIn, animateOut } from '@/services/motion';
+
+const ONBOARDING_KEY = 'cb:onboarding-complete';
+
+const INTERESTS = [
+  'Geopolitical',
+  'Weather',
+  'Cyber',
+  'Markets',
+  'Infrastructure',
+  'Military',
+] as const;
+
+const FREE_APIS = [
+  { name: 'USGS Earthquakes', label: 'free' },
+  { name: 'GDACS Disasters', label: 'free' },
+  { name: 'Open-Meteo Weather', label: 'free' },
+  { name: 'GDELT News', label: 'free' },
+  { name: 'NewsAPI', label: 'free tier' },
+  { name: 'OpenWeatherMap', label: 'free tier' },
+];
+
+export interface WelcomeFlowOptions {
+  onLocationSet?: (lat: number, lng: number) => void;
+  onInterestsSet?: (interests: string[]) => void;
+  onComplete?: () => void;
+}
+
+export class WelcomeFlow {
+  private backdrop: HTMLElement;
+  private modal: HTMLElement;
+  private stepEl: HTMLElement;
+  private dotsEl: HTMLElement;
+  private step = 0;
+  private selectedInterests = new Set<string>(['Geopolitical', 'Weather']);
+  private options: WelcomeFlowOptions;
+
+  constructor(options: WelcomeFlowOptions = {}) {
+    this.options = options;
+
+    this.backdrop = document.createElement('div');
+    this.backdrop.className = 'cb-backdrop';
+    Object.assign(this.backdrop.style, {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    });
+
+    this.modal = document.createElement('div');
+    this.modal.className = 'cb-modal-content';
+    Object.assign(this.modal.style, {
+      width: '440px',
+      maxWidth: 'calc(100vw - 32px)',
+      background: 'rgba(18, 18, 22, 0.92)',
+      backdropFilter: 'blur(24px)',
+      WebkitBackdropFilter: 'blur(24px)',
+      border: '1px solid rgba(255, 255, 255, 0.08)',
+      borderRadius: 'var(--radius-xl)',
+      padding: 'var(--space-8)',
+      boxShadow: '0 32px 64px rgba(0, 0, 0, 0.6)',
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 'var(--space-6)',
+    });
+
+    this.dotsEl = document.createElement('div');
+    Object.assign(this.dotsEl.style, {
+      display: 'flex',
+      justifyContent: 'center',
+      gap: 'var(--space-2)',
+    });
+
+    this.stepEl = document.createElement('div');
+
+    this.modal.append(this.dotsEl);
+    this.modal.append(this.stepEl);
+    this.backdrop.append(this.modal);
+  }
+
+  static shouldShow(): boolean {
+    return localStorage.getItem(ONBOARDING_KEY) !== 'true';
+  }
+
+  show(): void {
+    document.body.append(this.backdrop);
+    this.renderDots();
+    this.renderStep();
+    void animateIn(this.modal, 'scale');
+  }
+
+  private close(): void {
+    void animateOut(this.modal, 'scale-down').then(() => {
+      this.backdrop.classList.add('closing');
+      this.backdrop.addEventListener('animationend', () => {
+        this.backdrop.remove();
+      }, { once: true });
+      // Fallback if no animation
+      setTimeout(() => this.backdrop.remove(), 400);
+    });
+  }
+
+  private renderDots(): void {
+    this.dotsEl.textContent = '';
+    for (let i = 0; i < 3; i++) {
+      const dot = document.createElement('div');
+      Object.assign(dot.style, {
+        width: '6px',
+        height: '6px',
+        borderRadius: '50%',
+        background: i === this.step ? 'var(--accent)' : 'rgba(255, 255, 255, 0.2)',
+        transition: 'background 0.2s ease',
+      });
+      this.dotsEl.append(dot);
+    }
+  }
+
+  private renderStep(): void {
+    this.stepEl.textContent = '';
+    switch (this.step) {
+      case 0: { this.renderLocation(); break;
+      }
+      case 1: { this.renderInterests(); break;
+      }
+      case 2: { this.renderApiKeys(); break;
+      }
+    }
+  }
+
+  private renderLocation(): void {
+    const title = document.createElement('h2');
+    title.textContent = 'Set Your Location';
+    Object.assign(title.style, {
+      margin: '0',
+      fontSize: 'var(--text-xl)',
+      fontWeight: 'var(--fw-semibold)',
+      fontFamily: 'var(--font-ui)',
+      color: '#f0f0f0',
+    });
+
+    const desc = document.createElement('p');
+    desc.textContent = 'Crystal Ball tailors alerts to your region.';
+    Object.assign(desc.style, {
+      margin: '0',
+      fontSize: 'var(--text-sm)',
+      color: '#888',
+      fontFamily: 'var(--font-ui)',
+    });
+
+    const gpsBtn = document.createElement('button');
+    gpsBtn.className = 'cb-button accent';
+    gpsBtn.textContent = 'Use My Location';
+    gpsBtn.style.width = '100%';
+    gpsBtn.style.padding = 'var(--space-3) var(--space-4)';
+    gpsBtn.addEventListener('click', () => this.requestLocation(gpsBtn));
+
+    const skipLink = document.createElement('button');
+    skipLink.textContent = 'Skip for now';
+    Object.assign(skipLink.style, {
+      background: 'none',
+      border: 'none',
+      color: '#666',
+      fontSize: 'var(--text-sm)',
+      fontFamily: 'var(--font-ui)',
+      cursor: 'pointer',
+      textAlign: 'center',
+      width: '100%',
+      padding: 'var(--space-1)',
+    });
+    skipLink.addEventListener('click', () => this.advance());
+
+    this.stepEl.append(title, desc, gpsBtn, skipLink);
+  }
+
+  private requestLocation(btn: HTMLButtonElement): void {
+    if (!navigator.geolocation) {
+      this.advance();
+      return;
+    }
+    const originalText = btn.textContent;
+    btn.textContent = 'Locating...';
+    btn.disabled = true;
+    // eslint-disable-next-line sonarjs/no-intrusive-permissions
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        this.options.onLocationSet?.(pos.coords.latitude, pos.coords.longitude);
+        this.advance();
+      },
+      () => {
+        btn.textContent = originalText;
+        btn.disabled = false;
+      },
+      { timeout: 8000 },
+    );
+  }
+
+  private renderInterests(): void {
+    const title = document.createElement('h2');
+    title.textContent = 'What interests you?';
+    Object.assign(title.style, {
+      margin: '0',
+      fontSize: 'var(--text-xl)',
+      fontWeight: 'var(--fw-semibold)',
+      fontFamily: 'var(--font-ui)',
+      color: '#f0f0f0',
+    });
+
+    const pillWrap = document.createElement('div');
+    Object.assign(pillWrap.style, {
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: 'var(--space-2)',
+    });
+
+    for (const interest of INTERESTS) {
+      const pill = document.createElement('button');
+      pill.textContent = interest;
+      const active = this.selectedInterests.has(interest);
+      Object.assign(pill.style, {
+        padding: 'var(--space-2) var(--space-3)',
+        fontSize: 'var(--text-sm)',
+        fontWeight: 'var(--fw-medium)',
+        fontFamily: 'var(--font-ui)',
+        borderRadius: 'var(--radius-lg)',
+        border: `1px solid ${active ? 'var(--accent)' : 'rgba(255,255,255,0.12)'}`,
+        background: active ? 'rgba(59, 130, 246, 0.2)' : 'rgba(255,255,255,0.04)',
+        color: active ? '#93c5fd' : '#888',
+        cursor: 'pointer',
+        transition: 'all 0.15s ease',
+      });
+      pill.addEventListener('click', () => {
+        if (this.selectedInterests.has(interest)) {
+          this.selectedInterests.delete(interest);
+          pill.style.border = '1px solid rgba(255,255,255,0.12)';
+          pill.style.background = 'rgba(255,255,255,0.04)';
+          pill.style.color = '#888';
+        } else {
+          this.selectedInterests.add(interest);
+          pill.style.border = '1px solid var(--accent)';
+          pill.style.background = 'rgba(59, 130, 246, 0.2)';
+          pill.style.color = '#93c5fd';
+        }
+      });
+      pillWrap.append(pill);
+    }
+
+    const continueBtn = document.createElement('button');
+    continueBtn.className = 'cb-button accent';
+    continueBtn.textContent = 'Continue';
+    continueBtn.style.width = '100%';
+    continueBtn.style.padding = 'var(--space-3) var(--space-4)';
+    continueBtn.addEventListener('click', () => {
+      this.options.onInterestsSet?.([...this.selectedInterests]);
+      this.advance();
+    });
+
+    this.stepEl.append(title, pillWrap, continueBtn);
+  }
+
+  private renderApiKeys(): void {
+    const title = document.createElement('h2');
+    title.textContent = 'Connect your data sources';
+    Object.assign(title.style, {
+      margin: '0',
+      fontSize: 'var(--text-xl)',
+      fontWeight: 'var(--fw-semibold)',
+      fontFamily: 'var(--font-ui)',
+      color: '#f0f0f0',
+    });
+
+    const desc = document.createElement('p');
+    desc.textContent = 'These free sources work right away — no key needed.';
+    Object.assign(desc.style, {
+      margin: '0',
+      fontSize: 'var(--text-sm)',
+      color: '#888',
+      fontFamily: 'var(--font-ui)',
+    });
+
+    const list = document.createElement('div');
+    Object.assign(list.style, {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '2px',
+      borderRadius: 'var(--radius-md)',
+      overflow: 'hidden',
+      border: '1px solid rgba(255,255,255,0.06)',
+    });
+
+    for (const api of FREE_APIS) {
+      const row = document.createElement('div');
+      Object.assign(row.style, {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: 'var(--space-2) var(--space-3)',
+        background: 'rgba(255,255,255,0.02)',
+        fontFamily: 'var(--font-ui)',
+      });
+
+      const name = document.createElement('span');
+      name.textContent = api.name;
+      Object.assign(name.style, {
+        fontSize: 'var(--text-sm)',
+        color: '#ccc',
+      });
+
+      const badge = document.createElement('span');
+      badge.textContent = api.label;
+      Object.assign(badge.style, {
+        fontSize: 'var(--text-2xs)',
+        fontWeight: 'var(--fw-medium)',
+        color: '#4ade80',
+        background: 'rgba(74, 222, 128, 0.1)',
+        border: '1px solid rgba(74, 222, 128, 0.2)',
+        borderRadius: 'var(--radius-sm)',
+        padding: '1px var(--space-2)',
+      });
+
+      row.append(name, badge);
+      list.append(row);
+    }
+
+    const btnRow = document.createElement('div');
+    Object.assign(btnRow.style, {
+      display: 'flex',
+      gap: 'var(--space-3)',
+    });
+
+    const skipBtn = document.createElement('button');
+    skipBtn.className = 'cb-button';
+    skipBtn.textContent = 'Skip for now';
+    skipBtn.style.flex = '1';
+    skipBtn.style.padding = 'var(--space-3) var(--space-4)';
+    skipBtn.addEventListener('click', () => this.complete());
+
+    const settingsBtn = document.createElement('button');
+    settingsBtn.className = 'cb-button accent';
+    settingsBtn.textContent = 'Open Settings';
+    settingsBtn.style.flex = '1';
+    settingsBtn.style.padding = 'var(--space-3) var(--space-4)';
+    settingsBtn.addEventListener('click', () => {
+      this.complete();
+      this.options.onComplete?.();
+    });
+
+    btnRow.append(skipBtn, settingsBtn);
+    this.stepEl.append(title, desc, list, btnRow);
+  }
+
+  private advance(): void {
+    this.step++;
+    this.renderDots();
+    this.renderStep();
+  }
+
+  private complete(): void {
+    localStorage.setItem(ONBOARDING_KEY, 'true');
+    this.options.onComplete?.();
+    this.close();
+  }
+}

--- a/src/components/WelcomeFlow.ts
+++ b/src/components/WelcomeFlow.ts
@@ -1,4 +1,5 @@
-import { animateIn, animateOut, prefersReducedMotion } from '@/services/motion';
+import { animateIn, prefersReducedMotion } from '@/services/motion';
+import { hasTauriInvokeBridge, invokeTauri } from '@/services/tauri-bridge';
 
 const ONBOARDING_KEY = 'cb:onboarding-complete';
 
@@ -91,14 +92,12 @@ export class WelcomeFlow {
   }
 
   private close(): void {
-    void animateOut(this.modal, 'scale-down').then(() => {
-      this.backdrop.classList.add('closing');
-      this.backdrop.addEventListener('animationend', () => {
-        this.backdrop.remove();
-      }, { once: true });
-      // Fallback if no animation
-      setTimeout(() => this.backdrop.remove(), 400);
-    });
+    this.modal.classList.add('closing');
+    this.backdrop.classList.add('closing');
+
+    this.backdrop.addEventListener('animationend', () => this.backdrop.remove(), { once: true });
+    // Fallback if reduced-motion or animation doesn't fire
+    setTimeout(() => this.backdrop.remove(), 500);
   }
 
   private renderDots(): void {
@@ -174,13 +173,27 @@ export class WelcomeFlow {
   }
 
   private requestLocation(btn: HTMLButtonElement): void {
+    const originalText = btn.textContent;
+    btn.textContent = 'Locating...';
+    btn.disabled = true;
+
+    if (hasTauriInvokeBridge()) {
+      void invokeTauri<[number, number]>('get_native_location')
+        .then(([lat, lon]) => {
+          this.options.onLocationSet?.(lat, lon);
+          this.advance();
+        })
+        .catch(() => {
+          btn.textContent = originalText;
+          btn.disabled = false;
+        });
+      return;
+    }
+
     if (!navigator.geolocation) {
       this.advance();
       return;
     }
-    const originalText = btn.textContent;
-    btn.textContent = 'Locating...';
-    btn.disabled = true;
     // eslint-disable-next-line sonarjs/no-intrusive-permissions
     navigator.geolocation.getCurrentPosition(
       (pos) => {
@@ -361,7 +374,10 @@ export class WelcomeFlow {
     this.stepEl.style.transform = 'translateX(-40px)';
     this.stepEl.style.opacity = '0';
 
-    this.stepEl.addEventListener('transitionend', () => {
+    let advanced = false;
+    const doAdvance = () => {
+      if (advanced) return;
+      advanced = true;
       this.step++;
       this.renderDots();
       this.renderStep();
@@ -370,7 +386,11 @@ export class WelcomeFlow {
         this.stepEl.style.transform = 'translateX(0)';
         this.stepEl.style.opacity = '1';
       });
-    }, { once: true });
+    };
+
+    this.stepEl.addEventListener('transitionend', doAdvance, { once: true });
+    // Fallback if transitionend doesn't fire
+    setTimeout(doAdvance, 400);
   }
 
   private complete(): void {

--- a/src/components/WelcomeFlow.ts
+++ b/src/components/WelcomeFlow.ts
@@ -1,4 +1,4 @@
-import { animateIn, animateOut } from '@/services/motion';
+import { animateIn, animateOut, prefersReducedMotion } from '@/services/motion';
 
 const ONBOARDING_KEY = 'cb:onboarding-complete';
 
@@ -9,6 +9,8 @@ const INTERESTS = [
   'Markets',
   'Infrastructure',
   'Military',
+  'Health',
+  'Space',
 ] as const;
 
 const FREE_APIS = [
@@ -348,9 +350,27 @@ export class WelcomeFlow {
   }
 
   private advance(): void {
-    this.step++;
-    this.renderDots();
-    this.renderStep();
+    if (prefersReducedMotion()) {
+      this.step++;
+      this.renderDots();
+      this.renderStep();
+      return;
+    }
+
+    this.stepEl.style.transition = 'transform 350ms var(--ease-out), opacity 350ms var(--ease-out)';
+    this.stepEl.style.transform = 'translateX(-40px)';
+    this.stepEl.style.opacity = '0';
+
+    this.stepEl.addEventListener('transitionend', () => {
+      this.step++;
+      this.renderDots();
+      this.renderStep();
+      this.stepEl.style.transform = 'translateX(40px)';
+      requestAnimationFrame(() => {
+        this.stepEl.style.transform = 'translateX(0)';
+        this.stepEl.style.opacity = '1';
+      });
+    }, { once: true });
   }
 
   private complete(): void {

--- a/src/services/motion.ts
+++ b/src/services/motion.ts
@@ -69,7 +69,7 @@ export function animateNumber(
 }
 
 export function animateIn(
-  el: HTMLElement, animation: 'slide-up' | 'fade' | 'scale' = 'slide-up',
+  el: HTMLElement, animation: 'slide-up' | 'fade' | 'scale' | 'slide-right' = 'slide-up',
 ): Promise<void> {
   if (prefersReducedMotion()) {
     el.style.opacity = '1';
@@ -79,6 +79,7 @@ export function animateIn(
     'slide-up': 'cb-animate-slide-up',
     'fade': 'cb-animate-fade-in',
     'scale': 'cb-animate-scale-in',
+    'slide-right': 'cb-animate-slide-in-right',
   };
   return new Promise((resolve) => {
     el.classList.add(classMap[animation]);

--- a/src/services/motion.ts
+++ b/src/services/motion.ts
@@ -25,12 +25,10 @@ export function staggerIn(
   }
 }
 
-export function crossfadeContent(panel: HTMLElement, newHTML: string): Promise<void> {
+export function crossfadeContent(panel: HTMLElement, newContent: HTMLElement | DocumentFragment): Promise<void> {
   if (prefersReducedMotion()) {
     panel.textContent = '';
-    const temp = document.createElement('div');
-    temp.insertAdjacentHTML('afterbegin', newHTML);
-    while (temp.firstChild) panel.append(temp.firstChild);
+    panel.append(newContent);
     return Promise.resolve();
   }
 
@@ -40,9 +38,7 @@ export function crossfadeContent(panel: HTMLElement, newHTML: string): Promise<v
       panel.removeEventListener('animationend', handler);
       panel.classList.remove('cb-animate-fade-out');
       panel.textContent = '';
-      const temp = document.createElement('div');
-      temp.insertAdjacentHTML('afterbegin', newHTML);
-      while (temp.firstChild) panel.append(temp.firstChild);
+      panel.append(newContent);
       panel.classList.add('cb-animate-fade-in');
       panel.addEventListener('animationend', function handler2() {
         panel.removeEventListener('animationend', handler2);

--- a/src/services/motion.ts
+++ b/src/services/motion.ts
@@ -1,0 +1,135 @@
+// src/services/motion.ts
+
+const STAGGER_DELAY_MS = 30;
+const STAGGER_MAX_ITEMS = 10;
+
+export function prefersReducedMotion(): boolean {
+  return (
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches ||
+    document.body.classList.contains('animations-paused')
+  );
+}
+
+export function staggerIn(
+  container: Element,
+  selector: string,
+  delay: number = STAGGER_DELAY_MS,
+): void {
+  if (prefersReducedMotion()) return;
+  const items = container.querySelectorAll(selector);
+  const count = Math.min(items.length, STAGGER_MAX_ITEMS);
+  for (let i = 0; i < count; i++) {
+    const el = items[i] as HTMLElement;
+    el.classList.add('cb-stagger-item');
+    el.style.animationDelay = `${i * delay}ms`;
+  }
+}
+
+export function crossfadeContent(panel: HTMLElement, newHTML: string): Promise<void> {
+  if (prefersReducedMotion()) {
+    panel.textContent = '';
+    const temp = document.createElement('div');
+    temp.insertAdjacentHTML('afterbegin', newHTML);
+    while (temp.firstChild) panel.append(temp.firstChild);
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    panel.classList.add('cb-animate-fade-out');
+    panel.addEventListener('animationend', function handler() {
+      panel.removeEventListener('animationend', handler);
+      panel.classList.remove('cb-animate-fade-out');
+      panel.textContent = '';
+      const temp = document.createElement('div');
+      temp.insertAdjacentHTML('afterbegin', newHTML);
+      while (temp.firstChild) panel.append(temp.firstChild);
+      panel.classList.add('cb-animate-fade-in');
+      panel.addEventListener('animationend', function handler2() {
+        panel.removeEventListener('animationend', handler2);
+        panel.classList.remove('cb-animate-fade-in');
+        resolve();
+      }, { once: true });
+    }, { once: true });
+  });
+}
+
+export function animateNumber(
+  el: Element, from: number, to: number, duration = 300,
+): void {
+  if (prefersReducedMotion() || from === to) {
+    el.textContent = String(to);
+    return;
+  }
+  const start = performance.now();
+  const range = to - from;
+  function step(now: number) {
+    const elapsed = now - start;
+    const progress = Math.min(elapsed / duration, 1);
+    const eased = 1 - Math.pow(1 - progress, 3);
+    el.textContent = String(Math.round(from + range * eased));
+    if (progress < 1) requestAnimationFrame(step);
+  }
+  requestAnimationFrame(step);
+}
+
+export function animateIn(
+  el: HTMLElement, animation: 'slide-up' | 'fade' | 'scale' = 'slide-up',
+): Promise<void> {
+  if (prefersReducedMotion()) {
+    el.style.opacity = '1';
+    return Promise.resolve();
+  }
+  const classMap = {
+    'slide-up': 'cb-animate-slide-up',
+    'fade': 'cb-animate-fade-in',
+    'scale': 'cb-animate-scale-in',
+  };
+  return new Promise((resolve) => {
+    el.classList.add(classMap[animation]);
+    el.addEventListener('animationend', () => {
+      el.classList.remove(classMap[animation]);
+      resolve();
+    }, { once: true });
+  });
+}
+
+export function animateOut(
+  el: HTMLElement, animation: 'fade' | 'scale-down' = 'fade',
+): Promise<void> {
+  if (prefersReducedMotion()) {
+    el.style.opacity = '0';
+    return Promise.resolve();
+  }
+  const classMap = {
+    'fade': 'cb-animate-fade-out',
+    'scale-down': 'cb-animate-scale-out',
+  };
+  return new Promise((resolve) => {
+    el.classList.add(classMap[animation]);
+    el.addEventListener('animationend', () => {
+      el.classList.remove(classMap[animation]);
+      resolve();
+    }, { once: true });
+  });
+}
+
+export function revealContent(skeleton: HTMLElement, content: HTMLElement): Promise<void> {
+  if (prefersReducedMotion()) {
+    skeleton.style.display = 'none';
+    content.style.display = '';
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    skeleton.classList.add('cb-animate-fade-out');
+    skeleton.addEventListener('animationend', () => {
+      skeleton.style.display = 'none';
+      skeleton.classList.remove('cb-animate-fade-out');
+      content.style.display = '';
+      content.classList.add('cb-animate-fade-in');
+      content.addEventListener('animationend', () => {
+        content.classList.remove('cb-animate-fade-in');
+        resolve();
+      }, { once: true });
+    }, { once: true });
+  });
+}

--- a/src/services/sound.ts
+++ b/src/services/sound.ts
@@ -23,9 +23,13 @@ function canPlay(): boolean {
   return true;
 }
 
+let sharedCtx: AudioContext | null = null;
+
 function getContext(): AudioContext | null {
   try {
-    return new AudioContext();
+    if (sharedCtx && sharedCtx.state !== 'closed') return sharedCtx;
+    sharedCtx = new AudioContext();
+    return sharedCtx;
   } catch {
     return null;
   }

--- a/src/services/sound.ts
+++ b/src/services/sound.ts
@@ -1,0 +1,84 @@
+import { isGhostMode } from '@/services/mode-manager';
+
+const MIN_INTERVAL_MS = 3000;
+let lastPlayedAt = 0;
+
+function getVolume(): number {
+  const raw = localStorage.getItem('cb:sound-volume');
+  const parsed = Number.parseFloat(raw ?? '');
+  return Number.isNaN(parsed) ? 0.3 : Math.max(0, Math.min(1, parsed));
+}
+
+function isSoundEnabled(): boolean {
+  const raw = localStorage.getItem('cb:sound-enabled');
+  return raw !== 'false';
+}
+
+function canPlay(): boolean {
+  if (isGhostMode()) return false;
+  if (!isSoundEnabled()) return false;
+  const now = Date.now();
+  if (now - lastPlayedAt < MIN_INTERVAL_MS) return false;
+  lastPlayedAt = now;
+  return true;
+}
+
+function getContext(): AudioContext | null {
+  try {
+    return new AudioContext();
+  } catch {
+    return null;
+  }
+}
+
+function playTone(
+  ctx: AudioContext,
+  frequency: number,
+  startTime: number,
+  duration: number,
+  volume: number,
+  type: OscillatorType = 'sine',
+) {
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = type;
+  osc.frequency.setValueAtTime(frequency, startTime);
+  gain.gain.setValueAtTime(volume, startTime);
+  gain.gain.exponentialRampToValueAtTime(0.001, startTime + duration);
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.start(startTime);
+  osc.stop(startTime + duration);
+}
+
+export function playAlertSound(severity: 'critical' | 'high' | 'elevated'): void {
+  if (!canPlay()) return;
+  const ctx = getContext();
+  if (!ctx) return;
+  const vol = getVolume();
+  const now = ctx.currentTime;
+
+  if (severity === 'critical') {
+    // C5 to E5 rising chime (300ms)
+    playTone(ctx, 523.25, now, 0.15, vol);
+    playTone(ctx, 659.25, now + 0.15, 0.15, vol);
+  } else if (severity === 'high') {
+    // G4 single tone (200ms)
+    playTone(ctx, 392, now, 0.2, vol);
+  } else {
+    // Elevated: 800Hz tap (50ms)
+    playTone(ctx, 800, now, 0.05, vol);
+  }
+}
+
+export function playAckSound(): void {
+  if (!canPlay()) return;
+  const ctx = getContext();
+  if (!ctx) return;
+  const vol = getVolume();
+  const now = ctx.currentTime;
+
+  // E4 to C4 descending (150ms)
+  playTone(ctx, 329.63, now, 0.075, vol);
+  playTone(ctx, 261.63, now + 0.075, 0.075, vol);
+}

--- a/src/services/threat-classifier.ts
+++ b/src/services/threat-classifier.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console, sonarjs/pseudo-random, sonarjs/cognitive-complexity, sonarjs/regex-complexity, @typescript-eslint/no-floating-promises */
 export type ThreatLevel = 'critical' | 'high' | 'medium' | 'low' | 'info';
 
 export type EventCategory =
@@ -424,6 +425,7 @@ const MIN_GAP_MS = 2000;
 const MAX_RETRIES = 2;
 const MAX_QUEUE_LENGTH = 100;
 let batchPaused = false;
+let consecutiveServerErrors = 0;
 let batchInFlight = false;
 let batchTimer: ReturnType<typeof setTimeout> | null = null;
 let lastRequestAt = 0;
@@ -461,11 +463,14 @@ function flushBatch(): void {
  title: job.title, description: '', source: '', country: '',
  });
  job.resolve(toThreat(resp));
+ consecutiveServerErrors = 0;
  } catch (error) {
  if (error instanceof ApiError && (error.statusCode === 429 || error.statusCode >= 500)) {
  batchPaused = true;
- const delay = error.statusCode === 429 ? 60_000 : 30_000;
- console.warn(`[Classify] ${error.statusCode} — pausing AI classification for ${delay / 1000}s`);
+ consecutiveServerErrors++;
+ const baseDelay = error.statusCode === 429 ? 60_000 : 30_000;
+ const delay = Math.min(baseDelay * Math.pow(2, consecutiveServerErrors - 1), 600_000);
+ console.warn(`[Classify] ${error.statusCode} — pausing AI classification for ${delay / 1000}s (attempt ${consecutiveServerErrors})`);
  const remaining = batch.slice(i + 1);
  // Failed job: increment attempts, requeue if under limit
  if ((job.attempts ?? 0) < MAX_RETRIES) {

--- a/src/styles/alerts.css
+++ b/src/styles/alerts.css
@@ -530,3 +530,13 @@
   30% { transform: translateX(6px); }
   100% { transform: translateX(0); }
 }
+
+.triage-bar-item { position: relative; transition: transform var(--duration-fast) var(--ease-default); }
+
+.triage-bar-item.hottest::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 2px;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+}
+.triage-bar-item.hottest[data-severity="critical"]::before { background: var(--severity-critical); }
+.triage-bar-item.hottest[data-severity="high"]::before { background: var(--severity-high); }
+.triage-bar-item.hottest[data-severity="elevated"]::before { background: var(--severity-elevated); }

--- a/src/styles/alerts.css
+++ b/src/styles/alerts.css
@@ -506,3 +506,27 @@
   font-variant-numeric: tabular-nums;
   flex-shrink: 0;
 }
+
+@media (prefers-reduced-motion: no-preference) {
+  .alert-row-ack { animation: cb-alert-ack 200ms var(--ease-default) both; }
+  .alert-row-dismiss { animation: cb-alert-dismiss 200ms var(--ease-in) both; }
+  .alert-row-snooze { animation: cb-alert-snooze 200ms var(--ease-default) both; }
+  .alert-row-arrive { animation: cb-slide-down var(--duration-moderate) var(--ease-out) both; }
+}
+
+@keyframes cb-alert-ack {
+  0% { background: transparent; }
+  30% { background: var(--severity-positive-bg); }
+  100% { background: transparent; }
+}
+
+@keyframes cb-alert-dismiss {
+  to { opacity: 0; transform: translateX(40px); max-height: 0;
+       padding-top: 0; padding-bottom: 0; overflow: hidden; }
+}
+
+@keyframes cb-alert-snooze {
+  0% { transform: translateX(0); }
+  30% { transform: translateX(6px); }
+  100% { transform: translateX(0); }
+}

--- a/src/styles/alerts.css
+++ b/src/styles/alerts.css
@@ -521,8 +521,7 @@
 }
 
 @keyframes cb-alert-dismiss {
-  to { opacity: 0; transform: translateX(40px); max-height: 0;
-       padding-top: 0; padding-bottom: 0; overflow: hidden; }
+  to { opacity: 0; transform: translateX(40px); }
 }
 
 @keyframes cb-alert-snooze {

--- a/src/styles/alerts.css
+++ b/src/styles/alerts.css
@@ -4,12 +4,12 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 8px 14px;
+  padding: var(--space-2) 14px;
   margin: 0 0 10px 0;
   background: linear-gradient(90deg, rgba(40, 0, 0, 0.85), rgba(20, 20, 30, 0.85));
   border: 1px solid rgba(255, 80, 80, 0.4);
-  border-radius: 8px;
-  font: 12px/1.2 -apple-system, system-ui, sans-serif;
+  border-radius: var(--radius-md);
+  font: var(--text-sm)/1.2 -apple-system, system-ui, sans-serif;
   color: #f5f5f7;
   position: sticky;
   top: 0;
@@ -38,7 +38,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 10px;
+  padding: var(--space-1) 10px;
   border-radius: 14px;
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -59,11 +59,11 @@
   background: #888;
   flex-shrink: 0;
 }
-.triage-sev-critical .triage-sev-dot { background: #ff3b30; box-shadow: 0 0 6px #ff3b30; }
-.triage-sev-high .triage-sev-dot { background: #ff9500; }
-.triage-sev-medium .triage-sev-dot { background: #ffcc00; }
-.triage-sev-low .triage-sev-dot { background: #34c759; }
-.triage-sev-info .triage-sev-dot { background: #5ac8fa; }
+.triage-sev-critical .triage-sev-dot { background: var(--severity-critical); box-shadow: 0 0 6px var(--severity-critical-glow); }
+.triage-sev-high .triage-sev-dot { background: var(--severity-high); }
+.triage-sev-medium .triage-sev-dot { background: var(--severity-elevated); }
+.triage-sev-low .triage-sev-dot { background: var(--severity-positive); }
+.triage-sev-info .triage-sev-dot { background: var(--severity-normal); }
 
 .triage-source {
   font-size: 10px;
@@ -78,8 +78,8 @@
   background: rgba(255, 255, 255, 0.08);
   border: 1px solid rgba(255, 255, 255, 0.15);
   color: #f5f5f7;
-  padding: 4px 10px;
-  border-radius: 6px;
+  padding: var(--space-1) 10px;
+  border-radius: var(--radius-sm);
   font: 11px/1 -apple-system, system-ui, sans-serif;
   cursor: pointer;
   flex-shrink: 0;
@@ -237,10 +237,10 @@
 /* Snooze context menu */
 .triage-snooze-menu {
   position: fixed;
-  background: rgba(28, 28, 32, 0.98);
+  background: var(--surface-overlay);
   border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: 8px;
-  padding: 4px;
+  border-radius: var(--radius-md);
+  padding: var(--space-1);
   z-index: 10000;
   display: flex;
   flex-direction: column;
@@ -252,10 +252,10 @@
   border: none;
   color: #f5f5f7;
   text-align: left;
-  padding: 8px 12px;
-  border-radius: 4px;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  font: 12px/1 -apple-system, system-ui, sans-serif;
+  font: var(--text-sm)/1 -apple-system, system-ui, sans-serif;
 }
 .triage-snooze-menu button:hover { background: rgba(255, 255, 255, 0.12); }
 
@@ -264,8 +264,8 @@
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid rgba(255, 255, 255, 0.15);
   color: #f5f5f7;
-  padding: 4px 10px;
-  border-radius: 6px;
+  padding: var(--space-1) 10px;
+  border-radius: var(--radius-sm);
   font: 11px/1 -apple-system, system-ui, sans-serif;
   cursor: pointer;
   flex-shrink: 0;

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -279,6 +279,38 @@
   background-size: 200% 100%;
 }
 
+.cb-input {
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-sm);
+  font-family: var(--font-ui);
+  color: #e5e5e5;
+  background: var(--surface-raised);
+  border: var(--border-medium);
+  border-radius: var(--radius-md);
+  outline: none;
+  transition: border-color var(--duration-fast) var(--ease-default),
+              box-shadow var(--duration-fast) var(--ease-default);
+}
+
+.cb-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
+}
+
+.cb-input::placeholder {
+  color: #555;
+}
+
+[data-theme="light"] .cb-input {
+  color: #1c1c1e;
+  background: var(--surface-raised);
+}
+
+[data-theme="light"] .cb-input::placeholder {
+  color: #999;
+}
+
 .cb-pill-group {
   display: inline-flex;
   gap: 2px;
@@ -316,6 +348,11 @@
 *:focus-visible {
   outline: none;
   box-shadow: var(--focus-ring);
+}
+
+/* Yield to macOS native focus ring when present */
+body.is-desktop-macos *:focus-visible {
+  box-shadow: none;
 }
 
 /* ── Scrollbar ── */

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -120,3 +120,227 @@
   --border-medium: 1px solid rgba(0, 0, 0, 0.1);
   --border-strong: 1px solid rgba(0, 0, 0, 0.15);
 }
+
+/* ══ Component Primitives ══ */
+
+.cb-card {
+  background: var(--surface-overlay);
+  border: var(--border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow: var(--elevation-1);
+  transition: transform var(--duration-fast) var(--ease-default),
+              box-shadow var(--duration-fast) var(--ease-default),
+              border-color var(--duration-fast) var(--ease-default);
+}
+
+.cb-card:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--elevation-2);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.cb-card.selected {
+  background: var(--severity-normal-bg);
+  border-color: rgba(59, 130, 246, 0.2);
+  box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.15);
+}
+
+.cb-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px var(--space-2);
+  font-size: var(--text-2xs);
+  font-weight: var(--fw-medium);
+  border-radius: var(--radius-sm);
+  line-height: 1.4;
+}
+
+.cb-badge[data-severity="critical"] {
+  color: var(--severity-critical);
+  background: var(--severity-critical-bg);
+  border: 1px solid var(--severity-critical-border);
+}
+
+.cb-badge[data-severity="high"] {
+  color: var(--severity-high);
+  background: var(--severity-high-bg);
+  border: 1px solid var(--severity-high-border);
+}
+
+.cb-badge[data-severity="elevated"] {
+  color: var(--severity-elevated);
+  background: var(--severity-elevated-bg);
+  border: 1px solid var(--severity-elevated-border);
+}
+
+.cb-badge[data-severity="normal"] {
+  color: var(--severity-normal);
+  background: var(--severity-normal-bg);
+  border: 1px solid var(--severity-normal-border);
+}
+
+.cb-badge[data-severity="positive"] {
+  color: var(--severity-positive);
+  background: var(--severity-positive-bg);
+  border: 1px solid var(--severity-positive-border);
+}
+
+.cb-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--text-sm);
+  font-weight: var(--fw-medium);
+  font-family: var(--font-ui);
+  border-radius: var(--radius-md);
+  border: var(--border-medium);
+  background: rgba(255, 255, 255, 0.04);
+  color: #aaa;
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-default),
+              transform var(--duration-fast) var(--ease-default);
+}
+
+.cb-button:hover {
+  background: var(--hover-bg);
+}
+
+.cb-button:active {
+  transform: scale(0.97);
+}
+
+.cb-button:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.cb-button.accent {
+  background: var(--accent);
+  color: #fff;
+  border-color: transparent;
+}
+
+.cb-button.accent:hover {
+  background: #2563eb;
+}
+
+.cb-list-row {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  transition: background var(--duration-fast) var(--ease-default),
+              transform var(--duration-fast) var(--ease-default);
+}
+
+.cb-list-row:hover {
+  background: var(--hover-bg);
+  transform: translateY(-1px);
+}
+
+.cb-list-row:active {
+  transform: scale(0.99);
+  background: var(--active-bg);
+}
+
+.cb-separator {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.06);
+  margin: var(--space-2) var(--space-4);
+}
+
+[data-theme="light"] .cb-separator {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.cb-skeleton {
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.04) 25%,
+    rgba(255, 255, 255, 0.08) 50%,
+    rgba(255, 255, 255, 0.04) 75%
+  );
+  background-size: 200% 100%;
+  animation: cb-shimmer 1.5s ease-in-out infinite;
+  border-radius: var(--radius-sm);
+}
+
+@keyframes cb-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+[data-theme="light"] .cb-skeleton {
+  background: linear-gradient(
+    90deg,
+    rgba(0, 0, 0, 0.04) 25%,
+    rgba(0, 0, 0, 0.08) 50%,
+    rgba(0, 0, 0, 0.04) 75%
+  );
+  background-size: 200% 100%;
+}
+
+.cb-pill-group {
+  display: inline-flex;
+  gap: 2px;
+  padding: 3px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius-md);
+}
+
+.cb-pill-group button {
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-2xs);
+  font-weight: var(--fw-medium);
+  font-family: var(--font-ui);
+  color: #888;
+  background: transparent;
+  border: none;
+  border-radius: calc(var(--radius-md) - 2px);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-default),
+              color var(--duration-fast) var(--ease-default);
+}
+
+.cb-pill-group button.active {
+  background: rgba(255, 255, 255, 0.1);
+  color: #e5e5e5;
+  font-weight: var(--fw-semibold);
+}
+
+.cb-pill-group button:hover:not(.active) {
+  background: rgba(255, 255, 255, 0.06);
+  color: #bbb;
+}
+
+/* ── Focus Ring Global ── */
+*:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+/* ── Scrollbar ── */
+::-webkit-scrollbar {
+  width: 4px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 2px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.25);
+  width: 6px;
+}
+
+[data-theme="light"] ::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.12);
+}
+
+[data-theme="light"] ::-webkit-scrollbar-thumb:hover {
+  background: rgba(0, 0, 0, 0.25);
+}

--- a/src/styles/design-system.css
+++ b/src/styles/design-system.css
@@ -1,0 +1,122 @@
+/* src/styles/design-system.css */
+/* Crystal Ball Design System — Apple-Native Tokens */
+
+:root {
+  /* ── Typography ── */
+  --font-ui: -apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text", system-ui, sans-serif;
+  --font-mono: "SF Mono", "Fira Code", "Cascadia Code", ui-monospace, monospace;
+
+  --text-2xs: 10px;
+  --text-xs: 11px;
+  --text-sm: 12px;
+  --text-base: 13px;
+  --text-md: 14px;
+  --text-lg: 16px;
+  --text-xl: 20px;
+  --text-2xl: 24px;
+
+  --fw-regular: 400;
+  --fw-medium: 500;
+  --fw-semibold: 600;
+  --fw-bold: 700;
+
+  /* ── Spacing (4px grid) ── */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* ── Border Radius ── */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+
+  /* ── Motion ── */
+  --duration-fast: 100ms;
+  --duration-normal: 200ms;
+  --duration-moderate: 350ms;
+  --duration-slow: 500ms;
+
+  --ease-default: cubic-bezier(0.25, 0.1, 0.25, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in: cubic-bezier(0.55, 0, 1, 0.45);
+
+  /* ── Surfaces (dark) ── */
+  --surface-base: #0a0a0a;
+  --surface-raised: #141414;
+  --surface-overlay: #1c1c1e;
+  --surface-popover: #2c2c2e;
+
+  /* ── Interactive States ── */
+  --accent: #3b82f6;
+  --hover-bg: rgba(255, 255, 255, 0.06);
+  --active-bg: rgba(255, 255, 255, 0.1);
+  --focus-ring: 0 0 0 2px rgba(59, 130, 246, 0.5), 0 0 0 4px rgba(59, 130, 246, 0.15);
+
+  /* ── Severity: Critical ── */
+  --severity-critical: #ef4444;
+  --severity-critical-bg: rgba(239, 68, 68, 0.1);
+  --severity-critical-border: rgba(239, 68, 68, 0.25);
+  --severity-critical-glow: rgba(239, 68, 68, 0.3);
+
+  /* ── Severity: High ── */
+  --severity-high: #f97316;
+  --severity-high-bg: rgba(249, 115, 22, 0.1);
+  --severity-high-border: rgba(249, 115, 22, 0.25);
+  --severity-high-glow: rgba(249, 115, 22, 0.3);
+
+  /* ── Severity: Elevated ── */
+  --severity-elevated: #eab308;
+  --severity-elevated-bg: rgba(234, 179, 8, 0.1);
+  --severity-elevated-border: rgba(234, 179, 8, 0.25);
+  --severity-elevated-glow: rgba(234, 179, 8, 0.3);
+
+  /* ── Severity: Normal ── */
+  --severity-normal: #3b82f6;
+  --severity-normal-bg: rgba(59, 130, 246, 0.08);
+  --severity-normal-border: rgba(59, 130, 246, 0.2);
+  --severity-normal-glow: rgba(59, 130, 246, 0.2);
+
+  /* ── Severity: Positive ── */
+  --severity-positive: #22c55e;
+  --severity-positive-bg: rgba(34, 197, 94, 0.08);
+  --severity-positive-border: rgba(34, 197, 94, 0.2);
+  --severity-positive-glow: rgba(34, 197, 94, 0.2);
+
+  /* ── Elevation ── */
+  --elevation-1: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --elevation-2: 0 4px 12px rgba(0, 0, 0, 0.4);
+  --elevation-3: 0 8px 32px rgba(0, 0, 0, 0.5);
+  --elevation-4: 0 16px 48px rgba(0, 0, 0, 0.6);
+
+  --border-subtle: 1px solid rgba(255, 255, 255, 0.06);
+  --border-medium: 1px solid rgba(255, 255, 255, 0.08);
+  --border-strong: 1px solid rgba(255, 255, 255, 0.1);
+  --border-accent: 1px solid rgba(59, 130, 246, 0.2);
+}
+
+/* ── Light theme overrides ── */
+[data-theme="light"] {
+  --surface-base: #f5f5f7;
+  --surface-raised: #ffffff;
+  --surface-overlay: #f2f2f7;
+  --surface-popover: #ffffff;
+
+  --hover-bg: rgba(0, 0, 0, 0.04);
+  --active-bg: rgba(0, 0, 0, 0.08);
+
+  --elevation-1: 0 1px 3px rgba(0, 0, 0, 0.08);
+  --elevation-2: 0 4px 12px rgba(0, 0, 0, 0.1);
+  --elevation-3: 0 8px 32px rgba(0, 0, 0, 0.12);
+  --elevation-4: 0 16px 48px rgba(0, 0, 0, 0.15);
+
+  --border-subtle: 1px solid rgba(0, 0, 0, 0.06);
+  --border-medium: 1px solid rgba(0, 0, 0, 0.1);
+  --border-strong: 1px solid rgba(0, 0, 0, 0.15);
+}

--- a/src/styles/gods-vision.css
+++ b/src/styles/gods-vision.css
@@ -783,3 +783,10 @@ body.gods-vision-lock {
 }
 .ge-minimap-canvas { display: block; }
 
+@media (prefers-reduced-motion: no-preference) {
+  .ge-entering .ge-globe-container { animation: cb-fade-in 500ms var(--ease-out) 200ms both; }
+  .ge-entering .ge-hud-element { animation: cb-slide-up var(--duration-moderate) var(--ease-out) both; }
+  .ge-exiting .ge-globe-container { animation: cb-fade-out 300ms var(--ease-in) both; }
+  .ge-exiting .ge-hud-element { animation: cb-fade-out 200ms var(--ease-in) both; }
+}
+

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,4 +1,5 @@
 @import './design-system.css';
+@import './motion.css';
 @import './rtl-overrides.css';
 @import './panels.css';
 @import './macos-native.css';

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,3 +1,4 @@
+@import './design-system.css';
 @import './rtl-overrides.css';
 @import './panels.css';
 @import './macos-native.css';

--- a/src/styles/motion.css
+++ b/src/styles/motion.css
@@ -1,0 +1,102 @@
+/* src/styles/motion.css */
+
+@keyframes cb-slide-up {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes cb-slide-down {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes cb-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes cb-fade-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
+@keyframes cb-scale-in {
+  from { opacity: 0; transform: scale(0.97); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes cb-scale-out {
+  from { opacity: 1; transform: scale(1); }
+  to { opacity: 0; transform: scale(0.98); }
+}
+
+@keyframes cb-slide-in-right {
+  from { opacity: 0; transform: translateX(100%); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes cb-slide-out-right {
+  from { opacity: 1; transform: translateX(0); }
+  to { opacity: 0; transform: translateX(100%); }
+}
+
+@keyframes cb-pulse-scale {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.15); }
+  100% { transform: scale(1); }
+}
+
+@keyframes cb-ripple {
+  from { transform: scale(1); opacity: 0.4; }
+  to { transform: scale(2.5); opacity: 0; }
+}
+
+/* ══ Utility Classes ══ */
+
+@media (prefers-reduced-motion: no-preference) {
+  .cb-animate-slide-up { animation: cb-slide-up var(--duration-moderate) var(--ease-out) both; }
+  .cb-animate-slide-down { animation: cb-slide-down var(--duration-moderate) var(--ease-out) both; }
+  .cb-animate-fade-in { animation: cb-fade-in var(--duration-normal) var(--ease-default) both; }
+  .cb-animate-fade-out { animation: cb-fade-out var(--duration-normal) var(--ease-in) both; }
+  .cb-animate-scale-in { animation: cb-scale-in var(--duration-moderate) var(--ease-out) both; }
+  .cb-animate-scale-out { animation: cb-scale-out var(--duration-normal) var(--ease-in) both; }
+  .cb-animate-slide-in-right { animation: cb-slide-in-right var(--duration-moderate) var(--ease-spring) both; }
+  .cb-animate-slide-out-right { animation: cb-slide-out-right var(--duration-normal) var(--ease-in) both; }
+  .cb-animate-pulse { animation: cb-pulse-scale var(--duration-moderate) var(--ease-spring); }
+  .cb-stagger-item { animation: cb-slide-up var(--duration-moderate) var(--ease-out) both; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cb-animate-slide-up, .cb-animate-slide-down, .cb-animate-scale-in,
+  .cb-animate-slide-in-right, .cb-stagger-item { animation: cb-fade-in 1ms both; }
+  .cb-animate-fade-out, .cb-animate-scale-out, .cb-animate-slide-out-right { animation: cb-fade-out 1ms both; }
+  .cb-animate-pulse { animation: none; }
+}
+
+body.animations-paused .cb-animate-slide-up,
+body.animations-paused .cb-animate-slide-down,
+body.animations-paused .cb-animate-fade-in,
+body.animations-paused .cb-animate-fade-out,
+body.animations-paused .cb-animate-scale-in,
+body.animations-paused .cb-animate-scale-out,
+body.animations-paused .cb-animate-slide-in-right,
+body.animations-paused .cb-animate-slide-out-right,
+body.animations-paused .cb-animate-pulse,
+body.animations-paused .cb-stagger-item { animation: none !important; }
+
+/* ══ Modal / Overlay ══ */
+
+.cb-backdrop {
+  position: fixed; inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 9998;
+}
+
+.cb-modal-content { z-index: 9999; }
+
+@media (prefers-reduced-motion: no-preference) {
+  .cb-backdrop { animation: cb-fade-in var(--duration-normal) var(--ease-default) both; }
+  .cb-backdrop.closing { animation: cb-fade-out var(--duration-normal) var(--ease-in) both; }
+  .cb-modal-content { animation: cb-scale-in var(--duration-moderate) var(--ease-out) both; }
+  .cb-modal-content.closing { animation: cb-scale-out var(--duration-normal) var(--ease-in) both; }
+}

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -449,6 +449,49 @@
 .sit-map-btn:hover { border-color: #555; background: #1a1a1a; }
 
 /* ----------------------------------------------------------
+ Unified Alert Inbox Panel
+ ---------------------------------------------------------- */
+.uai-container { display: flex; flex-direction: column; height: 100%; }
+.uai-toolbar { display: flex; flex-wrap: wrap; gap: var(--space-2); padding: var(--space-2) var(--space-2) 0; }
+.uai-toolbar-group { display: flex; align-items: center; gap: 2px; }
+.uai-toolbar-label { font-size: var(--text-2xs); color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px; margin-right: 4px; }
+.uai-toolbar-btn { background: transparent; border: 1px solid var(--border-medium); color: var(--text-dim); padding: 2px 8px; font-size: var(--text-2xs); border-radius: var(--radius-sm); cursor: pointer; transition: background 0.12s, color 0.12s; }
+.uai-toolbar-btn:hover { background: var(--surface-overlay); color: var(--text); }
+.uai-toolbar-btn.uai-active { background: var(--severity-critical-bg); border-color: var(--severity-critical-border); color: var(--severity-critical); }
+.uai-sev-btn.uai-active { background: var(--severity-elevated-bg); border-color: var(--severity-elevated-border); color: var(--severity-elevated); }
+.uai-clear-btn { border-color: var(--border-strong); color: var(--text-secondary); }
+.uai-list { flex: 1; overflow-y: auto; }
+.uai-table { width: 100%; border-collapse: collapse; font-size: var(--text-sm); }
+.uai-th-sev { width: 56px; }
+.uai-th-src { width: 60px; }
+.uai-th-score { width: 56px; }
+.uai-th-dist { width: 50px; }
+.uai-th-age { width: 40px; }
+.uai-th-act { width: 56px; }
+.uai-src-cell { white-space: nowrap; }
+.uai-src-tag { display: inline-block; font-size: var(--text-2xs); padding: 1px 5px; border-radius: var(--radius-sm); background: var(--surface-overlay); color: var(--text-dim); cursor: pointer; white-space: nowrap; }
+.uai-src-tag:hover { background: var(--surface-popover); color: var(--text); }
+.uai-title-cell { max-width: 0; }
+.uai-title { font-size: var(--text-sm); color: var(--text); line-height: 1.35; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.uai-title a { color: var(--accent); text-decoration: none; }
+.uai-title a:hover { text-decoration: underline; }
+.uai-body { font-size: var(--text-2xs); color: var(--text-dim); line-height: 1.3; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; margin-top: 1px; }
+.uai-score-cell { white-space: nowrap; }
+.uai-score-bar { position: relative; width: 48px; height: 14px; background: var(--surface-overlay); border-radius: var(--radius-sm); overflow: hidden; }
+.uai-score-fill { height: 100%; border-radius: var(--radius-sm); }
+.uai-score-label { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; font-size: var(--text-2xs); color: var(--text); font-weight: 600; mix-blend-mode: difference; }
+.uai-dist-cell { font-size: var(--text-2xs); color: var(--text-dim); white-space: nowrap; }
+.uai-actions { white-space: nowrap; }
+.uai-act-btn { background: transparent; border: none; color: var(--text-muted); cursor: pointer; font-size: var(--text-xs); padding: 2px; line-height: 1; }
+.uai-act-btn:hover { color: var(--text); }
+.uai-why-btn { background: transparent; border: 1px solid var(--border-medium); color: var(--text-dim); font-size: var(--text-2xs); padding: 1px 5px; border-radius: var(--radius-sm); cursor: pointer; margin-left: 4px; }
+.uai-why-btn:hover { border-color: var(--accent); color: var(--accent); }
+.uai-related-badge { display: inline-block; font-size: var(--text-2xs); padding: 1px 5px; border-radius: var(--radius-sm); background: var(--surface-overlay); color: var(--text-muted); margin-left: var(--space-1); }
+.uai-pinned { background: color-mix(in srgb, var(--severity-elevated) 5%, transparent); }
+.uai-acked { opacity: 0.45; }
+.uai-selected { background: color-mix(in srgb, var(--accent) 8%, transparent); outline: 1px solid var(--accent); }
+
+/* ----------------------------------------------------------
  Alert Center Panel
  ---------------------------------------------------------- */
 .ac-sev { width: 70px; }

--- a/tests/design-system.test.mts
+++ b/tests/design-system.test.mts
@@ -1,0 +1,72 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const css = readFileSync(resolve(import.meta.dirname, '../src/styles/design-system.css'), 'utf-8');
+
+describe('design-system.css tokens', () => {
+  const requiredTokens = [
+    '--font-ui', '--font-mono',
+    '--text-2xs', '--text-xs', '--text-sm', '--text-base',
+    '--text-md', '--text-lg', '--text-xl', '--text-2xl',
+    '--fw-regular', '--fw-medium', '--fw-semibold', '--fw-bold',
+    '--space-1', '--space-2', '--space-3', '--space-4',
+    '--space-6', '--space-8', '--space-12', '--space-16',
+    '--radius-sm', '--radius-md', '--radius-lg', '--radius-xl',
+    '--duration-fast', '--duration-normal', '--duration-moderate', '--duration-slow',
+    '--ease-default', '--ease-spring', '--ease-out', '--ease-in',
+    '--surface-base', '--surface-raised', '--surface-overlay', '--surface-popover',
+    '--accent', '--hover-bg', '--active-bg', '--focus-ring',
+    '--elevation-1', '--elevation-2', '--elevation-3', '--elevation-4',
+    '--border-subtle', '--border-medium', '--border-strong',
+  ];
+
+  for (const token of requiredTokens) {
+    it(`defines ${token}`, () => {
+      assert.ok(css.includes(`${token}:`), `Missing token: ${token}`);
+    });
+  }
+
+  const severityLevels = ['critical', 'high', 'elevated', 'normal', 'positive'];
+  const severityVariants = ['', '-bg', '-border', '-glow'];
+
+  for (const level of severityLevels) {
+    for (const variant of severityVariants) {
+      const token = `--severity-${level}${variant}`;
+      it(`defines ${token}`, () => {
+        assert.ok(css.includes(`${token}:`), `Missing severity token: ${token}`);
+      });
+    }
+  }
+
+  it('includes light theme overrides', () => {
+    assert.ok(css.includes('[data-theme="light"]'), 'Missing light theme selector');
+  });
+
+  it('includes shimmer keyframe', () => {
+    assert.ok(css.includes('@keyframes cb-shimmer'), 'Missing shimmer animation');
+  });
+});
+
+describe('design-system.css component primitives', () => {
+  const requiredClasses = [
+    '.cb-card', '.cb-badge', '.cb-button', '.cb-list-row',
+    '.cb-separator', '.cb-skeleton', '.cb-pill-group',
+  ];
+
+  for (const cls of requiredClasses) {
+    it(`defines ${cls}`, () => {
+      assert.ok(css.includes(cls), `Missing class: ${cls}`);
+    });
+  }
+
+  it('defines severity badge variants', () => {
+    for (const level of ['critical', 'high', 'elevated', 'normal', 'positive']) {
+      assert.ok(
+        css.includes(`[data-severity="${level}"]`),
+        `Missing badge variant: ${level}`,
+      );
+    }
+  });
+});

--- a/tests/design-system.test.mts
+++ b/tests/design-system.test.mts
@@ -51,7 +51,7 @@ describe('design-system.css tokens', () => {
 
 describe('design-system.css component primitives', () => {
   const requiredClasses = [
-    '.cb-card', '.cb-badge', '.cb-button', '.cb-list-row',
+    '.cb-card', '.cb-badge', '.cb-button', '.cb-input', '.cb-list-row',
     '.cb-separator', '.cb-skeleton', '.cb-pill-group',
   ];
 

--- a/tests/empty-state.test.mts
+++ b/tests/empty-state.test.mts
@@ -1,0 +1,29 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const src = readFileSync(resolve(import.meta.dirname, '../src/components/EmptyState.ts'), 'utf-8');
+
+describe('EmptyState component', () => {
+  it('exports renderEmptyState function', () => {
+    assert.ok(src.includes('export function renderEmptyState'));
+  });
+  it('exports getEmptyStateDefaults function', () => {
+    assert.ok(src.includes('export function getEmptyStateDefaults'));
+  });
+  it('exports EmptyState class', () => {
+    assert.ok(src.includes('export class EmptyState'));
+  });
+  it('supports icon, title, message', () => {
+    assert.ok(src.includes('icon') && src.includes('title') && src.includes('message'));
+  });
+  it('supports optional CTA button', () => {
+    assert.ok(src.includes('cta'));
+  });
+  it('has category defaults', () => {
+    for (const cat of ['geopolitical', 'infrastructure', 'cyber', 'markets', 'weather']) {
+      assert.ok(src.includes(cat), `Missing category: ${cat}`);
+    }
+  });
+});

--- a/tests/motion.test.mts
+++ b/tests/motion.test.mts
@@ -1,0 +1,31 @@
+// tests/motion.test.mts
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const src = readFileSync(resolve(import.meta.dirname, '../src/services/motion.ts'), 'utf-8');
+
+describe('motion.ts exports', () => {
+  const requiredExports = [
+    'staggerIn', 'crossfadeContent', 'animateNumber',
+    'animateIn', 'animateOut', 'revealContent', 'prefersReducedMotion',
+  ];
+
+  for (const name of requiredExports) {
+    it(`exports ${name}`, () => {
+      assert.ok(
+        src.includes(`export function ${name}`) || src.includes(`export const ${name}`),
+        `Missing export: ${name}`,
+      );
+    });
+  }
+
+  it('checks prefers-reduced-motion', () => {
+    assert.ok(src.includes('prefers-reduced-motion'), 'Must check reduced motion preference');
+  });
+
+  it('checks body.animations-paused', () => {
+    assert.ok(src.includes('animations-paused'), 'Must respect animations-paused class');
+  });
+});

--- a/tests/sound.test.mts
+++ b/tests/sound.test.mts
@@ -1,0 +1,28 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const src = readFileSync(resolve(import.meta.dirname, '../src/services/sound.ts'), 'utf-8');
+
+describe('sound service', () => {
+  it('exports playAlertSound', () => {
+    assert.ok(src.includes('export function playAlertSound'));
+  });
+
+  it('exports playAckSound', () => {
+    assert.ok(src.includes('export function playAckSound'));
+  });
+
+  it('uses Web Audio API', () => {
+    assert.ok(src.includes('AudioContext'));
+  });
+
+  it('respects Ghost Mode', () => {
+    assert.ok(src.includes('isGhostMode'));
+  });
+
+  it('rate-limits sounds', () => {
+    assert.ok(src.includes('MIN_INTERVAL'));
+  });
+});

--- a/tests/toast.test.mts
+++ b/tests/toast.test.mts
@@ -1,0 +1,34 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const src = readFileSync(resolve(import.meta.dirname, '../src/components/Toast.ts'), 'utf-8');
+
+describe('Toast component', () => {
+  it('exports Toast class', () => {
+    assert.ok(src.includes('export class Toast'), 'Must export Toast class');
+  });
+
+  it('exports showToast function', () => {
+    assert.ok(src.includes('export function showToast'), 'Must export showToast');
+  });
+
+  it('supports severity levels', () => {
+    for (const s of ['critical', 'high', 'elevated']) {
+      assert.ok(src.includes(s), `Must support ${s} severity`);
+    }
+  });
+
+  it('implements auto-dismiss', () => {
+    assert.ok(src.includes('setTimeout'), 'Must implement auto-dismiss timer');
+  });
+
+  it('respects Ghost Mode', () => {
+    assert.ok(src.includes('isGhostMode'), 'Must check Ghost Mode');
+  });
+
+  it('limits stack size', () => {
+    assert.ok(src.includes('MAX_TOASTS'), 'Must limit toast stack');
+  });
+});


### PR DESCRIPTION
## Summary

Preserves `claude/apple-native-polish-spec` (26 commits, 31 files) — a substantial UX polish stream.

### Commits (highlights)

- `feat: add WelcomeFlow 3-step onboarding modal`
- `feat: add ContextualHint one-time tooltip component`
- `feat: add EmptyState component with category defaults`
- `feat: wire WelcomeFlow and contextual hints into app init`
- `feat: cinematic God's Vision entry/exit transitions`
- `feat: render flights as airplane icons instead of dots`
- `feat: Toast component`
- `fix: WelcomeFlow stuck + exponential backoff for failed refreshes`
- `test: add E2E smoke test for design system tokens`
- `fix: address code review — 3 critical + 1 important issue`

### Files (selected)

- `docs/superpowers/plans/2026-04-13-apple-native-polish.md`
- `docs/superpowers/specs/2026-04-13-apple-native-polish-design.md`
- `e2e/design-system.spec.ts`
- `src/app/panel-layout.ts` (⚠️ heavily refactored by PR #52)
- `src/components/{CesiumGlobe,DeckGLMap,GlobeHUD,GodsVisionView,MapPopup,Panel,TriageBar}.ts`
- `src/components/{ContextualHint,EmptyState,Toast}.ts` (new)

### Verdict

**67 commits behind main.** Rebase is expensive. Most valuable pieces to salvage individually:
- `ContextualHint`, `EmptyState`, `Toast` components (new files, low conflict)
- WelcomeFlow onboarding (new feature)
- Airplane-icon rendering for flights
- Cinematic God's Vision transitions (depends on the GodsVisionView refactor state)

### Test plan

- [ ] Product-level review: decide which of the 7 UX additions above are in scope
- [ ] Cherry-pick `ContextualHint` / `EmptyState` / `Toast` first (low conflict)
- [ ] Evaluate WelcomeFlow onboarding UX independently
- [ ] Revisit cinematic transitions after PR #52 lands (panel-layout.ts structure changed)