### PR TITLE
salvage: review-cli-performance (entire cb-control subsystem — iPhone PWA + daemon for remote Claude sessions)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,3 +113,24 @@ API keys entered via gear icon → API Keys tab. None embed the brand in their n
 ## Secret Scan Guardrail
 
 Mandatory repo secret scan enforcement in hooks and CI. Keep `npm run secrets:scan:staged` and `npm run secrets:scan` active and passing.
+
+## Cross-session coordination: `tools/cb-control/`
+
+A local daemon at `http://127.0.0.1:46987` registers every Claude CLI
+session on this Mac and exposes an HTTP API to list them, read their
+recent output, relay commands into them, and spawn new ones. It's how
+the user drives sessions remotely from their iPhone and how Claude
+sessions can coordinate with each other.
+
+**If the user asks you to check what another session is doing, hand off
+work to another session, or spawn parallel sessions, read
+`tools/cb-control/CLAUDE.md` — it has the full API surface, patterns,
+and safety rules.**
+
+Quick check it's running:
+```bash
+curl -fsS http://127.0.0.1:46987/health && \
+  TOKEN=$(cat ~/.config/cb-control/token) && \
+  curl -fsS -H "Authorization: Bearer $TOKEN" http://127.0.0.1:46987/api/sessions | jq
+```
+

--- a/tools/cb-control/.gitignore
+++ b/tools/cb-control/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+data/
+*.log
+.DS_Store

--- a/tools/cb-control/CLAUDE.md
+++ b/tools/cb-control/CLAUDE.md
@@ -1,0 +1,221 @@
+# cb-control — Claude session guide
+
+**If you are a Claude Code session running in this repo, read this file.**
+It explains a local tool that lets you see and coordinate with other Claude
+sessions running on the same Mac.
+
+## What cb-control is
+
+`cb-control` is a local daemon on this Mac (default `http://127.0.0.1:46987`)
+that:
+
+- Registers every Claude CLI session via a `SessionStart` hook (so each
+  session can see the others)
+- Spawns new Claude sessions in PTYs
+- Relays input (keystrokes, commands) into existing tmux-hosted sessions
+- Mirrors live output over WebSocket
+- Persists events to SQLite with full-text search
+
+If you are this Claude session, you yourself are probably registered with
+it. Other sessions running on this Mac — including ones the user is
+driving from their iPhone via the PWA — are visible to you through the
+HTTP API documented below.
+
+## First: is it running?
+
+```bash
+curl -fsS http://127.0.0.1:46987/health
+# -> {"ok":true,"version":"0.1.0"}
+```
+
+If that fails, cb-control isn't running. Do nothing else — the user starts
+it manually; don't launch it yourself. If the user asked you to interact
+with cb-control and it's down, say so.
+
+## Load the bearer token
+
+Every API call (except `/health`) needs a bearer token at
+`~/.config/cb-control/token`:
+
+```bash
+TOKEN=$(cat ~/.config/cb-control/token)
+```
+
+If the token file doesn't exist, cb-control has never been started. Tell
+the user.
+
+## Core operations
+
+### List all live and recent sessions
+
+```bash
+curl -fsS -H "Authorization: Bearer $TOKEN" \
+  http://127.0.0.1:46987/api/sessions | jq
+```
+
+Returns `{sessions: [{id, label, cwd, branch, status, source, live, bridge, ...}]}`.
+
+- `source: "daemon"` — spawned by cb-control (managed PTY; full I/O)
+- `source: "external"` with `bridge: "tmux"` — user-launched CLI in a tmux pane (full I/O)
+- `source: "external"` with `bridge: null` — user-launched CLI **not** in tmux (metadata-only; can't send input)
+
+**Identify yourself:** your own `session_id` is passed to your hooks; you
+won't usually know it directly, but you can match by `cwd` (current
+working directory) to find your row.
+
+### Read another session's recent output
+
+```bash
+SESSION_ID=...
+curl -fsS -H "Authorization: Bearer $TOKEN" \
+  "http://127.0.0.1:46987/api/sessions/$SESSION_ID" | jq -r .snapshot
+```
+
+The `snapshot` field contains the last ~200KB of that session's pane
+output — what the other Claude just said/did.
+
+### Relay a command to another session
+
+**Only do this when the user has clearly authorized cross-session action.**
+Injecting input into another Claude is equivalent to the user typing at
+that Claude — it has full permission to edit files, run commands, etc.
+
+```bash
+curl -fsS -H "Authorization: Bearer $TOKEN" \
+  -H "content-type: application/json" \
+  -d '{"data":"please rebase onto main and rerun the benchmarks","enter":true}' \
+  http://127.0.0.1:46987/api/sessions/$SESSION_ID/input
+```
+
+`enter: true` appends a carriage return so the message submits. If
+`enter: false`, you just push characters into the prompt buffer — useful
+for appending to what the user is already typing, rarely what you want.
+
+### Spawn a fresh session
+
+```bash
+curl -fsS -H "Authorization: Bearer $TOKEN" \
+  -H "content-type: application/json" \
+  -d '{"cwd":"/Users/you/developer/crystalball","label":"parallel-test","args":[]}' \
+  http://127.0.0.1:46987/api/sessions
+```
+
+Use this for fan-out work the user has asked for: parallel branch
+refactors, multi-repo edits, etc. Spawned sessions boot into whatever
+working state the `cwd` has — so check that `cwd` is the right branch
+before spawning.
+
+### Search across every session's transcript
+
+```bash
+curl -fsS -H "Authorization: Bearer $TOKEN" \
+  "http://127.0.0.1:46987/api/search?q=migration+0042&limit=20" | jq
+```
+
+Useful for answering "what did the other session already try?" before you
+redo the work.
+
+### Compose (relay to many at once)
+
+```bash
+curl -fsS -H "Authorization: Bearer $TOKEN" \
+  -H "content-type: application/json" \
+  -d '{"ids":["id1","id2","id3"],"data":"git fetch origin && git status","enter":true}' \
+  http://127.0.0.1:46987/api/compose
+```
+
+## When to use this vs. not
+
+**Use it when:**
+- The user asked to coordinate across sessions
+- The user asked what another session is doing
+- You need context another session built and you can search for it
+
+**Don't use it when:**
+- The user hasn't mentioned other sessions — don't freelance and start
+  chattering at them
+- You'd be saying anything secret (tokens, keys, passwords) — the
+  transcript is persisted to SQLite
+
+**Never:**
+- Mass-kill sessions (`DELETE /api/sessions/:id`) without explicit user approval
+- Spawn sessions with `--dangerously-skip-permissions` via the `args` field
+- Loop automated retries against another session — a human review gate
+  between agent actions matters
+
+## Workflow patterns
+
+### Pattern 1: "what did the other session find?"
+
+```bash
+TOKEN=$(cat ~/.config/cb-control/token)
+curl -fsS -H "Authorization: Bearer $TOKEN" http://127.0.0.1:46987/api/sessions \
+  | jq -r '.sessions[] | select(.live) | "\(.id)\t\(.label)\t\(.cwd)"'
+# pick the relevant session id, then:
+curl -fsS -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:46987/api/sessions/$ID" \
+  | jq -r .snapshot | tail -200
+```
+
+### Pattern 2: "hand off a task"
+
+After you've prepared context, ask the user to confirm, then:
+
+```bash
+curl -fsS -H "Authorization: Bearer $TOKEN" \
+  -H "content-type: application/json" \
+  -d "$(jq -nc --arg msg "Session A (perf-review) prepared benchmarks at /tmp/bench.json. Please review and decide whether to merge." '{data:$msg, enter:true}')" \
+  http://127.0.0.1:46987/api/sessions/$TARGET/input
+```
+
+### Pattern 3: "parallel exploration"
+
+```bash
+# spawn three sessions investigating three different hypotheses
+for q in "redis-cache" "eager-load" "denormalize"; do
+  curl -fsS -H "Authorization: Bearer $TOKEN" -H "content-type: application/json" \
+    -d "$(jq -nc --arg cwd "$PWD" --arg label "$q" '{cwd:$cwd, label:$label}')" \
+    http://127.0.0.1:46987/api/sessions | jq .id
+done
+```
+
+Then relay the initial prompt into each with `POST /api/sessions/:id/input`.
+
+## Full API / setup docs
+
+See `README.md` in this directory. TL;DR: PWA lives at the daemon root
+(e.g. `https://<mac>.tailnet.ts.net/`), PWA gives the user full remote
+control from iPhone.
+
+## Source layout
+
+```
+server/       # HTTP + WebSocket daemon
+  config.mjs  # host/port/token/paths
+  storage.mjs # SQLite + FTS5
+  sessions.mjs# managed PTY + external tmux session classes
+  tmux-bridge.mjs # send-keys / pipe-pane / capture-pane helpers
+  api.mjs     # HTTP routes
+  ws.mjs      # WebSocket streaming
+  index.mjs   # entrypoint
+web/          # PWA (vanilla ESM, no build step)
+hooks/        # SessionStart + Stop, installed into ~/.claude/settings.json
+scripts/      # install-hooks, install-launchd, setup-tailscale-https
+```
+
+## Don't break things
+
+- Before editing `sessions.mjs` or `storage.mjs`, read them fully. Both
+  have non-obvious invariants (sessionBus contract; FTS5 triggers).
+- Every managed and external session must expose the same shape
+  (`write`, `snapshot`, `kill`, `status`) so HTTP and WS layers stay
+  shape-polymorphic.
+- Keep zero-build-step for the PWA: no bundlers, no transpiling, no
+  framework runtime. Vanilla ESM is a hard requirement.
+- Keep dependencies minimal (`node-pty`, `ws`, `better-sqlite3`). Adding
+  a dep requires a strong reason.
+
+## Commit style
+
+Same as the parent repo: trailer `Co-Authored-By: Claude Sonnet 4.6
+<noreply@anthropic.com>`, develop on `claude/*` branches, never push to
+`main`.

--- a/tools/cb-control/HANDOFF.md
+++ b/tools/cb-control/HANDOFF.md
@@ -1,0 +1,132 @@
+# cb-control handoff
+
+**You are a Claude session being asked to learn about, set up, or
+coordinate with a tool called `cb-control`. Read this file first.**
+
+## One-paragraph summary
+
+`cb-control` is a local daemon + PWA that lets the user drive Claude Code
+CLI sessions from their iPhone over Tailscale, and lets Claude sessions
+coordinate with each other on the same Mac. Work was scaffolded and fully
+built out by an earlier Claude session on branch
+`claude/review-cli-performance-RVsx6` of `bradleybond512/crystal-ball`.
+The code exists but has not yet been installed or run on the user's Mac.
+
+## Where the code is
+
+- **Repo**: `bradleybond512/crystal-ball`
+- **Branch**: `claude/review-cli-performance-RVsx6`
+- **Not on `main`** — the user has not merged.
+- **Path in the repo**: `tools/cb-control/`
+- **Commit range**: `dc76658..e66c570` (three commits: scaffold → full
+  feature set → Claude-session docs)
+
+## Current state (as of handoff)
+
+**Done:**
+
+- Node daemon: HTTP + WebSocket + PTY spawn + SQLite + FTS5 search + tmux
+  bridge for external sessions (send-keys in, pipe-pane out).
+- PWA (no build step): sessions list, live terminal with ANSI coloring,
+  command input bar, multi-session compose, transcript search,
+  biometric (WebAuthn) unlock gate.
+- SessionStart + Stop hooks + idempotent installer for
+  `~/.claude/settings.json`.
+- macOS launchd installer (`npm run install-launchd`).
+- Tailscale HTTPS helper (`npm run setup-https`).
+- Docs: `tools/cb-control/README.md` (user-facing),
+  `tools/cb-control/CLAUDE.md` (session-facing), root `CLAUDE.md`
+  pointer.
+
+**Not done (three gates the user must close before any session can
+actually use cb-control):**
+
+1. **Pull the branch to the Mac**
+   ```bash
+   cd ~/developer/crystalball
+   git fetch origin
+   git checkout claude/review-cli-performance-RVsx6
+   ```
+
+2. **Install and run the daemon**
+   ```bash
+   cd tools/cb-control
+   npm install
+   npm run install-hooks
+   npm run install-launchd        # or `npm start` for foreground
+   ```
+   After this, `curl http://127.0.0.1:46987/health` should return
+   `{"ok":true,...}` and a bearer token lives at
+   `~/.config/cb-control/token`.
+
+3. **Make it discoverable machine-wide** (optional but recommended)
+   Add a section to `~/.claude/CLAUDE.md` so every Claude session on
+   the Mac learns to check for the daemon, regardless of cwd:
+   ```
+   ## cb-control (machine-wide Claude session coordination)
+   Local daemon at http://127.0.0.1:46987 for cross-session coordination.
+   Check on startup when the user mentions "other session", "hand off",
+   "relay", "parallel session", or "the daemon":
+     test -f ~/.config/cb-control/token && curl -fsS http://127.0.0.1:46987/health
+   Full API: ~/developer/crystalball/tools/cb-control/CLAUDE.md
+   ```
+
+Until gates 1 and 2 close, every API call in the docs below will fail
+with "Connection refused" — that is the expected state right now.
+
+## After setup: what to read next
+
+- **`tools/cb-control/CLAUDE.md`** — full HTTP API surface, safety
+  rules, workflow patterns (hand-off, parallel exploration, "what did
+  the other session find?"). Read this if you're going to *use* or
+  *modify* the daemon.
+- **`tools/cb-control/README.md`** — user-facing install, Tailscale
+  setup, iPhone PWA install, launchd, HTTPS, uninstall. Read this if
+  you're helping the user with setup.
+- **`tools/cb-control/server/`** — the daemon source. Read this if
+  you're debugging or extending the daemon itself. Non-obvious
+  invariants live in `sessions.mjs` (sessionBus shape) and
+  `storage.mjs` (FTS5 triggers).
+
+## Never
+
+- Don't spawn sessions with `--dangerously-skip-permissions`.
+- Don't mass-kill other sessions via `DELETE /api/sessions/:id` without
+  explicit user approval.
+- Don't loop-retry commands against another session — always leave a
+  human review gate.
+- Don't relay secrets (tokens, API keys) through session input — the
+  transcript is persisted to SQLite and indexed for full-text search.
+
+## If the user asks "what did the earlier session do?"
+
+They are probably referring to the session that built this tool. Answer
+with the summary above. The full work product is the three commits on
+`claude/review-cli-performance-RVsx6` and the two doc files listed.
+
+## Machine-readable manifest
+
+```json
+{
+  "repo": "bradleybond512/crystal-ball",
+  "branch": "claude/review-cli-performance-RVsx6",
+  "path": "tools/cb-control/",
+  "daemon": {
+    "url": "http://127.0.0.1:46987",
+    "token_path": "~/.config/cb-control/token",
+    "state_dir": "~/.config/cb-control/",
+    "log_path": "~/Library/Logs/cb-control.log"
+  },
+  "docs": {
+    "handoff": "tools/cb-control/HANDOFF.md",
+    "session_guide": "tools/cb-control/CLAUDE.md",
+    "user_readme": "tools/cb-control/README.md"
+  },
+  "install_order": [
+    "git checkout claude/review-cli-performance-RVsx6",
+    "cd tools/cb-control && npm install",
+    "npm run install-hooks",
+    "npm run install-launchd"
+  ]
+}
+```

--- a/tools/cb-control/README.md
+++ b/tools/cb-control/README.md
@@ -1,0 +1,195 @@
+# cb-control
+
+Remote control for Claude Code CLI sessions. Runs as a local daemon on your
+Mac, exposes a mobile-first PWA, and is accessed securely from your iPhone
+over Tailscale.
+
+What you get:
+
+- **Spawn Claude sessions from your phone** — full Claude Code features, running
+  on your Mac with all its tools and keys.
+- **Relay commands to existing sessions** — CLI sessions you started in a
+  terminal register themselves via a `SessionStart` hook and show up in the PWA.
+- **Live output streaming** over WebSocket.
+- **Persistent transcripts** in SQLite (searchable across sessions).
+
+Architecture: one daemon (`~500 LOC` Node), one PWA (no build step, plain ES
+modules), Tailscale for remote access. No App Store, no native iOS code, no
+public internet exposure.
+
+> Note: this tool currently lives inside the `crystal-ball` repo under
+> `tools/cb-control/` but is self-contained. It can be extracted to its own
+> repo any time with `git subtree split --prefix=tools/cb-control`.
+
+## Requirements
+
+- macOS (or Linux) with Node.js 20+
+- Claude Code CLI installed on PATH as `claude`
+- Tailscale on both your Mac and iPhone (free tier is fine)
+
+## Install
+
+```bash
+cd tools/cb-control
+npm install              # installs node-pty, ws, better-sqlite3
+npm run install-hooks    # writes SessionStart + Stop hooks into ~/.claude/settings.json
+```
+
+## First run
+
+```bash
+npm start
+```
+
+Output will include:
+
+```
+[cb-control] listening on http://127.0.0.1:46987
+[cb-control] token:     <64-hex-chars>
+[cb-control] token path: /Users/you/.config/cb-control/token
+```
+
+Copy that token — you'll paste it into the PWA once.
+
+## Exposing to your iPhone (Tailscale)
+
+```bash
+# 1. Sign in to Tailscale on Mac and iPhone (same account).
+# 2. Find your Mac's Tailscale hostname:
+tailscale status                         # e.g. "mac.tail-abcd.ts.net"
+
+# 3. Restart the daemon bound to all interfaces:
+CB_CONTROL_HOST=0.0.0.0 npm start
+```
+
+On your iPhone, open Safari and navigate to:
+
+```
+http://mac.tail-abcd.ts.net:46987/
+```
+
+Tap **Share → Add to Home Screen**. Launch the icon, open Settings, paste:
+
+- **Server URL**: `http://mac.tail-abcd.ts.net:46987`
+- **Bearer token**: the token printed at daemon startup
+- **Default working dir**: e.g. `/Users/you/developer/crystalball`
+
+Tap **Save**, then **Test connection** — you should see `Connected ✓`.
+
+### Optional: HTTPS via Tailscale certs
+
+For nicer PWA behavior (some iOS APIs require secure context), enable
+Tailscale HTTPS:
+
+```bash
+tailscale serve --bg --https=443 localhost:46987
+```
+
+Then use `https://mac.tail-abcd.ts.net/` in the PWA settings.
+
+## Using it
+
+### Spawn a new session from the phone
+Tap **+ New session** → enter `cwd`, optional label, optional extra args.
+A managed `claude` process spawns in a PTY; you're dropped into the terminal view.
+
+### Relay commands to an existing CLI session
+Open a terminal on your Mac, `cd` to a repo, run `claude`. The SessionStart
+hook registers it. Refresh the PWA — the session appears with an `external`
+badge. Tap to open.
+
+> External sessions are read-only for input by default (we don't own their
+> stdin). To relay input into them, you need a managed session. A future
+> revision will add a named-pipe bridge so external sessions accept input too.
+
+### Send input
+The input bar at the bottom sends each line as if typed. **^C** sends SIGINT
+(Ctrl-C); **Esc** sends ESC. Shift-Enter inserts a newline without sending.
+
+## Configuration
+
+Environment variables (set before `npm start`):
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `CB_CONTROL_HOST` | `127.0.0.1` | Bind host. Set `0.0.0.0` for Tailscale. |
+| `CB_CONTROL_PORT` | `46987` | Listen port. |
+| `CB_CONTROL_DIR` | `~/.config/cb-control` | Token + SQLite location. |
+| `CB_CONTROL_CLAUDE` | `claude` | Path to Claude CLI binary. |
+| `CB_CONTROL_URL` | `http://127.0.0.1:46987` | (hooks) daemon URL. |
+
+## Running as a launchd service (macOS)
+
+Create `~/Library/LaunchAgents/com.cb-control.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.cb-control</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/node</string>
+    <string>/Users/you/developer/crystalball/tools/cb-control/server/index.mjs</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>CB_CONTROL_HOST</key><string>0.0.0.0</string>
+    <key>PATH</key><string>/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>/Users/you/Library/Logs/cb-control.log</string>
+  <key>StandardErrorPath</key><string>/Users/you/Library/Logs/cb-control.err.log</string>
+</dict>
+</plist>
+```
+
+Load with:
+
+```bash
+launchctl load -w ~/Library/LaunchAgents/com.cb-control.plist
+```
+
+## Security model
+
+- **Bearer token** (256 bits) required for every API call and WebSocket.
+  Stored at `~/.config/cb-control/token` with mode 0600.
+- **Tailscale** is the network boundary — nothing is ever exposed to the
+  public internet. Even without Tailscale, bind stays on `127.0.0.1` by default.
+- **Daemon runs as your user** and spawns `claude` with your full shell env.
+  A compromised token = shell access to your Mac. Treat it like an SSH key.
+- **No `--dangerously-skip-permissions`** is passed to Claude. Each session
+  gets the normal Claude Code permission prompts (visible as output in the
+  terminal view; respond via the input bar).
+
+To rotate the token, delete `~/.config/cb-control/token` and restart.
+
+## Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET  | `/health` | Liveness (no auth) |
+| GET  | `/api/sessions` | List sessions |
+| POST | `/api/sessions` | Spawn new managed session `{cwd, label?, args?}` |
+| GET  | `/api/sessions/:id` | Session detail + last output snapshot |
+| POST | `/api/sessions/:id/input` | Send `{data, enter?}` |
+| POST | `/api/sessions/:id/resize` | `{cols, rows}` |
+| DELETE | `/api/sessions/:id` | Kill (managed) or mark ended (external) |
+| GET  | `/api/sessions/:id/events` | Paginated events (`?after=<id>`) |
+| POST | `/api/hooks/session-start` | Called by SessionStart hook |
+| POST | `/api/hooks/session-stop` | Called by Stop hook |
+| WS   | `/ws/sessions/:id?token=…` | Live output stream + input |
+
+## Roadmap
+
+- Named-pipe bridge so external sessions accept input relay
+- Multi-session **compose** view (write once, send to N sessions)
+- Full-text search across transcripts
+- iOS push notifications when a session requests a permission prompt
+- Touch-ID gate on the PWA before sending input
+
+## License
+
+Same as the parent repo.

--- a/tools/cb-control/README.md
+++ b/tools/cb-control/README.md
@@ -1,170 +1,121 @@
 # cb-control
 
-Remote control for Claude Code CLI sessions. Runs as a local daemon on your
-Mac, exposes a mobile-first PWA, and is accessed securely from your iPhone
-over Tailscale.
+Remote control for Claude Code CLI sessions. A daemon on your Mac +
+mobile-first PWA on your iPhone, connected over Tailscale. Full Claude
+features from your phone, with full command relay into any running CLI
+session.
 
-What you get:
+**What it does:**
+- **Spawn Claude sessions from your phone** — they run on your Mac with your
+  real env, keys, and tools.
+- **Attach to existing CLI sessions** you started in a terminal. As long as
+  the terminal is a tmux pane, you get fully bidirectional I/O (send-keys
+  in, pipe-pane out).
+- **Relay the same command to many sessions at once** (compose view).
+- **Full-text search** across every session's transcript (SQLite FTS5).
+- **Biometric gate** (Face ID / Touch ID) before any write from the phone.
 
-- **Spawn Claude sessions from your phone** — full Claude Code features, running
-  on your Mac with all its tools and keys.
-- **Relay commands to existing sessions** — CLI sessions you started in a
-  terminal register themselves via a `SessionStart` hook and show up in the PWA.
-- **Live output streaming** over WebSocket.
-- **Persistent transcripts** in SQLite (searchable across sessions).
+**Architecture:**
+- Node 20 daemon: HTTP + WebSocket + PTY + SQLite (~1000 LOC)
+- Vanilla-ESM PWA: no build step
+- Tailscale: secure transport, no public internet exposure
 
-Architecture: one daemon (`~500 LOC` Node), one PWA (no build step, plain ES
-modules), Tailscale for remote access. No App Store, no native iOS code, no
-public internet exposure.
-
-> Note: this tool currently lives inside the `crystal-ball` repo under
-> `tools/cb-control/` but is self-contained. It can be extracted to its own
-> repo any time with `git subtree split --prefix=tools/cb-control`.
+> Lives at `tools/cb-control/` in the `crystal-ball` repo but is
+> self-contained. Split out any time with
+> `git subtree split --prefix=tools/cb-control`.
 
 ## Requirements
 
-- macOS (or Linux) with Node.js 20+
-- Claude Code CLI installed on PATH as `claude`
-- Tailscale on both your Mac and iPhone (free tier is fine)
+- macOS (Linux works minus launchd) with Node 20+
+- Claude Code CLI on PATH as `claude`
+- Tailscale on Mac + iPhone (free tier)
+- **tmux** for attaching to external CLI sessions (optional but strongly
+  recommended — without it, external sessions are metadata-only)
 
-## Install
+## Quick start
 
 ```bash
 cd tools/cb-control
-npm install              # installs node-pty, ws, better-sqlite3
-npm run install-hooks    # writes SessionStart + Stop hooks into ~/.claude/settings.json
+npm install              # node-pty, ws, better-sqlite3
+npm run install-hooks    # wires SessionStart + Stop into ~/.claude/settings.json
+npm run install-launchd  # macOS: run as login-time launchd agent
+npm run setup-https      # serve over HTTPS via Tailscale
 ```
 
-## First run
+Then on your iPhone: open `https://<mac>.your-tailnet.ts.net/` in Safari,
+**Share → Add to Home Screen**, launch the icon, tap the gear, paste the
+bearer token (printed in `~/Library/Logs/cb-control.log`), **Save**,
+**Test connection** → should show `Connected ✓`.
+
+## First run (manual, no launchd)
 
 ```bash
-npm start
-```
-
-Output will include:
-
-```
-[cb-control] listening on http://127.0.0.1:46987
-[cb-control] token:     <64-hex-chars>
-[cb-control] token path: /Users/you/.config/cb-control/token
-```
-
-Copy that token — you'll paste it into the PWA once.
-
-## Exposing to your iPhone (Tailscale)
-
-```bash
-# 1. Sign in to Tailscale on Mac and iPhone (same account).
-# 2. Find your Mac's Tailscale hostname:
-tailscale status                         # e.g. "mac.tail-abcd.ts.net"
-
-# 3. Restart the daemon bound to all interfaces:
 CB_CONTROL_HOST=0.0.0.0 npm start
 ```
 
-On your iPhone, open Safari and navigate to:
+Prints:
 
 ```
-http://mac.tail-abcd.ts.net:46987/
+[cb-control] listening on http://0.0.0.0:46987
+[cb-control] token:     <64-hex-chars>
 ```
 
-Tap **Share → Add to Home Screen**. Launch the icon, open Settings, paste:
-
-- **Server URL**: `http://mac.tail-abcd.ts.net:46987`
-- **Bearer token**: the token printed at daemon startup
-- **Default working dir**: e.g. `/Users/you/developer/crystalball`
-
-Tap **Save**, then **Test connection** — you should see `Connected ✓`.
-
-### Optional: HTTPS via Tailscale certs
-
-For nicer PWA behavior (some iOS APIs require secure context), enable
-Tailscale HTTPS:
-
-```bash
-tailscale serve --bg --https=443 localhost:46987
-```
-
-Then use `https://mac.tail-abcd.ts.net/` in the PWA settings.
+Copy the token into the PWA once and forget it.
 
 ## Using it
 
-### Spawn a new session from the phone
-Tap **+ New session** → enter `cwd`, optional label, optional extra args.
-A managed `claude` process spawns in a PTY; you're dropped into the terminal view.
+### Spawn from the phone
+**+ New session** → cwd + optional label + extra args. A managed `claude`
+process starts in a PTY; the terminal view opens.
 
-### Relay commands to an existing CLI session
-Open a terminal on your Mac, `cd` to a repo, run `claude`. The SessionStart
-hook registers it. Refresh the PWA — the session appears with an `external`
-badge. Tap to open.
+### Attach to a terminal session (tmux)
+```bash
+# in tmux
+claude
+```
+The `SessionStart` hook registers it and captures `$TMUX_PANE`. Open the
+PWA — the session appears with a `live · tmux` badge and full I/O works.
 
-> External sessions are read-only for input by default (we don't own their
-> stdin). To relay input into them, you need a managed session. A future
-> revision will add a named-pipe bridge so external sessions accept input too.
+Without tmux, the session still appears in the list but is **read-only**
+(metadata only; the daemon can't inject into a bare terminal's stdin).
 
-### Send input
-The input bar at the bottom sends each line as if typed. **^C** sends SIGINT
-(Ctrl-C); **Esc** sends ESC. Shift-Enter inserts a newline without sending.
+### Compose (multi-session relay)
+Tap the pencil icon. Check the sessions to target, type a command, **Relay
+to N**. Each selected session receives the same input in parallel. Useful
+for: "rebase all feature branches onto main", "run the test suite
+everywhere", "paste the same question into three branches to compare
+answers".
+
+### Search
+Tap the magnifying-glass icon. Queries FTS5-indexed events across every
+session. Tap a hit to jump into that session's terminal view.
+
+### Biometric unlock (optional but recommended)
+Settings → **Enable Face ID / Touch ID**. Once enabled, every write
+(spawn, input, compose) requires a platform-authenticator assertion. The
+unlock is cached for 60s to avoid re-prompting on every keystroke.
+
+This is a client-side gate on top of the server's bearer-token check — a
+second wall that protects against scenarios where someone has physical
+access to your unlocked phone.
+
+### Terminal keyboard
+- `Send` — relay the textarea + Enter
+- `^C` — SIGINT / Ctrl-C
+- `Esc` — Escape key (e.g. cancel a Claude thought)
+- `Tab` — Tab key (e.g. Claude permission prompt selections)
 
 ## Configuration
 
-Environment variables (set before `npm start`):
+Env vars (set before `npm start` or in the launchd plist):
 
 | Var | Default | Purpose |
 |-----|---------|---------|
 | `CB_CONTROL_HOST` | `127.0.0.1` | Bind host. Set `0.0.0.0` for Tailscale. |
 | `CB_CONTROL_PORT` | `46987` | Listen port. |
-| `CB_CONTROL_DIR` | `~/.config/cb-control` | Token + SQLite location. |
+| `CB_CONTROL_DIR` | `~/.config/cb-control` | Token + SQLite + pane logs. |
 | `CB_CONTROL_CLAUDE` | `claude` | Path to Claude CLI binary. |
 | `CB_CONTROL_URL` | `http://127.0.0.1:46987` | (hooks) daemon URL. |
-
-## Running as a launchd service (macOS)
-
-Create `~/Library/LaunchAgents/com.cb-control.plist`:
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key><string>com.cb-control</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/usr/local/bin/node</string>
-    <string>/Users/you/developer/crystalball/tools/cb-control/server/index.mjs</string>
-  </array>
-  <key>EnvironmentVariables</key>
-  <dict>
-    <key>CB_CONTROL_HOST</key><string>0.0.0.0</string>
-    <key>PATH</key><string>/usr/local/bin:/usr/bin:/bin</string>
-  </dict>
-  <key>RunAtLoad</key><true/>
-  <key>KeepAlive</key><true/>
-  <key>StandardOutPath</key><string>/Users/you/Library/Logs/cb-control.log</string>
-  <key>StandardErrorPath</key><string>/Users/you/Library/Logs/cb-control.err.log</string>
-</dict>
-</plist>
-```
-
-Load with:
-
-```bash
-launchctl load -w ~/Library/LaunchAgents/com.cb-control.plist
-```
-
-## Security model
-
-- **Bearer token** (256 bits) required for every API call and WebSocket.
-  Stored at `~/.config/cb-control/token` with mode 0600.
-- **Tailscale** is the network boundary — nothing is ever exposed to the
-  public internet. Even without Tailscale, bind stays on `127.0.0.1` by default.
-- **Daemon runs as your user** and spawns `claude` with your full shell env.
-  A compromised token = shell access to your Mac. Treat it like an SSH key.
-- **No `--dangerously-skip-permissions`** is passed to Claude. Each session
-  gets the normal Claude Code permission prompts (visible as output in the
-  terminal view; respond via the input bar).
-
-To rotate the token, delete `~/.config/cb-control/token` and restart.
 
 ## Endpoints
 
@@ -172,23 +123,78 @@ To rotate the token, delete `~/.config/cb-control/token` and restart.
 |--------|------|---------|
 | GET  | `/health` | Liveness (no auth) |
 | GET  | `/api/sessions` | List sessions |
-| POST | `/api/sessions` | Spawn new managed session `{cwd, label?, args?}` |
-| GET  | `/api/sessions/:id` | Session detail + last output snapshot |
-| POST | `/api/sessions/:id/input` | Send `{data, enter?}` |
+| POST | `/api/sessions` | Spawn managed session `{cwd, label?, args?}` |
+| GET  | `/api/sessions/:id` | Detail + last output snapshot |
+| POST | `/api/sessions/:id/input` | `{data, enter?}` |
 | POST | `/api/sessions/:id/resize` | `{cols, rows}` |
-| DELETE | `/api/sessions/:id` | Kill (managed) or mark ended (external) |
+| DELETE | `/api/sessions/:id` | Kill (managed) or mark ended |
 | GET  | `/api/sessions/:id/events` | Paginated events (`?after=<id>`) |
-| POST | `/api/hooks/session-start` | Called by SessionStart hook |
-| POST | `/api/hooks/session-stop` | Called by Stop hook |
-| WS   | `/ws/sessions/:id?token=…` | Live output stream + input |
+| POST | `/api/hooks/session-start` | Called by hook |
+| POST | `/api/hooks/session-stop` | Called by hook |
+| POST | `/api/hooks/event` | Called by hook (free-form events) |
+| POST | `/api/compose` | `{ids: string[], data, enter?}` — relay to many |
+| GET  | `/api/search?q=…&limit=…` | FTS5 over events |
+| WS   | `/ws/sessions/:id?token=…` | Live output + input |
+
+## Security posture
+
+- **Bearer token**: 256-bit, constant-time compared, stored 0600 at
+  `~/.config/cb-control/token`. Required on every API and WS call.
+- **Tailscale**: network-layer authn. Nothing is ever exposed to the
+  public internet — even the default bind stays on 127.0.0.1 unless you
+  explicitly set `CB_CONTROL_HOST=0.0.0.0`.
+- **Biometric unlock (optional)**: WebAuthn platform authenticator on the
+  PWA adds a second gate for writes. Credential lives in the phone's
+  secure enclave; revoke by clearing the PWA's site data.
+- **No `--dangerously-skip-permissions`**: managed sessions get Claude's
+  normal permission prompts, visible in the terminal view. Answer them
+  through the input bar.
+- **tmux relay scope**: `tmux send-keys` can inject keystrokes into any
+  pane it can see. cb-control sends only to the specific pane the hook
+  reported. If someone else's account has the token, they can relay keys
+  into your tmux session — treat the token like SSH access.
+
+Rotate the token: delete `~/.config/cb-control/token` and restart the
+daemon.
+
+## Running as a launchd service (macOS)
+
+```bash
+npm run install-launchd           # writes ~/Library/LaunchAgents/com.cb-control.plist and loads it
+npm run uninstall-launchd         # reverse
+```
+
+The installed agent:
+- Runs at login and respawns on crash
+- Binds to `0.0.0.0:46987` (override with `CB_CONTROL_HOST` / `CB_CONTROL_PORT`)
+- Logs to `~/Library/Logs/cb-control.log` and `cb-control.err.log`
+
+## Running over HTTPS (Tailscale)
+
+```bash
+npm run setup-https               # serves :443 → http://127.0.0.1:46987
+npm run setup-https -- 8443       # custom port
+npm run setup-https -- --off      # tear down
+```
+
+Needs Tailscale HTTPS enabled for your tailnet (one-time, in the admin
+console). iOS PWAs prefer HTTPS — some APIs (notification, persistent
+storage, future features) require a secure context.
+
+## Uninstall (everything)
+
+```bash
+npm run uninstall-launchd
+npm run uninstall-hooks
+rm -rf ~/.config/cb-control        # token, DB, pane logs
+```
 
 ## Roadmap
 
-- Named-pipe bridge so external sessions accept input relay
-- Multi-session **compose** view (write once, send to N sessions)
-- Full-text search across transcripts
-- iOS push notifications when a session requests a permission prompt
-- Touch-ID gate on the PWA before sending input
+- Pane persistence across tmux server restarts (re-attach on pane reappearance)
+- Session "handoff" primitive — tag a session, subscribe from another
+- iOS push notifications on permission prompts (APNS backend required)
+- Per-session transcript export (Markdown + Claude-compatible resume)
 
 ## License
 

--- a/tools/cb-control/hooks/session-start.mjs
+++ b/tools/cb-control/hooks/session-start.mjs
@@ -37,12 +37,18 @@ function currentBranch(cwd) {
   let payload = {};
   try { payload = raw ? JSON.parse(raw) : {}; } catch { /* stdin may be empty */ }
 
+  // If we're running inside tmux, capture the pane id so the daemon can
+  // relay input and mirror output. $TMUX_PANE is set by tmux for any child
+  // process of a pane. If unset, the external session is metadata-only.
+  const tmuxPane = process.env.TMUX_PANE || null;
+
   const body = {
     id: payload.session_id || payload.sessionId || process.env.CLAUDE_SESSION_ID || `cli-${process.pid}-${Date.now()}`,
     cwd: payload.cwd || process.cwd(),
     label: payload.label || `cli:${(payload.cwd || process.cwd()).split('/').pop()}`,
     branch: currentBranch(payload.cwd || process.cwd()),
     pid: process.ppid,
+    tmuxPane,
   };
 
   try {

--- a/tools/cb-control/hooks/session-start.mjs
+++ b/tools/cb-control/hooks/session-start.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// Claude Code SessionStart hook.
+// Reads the hook payload from stdin, extracts session metadata, and
+// registers the session with the cb-control daemon so it shows up in the PWA.
+//
+// Fails silently on any error (missing daemon, missing token, network): a
+// hook must never block a session from starting.
+
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+
+const DAEMON = process.env.CB_CONTROL_URL ?? 'http://127.0.0.1:46987';
+const TOKEN_PATH = process.env.CB_CONTROL_TOKEN_PATH ?? join(homedir(), '.config', 'cb-control', 'token');
+
+function readStdin() {
+  try { return readFileSync(0, 'utf8'); } catch { return ''; }
+}
+
+function readToken() {
+  try { return readFileSync(TOKEN_PATH, 'utf8').trim(); } catch { return ''; }
+}
+
+function currentBranch(cwd) {
+  try {
+    return execSync('git rev-parse --abbrev-ref HEAD', { cwd, stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString().trim();
+  } catch { return null; }
+}
+
+(async () => {
+  const token = readToken();
+  if (!token) process.exit(0);
+
+  const raw = readStdin();
+  let payload = {};
+  try { payload = raw ? JSON.parse(raw) : {}; } catch { /* stdin may be empty */ }
+
+  const body = {
+    id: payload.session_id || payload.sessionId || process.env.CLAUDE_SESSION_ID || `cli-${process.pid}-${Date.now()}`,
+    cwd: payload.cwd || process.cwd(),
+    label: payload.label || `cli:${(payload.cwd || process.cwd()).split('/').pop()}`,
+    branch: currentBranch(payload.cwd || process.cwd()),
+    pid: process.ppid,
+  };
+
+  try {
+    const res = await fetch(`${DAEMON}/api/hooks/session-start`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'authorization': 'Bearer ' + token,
+      },
+      body: JSON.stringify(body),
+      // short timeout so a dead daemon can't slow Claude startup
+      signal: AbortSignal.timeout(1500),
+    });
+    if (!res.ok) process.exit(0);
+  } catch { /* ignore */ }
+  process.exit(0);
+})();

--- a/tools/cb-control/hooks/session-stop.mjs
+++ b/tools/cb-control/hooks/session-stop.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+// Claude Code Stop hook — marks the session ended in cb-control.
+
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const DAEMON = process.env.CB_CONTROL_URL ?? 'http://127.0.0.1:46987';
+const TOKEN_PATH = process.env.CB_CONTROL_TOKEN_PATH ?? join(homedir(), '.config', 'cb-control', 'token');
+
+function readStdin() { try { return readFileSync(0, 'utf8'); } catch { return ''; } }
+function readToken() { try { return readFileSync(TOKEN_PATH, 'utf8').trim(); } catch { return ''; } }
+
+(async () => {
+  const token = readToken();
+  if (!token) process.exit(0);
+  const raw = readStdin();
+  let payload = {};
+  try { payload = raw ? JSON.parse(raw) : {}; } catch {}
+  const id = payload.session_id || payload.sessionId || process.env.CLAUDE_SESSION_ID;
+  if (!id) process.exit(0);
+  try {
+    await fetch(`${DAEMON}/api/hooks/session-stop`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'authorization': 'Bearer ' + token },
+      body: JSON.stringify({ id, exitCode: payload.exitCode ?? null }),
+      signal: AbortSignal.timeout(1500),
+    });
+  } catch {}
+  process.exit(0);
+})();

--- a/tools/cb-control/package.json
+++ b/tools/cb-control/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "cb-control",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Remote control for Claude Code CLI sessions. Daemon + PWA, accessed over Tailscale from iPhone.",
+  "type": "module",
+  "bin": {
+    "cb-control": "./server/index.mjs"
+  },
+  "scripts": {
+    "start": "node server/index.mjs",
+    "dev": "node --watch server/index.mjs",
+    "install-hooks": "node scripts/install-hooks.mjs"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.3.0",
+    "node-pty": "^1.0.0",
+    "ws": "^8.18.0"
+  }
+}

--- a/tools/cb-control/package.json
+++ b/tools/cb-control/package.json
@@ -10,7 +10,11 @@
   "scripts": {
     "start": "node server/index.mjs",
     "dev": "node --watch server/index.mjs",
-    "install-hooks": "node scripts/install-hooks.mjs"
+    "install-hooks": "node scripts/install-hooks.mjs",
+    "uninstall-hooks": "node scripts/install-hooks.mjs --uninstall",
+    "install-launchd": "node scripts/install-launchd.mjs",
+    "uninstall-launchd": "node scripts/install-launchd.mjs --uninstall",
+    "setup-https": "bash scripts/setup-tailscale-https.sh"
   },
   "engines": {
     "node": ">=20"

--- a/tools/cb-control/scripts/install-hooks.mjs
+++ b/tools/cb-control/scripts/install-hooks.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// Install cb-control SessionStart/Stop hooks into ~/.claude/settings.json.
+// Idempotent: running twice does not duplicate entries.
+//
+// Usage:
+//   node scripts/install-hooks.mjs            # install
+//   node scripts/install-hooks.mjs --uninstall
+
+import { mkdirSync, readFileSync, writeFileSync, existsSync, chmodSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SETTINGS = join(homedir(), '.claude', 'settings.json');
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '..');
+const HOOKS_DIR = join(ROOT, 'hooks');
+
+const START_HOOK = `node ${join(HOOKS_DIR, 'session-start.mjs')}`;
+const STOP_HOOK = `node ${join(HOOKS_DIR, 'session-stop.mjs')}`;
+
+const uninstall = process.argv.includes('--uninstall');
+
+function loadSettings() {
+  if (!existsSync(SETTINGS)) return {};
+  try { return JSON.parse(readFileSync(SETTINGS, 'utf8')); }
+  catch (err) {
+    console.error('Could not parse existing settings.json:', err.message);
+    process.exit(1);
+  }
+}
+
+function writeSettings(obj) {
+  mkdirSync(dirname(SETTINGS), { recursive: true });
+  writeFileSync(SETTINGS, JSON.stringify(obj, null, 2) + '\n');
+}
+
+function ensureMatcherList(settings, event) {
+  settings.hooks ??= {};
+  settings.hooks[event] ??= [];
+  let entry = settings.hooks[event].find((e) => e.matcher === '*' || e.matcher == null);
+  if (!entry) {
+    entry = { matcher: '*', hooks: [] };
+    settings.hooks[event].push(entry);
+  }
+  entry.hooks ??= [];
+  return entry;
+}
+
+function addHook(settings, event, command) {
+  const entry = ensureMatcherList(settings, event);
+  if (entry.hooks.some((h) => h.type === 'command' && h.command === command)) return false;
+  entry.hooks.push({ type: 'command', command });
+  return true;
+}
+
+function removeHook(settings, event, command) {
+  if (!settings.hooks?.[event]) return false;
+  let changed = false;
+  for (const entry of settings.hooks[event]) {
+    if (!entry.hooks) continue;
+    const before = entry.hooks.length;
+    entry.hooks = entry.hooks.filter((h) => h.command !== command);
+    if (entry.hooks.length !== before) changed = true;
+  }
+  return changed;
+}
+
+// Make hooks executable for good measure
+try {
+  chmodSync(join(HOOKS_DIR, 'session-start.mjs'), 0o755);
+  chmodSync(join(HOOKS_DIR, 'session-stop.mjs'), 0o755);
+} catch {}
+
+const settings = loadSettings();
+
+if (uninstall) {
+  const a = removeHook(settings, 'SessionStart', START_HOOK);
+  const b = removeHook(settings, 'Stop', STOP_HOOK);
+  if (a || b) { writeSettings(settings); console.log('Removed cb-control hooks.'); }
+  else console.log('No cb-control hooks to remove.');
+} else {
+  const a = addHook(settings, 'SessionStart', START_HOOK);
+  const b = addHook(settings, 'Stop', STOP_HOOK);
+  if (a || b) { writeSettings(settings); console.log('Installed cb-control hooks in ' + SETTINGS); }
+  else console.log('cb-control hooks already installed.');
+}

--- a/tools/cb-control/scripts/install-launchd.mjs
+++ b/tools/cb-control/scripts/install-launchd.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+// Install cb-control as a macOS launchd user agent (boots at login, respawns).
+//
+//   node scripts/install-launchd.mjs                # install + load
+//   node scripts/install-launchd.mjs --uninstall    # unload + remove
+
+import { execSync } from 'node:child_process';
+import { mkdirSync, writeFileSync, existsSync, unlinkSync } from 'node:fs';
+import { homedir, platform } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+if (platform() !== 'darwin') {
+  console.error('launchd installer is macOS-only. On Linux, use systemd --user.');
+  process.exit(1);
+}
+
+const LABEL = 'com.cb-control';
+const AGENTS_DIR = join(homedir(), 'Library', 'LaunchAgents');
+const PLIST = join(AGENTS_DIR, `${LABEL}.plist`);
+const LOG_DIR = join(homedir(), 'Library', 'Logs');
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '..');
+const ENTRY = join(ROOT, 'server', 'index.mjs');
+
+const HOST = process.env.CB_CONTROL_HOST ?? '0.0.0.0';
+const PORT = process.env.CB_CONTROL_PORT ?? '46987';
+
+const uninstall = process.argv.includes('--uninstall');
+
+function which(bin) {
+  try { return execSync(`command -v ${bin}`, { encoding: 'utf8' }).trim(); }
+  catch { return null; }
+}
+
+function load() {
+  try { execSync(`launchctl load -w ${PLIST}`, { stdio: 'inherit' }); } catch {}
+}
+function unload() {
+  try { execSync(`launchctl unload -w ${PLIST}`, { stdio: 'inherit' }); } catch {}
+}
+
+if (uninstall) {
+  if (!existsSync(PLIST)) { console.log('Nothing to uninstall.'); process.exit(0); }
+  unload();
+  unlinkSync(PLIST);
+  console.log('Uninstalled ' + PLIST);
+  process.exit(0);
+}
+
+const node = which('node');
+if (!node) {
+  console.error('Could not find `node` on PATH. Install Node 20+ first.');
+  process.exit(1);
+}
+
+mkdirSync(AGENTS_DIR, { recursive: true });
+mkdirSync(LOG_DIR, { recursive: true });
+
+const plist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${node}</string>
+    <string>${ENTRY}</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>CB_CONTROL_HOST</key><string>${HOST}</string>
+    <key>CB_CONTROL_PORT</key><string>${PORT}</string>
+    <key>PATH</key><string>${process.env.PATH ?? '/usr/local/bin:/usr/bin:/bin'}</string>
+  </dict>
+  <key>WorkingDirectory</key><string>${ROOT}</string>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>${join(LOG_DIR, 'cb-control.log')}</string>
+  <key>StandardErrorPath</key><string>${join(LOG_DIR, 'cb-control.err.log')}</string>
+</dict>
+</plist>
+`;
+
+// If a prior copy is loaded, unload it so the new plist takes effect.
+if (existsSync(PLIST)) unload();
+
+writeFileSync(PLIST, plist);
+console.log('Wrote ' + PLIST);
+load();
+console.log('Loaded. Logs: ' + join(LOG_DIR, 'cb-control.log'));
+console.log('Daemon URL: http://' + (HOST === '0.0.0.0' ? '<tailscale-host>' : HOST) + ':' + PORT);

--- a/tools/cb-control/scripts/setup-tailscale-https.sh
+++ b/tools/cb-control/scripts/setup-tailscale-https.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Serve cb-control over HTTPS via Tailscale.
+# Requires Tailscale signed in and HTTPS enabled for your tailnet
+# (https://login.tailscale.com/admin/dns → Enable HTTPS).
+#
+# Usage:
+#   ./scripts/setup-tailscale-https.sh           # serve on :443
+#   ./scripts/setup-tailscale-https.sh 8443      # alt port
+#   ./scripts/setup-tailscale-https.sh --off     # tear down
+
+set -euo pipefail
+
+PORT_UPSTREAM="${CB_CONTROL_PORT:-46987}"
+ARG="${1:-443}"
+
+if ! command -v tailscale >/dev/null 2>&1; then
+  echo "tailscale CLI not found. Install from https://tailscale.com/download" >&2
+  exit 1
+fi
+
+if [[ "$ARG" == "--off" || "$ARG" == "off" ]]; then
+  tailscale serve reset
+  echo "Tailscale serve configuration cleared."
+  exit 0
+fi
+
+PORT_HTTPS="$ARG"
+
+tailscale serve --bg --https="$PORT_HTTPS" "http://127.0.0.1:${PORT_UPSTREAM}"
+
+HOST="$(tailscale status --json 2>/dev/null | node -e '
+  let d=""; process.stdin.on("data",c=>d+=c); process.stdin.on("end",()=>{
+    try { const s=JSON.parse(d); console.log(s.Self.DNSName.replace(/\.$/,"")); } catch {}
+  });' || echo "")"
+
+echo ""
+echo "HTTPS serve active."
+if [[ -n "$HOST" ]]; then
+  SUFFIX=""
+  [[ "$PORT_HTTPS" != "443" ]] && SUFFIX=":$PORT_HTTPS"
+  echo "  URL:  https://${HOST}${SUFFIX}/"
+else
+  echo "  URL:  https://<your-tailnet-host>${PORT_HTTPS:+:${PORT_HTTPS}}/"
+fi
+echo ""
+echo "Paste that URL into the PWA Settings panel."

--- a/tools/cb-control/server/api.mjs
+++ b/tools/cb-control/server/api.mjs
@@ -1,0 +1,199 @@
+// HTTP API routes. Hand-rolled on top of node:http to avoid dep bloat.
+// All routes require a bearer token via Authorization: Bearer <token>
+// except GET /health and the static PWA files.
+
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { join, extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { config } from './config.mjs';
+import { sessions } from './sessions.mjs';
+import { storage } from './storage.mjs';
+
+const WEB_ROOT = resolve(fileURLToPath(new URL('../web', import.meta.url)));
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.mjs': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.webmanifest': 'application/manifest+json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.ico': 'image/x-icon',
+};
+
+function send(res, status, body, headers = {}) {
+  res.writeHead(status, { 'content-type': 'application/json; charset=utf-8', ...headers });
+  res.end(typeof body === 'string' ? body : JSON.stringify(body));
+}
+
+function sendJSON(res, status, obj) {
+  send(res, status, obj, { 'content-type': 'application/json; charset=utf-8' });
+}
+
+function authorized(req) {
+  const header = req.headers.authorization ?? '';
+  const [scheme, token] = header.split(' ');
+  if (scheme !== 'Bearer' || !token) return false;
+  // constant-time compare
+  if (token.length !== config.token.length) return false;
+  let diff = 0;
+  for (let i = 0; i < token.length; i++) diff |= token.charCodeAt(i) ^ config.token.charCodeAt(i);
+  return diff === 0;
+}
+
+async function readBody(req, limit = 1024 * 1024) {
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of req) {
+    size += chunk.length;
+    if (size > limit) throw new Error('body too large');
+    chunks.push(chunk);
+  }
+  const raw = Buffer.concat(chunks).toString('utf8');
+  if (!raw) return {};
+  try { return JSON.parse(raw); } catch { throw new Error('invalid JSON'); }
+}
+
+function serveStatic(req, res, pathname) {
+  const rel = pathname === '/' ? '/index.html' : pathname;
+  const filePath = join(WEB_ROOT, rel);
+  if (!filePath.startsWith(WEB_ROOT)) return send(res, 403, { error: 'forbidden' });
+  if (!existsSync(filePath) || !statSync(filePath).isFile()) return send(res, 404, { error: 'not found' });
+  const ext = extname(filePath).toLowerCase();
+  const body = readFileSync(filePath);
+  res.writeHead(200, {
+    'content-type': MIME[ext] ?? 'application/octet-stream',
+    'cache-control': ext === '.html' ? 'no-cache' : 'public, max-age=300',
+  });
+  res.end(body);
+}
+
+export async function handleRequest(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const { pathname } = url;
+
+  // CORS preflight: Tailscale-local only, but keep it simple and permissive
+  // for the same-origin PWA case. The bearer token is the real gate.
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, {
+      'access-control-allow-origin': req.headers.origin ?? '*',
+      'access-control-allow-methods': 'GET,POST,DELETE,OPTIONS',
+      'access-control-allow-headers': 'authorization,content-type',
+      'access-control-max-age': '600',
+    });
+    return res.end();
+  }
+
+  if (pathname === '/health') return sendJSON(res, 200, { ok: true, version: '0.1.0' });
+
+  // Static PWA
+  if (req.method === 'GET' && !pathname.startsWith('/api/')) {
+    return serveStatic(req, res, pathname);
+  }
+
+  // API routes from here down require auth.
+  if (!authorized(req)) return sendJSON(res, 401, { error: 'unauthorized' });
+
+  try {
+    if (req.method === 'GET' && pathname === '/api/sessions') {
+      return sendJSON(res, 200, { sessions: sessions.list() });
+    }
+
+    if (req.method === 'POST' && pathname === '/api/sessions') {
+      const body = await readBody(req);
+      if (!body.cwd) return sendJSON(res, 400, { error: 'cwd required' });
+      const s = sessions.spawn({
+        cwd: body.cwd,
+        label: body.label,
+        args: Array.isArray(body.args) ? body.args : [],
+        env: body.env && typeof body.env === 'object' ? body.env : {},
+      });
+      return sendJSON(res, 201, { id: s.id, pid: s.pid, cwd: s.cwd, label: s.label });
+    }
+
+    const sessionMatch = pathname.match(/^\/api\/sessions\/([^/]+)(\/.*)?$/);
+    if (sessionMatch) {
+      const id = sessionMatch[1];
+      const sub = sessionMatch[2] ?? '';
+      const row = storage.getSession(id);
+      if (!row) return sendJSON(res, 404, { error: 'session not found' });
+
+      if (req.method === 'GET' && sub === '') {
+        return sendJSON(res, 200, {
+          ...row,
+          live: sessions.has(id),
+          snapshot: sessions.snapshot(id),
+        });
+      }
+
+      if (req.method === 'GET' && sub === '/events') {
+        const after = Number(url.searchParams.get('after') ?? 0);
+        const events = storage.readEvents(id, after, 500);
+        return sendJSON(res, 200, { events });
+      }
+
+      if (req.method === 'POST' && sub === '/input') {
+        const body = await readBody(req);
+        const session = sessions.get(id);
+        if (!session) return sendJSON(res, 409, { error: 'session not live (external or ended)' });
+        const text = typeof body.data === 'string' ? body.data : '';
+        const appendEnter = body.enter !== false;
+        if (text) session.write(text);
+        if (appendEnter) session.write('\r');
+        storage.appendEvent(id, 'input', { bytes: text.length, enter: appendEnter });
+        return sendJSON(res, 200, { ok: true });
+      }
+
+      if (req.method === 'POST' && sub === '/resize') {
+        const body = await readBody(req);
+        const session = sessions.get(id);
+        if (!session) return sendJSON(res, 409, { error: 'session not live' });
+        session.resize(Number(body.cols) || 120, Number(body.rows) || 40);
+        return sendJSON(res, 200, { ok: true });
+      }
+
+      if (req.method === 'DELETE' && sub === '') {
+        const session = sessions.get(id);
+        if (session) session.kill('SIGTERM');
+        else sessions.markExternalEnded(id, null);
+        return sendJSON(res, 200, { ok: true });
+      }
+    }
+
+    // Hook endpoints (called by Claude Code SessionStart/Stop hooks).
+    if (req.method === 'POST' && pathname === '/api/hooks/session-start') {
+      const body = await readBody(req);
+      if (!body.id || !body.cwd) return sendJSON(res, 400, { error: 'id and cwd required' });
+      sessions.registerExternal({
+        id: body.id,
+        label: body.label,
+        cwd: body.cwd,
+        branch: body.branch,
+        pid: body.pid,
+      });
+      return sendJSON(res, 200, { ok: true });
+    }
+
+    if (req.method === 'POST' && pathname === '/api/hooks/session-stop') {
+      const body = await readBody(req);
+      if (!body.id) return sendJSON(res, 400, { error: 'id required' });
+      sessions.markExternalEnded(body.id, body.exitCode);
+      return sendJSON(res, 200, { ok: true });
+    }
+
+    if (req.method === 'POST' && pathname === '/api/hooks/event') {
+      const body = await readBody(req);
+      if (!body.id || !body.kind) return sendJSON(res, 400, { error: 'id and kind required' });
+      storage.appendEvent(body.id, body.kind, body.payload ?? null);
+      return sendJSON(res, 200, { ok: true });
+    }
+
+    return sendJSON(res, 404, { error: 'not found' });
+  } catch (err) {
+    return sendJSON(res, 400, { error: String(err.message ?? err) });
+  }
+}
+
+export { authorized };

--- a/tools/cb-control/server/api.mjs
+++ b/tools/cb-control/server/api.mjs
@@ -137,7 +137,7 @@ export async function handleRequest(req, res) {
       if (req.method === 'POST' && sub === '/input') {
         const body = await readBody(req);
         const session = sessions.get(id);
-        if (!session) return sendJSON(res, 409, { error: 'session not live (external or ended)' });
+        if (!session) return sendJSON(res, 409, { error: 'session not live (ended, or external without tmux bridge)' });
         const text = typeof body.data === 'string' ? body.data : '';
         const appendEnter = body.enter !== false;
         if (text) session.write(text);
@@ -172,8 +172,37 @@ export async function handleRequest(req, res) {
         cwd: body.cwd,
         branch: body.branch,
         pid: body.pid,
+        tmuxPane: body.tmuxPane || null,
       });
       return sendJSON(res, 200, { ok: true });
+    }
+
+    // Multi-session compose: relay the same payload to N sessions in parallel.
+    if (req.method === 'POST' && pathname === '/api/compose') {
+      const body = await readBody(req);
+      const ids = Array.isArray(body.ids) ? body.ids : [];
+      const text = typeof body.data === 'string' ? body.data : '';
+      const enter = body.enter !== false;
+      if (ids.length === 0) return sendJSON(res, 400, { error: 'ids required' });
+      const results = ids.map((id) => {
+        const session = sessions.get(id);
+        if (!session) return { id, ok: false, error: 'not live' };
+        try {
+          if (text) session.write(text);
+          if (enter) session.write('\r');
+          storage.appendEvent(id, 'input', { bytes: text.length, enter, compose: true });
+          return { id, ok: true };
+        } catch (err) { return { id, ok: false, error: String(err.message ?? err) }; }
+      });
+      return sendJSON(res, 200, { results });
+    }
+
+    // Full-text search across event payloads.
+    if (req.method === 'GET' && pathname === '/api/search') {
+      const q = (url.searchParams.get('q') ?? '').trim();
+      const limit = Math.min(200, Number(url.searchParams.get('limit') ?? 50));
+      if (!q) return sendJSON(res, 200, { results: [] });
+      return sendJSON(res, 200, { results: storage.search(q, limit) });
     }
 
     if (req.method === 'POST' && pathname === '/api/hooks/session-stop') {

--- a/tools/cb-control/server/config.mjs
+++ b/tools/cb-control/server/config.mjs
@@ -1,0 +1,35 @@
+// Runtime configuration: host/port, data directory, bearer token.
+// Token is auto-generated on first run and persisted with 0600 perms.
+
+import { randomBytes } from 'node:crypto';
+import { mkdirSync, readFileSync, writeFileSync, existsSync, chmodSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const CONFIG_DIR = process.env.CB_CONTROL_DIR ?? join(homedir(), '.config', 'cb-control');
+const TOKEN_PATH = join(CONFIG_DIR, 'token');
+const DATA_DIR = join(CONFIG_DIR, 'data');
+
+mkdirSync(CONFIG_DIR, { recursive: true });
+mkdirSync(DATA_DIR, { recursive: true });
+
+function ensureToken() {
+  if (existsSync(TOKEN_PATH)) {
+    return readFileSync(TOKEN_PATH, 'utf8').trim();
+  }
+  const token = randomBytes(32).toString('hex');
+  writeFileSync(TOKEN_PATH, token + '\n', { mode: 0o600 });
+  chmodSync(TOKEN_PATH, 0o600);
+  return token;
+}
+
+export const config = {
+  host: process.env.CB_CONTROL_HOST ?? '127.0.0.1',
+  port: Number(process.env.CB_CONTROL_PORT ?? 46987),
+  token: ensureToken(),
+  dataDir: DATA_DIR,
+  tokenPath: TOKEN_PATH,
+  dbPath: join(DATA_DIR, 'cb-control.sqlite'),
+  claudeBinary: process.env.CB_CONTROL_CLAUDE ?? 'claude',
+  shell: process.env.SHELL ?? '/bin/bash',
+};

--- a/tools/cb-control/server/index.mjs
+++ b/tools/cb-control/server/index.mjs
@@ -11,6 +11,7 @@ import { createServer } from 'node:http';
 import { config } from './config.mjs';
 import { handleRequest } from './api.mjs';
 import { attachWebSocket } from './ws.mjs';
+import { sessions } from './sessions.mjs';
 
 const server = createServer((req, res) => {
   handleRequest(req, res).catch((err) => {
@@ -23,6 +24,9 @@ const server = createServer((req, res) => {
 });
 
 attachWebSocket(server);
+
+// Re-attach to any external tmux sessions still alive from a previous run.
+try { sessions.rehydrate(); } catch (err) { console.error('[cb-control] rehydrate error:', err); }
 
 server.listen(config.port, config.host, () => {
   const origin = `http://${config.host}:${config.port}`;

--- a/tools/cb-control/server/index.mjs
+++ b/tools/cb-control/server/index.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// cb-control: local daemon for remote-controlling Claude Code CLI sessions.
+//
+//   npm start                    # run on 127.0.0.1:46987
+//   CB_CONTROL_HOST=0.0.0.0 npm start   # bind all interfaces (use with Tailscale)
+//
+// First run prints the bearer token and API URL. Put that token into the
+// PWA Settings panel on your iPhone.
+
+import { createServer } from 'node:http';
+import { config } from './config.mjs';
+import { handleRequest } from './api.mjs';
+import { attachWebSocket } from './ws.mjs';
+
+const server = createServer((req, res) => {
+  handleRequest(req, res).catch((err) => {
+    console.error('[cb-control] unhandled error:', err);
+    if (!res.headersSent) {
+      res.writeHead(500, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'internal error' }));
+    }
+  });
+});
+
+attachWebSocket(server);
+
+server.listen(config.port, config.host, () => {
+  const origin = `http://${config.host}:${config.port}`;
+  console.log('[cb-control] listening on ' + origin);
+  console.log('[cb-control] data dir:  ' + config.dataDir);
+  console.log('[cb-control] token:     ' + config.token);
+  console.log('[cb-control] token path: ' + config.tokenPath);
+  console.log('');
+  console.log('Open the PWA on your iPhone:');
+  console.log('  ' + origin + '/');
+  console.log('Paste the token above into Settings → Token.');
+});

--- a/tools/cb-control/server/sessions.mjs
+++ b/tools/cb-control/server/sessions.mjs
@@ -1,0 +1,151 @@
+// In-memory PTY session manager.
+//
+// Two kinds of sessions exist:
+//   1. "managed" — the daemon spawned the Claude CLI itself inside a PTY.
+//      We own stdin/stdout, so we can relay commands and stream output.
+//   2. "external" — a Claude CLI running somewhere else (e.g. a terminal on
+//      the same Mac) registered itself via the SessionStart hook. We have
+//      metadata only; input relay goes through a named pipe the hook creates.
+//
+// The MVP implements (1) fully and (2) as read-only registration.
+
+import { spawn as ptySpawn } from 'node-pty';
+import { randomUUID } from 'node:crypto';
+import { EventEmitter } from 'node:events';
+import { storage } from './storage.mjs';
+import { config } from './config.mjs';
+
+const RING_SIZE = 200_000; // bytes of recent output kept per session for replay
+
+export const sessionBus = new EventEmitter();
+sessionBus.setMaxListeners(0);
+
+/** @type {Map<string, ManagedSession>} */
+const managed = new Map();
+
+class ManagedSession {
+  constructor({ id, label, cwd, argv, env }) {
+    this.id = id;
+    this.label = label ?? 'claude';
+    this.cwd = cwd;
+    this.status = 'running';
+    this.ring = Buffer.alloc(0);
+    this.createdAt = Date.now();
+
+    this.pty = ptySpawn(argv[0], argv.slice(1), {
+      name: 'xterm-256color',
+      cols: 120,
+      rows: 40,
+      cwd,
+      env: { ...process.env, ...env, TERM: 'xterm-256color' },
+    });
+    this.pid = this.pty.pid;
+
+    this.pty.onData((data) => {
+      const chunk = Buffer.from(data, 'utf8');
+      this.ring = this.ring.length + chunk.length > RING_SIZE
+        ? Buffer.concat([this.ring.subarray(this.ring.length + chunk.length - RING_SIZE), chunk])
+        : Buffer.concat([this.ring, chunk]);
+      sessionBus.emit('data', { id: this.id, data });
+    });
+
+    this.pty.onExit(({ exitCode, signal }) => {
+      this.status = 'ended';
+      storage.markEnded(this.id, exitCode);
+      storage.appendEvent(this.id, 'exit', { exitCode, signal });
+      sessionBus.emit('exit', { id: this.id, exitCode, signal });
+      managed.delete(this.id);
+    });
+
+    storage.upsertSession({
+      id: this.id,
+      label: this.label,
+      cwd,
+      pid: this.pid,
+      status: 'running',
+      created_at: this.createdAt,
+      source: 'daemon',
+    });
+    storage.appendEvent(this.id, 'spawn', { argv, cwd });
+  }
+
+  write(input) {
+    if (this.status !== 'running') return false;
+    this.pty.write(input);
+    return true;
+  }
+
+  resize(cols, rows) {
+    if (this.status !== 'running') return;
+    try { this.pty.resize(cols, rows); } catch { /* ignore */ }
+  }
+
+  kill(signal = 'SIGTERM') {
+    if (this.status !== 'running') return;
+    try { this.pty.kill(signal); } catch { /* ignore */ }
+  }
+
+  snapshot() {
+    return this.ring.toString('utf8');
+  }
+}
+
+export const sessions = {
+  spawn({ cwd, label, args = [], env = {} }) {
+    const id = randomUUID();
+    const argv = [config.claudeBinary, ...args];
+    const session = new ManagedSession({ id, label, cwd, argv, env });
+    managed.set(id, session);
+    return session;
+  },
+
+  /** Register an external session that isn't spawned by us (via hook). */
+  registerExternal({ id, label, cwd, branch, pid }) {
+    storage.upsertSession({
+      id,
+      label: label ?? 'external',
+      cwd,
+      branch,
+      pid,
+      status: 'running',
+      created_at: Date.now(),
+      source: 'external',
+    });
+    storage.appendEvent(id, 'register', { branch, pid });
+    sessionBus.emit('register', { id });
+  },
+
+  markExternalEnded(id, exitCode) {
+    storage.markEnded(id, exitCode ?? null);
+    storage.appendEvent(id, 'exit', { exitCode: exitCode ?? null, external: true });
+    sessionBus.emit('exit', { id, exitCode: exitCode ?? null });
+  },
+
+  get(id) {
+    return managed.get(id);
+  },
+
+  has(id) {
+    return managed.has(id);
+  },
+
+  list() {
+    const durable = storage.listSessions(200);
+    return durable.map((row) => ({
+      ...row,
+      live: managed.has(row.id),
+    }));
+  },
+
+  snapshot(id) {
+    const s = managed.get(id);
+    return s ? s.snapshot() : '';
+  },
+
+  shutdownAll() {
+    for (const s of managed.values()) s.kill('SIGTERM');
+  },
+};
+
+process.on('SIGINT', () => { sessions.shutdownAll(); process.exit(0); });
+process.on('SIGTERM', () => { sessions.shutdownAll(); process.exit(0); });

--- a/tools/cb-control/server/sessions.mjs
+++ b/tools/cb-control/server/sessions.mjs
@@ -1,21 +1,21 @@
-// In-memory PTY session manager.
+// Session manager. Two kinds of sessions:
 //
-// Two kinds of sessions exist:
-//   1. "managed" — the daemon spawned the Claude CLI itself inside a PTY.
-//      We own stdin/stdout, so we can relay commands and stream output.
-//   2. "external" — a Claude CLI running somewhere else (e.g. a terminal on
-//      the same Mac) registered itself via the SessionStart hook. We have
-//      metadata only; input relay goes through a named pipe the hook creates.
+//   1. "managed" — the daemon spawned Claude inside a PTY. We own stdin/stdout.
+//   2. "external" — user launched `claude` in a terminal. If that terminal is
+//      tmux, we bridge I/O via `tmux send-keys` + `tmux pipe-pane`. Otherwise
+//      it's metadata-only.
 //
-// The MVP implements (1) fully and (2) as read-only registration.
+// Both surface the same interface through sessionBus + sessions.get(), so
+// the HTTP + WebSocket layers don't care which kind they're driving.
 
 import { spawn as ptySpawn } from 'node-pty';
 import { randomUUID } from 'node:crypto';
 import { EventEmitter } from 'node:events';
 import { storage } from './storage.mjs';
 import { config } from './config.mjs';
+import * as tmux from './tmux-bridge.mjs';
 
-const RING_SIZE = 200_000; // bytes of recent output kept per session for replay
+const RING_SIZE = 200_000;
 
 export const sessionBus = new EventEmitter();
 sessionBus.setMaxListeners(0);
@@ -23,20 +23,23 @@ sessionBus.setMaxListeners(0);
 /** @type {Map<string, ManagedSession>} */
 const managed = new Map();
 
+/** @type {Map<string, ExternalTmuxSession>} */
+const externals = new Map();
+
+// --------------------------- Managed (PTY) ---------------------------------
+
 class ManagedSession {
   constructor({ id, label, cwd, argv, env }) {
     this.id = id;
     this.label = label ?? 'claude';
     this.cwd = cwd;
+    this.kind = 'managed';
     this.status = 'running';
     this.ring = Buffer.alloc(0);
     this.createdAt = Date.now();
 
     this.pty = ptySpawn(argv[0], argv.slice(1), {
-      name: 'xterm-256color',
-      cols: 120,
-      rows: 40,
-      cwd,
+      name: 'xterm-256color', cols: 120, rows: 40, cwd,
       env: { ...process.env, ...env, TERM: 'xterm-256color' },
     });
     this.pid = this.pty.pid;
@@ -58,94 +61,171 @@ class ManagedSession {
     });
 
     storage.upsertSession({
-      id: this.id,
-      label: this.label,
-      cwd,
-      pid: this.pid,
-      status: 'running',
-      created_at: this.createdAt,
-      source: 'daemon',
+      id: this.id, label: this.label, cwd, pid: this.pid,
+      status: 'running', created_at: this.createdAt, source: 'daemon',
     });
     storage.appendEvent(this.id, 'spawn', { argv, cwd });
   }
 
+  write(input)      { if (this.status === 'running') this.pty.write(input); }
+  resize(cols, rows){ if (this.status === 'running') { try { this.pty.resize(cols, rows); } catch {} } }
+  kill(signal='SIGTERM'){ if (this.status === 'running') { try { this.pty.kill(signal); } catch {} } }
+  snapshot()        { return this.ring.toString('utf8'); }
+}
+
+// ------------------------ External (tmux bridge) ---------------------------
+
+class ExternalTmuxSession {
+  constructor({ id, label, cwd, pane, branch, pid, rehydrated = false }) {
+    this.id = id;
+    this.label = label ?? 'external';
+    this.cwd = cwd;
+    this.pane = pane;
+    this.kind = 'external-tmux';
+    this.status = 'running';
+    this.watcher = null;
+
+    storage.upsertSession({
+      id, label: this.label, cwd, branch, pid,
+      status: 'running', source: 'external', tmux_pane: pane,
+    });
+    // Only log a new "register" event on first registration — rehydration
+    // after a daemon restart is an implementation detail, not a user event.
+    if (!rehydrated) storage.appendEvent(id, 'register', { branch, pid, pane });
+
+    // Enable pipe-pane so subsequent pane output gets written to a log file
+    // we can tail. Idempotent (`-o` skips if already piping).
+    tmux.attachPane(id, pane);
+
+    // Start streaming immediately so multiple subscribers share one watcher.
+    this.watcher = tmux.watchLog(id, (chunk) => {
+      sessionBus.emit('data', { id: this.id, data: chunk });
+    });
+  }
+
   write(input) {
-    if (this.status !== 'running') return false;
-    this.pty.write(input);
-    return true;
-  }
-
-  resize(cols, rows) {
     if (this.status !== 'running') return;
-    try { this.pty.resize(cols, rows); } catch { /* ignore */ }
+    // If input ends with \r we split it into literal+Enter for tmux, which
+    // treats \r as a key it does not accept literally.
+    const hasCR = input.endsWith('\r') || input.endsWith('\n');
+    const literal = hasCR ? input.slice(0, -1) : input;
+    if (literal) tmux.sendText(this.pane, literal);
+    if (hasCR) tmux.sendKey(this.pane, 'Enter');
   }
-
-  kill(signal = 'SIGTERM') {
+  resize(){ /* tmux panes size with the tmux window; no-op */ }
+  kill(){
     if (this.status !== 'running') return;
-    try { this.pty.kill(signal); } catch { /* ignore */ }
+    this.status = 'ended';
+    try { this.watcher?.stop(); } catch {}
+    tmux.detachPane(this.pane);
+    storage.markEnded(this.id, null);
+    sessionBus.emit('exit', { id: this.id, exitCode: null });
+    externals.delete(this.id);
   }
-
   snapshot() {
-    return this.ring.toString('utf8');
+    // Prefer the tmux capture (has the live scrollback) over the log file,
+    // which only has bytes written since pipe-pane started.
+    const cap = tmux.capture(this.pane, { lines: 2000 });
+    return cap || '';
   }
 }
+
+// ---------------------------- Public API -----------------------------------
 
 export const sessions = {
   spawn({ cwd, label, args = [], env = {} }) {
     const id = randomUUID();
     const argv = [config.claudeBinary, ...args];
-    const session = new ManagedSession({ id, label, cwd, argv, env });
-    managed.set(id, session);
-    return session;
+    const s = new ManagedSession({ id, label, cwd, argv, env });
+    managed.set(id, s);
+    return s;
   },
 
-  /** Register an external session that isn't spawned by us (via hook). */
-  registerExternal({ id, label, cwd, branch, pid }) {
+  registerExternal({ id, label, cwd, branch, pid, tmuxPane }) {
+    // If we already have it live, refresh metadata and keep the watcher.
+    const existing = externals.get(id);
+    if (existing) {
+      storage.upsertSession({
+        id, label: label ?? existing.label, cwd, branch, pid,
+        status: 'running', source: 'external', tmux_pane: tmuxPane ?? existing.pane,
+      });
+      return existing;
+    }
+
+    if (tmuxPane && tmux.paneExists(tmuxPane)) {
+      const s = new ExternalTmuxSession({ id, label, cwd, pane: tmuxPane, branch, pid });
+      externals.set(id, s);
+      sessionBus.emit('register', { id });
+      return s;
+    }
+
+    // Fallback: metadata-only (no I/O bridge)
     storage.upsertSession({
-      id,
-      label: label ?? 'external',
-      cwd,
-      branch,
-      pid,
-      status: 'running',
-      created_at: Date.now(),
-      source: 'external',
+      id, label: label ?? 'external', cwd, branch, pid,
+      status: 'running', source: 'external', tmux_pane: null,
     });
     storage.appendEvent(id, 'register', { branch, pid });
     sessionBus.emit('register', { id });
+    return null;
   },
 
   markExternalEnded(id, exitCode) {
-    storage.markEnded(id, exitCode ?? null);
-    storage.appendEvent(id, 'exit', { exitCode: exitCode ?? null, external: true });
-    sessionBus.emit('exit', { id, exitCode: exitCode ?? null });
+    const s = externals.get(id);
+    if (s) s.kill();
+    else {
+      storage.markEnded(id, exitCode ?? null);
+      storage.appendEvent(id, 'exit', { exitCode: exitCode ?? null, external: true });
+      sessionBus.emit('exit', { id, exitCode: exitCode ?? null });
+    }
   },
 
+  /** Returns a writable session (managed or bridged external) or null. */
   get(id) {
-    return managed.get(id);
+    return managed.get(id) ?? externals.get(id) ?? null;
   },
 
-  has(id) {
-    return managed.has(id);
-  },
+  has(id) { return managed.has(id) || externals.has(id); },
 
+  /** Rich detail for the list view: merges durable row with live flags. */
   list() {
     const durable = storage.listSessions(200);
     return durable.map((row) => ({
       ...row,
-      live: managed.has(row.id),
+      live: this.has(row.id),
+      bridge: externals.has(row.id) ? 'tmux' : managed.has(row.id) ? 'pty' : null,
     }));
   },
 
   snapshot(id) {
-    const s = managed.get(id);
+    const s = this.get(id);
     return s ? s.snapshot() : '';
+  },
+
+  /** On daemon startup, re-attach to any external tmux sessions still alive. */
+  rehydrate() {
+    const rows = storage.listRunningExternalWithTmux();
+    for (const row of rows) {
+      if (!row.tmux_pane) continue;
+      if (!tmux.paneExists(row.tmux_pane)) {
+        storage.markEnded(row.id, null);
+        continue;
+      }
+      const s = new ExternalTmuxSession({
+        id: row.id, label: row.label, cwd: row.cwd, pane: row.tmux_pane,
+        branch: row.branch, pid: row.pid, rehydrated: true,
+      });
+      externals.set(row.id, s);
+    }
   },
 
   shutdownAll() {
     for (const s of managed.values()) s.kill('SIGTERM');
+    for (const s of externals.values()) {
+      try { s.watcher?.stop(); } catch {}
+      // Leave tmux pipe-pane in place — the pane is still a real terminal.
+    }
   },
 };
 
-process.on('SIGINT', () => { sessions.shutdownAll(); process.exit(0); });
+process.on('SIGINT',  () => { sessions.shutdownAll(); process.exit(0); });
 process.on('SIGTERM', () => { sessions.shutdownAll(); process.exit(0); });

--- a/tools/cb-control/server/storage.mjs
+++ b/tools/cb-control/server/storage.mjs
@@ -1,6 +1,4 @@
-// SQLite persistence: session registry + transcript ring buffer.
-// Sessions are spawned in-memory (see sessions.mjs); this table is the
-// durable record of what existed, when, and the last captured output.
+// SQLite persistence: session registry, event log, FTS5 search index.
 
 import Database from 'better-sqlite3';
 import { config } from './config.mjs';
@@ -20,7 +18,8 @@ db.exec(`
     created_at INTEGER NOT NULL,
     ended_at INTEGER,
     exit_code INTEGER,
-    source TEXT NOT NULL DEFAULT 'daemon'
+    source TEXT NOT NULL DEFAULT 'daemon',
+    tmux_pane TEXT
   );
 
   CREATE TABLE IF NOT EXISTS events (
@@ -35,15 +34,47 @@ db.exec(`
   CREATE INDEX IF NOT EXISTS events_session_ts ON events(session_id, ts);
 `);
 
+// Lightweight schema evolution: add columns if missing.
+function ensureColumn(table, column, def) {
+  const cols = db.prepare(`PRAGMA table_info(${table})`).all();
+  if (!cols.some((c) => c.name === column)) {
+    db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${def}`);
+  }
+}
+ensureColumn('sessions', 'tmux_pane', 'TEXT');
+
+// FTS5 virtual table + triggers for full-text search over event payloads.
+// We index kind + payload text; session_id is a filter column.
+// External-content FTS would be nicer but keeps the schema simpler as an
+// independent table with a trigger-maintained link.
+db.exec(`
+  CREATE VIRTUAL TABLE IF NOT EXISTS events_fts USING fts5(
+    session_id UNINDEXED,
+    kind,
+    payload,
+    tokenize = 'porter unicode61'
+  );
+
+  CREATE TRIGGER IF NOT EXISTS events_ai AFTER INSERT ON events BEGIN
+    INSERT INTO events_fts(rowid, session_id, kind, payload)
+    VALUES (new.id, new.session_id, new.kind, COALESCE(new.payload, ''));
+  END;
+
+  CREATE TRIGGER IF NOT EXISTS events_ad AFTER DELETE ON events BEGIN
+    DELETE FROM events_fts WHERE rowid = old.id;
+  END;
+`);
+
 const insertSession = db.prepare(`
-  INSERT INTO sessions (id, label, cwd, branch, pid, status, created_at, source)
-  VALUES (@id, @label, @cwd, @branch, @pid, @status, @created_at, @source)
+  INSERT INTO sessions (id, label, cwd, branch, pid, status, created_at, source, tmux_pane)
+  VALUES (@id, @label, @cwd, @branch, @pid, @status, @created_at, @source, @tmux_pane)
   ON CONFLICT(id) DO UPDATE SET
     label = excluded.label,
     cwd = excluded.cwd,
     branch = excluded.branch,
     pid = excluded.pid,
-    status = excluded.status
+    status = excluded.status,
+    tmux_pane = COALESCE(excluded.tmux_pane, sessions.tmux_pane)
 `);
 
 const updateSessionStatus = db.prepare(`
@@ -54,6 +85,10 @@ const selectSessions = db.prepare(`
   SELECT * FROM sessions ORDER BY created_at DESC LIMIT ?
 `);
 
+const selectRunningExternal = db.prepare(`
+  SELECT * FROM sessions WHERE status = 'running' AND source = 'external' AND tmux_pane IS NOT NULL
+`);
+
 const selectSession = db.prepare(`SELECT * FROM sessions WHERE id = ?`);
 
 const insertEvent = db.prepare(`
@@ -62,6 +97,25 @@ const insertEvent = db.prepare(`
 
 const selectEvents = db.prepare(`
   SELECT * FROM events WHERE session_id = ? AND id > ? ORDER BY id ASC LIMIT ?
+`);
+
+// FTS query: joins back to events + sessions to build a helpful result row.
+const searchEvents = db.prepare(`
+  SELECT
+    e.id           AS event_id,
+    e.session_id   AS session_id,
+    e.ts           AS ts,
+    e.kind         AS kind,
+    snippet(events_fts, 2, '<mark>', '</mark>', '…', 16) AS snippet,
+    s.label        AS label,
+    s.cwd          AS cwd,
+    s.status       AS status
+  FROM events_fts
+  JOIN events   e ON e.id = events_fts.rowid
+  JOIN sessions s ON s.id = e.session_id
+  WHERE events_fts MATCH ?
+  ORDER BY e.ts DESC
+  LIMIT ?
 `);
 
 export const storage = {
@@ -75,6 +129,7 @@ export const storage = {
       status: row.status ?? 'running',
       created_at: row.created_at ?? Date.now(),
       source: row.source ?? 'daemon',
+      tmux_pane: row.tmux_pane ?? null,
     });
   },
   markEnded(id, exitCode) {
@@ -82,6 +137,9 @@ export const storage = {
   },
   listSessions(limit = 100) {
     return selectSessions.all(limit);
+  },
+  listRunningExternalWithTmux() {
+    return selectRunningExternal.all();
   },
   getSession(id) {
     return selectSession.get(id);
@@ -91,5 +149,15 @@ export const storage = {
   },
   readEvents(sessionId, afterId = 0, limit = 500) {
     return selectEvents.all(sessionId, afterId, limit);
+  },
+  /** Full-text search. Query string is passed to FTS5 directly. */
+  search(query, limit = 50) {
+    if (!query || typeof query !== 'string') return [];
+    // Protect against FTS5 syntax errors by quoting the whole query as a phrase
+    // unless the caller wrote an explicit FTS operator (AND/OR/NOT).
+    const hasOp = /\b(AND|OR|NOT|NEAR)\b|"/.test(query);
+    const q = hasOp ? query : '"' + query.replace(/"/g, '""') + '"';
+    try { return searchEvents.all(q, limit); }
+    catch { return []; }
   },
 };

--- a/tools/cb-control/server/storage.mjs
+++ b/tools/cb-control/server/storage.mjs
@@ -1,0 +1,95 @@
+// SQLite persistence: session registry + transcript ring buffer.
+// Sessions are spawned in-memory (see sessions.mjs); this table is the
+// durable record of what existed, when, and the last captured output.
+
+import Database from 'better-sqlite3';
+import { config } from './config.mjs';
+
+export const db = new Database(config.dbPath);
+db.pragma('journal_mode = WAL');
+db.pragma('foreign_keys = ON');
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS sessions (
+    id TEXT PRIMARY KEY,
+    label TEXT,
+    cwd TEXT NOT NULL,
+    branch TEXT,
+    pid INTEGER,
+    status TEXT NOT NULL DEFAULT 'running',
+    created_at INTEGER NOT NULL,
+    ended_at INTEGER,
+    exit_code INTEGER,
+    source TEXT NOT NULL DEFAULT 'daemon'
+  );
+
+  CREATE TABLE IF NOT EXISTS events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    ts INTEGER NOT NULL,
+    kind TEXT NOT NULL,
+    payload TEXT,
+    FOREIGN KEY(session_id) REFERENCES sessions(id) ON DELETE CASCADE
+  );
+
+  CREATE INDEX IF NOT EXISTS events_session_ts ON events(session_id, ts);
+`);
+
+const insertSession = db.prepare(`
+  INSERT INTO sessions (id, label, cwd, branch, pid, status, created_at, source)
+  VALUES (@id, @label, @cwd, @branch, @pid, @status, @created_at, @source)
+  ON CONFLICT(id) DO UPDATE SET
+    label = excluded.label,
+    cwd = excluded.cwd,
+    branch = excluded.branch,
+    pid = excluded.pid,
+    status = excluded.status
+`);
+
+const updateSessionStatus = db.prepare(`
+  UPDATE sessions SET status = ?, ended_at = ?, exit_code = ? WHERE id = ?
+`);
+
+const selectSessions = db.prepare(`
+  SELECT * FROM sessions ORDER BY created_at DESC LIMIT ?
+`);
+
+const selectSession = db.prepare(`SELECT * FROM sessions WHERE id = ?`);
+
+const insertEvent = db.prepare(`
+  INSERT INTO events (session_id, ts, kind, payload) VALUES (?, ?, ?, ?)
+`);
+
+const selectEvents = db.prepare(`
+  SELECT * FROM events WHERE session_id = ? AND id > ? ORDER BY id ASC LIMIT ?
+`);
+
+export const storage = {
+  upsertSession(row) {
+    insertSession.run({
+      id: row.id,
+      label: row.label ?? null,
+      cwd: row.cwd,
+      branch: row.branch ?? null,
+      pid: row.pid ?? null,
+      status: row.status ?? 'running',
+      created_at: row.created_at ?? Date.now(),
+      source: row.source ?? 'daemon',
+    });
+  },
+  markEnded(id, exitCode) {
+    updateSessionStatus.run('ended', Date.now(), exitCode ?? null, id);
+  },
+  listSessions(limit = 100) {
+    return selectSessions.all(limit);
+  },
+  getSession(id) {
+    return selectSession.get(id);
+  },
+  appendEvent(sessionId, kind, payload) {
+    insertEvent.run(sessionId, Date.now(), kind, payload == null ? null : JSON.stringify(payload));
+  },
+  readEvents(sessionId, afterId = 0, limit = 500) {
+    return selectEvents.all(sessionId, afterId, limit);
+  },
+};

--- a/tools/cb-control/server/tmux-bridge.mjs
+++ b/tools/cb-control/server/tmux-bridge.mjs
@@ -1,0 +1,178 @@
+// tmux bridge for external Claude CLI sessions.
+//
+// External sessions — those launched in a real terminal by the user —
+// can become fully interactive as long as they run inside tmux. The
+// SessionStart hook reports $TMUX_PANE; this module uses the tmux command
+// line to:
+//   - inject keystrokes   via `tmux send-keys`
+//   - mirror live output  via `tmux pipe-pane -o "cat >> <logfile>"`
+//
+// One log file per session is opened for append by tmux. We tail it with
+// fs.watch and emit new bytes over the session event bus, exactly like
+// managed PTY sessions do. So the PWA treats the two identically.
+
+import { spawnSync } from 'node:child_process';
+import { promises as fsp } from 'node:fs';
+import { createReadStream, watch, statSync, existsSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { config } from './config.mjs';
+
+const PANES_DIR = join(config.dataDir, 'panes');
+mkdirSync(PANES_DIR, { recursive: true });
+
+function paneLogPath(sessionId) {
+  // sessionId is a UUID or cli-<pid>-<ts>; both safe as filenames.
+  return join(PANES_DIR, `${sessionId}.log`);
+}
+
+/** Runs a tmux command, returns {ok, stdout, stderr}. */
+function tmux(args, { input } = {}) {
+  const res = spawnSync('tmux', args, {
+    encoding: 'utf8',
+    input,
+    timeout: 3000,
+  });
+  return {
+    ok: res.status === 0,
+    stdout: res.stdout ?? '',
+    stderr: res.stderr ?? '',
+    error: res.error,
+  };
+}
+
+/** Returns true if a pane exists in any tmux server. */
+export function paneExists(pane) {
+  if (!pane) return false;
+  const r = tmux(['display-message', '-p', '-t', pane, '#{pane_id}']);
+  return r.ok && r.stdout.trim().length > 0;
+}
+
+/**
+ * Attach to an external session's tmux pane: enable pipe-pane to a log file.
+ * Idempotent (uses `-o` to skip if already piping).
+ */
+export function attachPane(sessionId, pane) {
+  const log = paneLogPath(sessionId);
+  // Ensure file exists so fs.watch can start before tmux writes.
+  try { if (!existsSync(log)) fsp.writeFile(log, ''); } catch {}
+  // Quote the log path once — tmux will re-parse the command.
+  const quoted = log.replace(/'/g, "'\\''");
+  const r = tmux(['pipe-pane', '-o', '-t', pane, `cat >> '${quoted}'`]);
+  return { ok: r.ok, log, error: r.stderr || r.error?.message };
+}
+
+/** Disable pipe-pane for the pane (called on Stop). */
+export function detachPane(pane) {
+  if (!pane) return;
+  tmux(['pipe-pane', '-t', pane]);
+}
+
+/**
+ * Send text to the pane. We use `-l` (literal) so ANSI/control bytes aren't
+ * re-parsed as tmux key names. For Ctrl/special keys, use sendKey().
+ */
+export function sendText(pane, text) {
+  if (!pane || !text) return { ok: false, error: 'no pane or text' };
+  const r = tmux(['send-keys', '-t', pane, '-l', text]);
+  return { ok: r.ok, error: r.stderr || r.error?.message };
+}
+
+/** Send a named key ("Enter", "C-c", "Escape", etc.) */
+export function sendKey(pane, keyName) {
+  if (!pane || !keyName) return { ok: false };
+  const r = tmux(['send-keys', '-t', pane, keyName]);
+  return { ok: r.ok, error: r.stderr || r.error?.message };
+}
+
+/**
+ * Convenience: send text + Enter (the typical "relay a command" action).
+ * Sends text literally, then the Enter key name.
+ */
+export function relayCommand(pane, text, { enter = true } = {}) {
+  if (text) {
+    const r1 = sendText(pane, text);
+    if (!r1.ok) return r1;
+  }
+  if (enter) return sendKey(pane, 'Enter');
+  return { ok: true };
+}
+
+/**
+ * Snapshot the pane's current visible contents + scrollback.
+ * Used to bootstrap a PWA client before live tailing kicks in.
+ */
+export function capture(pane, { lines = 2000 } = {}) {
+  if (!pane) return '';
+  const r = tmux(['capture-pane', '-t', pane, '-p', '-J', '-e', '-S', String(-lines)]);
+  return r.ok ? r.stdout : '';
+}
+
+/**
+ * Watch a pane's pipe-pane log file and emit new bytes via callback.
+ * Returns { stop } to cancel the watcher.
+ *
+ * We use a polling fallback alongside fs.watch because macOS fs.watch on
+ * append-only files is unreliable — watch can miss writes, especially on
+ * APFS network volumes. A 500ms poll interval is cheap and robust.
+ */
+export function watchLog(sessionId, onData) {
+  const log = paneLogPath(sessionId);
+  let offset = 0;
+  try { offset = existsSync(log) ? statSync(log).size : 0; } catch { offset = 0; }
+
+  let stopped = false;
+  let reading = false;
+
+  const drain = async () => {
+    if (stopped || reading) return;
+    reading = true;
+    try {
+      const stat = existsSync(log) ? statSync(log) : null;
+      if (!stat) { reading = false; return; }
+      if (stat.size < offset) offset = 0; // truncation
+      if (stat.size > offset) {
+        await new Promise((resolve) => {
+          const stream = createReadStream(log, { start: offset, end: stat.size - 1, encoding: 'utf8' });
+          let buf = '';
+          stream.on('data', (chunk) => { buf += chunk; });
+          stream.on('end', () => { offset = stat.size; if (buf) onData(buf); resolve(); });
+          stream.on('error', () => resolve());
+        });
+      }
+    } finally { reading = false; }
+  };
+
+  // Initial snapshot replay if log already has content.
+  drain();
+
+  let watcher = null;
+  try { watcher = watch(log, { persistent: false }, () => { drain(); }); }
+  catch { /* fs.watch unsupported — polling still works */ }
+
+  const interval = setInterval(drain, 500);
+
+  return {
+    stop() {
+      stopped = true;
+      try { watcher?.close(); } catch {}
+      clearInterval(interval);
+    },
+  };
+}
+
+/** Read the entire pane log file (used for HTTP snapshot endpoint). */
+export async function readLog(sessionId, { maxBytes = 200_000 } = {}) {
+  const log = paneLogPath(sessionId);
+  try {
+    if (!existsSync(log)) return '';
+    const s = statSync(log);
+    const start = Math.max(0, s.size - maxBytes);
+    return await new Promise((resolve) => {
+      const stream = createReadStream(log, { start, encoding: 'utf8' });
+      let buf = '';
+      stream.on('data', (c) => { buf += c; });
+      stream.on('end', () => resolve(buf));
+      stream.on('error', () => resolve(''));
+    });
+  } catch { return ''; }
+}

--- a/tools/cb-control/server/ws.mjs
+++ b/tools/cb-control/server/ws.mjs
@@ -57,9 +57,10 @@ function handleClient(ws, sessionId) {
     if (msg.type === 'input' && typeof msg.data === 'string') {
       const s = sessions.get(sessionId);
       if (s) s.write(msg.data);
+      else ws.send(JSON.stringify({ type: 'error', error: 'session not live' }));
     } else if (msg.type === 'resize') {
       const s = sessions.get(sessionId);
-      if (s) s.resize(Number(msg.cols) || 120, Number(msg.rows) || 40);
+      if (s && typeof s.resize === 'function') s.resize(Number(msg.cols) || 120, Number(msg.rows) || 40);
     } else if (msg.type === 'ping') {
       ws.send(JSON.stringify({ type: 'pong' }));
     }

--- a/tools/cb-control/server/ws.mjs
+++ b/tools/cb-control/server/ws.mjs
@@ -1,0 +1,72 @@
+// WebSocket streaming. One socket per session subscription.
+// URL form: /ws/sessions/:id?token=<bearer>
+//
+// We accept the token in the query string because browsers cannot set
+// Authorization headers on WebSocket handshake. This is acceptable because:
+//   - TLS terminates at Tailscale (or at the host, encrypted on the LAN)
+//   - the token is 256 bits and long-lived per install
+//   - it's the same token as HTTP, so exposure surface doesn't grow
+
+import { WebSocketServer } from 'ws';
+import { config } from './config.mjs';
+import { sessions, sessionBus } from './sessions.mjs';
+
+function tokenOk(token) {
+  if (!token || token.length !== config.token.length) return false;
+  let diff = 0;
+  for (let i = 0; i < token.length; i++) diff |= token.charCodeAt(i) ^ config.token.charCodeAt(i);
+  return diff === 0;
+}
+
+export function attachWebSocket(server) {
+  const wss = new WebSocketServer({ noServer: true });
+
+  server.on('upgrade', (req, socket, head) => {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const match = url.pathname.match(/^\/ws\/sessions\/([^/]+)$/);
+    if (!match) { socket.destroy(); return; }
+    const token = url.searchParams.get('token');
+    if (!tokenOk(token)) { socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n'); socket.destroy(); return; }
+    const id = match[1];
+    wss.handleUpgrade(req, socket, head, (ws) => handleClient(ws, id));
+  });
+}
+
+function handleClient(ws, sessionId) {
+  // Replay recent output so the client has context immediately.
+  const snapshot = sessions.snapshot(sessionId);
+  if (snapshot) ws.send(JSON.stringify({ type: 'snapshot', data: snapshot }));
+
+  const onData = (evt) => {
+    if (evt.id !== sessionId) return;
+    if (ws.readyState !== 1) return;
+    ws.send(JSON.stringify({ type: 'data', data: evt.data }));
+  };
+  const onExit = (evt) => {
+    if (evt.id !== sessionId) return;
+    if (ws.readyState !== 1) return;
+    ws.send(JSON.stringify({ type: 'exit', exitCode: evt.exitCode }));
+  };
+
+  sessionBus.on('data', onData);
+  sessionBus.on('exit', onExit);
+
+  ws.on('message', (raw) => {
+    let msg;
+    try { msg = JSON.parse(raw.toString('utf8')); } catch { return; }
+    if (msg.type === 'input' && typeof msg.data === 'string') {
+      const s = sessions.get(sessionId);
+      if (s) s.write(msg.data);
+    } else if (msg.type === 'resize') {
+      const s = sessions.get(sessionId);
+      if (s) s.resize(Number(msg.cols) || 120, Number(msg.rows) || 40);
+    } else if (msg.type === 'ping') {
+      ws.send(JSON.stringify({ type: 'pong' }));
+    }
+  });
+
+  ws.on('close', () => {
+    sessionBus.off('data', onData);
+    sessionBus.off('exit', onExit);
+  });
+}

--- a/tools/cb-control/web/ansi.js
+++ b/tools/cb-control/web/ansi.js
@@ -1,0 +1,83 @@
+// Minimal ANSI → HTML converter. Handles:
+//   - SGR codes: 0 (reset), 1 (bold), 2 (dim), 30-37/90-97 (fg colors)
+//   - Carriage return (\r) with line reset (so spinners don't spam the log)
+//   - Strips all other CSI/OSC sequences
+// Good enough for Claude CLI output on a phone. Not a full terminal emulator.
+
+const COLOR_CLASS = {
+  31: 'ansi-red', 91: 'ansi-red',
+  32: 'ansi-green', 92: 'ansi-green',
+  33: 'ansi-yellow', 93: 'ansi-yellow',
+  34: 'ansi-blue', 94: 'ansi-blue',
+  35: 'ansi-magenta', 95: 'ansi-magenta',
+  36: 'ansi-cyan', 96: 'ansi-cyan',
+};
+
+export function ansiToHtml(text, state = { classes: new Set() }) {
+  let html = '';
+  let i = 0;
+  const esc = (s) => s.replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]));
+
+  const applyCodes = (codes) => {
+    for (const raw of codes) {
+      const n = parseInt(raw, 10);
+      if (!Number.isFinite(n) || n === 0) { state.classes.clear(); continue; }
+      if (n === 1) { state.classes.add('ansi-bold'); continue; }
+      if (n === 2) { state.classes.add('ansi-dim'); continue; }
+      if (n === 22) { state.classes.delete('ansi-bold'); state.classes.delete('ansi-dim'); continue; }
+      if (n === 39) {
+        for (const c of [...state.classes]) if (c.startsWith('ansi-') && !['ansi-bold','ansi-dim'].includes(c)) state.classes.delete(c);
+        continue;
+      }
+      const klass = COLOR_CLASS[n];
+      if (klass) {
+        for (const c of [...state.classes]) if (c.startsWith('ansi-') && !['ansi-bold','ansi-dim'].includes(c)) state.classes.delete(c);
+        state.classes.add(klass);
+      }
+    }
+  };
+
+  const openSpan = () => state.classes.size ? `<span class="${[...state.classes].join(' ')}">` : '';
+  const closeSpan = () => state.classes.size ? '</span>' : '';
+
+  let buf = '';
+  const flush = () => {
+    if (!buf) return;
+    html += openSpan() + esc(buf) + closeSpan();
+    buf = '';
+  };
+
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === '\x1b' && text[i + 1] === '[') {
+      flush();
+      // CSI ... final-byte
+      let j = i + 2;
+      while (j < text.length && !/[\x40-\x7e]/.test(text[j])) j++;
+      const seq = text.slice(i + 2, j);
+      const final = text[j];
+      if (final === 'm') applyCodes(seq.split(';'));
+      // all other CSI (cursor moves, erase) are ignored
+      i = j + 1;
+      continue;
+    }
+    if (ch === '\x1b' && text[i + 1] === ']') {
+      // OSC ... BEL or ESC \\
+      flush();
+      let j = i + 2;
+      while (j < text.length && text[j] !== '\x07' && !(text[j] === '\x1b' && text[j + 1] === '\\')) j++;
+      i = j + (text[j] === '\x07' ? 1 : 2);
+      continue;
+    }
+    if (ch === '\r' && text[i + 1] !== '\n') {
+      // Overwrite the current line — for the PWA we just emit a newline so spinners don't replace content.
+      buf += '\n';
+      i++;
+      continue;
+    }
+    buf += ch;
+    i++;
+  }
+  flush();
+  return html;
+}

--- a/tools/cb-control/web/api.js
+++ b/tools/cb-control/web/api.js
@@ -1,0 +1,64 @@
+// API client for cb-control daemon.
+// Settings persist in localStorage.
+
+const LS_KEY = 'cb-control:settings:v1';
+
+export function loadSettings() {
+  try {
+    const raw = localStorage.getItem(LS_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch {}
+  // Default to same origin the PWA was served from.
+  return {
+    serverUrl: location.origin,
+    token: '',
+    defaultCwd: '',
+  };
+}
+
+export function saveSettings(s) {
+  localStorage.setItem(LS_KEY, JSON.stringify(s));
+}
+
+export class Api {
+  constructor(settings) { this.settings = settings; }
+
+  update(settings) { this.settings = settings; }
+
+  async #fetch(path, opts = {}) {
+    const url = this.settings.serverUrl.replace(/\/$/, '') + path;
+    const headers = {
+      'content-type': 'application/json',
+      'authorization': 'Bearer ' + this.settings.token,
+      ...(opts.headers ?? {}),
+    };
+    const res = await fetch(url, { ...opts, headers });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`${res.status} ${res.statusText}${text ? ' — ' + text : ''}`);
+    }
+    const ct = res.headers.get('content-type') ?? '';
+    if (ct.includes('application/json')) return res.json();
+    return res.text();
+  }
+
+  health() { return this.#fetch('/health'); }
+  listSessions() { return this.#fetch('/api/sessions'); }
+  getSession(id) { return this.#fetch('/api/sessions/' + encodeURIComponent(id)); }
+  spawnSession(body) {
+    return this.#fetch('/api/sessions', { method: 'POST', body: JSON.stringify(body) });
+  }
+  sendInput(id, data, enter = true) {
+    return this.#fetch('/api/sessions/' + encodeURIComponent(id) + '/input', {
+      method: 'POST', body: JSON.stringify({ data, enter }),
+    });
+  }
+  killSession(id) {
+    return this.#fetch('/api/sessions/' + encodeURIComponent(id), { method: 'DELETE' });
+  }
+
+  wsUrl(id) {
+    const base = this.settings.serverUrl.replace(/^http/, 'ws').replace(/\/$/, '');
+    return `${base}/ws/sessions/${encodeURIComponent(id)}?token=${encodeURIComponent(this.settings.token)}`;
+  }
+}

--- a/tools/cb-control/web/api.js
+++ b/tools/cb-control/web/api.js
@@ -56,6 +56,15 @@ export class Api {
   killSession(id) {
     return this.#fetch('/api/sessions/' + encodeURIComponent(id), { method: 'DELETE' });
   }
+  compose(ids, data, enter = true) {
+    return this.#fetch('/api/compose', {
+      method: 'POST', body: JSON.stringify({ ids, data, enter }),
+    });
+  }
+  search(query, limit = 50) {
+    const q = encodeURIComponent(query);
+    return this.#fetch(`/api/search?q=${q}&limit=${limit}`);
+  }
 
   wsUrl(id) {
     const base = this.settings.serverUrl.replace(/^http/, 'ws').replace(/\/$/, '');

--- a/tools/cb-control/web/app.js
+++ b/tools/cb-control/web/app.js
@@ -1,16 +1,18 @@
-// PWA entry point. Three views: sessions, terminal, settings.
+// PWA entry point. Five views: sessions, terminal, compose, search, settings.
 
 import { Api, loadSettings, saveSettings } from './api.js';
 import { ansiToHtml } from './ansi.js';
+import * as biometric from './biometric.js';
 
 const state = {
   settings: loadSettings(),
   api: null,
   view: 'sessions',
-  currentSessionId: null,
+  currentSession: null,     // full row of selected session (for terminal view)
   ws: null,
   ansiState: { classes: new Set() },
   pollTimer: null,
+  composeSelection: new Set(),
 };
 
 state.api = new Api(state.settings);
@@ -20,27 +22,37 @@ state.api = new Api(state.settings);
 const views = {
   sessions: document.getElementById('view-sessions'),
   terminal: document.getElementById('view-terminal'),
+  compose:  document.getElementById('view-compose'),
+  search:   document.getElementById('view-search'),
   settings: document.getElementById('view-settings'),
 };
 const titleEl = document.getElementById('view-title');
 const backBtn = document.getElementById('nav-back');
+const searchBtn = document.getElementById('nav-search');
+const composeBtn = document.getElementById('nav-compose');
 const settingsBtn = document.getElementById('nav-settings');
 
 function showView(name) {
   state.view = name;
   for (const [k, el] of Object.entries(views)) el.hidden = (k !== name);
-  titleEl.textContent = { sessions: 'Sessions', terminal: 'Terminal', settings: 'Settings' }[name];
+  titleEl.textContent = { sessions: 'Sessions', terminal: 'Terminal', compose: 'Compose', search: 'Search', settings: 'Settings' }[name];
   backBtn.hidden = (name === 'sessions');
+  searchBtn.hidden = (name !== 'sessions');
+  composeBtn.hidden = (name !== 'sessions');
   settingsBtn.hidden = (name === 'settings');
+
   if (name === 'sessions') { stopStream(); refreshSessions(); startPolling(); }
   else stopPolling();
+  if (name === 'compose') loadComposeList();
   if (name === 'settings') hydrateSettingsForm();
 }
 
 backBtn.addEventListener('click', () => {
   if (state.view === 'terminal') { stopStream(); showView('sessions'); }
-  else if (state.view === 'settings') showView('sessions');
+  else showView('sessions');
 });
+searchBtn.addEventListener('click', () => showView('search'));
+composeBtn.addEventListener('click', () => showView('compose'));
 settingsBtn.addEventListener('click', () => showView('settings'));
 
 // --- Sessions list --------------------------------------------------------
@@ -64,6 +76,13 @@ function renderEmpty(msg) {
   emptyStateEl.textContent = msg;
 }
 
+function bridgeBadge(s) {
+  if (!s.live) return '<span class="badge ended">ended</span>';
+  if (s.bridge === 'pty') return '<span class="badge live">live · pty</span>';
+  if (s.bridge === 'tmux') return '<span class="badge live">live · tmux</span>';
+  return '<span class="badge live">live</span>';
+}
+
 function renderSessions(sessions) {
   sessionListEl.innerHTML = '';
   if (!sessions.length) {
@@ -75,12 +94,11 @@ function renderSessions(sessions) {
   for (const s of sessions) {
     const li = document.createElement('li');
     li.className = 'session-item';
-    const isLive = s.live && s.status === 'running';
     const isExternal = s.source === 'external';
     li.innerHTML = `
       <div class="row">
         <span class="label"></span>
-        <span class="badge ${isLive ? 'live' : 'ended'}">${isLive ? 'live' : 'ended'}</span>
+        ${bridgeBadge(s)}
         ${isExternal ? '<span class="badge external">external</span>' : ''}
       </div>
       <div class="cwd"></div>
@@ -88,8 +106,8 @@ function renderSessions(sessions) {
     `;
     li.querySelector('.label').textContent = s.label || 'claude';
     li.querySelector('.cwd').textContent = s.cwd;
-    li.querySelector('.meta').textContent = `${s.id.slice(0, 8)} · pid ${s.pid ?? '—'} · ${new Date(s.created_at).toLocaleTimeString()}`;
-    li.addEventListener('click', () => openTerminal(s.id));
+    li.querySelector('.meta').textContent = `${s.id.slice(0, 8)} · pid ${s.pid ?? '—'} · ${s.branch ? s.branch + ' · ' : ''}${new Date(s.created_at).toLocaleTimeString()}`;
+    li.addEventListener('click', () => openTerminal(s));
     sessionListEl.appendChild(li);
   }
 }
@@ -120,30 +138,47 @@ newDialog.addEventListener('close', async () => {
   const args = argsRaw ? argsRaw.split(/\s+/) : [];
   if (!cwd) return;
   try {
+    await biometric.require();
     const s = await state.api.spawnSession({ cwd, label, args });
     await refreshSessions();
-    openTerminal(s.id);
+    const full = await state.api.getSession(s.id);
+    openTerminal(full);
   } catch (err) { alert('Spawn failed: ' + err.message); }
 });
 
 // --- Terminal view --------------------------------------------------------
 
 const termEl = document.getElementById('terminal');
+const termMetaEl = document.getElementById('terminal-meta');
 const inputForm = document.getElementById('input-form');
 const inputText = document.getElementById('input-text');
 
-function openTerminal(id) {
-  state.currentSessionId = id;
+function openTerminal(s) {
+  state.currentSession = s;
   termEl.innerHTML = '';
   state.ansiState.classes = new Set();
+
+  const live = Boolean(s.live);
+  const bridge = s.bridge ?? (s.source === 'external' && s.tmux_pane ? 'tmux' : s.source === 'daemon' ? 'pty' : 'none');
+  termMetaEl.innerHTML = '';
+  const mkChip = (label, value) => {
+    const span = document.createElement('span');
+    span.textContent = `${label}: ${value}`;
+    return span;
+  };
+  termMetaEl.appendChild(mkChip('id', s.id.slice(0, 8)));
+  if (s.cwd) termMetaEl.appendChild(mkChip('cwd', s.cwd));
+  if (s.branch) termMetaEl.appendChild(mkChip('branch', s.branch));
+  termMetaEl.appendChild(mkChip('bridge', bridge));
+  termMetaEl.appendChild(mkChip('status', live ? 'live' : 'ended'));
+
   showView('terminal');
-  startStream(id);
+  startStream(s.id);
 }
 
 function appendOutput(text) {
   const html = ansiToHtml(text, state.ansiState);
   termEl.insertAdjacentHTML('beforeend', html);
-  // keep it bounded
   if (termEl.textContent.length > 500_000) {
     termEl.innerHTML = termEl.innerHTML.slice(termEl.innerHTML.length - 400_000);
   }
@@ -159,8 +194,8 @@ function startStream(id) {
       let msg; try { msg = JSON.parse(ev.data); } catch { return; }
       if (msg.type === 'snapshot' || msg.type === 'data') appendOutput(msg.data);
       if (msg.type === 'exit') appendOutput(`\n\n[session exited${msg.exitCode != null ? ' code=' + msg.exitCode : ''}]\n`);
+      if (msg.type === 'error') appendOutput(`\n[error: ${msg.error}]\n`);
     };
-    ws.onclose = () => { /* state.ws cleared on next startStream */ };
     ws.onerror = () => appendOutput('\n[stream error]\n');
   } catch (err) {
     appendOutput('\n[stream failed: ' + err.message + ']\n');
@@ -171,44 +206,174 @@ function stopStream() {
   if (state.ws) { try { state.ws.close(); } catch {} state.ws = null; }
 }
 
+async function sendToCurrent(data, enter) {
+  if (!state.currentSession) return;
+  await biometric.require();
+  if (state.ws && state.ws.readyState === 1) {
+    state.ws.send(JSON.stringify({ type: 'input', data: enter ? data + '\r' : data }));
+  } else {
+    await state.api.sendInput(state.currentSession.id, data, !!enter);
+  }
+}
+
 inputForm.addEventListener('submit', async (e) => {
   e.preventDefault();
   const text = inputText.value;
-  if (!state.currentSessionId) return;
   try {
-    if (state.ws && state.ws.readyState === 1) {
-      state.ws.send(JSON.stringify({ type: 'input', data: text + '\r' }));
-    } else {
-      await state.api.sendInput(state.currentSessionId, text, true);
-    }
+    await sendToCurrent(text, true);
     inputText.value = '';
   } catch (err) { alert('Send failed: ' + err.message); }
 });
 
 document.getElementById('send-interrupt').addEventListener('click', async () => {
-  if (!state.currentSessionId) return;
-  if (state.ws && state.ws.readyState === 1) state.ws.send(JSON.stringify({ type: 'input', data: '\x03' }));
-  else await state.api.sendInput(state.currentSessionId, '\x03', false);
+  try { await sendToCurrent('\x03', false); } catch (err) { alert(err.message); }
 });
 document.getElementById('send-esc').addEventListener('click', async () => {
-  if (!state.currentSessionId) return;
-  if (state.ws && state.ws.readyState === 1) state.ws.send(JSON.stringify({ type: 'input', data: '\x1b' }));
-  else await state.api.sendInput(state.currentSessionId, '\x1b', false);
+  try { await sendToCurrent('\x1b', false); } catch (err) { alert(err.message); }
+});
+document.getElementById('send-tab').addEventListener('click', async () => {
+  try { await sendToCurrent('\t', false); } catch (err) { alert(err.message); }
 });
 
-// --- Settings -------------------------------------------------------------
+// --- Compose view ---------------------------------------------------------
+
+const composeListEl = document.getElementById('compose-list');
+const composeText = document.getElementById('compose-text');
+const composeEnter = document.getElementById('compose-enter');
+const composeForm = document.getElementById('compose-form');
+const composeCount = document.getElementById('compose-count');
+const composeStatus = document.getElementById('compose-status');
+
+async function loadComposeList() {
+  composeStatus.textContent = '';
+  composeListEl.innerHTML = '';
+  try {
+    const { sessions } = await state.api.listSessions();
+    const live = sessions.filter((s) => s.live);
+    if (!live.length) {
+      composeListEl.innerHTML = '<li class="empty">No live sessions.</li>';
+    }
+    for (const s of live) {
+      const li = document.createElement('li');
+      const id = 'compose-cb-' + s.id;
+      li.innerHTML = `
+        <input type="checkbox" id="${id}" value="${s.id}">
+        <label for="${id}" style="flex:1">
+          <div><b></b> <span class="meta"></span></div>
+          <div class="meta cwd"></div>
+        </label>
+      `;
+      li.querySelector('b').textContent = s.label || 'claude';
+      li.querySelector('.meta:not(.cwd)').textContent = `${s.bridge ?? 'none'} · ${s.id.slice(0, 8)}`;
+      li.querySelector('.cwd').textContent = s.cwd;
+      const cb = li.querySelector('input');
+      cb.checked = state.composeSelection.has(s.id);
+      cb.addEventListener('change', () => {
+        if (cb.checked) state.composeSelection.add(s.id);
+        else state.composeSelection.delete(s.id);
+        updateComposeCount();
+      });
+      composeListEl.appendChild(li);
+    }
+    updateComposeCount();
+  } catch (err) {
+    composeStatus.className = 'status err';
+    composeStatus.textContent = 'Error: ' + err.message;
+  }
+}
+function updateComposeCount() { composeCount.textContent = String(state.composeSelection.size); }
+
+composeForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const ids = [...state.composeSelection];
+  if (!ids.length) { composeStatus.textContent = 'Select at least one session.'; return; }
+  try {
+    await biometric.require(true);  // force fresh for broadcast
+    const { results } = await state.api.compose(ids, composeText.value, composeEnter.checked);
+    const okCount = results.filter((r) => r.ok).length;
+    composeStatus.className = 'status ok';
+    composeStatus.textContent = `Relayed to ${okCount}/${results.length}.`;
+    composeText.value = '';
+  } catch (err) {
+    composeStatus.className = 'status err';
+    composeStatus.textContent = 'Error: ' + err.message;
+  }
+});
+
+// --- Search view ----------------------------------------------------------
+
+const searchForm = document.getElementById('search-form');
+const searchQuery = document.getElementById('search-query');
+const searchResultsEl = document.getElementById('search-results');
+const searchEmptyEl = document.getElementById('search-empty');
+
+searchForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const q = searchQuery.value.trim();
+  searchResultsEl.innerHTML = '';
+  searchEmptyEl.hidden = true;
+  if (!q) return;
+  try {
+    const { results } = await state.api.search(q, 100);
+    if (!results.length) { searchEmptyEl.hidden = false; return; }
+    for (const r of results) {
+      const li = document.createElement('li');
+      const labelSafe = escapeHtml(r.label ?? 'claude');
+      const idSafe = escapeHtml(r.session_id.slice(0, 8));
+      const when = new Date(r.ts).toLocaleString();
+      li.innerHTML = `
+        <div class="row">
+          <span class="label">${labelSafe}</span>
+          <span class="meta">${escapeHtml(r.kind)} · ${idSafe} · ${when}</span>
+        </div>
+        <div class="snippet">${r.snippet ?? ''}</div>
+      `;
+      li.addEventListener('click', async () => {
+        try {
+          const full = await state.api.getSession(r.session_id);
+          openTerminal(full);
+        } catch (err) { alert('Could not open session: ' + err.message); }
+      });
+      searchResultsEl.appendChild(li);
+    }
+  } catch (err) {
+    searchResultsEl.innerHTML = `<li class="empty">Error: ${escapeHtml(err.message)}</li>`;
+  }
+});
+function escapeHtml(s) { return String(s).replace(/[&<>"']/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }
+
+// --- Settings + biometric -------------------------------------------------
 
 const settingsForm = document.getElementById('settings-form');
 const serverUrlInput = document.getElementById('server-url');
 const tokenInput = document.getElementById('server-token');
 const defaultCwdInput = document.getElementById('default-cwd');
 const settingsStatus = document.getElementById('settings-status');
+const bioStatusEl = document.getElementById('biometric-status');
+const bioEnableBtn = document.getElementById('biometric-enable');
+const bioDisableBtn = document.getElementById('biometric-disable');
+
+function renderBiometricStatus() {
+  if (!biometric.isSupported()) {
+    bioStatusEl.textContent = 'Not supported on this device.';
+    bioEnableBtn.disabled = true; bioDisableBtn.disabled = true;
+    return;
+  }
+  if (biometric.isEnabled()) {
+    bioStatusEl.textContent = 'Enabled. You will be prompted before each relay.';
+    bioEnableBtn.hidden = true; bioDisableBtn.hidden = false;
+  } else {
+    bioStatusEl.textContent = 'Disabled.';
+    bioEnableBtn.hidden = false; bioDisableBtn.hidden = true;
+  }
+}
 
 function hydrateSettingsForm() {
   serverUrlInput.value = state.settings.serverUrl;
   tokenInput.value = state.settings.token;
   defaultCwdInput.value = state.settings.defaultCwd;
   settingsStatus.textContent = '';
+  renderBiometricStatus();
 }
 
 settingsForm.addEventListener('submit', (e) => {
@@ -234,7 +399,7 @@ document.getElementById('test-connection').addEventListener('click', async () =>
   settingsStatus.textContent = 'Testing…';
   try {
     await probe.health();
-    await probe.listSessions(); // exercises auth
+    await probe.listSessions();
     settingsStatus.className = 'status ok';
     settingsStatus.textContent = 'Connected ✓';
   } catch (err) {
@@ -242,6 +407,12 @@ document.getElementById('test-connection').addEventListener('click', async () =>
     settingsStatus.textContent = 'Failed: ' + err.message;
   }
 });
+
+bioEnableBtn.addEventListener('click', async () => {
+  try { await biometric.enable(); renderBiometricStatus(); }
+  catch (err) { alert('Could not enable: ' + err.message); }
+});
+bioDisableBtn.addEventListener('click', () => { biometric.disable(); renderBiometricStatus(); });
 
 // --- Service worker registration -----------------------------------------
 

--- a/tools/cb-control/web/app.js
+++ b/tools/cb-control/web/app.js
@@ -1,0 +1,255 @@
+// PWA entry point. Three views: sessions, terminal, settings.
+
+import { Api, loadSettings, saveSettings } from './api.js';
+import { ansiToHtml } from './ansi.js';
+
+const state = {
+  settings: loadSettings(),
+  api: null,
+  view: 'sessions',
+  currentSessionId: null,
+  ws: null,
+  ansiState: { classes: new Set() },
+  pollTimer: null,
+};
+
+state.api = new Api(state.settings);
+
+// --- View routing ---------------------------------------------------------
+
+const views = {
+  sessions: document.getElementById('view-sessions'),
+  terminal: document.getElementById('view-terminal'),
+  settings: document.getElementById('view-settings'),
+};
+const titleEl = document.getElementById('view-title');
+const backBtn = document.getElementById('nav-back');
+const settingsBtn = document.getElementById('nav-settings');
+
+function showView(name) {
+  state.view = name;
+  for (const [k, el] of Object.entries(views)) el.hidden = (k !== name);
+  titleEl.textContent = { sessions: 'Sessions', terminal: 'Terminal', settings: 'Settings' }[name];
+  backBtn.hidden = (name === 'sessions');
+  settingsBtn.hidden = (name === 'settings');
+  if (name === 'sessions') { stopStream(); refreshSessions(); startPolling(); }
+  else stopPolling();
+  if (name === 'settings') hydrateSettingsForm();
+}
+
+backBtn.addEventListener('click', () => {
+  if (state.view === 'terminal') { stopStream(); showView('sessions'); }
+  else if (state.view === 'settings') showView('sessions');
+});
+settingsBtn.addEventListener('click', () => showView('settings'));
+
+// --- Sessions list --------------------------------------------------------
+
+const sessionListEl = document.getElementById('session-list');
+const emptyStateEl = document.getElementById('empty-state');
+
+async function refreshSessions() {
+  if (!state.settings.token) { renderEmpty('Open Settings and paste the daemon bearer token.'); return; }
+  try {
+    const { sessions } = await state.api.listSessions();
+    renderSessions(sessions);
+  } catch (err) {
+    renderEmpty('Error: ' + err.message);
+  }
+}
+
+function renderEmpty(msg) {
+  sessionListEl.innerHTML = '';
+  emptyStateEl.hidden = false;
+  emptyStateEl.textContent = msg;
+}
+
+function renderSessions(sessions) {
+  sessionListEl.innerHTML = '';
+  if (!sessions.length) {
+    emptyStateEl.hidden = false;
+    emptyStateEl.textContent = 'No sessions yet. Tap + New session or start Claude CLI with the SessionStart hook installed.';
+    return;
+  }
+  emptyStateEl.hidden = true;
+  for (const s of sessions) {
+    const li = document.createElement('li');
+    li.className = 'session-item';
+    const isLive = s.live && s.status === 'running';
+    const isExternal = s.source === 'external';
+    li.innerHTML = `
+      <div class="row">
+        <span class="label"></span>
+        <span class="badge ${isLive ? 'live' : 'ended'}">${isLive ? 'live' : 'ended'}</span>
+        ${isExternal ? '<span class="badge external">external</span>' : ''}
+      </div>
+      <div class="cwd"></div>
+      <div class="meta"></div>
+    `;
+    li.querySelector('.label').textContent = s.label || 'claude';
+    li.querySelector('.cwd').textContent = s.cwd;
+    li.querySelector('.meta').textContent = `${s.id.slice(0, 8)} · pid ${s.pid ?? '—'} · ${new Date(s.created_at).toLocaleTimeString()}`;
+    li.addEventListener('click', () => openTerminal(s.id));
+    sessionListEl.appendChild(li);
+  }
+}
+
+document.getElementById('refresh').addEventListener('click', refreshSessions);
+
+function startPolling() {
+  stopPolling();
+  state.pollTimer = setInterval(refreshSessions, 4000);
+}
+function stopPolling() {
+  if (state.pollTimer) clearInterval(state.pollTimer);
+  state.pollTimer = null;
+}
+
+// --- New session dialog ---------------------------------------------------
+
+const newDialog = document.getElementById('new-session-dialog');
+document.getElementById('new-session').addEventListener('click', () => {
+  document.getElementById('ns-cwd').value = state.settings.defaultCwd || '';
+  newDialog.showModal();
+});
+newDialog.addEventListener('close', async () => {
+  if (newDialog.returnValue !== 'confirm') return;
+  const cwd = document.getElementById('ns-cwd').value.trim();
+  const label = document.getElementById('ns-label').value.trim();
+  const argsRaw = document.getElementById('ns-args').value.trim();
+  const args = argsRaw ? argsRaw.split(/\s+/) : [];
+  if (!cwd) return;
+  try {
+    const s = await state.api.spawnSession({ cwd, label, args });
+    await refreshSessions();
+    openTerminal(s.id);
+  } catch (err) { alert('Spawn failed: ' + err.message); }
+});
+
+// --- Terminal view --------------------------------------------------------
+
+const termEl = document.getElementById('terminal');
+const inputForm = document.getElementById('input-form');
+const inputText = document.getElementById('input-text');
+
+function openTerminal(id) {
+  state.currentSessionId = id;
+  termEl.innerHTML = '';
+  state.ansiState.classes = new Set();
+  showView('terminal');
+  startStream(id);
+}
+
+function appendOutput(text) {
+  const html = ansiToHtml(text, state.ansiState);
+  termEl.insertAdjacentHTML('beforeend', html);
+  // keep it bounded
+  if (termEl.textContent.length > 500_000) {
+    termEl.innerHTML = termEl.innerHTML.slice(termEl.innerHTML.length - 400_000);
+  }
+  termEl.scrollTop = termEl.scrollHeight;
+}
+
+function startStream(id) {
+  stopStream();
+  try {
+    const ws = new WebSocket(state.api.wsUrl(id));
+    state.ws = ws;
+    ws.onmessage = (ev) => {
+      let msg; try { msg = JSON.parse(ev.data); } catch { return; }
+      if (msg.type === 'snapshot' || msg.type === 'data') appendOutput(msg.data);
+      if (msg.type === 'exit') appendOutput(`\n\n[session exited${msg.exitCode != null ? ' code=' + msg.exitCode : ''}]\n`);
+    };
+    ws.onclose = () => { /* state.ws cleared on next startStream */ };
+    ws.onerror = () => appendOutput('\n[stream error]\n');
+  } catch (err) {
+    appendOutput('\n[stream failed: ' + err.message + ']\n');
+  }
+}
+
+function stopStream() {
+  if (state.ws) { try { state.ws.close(); } catch {} state.ws = null; }
+}
+
+inputForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const text = inputText.value;
+  if (!state.currentSessionId) return;
+  try {
+    if (state.ws && state.ws.readyState === 1) {
+      state.ws.send(JSON.stringify({ type: 'input', data: text + '\r' }));
+    } else {
+      await state.api.sendInput(state.currentSessionId, text, true);
+    }
+    inputText.value = '';
+  } catch (err) { alert('Send failed: ' + err.message); }
+});
+
+document.getElementById('send-interrupt').addEventListener('click', async () => {
+  if (!state.currentSessionId) return;
+  if (state.ws && state.ws.readyState === 1) state.ws.send(JSON.stringify({ type: 'input', data: '\x03' }));
+  else await state.api.sendInput(state.currentSessionId, '\x03', false);
+});
+document.getElementById('send-esc').addEventListener('click', async () => {
+  if (!state.currentSessionId) return;
+  if (state.ws && state.ws.readyState === 1) state.ws.send(JSON.stringify({ type: 'input', data: '\x1b' }));
+  else await state.api.sendInput(state.currentSessionId, '\x1b', false);
+});
+
+// --- Settings -------------------------------------------------------------
+
+const settingsForm = document.getElementById('settings-form');
+const serverUrlInput = document.getElementById('server-url');
+const tokenInput = document.getElementById('server-token');
+const defaultCwdInput = document.getElementById('default-cwd');
+const settingsStatus = document.getElementById('settings-status');
+
+function hydrateSettingsForm() {
+  serverUrlInput.value = state.settings.serverUrl;
+  tokenInput.value = state.settings.token;
+  defaultCwdInput.value = state.settings.defaultCwd;
+  settingsStatus.textContent = '';
+}
+
+settingsForm.addEventListener('submit', (e) => {
+  e.preventDefault();
+  state.settings = {
+    serverUrl: serverUrlInput.value.trim(),
+    token: tokenInput.value.trim(),
+    defaultCwd: defaultCwdInput.value.trim(),
+  };
+  saveSettings(state.settings);
+  state.api.update(state.settings);
+  settingsStatus.className = 'status ok';
+  settingsStatus.textContent = 'Saved.';
+});
+
+document.getElementById('test-connection').addEventListener('click', async () => {
+  const probe = new Api({
+    serverUrl: serverUrlInput.value.trim(),
+    token: tokenInput.value.trim(),
+    defaultCwd: defaultCwdInput.value.trim(),
+  });
+  settingsStatus.className = 'status';
+  settingsStatus.textContent = 'Testing…';
+  try {
+    await probe.health();
+    await probe.listSessions(); // exercises auth
+    settingsStatus.className = 'status ok';
+    settingsStatus.textContent = 'Connected ✓';
+  } catch (err) {
+    settingsStatus.className = 'status err';
+    settingsStatus.textContent = 'Failed: ' + err.message;
+  }
+});
+
+// --- Service worker registration -----------------------------------------
+
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/sw.js').catch(() => { /* fine */ });
+}
+
+// --- Boot -----------------------------------------------------------------
+
+showView('sessions');
+if (!state.settings.token) showView('settings');

--- a/tools/cb-control/web/biometric.js
+++ b/tools/cb-control/web/biometric.js
@@ -1,0 +1,101 @@
+// Biometric unlock via WebAuthn platform authenticator (Face ID / Touch ID).
+//
+// This is a lightweight client-side gate, not a server-verified auth factor.
+// The server still requires a bearer token for every API call. Biometric
+// unlock adds a second check: the PWA will not call any write endpoint
+// (input, spawn, kill, compose) until a fresh authentication assertion
+// is obtained from the phone's secure enclave.
+//
+// The credential is created on first enablement. The credential ID is
+// stored in localStorage; no user handle is sent to the server.
+// To revoke: delete the PWA's site data on the phone.
+//
+// UX:
+//   - If biometric is disabled  → this module is a no-op (everything passes)
+//   - If biometric is enabled   → require() prompts Face ID and resolves or throws
+//   - Successful unlocks cache for UNLOCK_TTL_MS so users aren't re-prompted
+//     on every keystroke, only on the first send in a window.
+
+const LS_KEY = 'cb-control:biometric:v1';
+const UNLOCK_TTL_MS = 60_000;
+
+const state = { lastUnlockTs: 0 };
+
+function load() {
+  try { return JSON.parse(localStorage.getItem(LS_KEY) ?? 'null') ?? { enabled: false, credentialId: null, rpId: location.hostname }; }
+  catch { return { enabled: false, credentialId: null, rpId: location.hostname }; }
+}
+function save(v) { localStorage.setItem(LS_KEY, JSON.stringify(v)); }
+
+function b64urlEncode(buf) {
+  const bin = String.fromCharCode(...new Uint8Array(buf));
+  return btoa(bin).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '');
+}
+function b64urlDecode(s) {
+  const pad = s.length % 4 === 2 ? '==' : s.length % 4 === 3 ? '=' : '';
+  const b64 = (s + pad).replaceAll('-', '+').replaceAll('_', '/');
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out.buffer;
+}
+
+export function isSupported() {
+  return !!(window.PublicKeyCredential && navigator.credentials?.create);
+}
+
+export function isEnabled() {
+  return load().enabled && !!load().credentialId;
+}
+
+export async function enable() {
+  if (!isSupported()) throw new Error('Web Authentication not supported on this device.');
+  const challenge = crypto.getRandomValues(new Uint8Array(32));
+  const userId = crypto.getRandomValues(new Uint8Array(16));
+  const cred = await navigator.credentials.create({
+    publicKey: {
+      challenge,
+      rp: { name: 'cb-control', id: location.hostname },
+      user: { id: userId, name: 'phone', displayName: 'Phone user' },
+      pubKeyCredParams: [{ type: 'public-key', alg: -7 }, { type: 'public-key', alg: -257 }],
+      authenticatorSelection: {
+        authenticatorAttachment: 'platform',
+        userVerification: 'required',
+        residentKey: 'preferred',
+      },
+      timeout: 60_000,
+      attestation: 'none',
+    },
+  });
+  if (!cred) throw new Error('Registration cancelled.');
+  save({ enabled: true, credentialId: b64urlEncode(cred.rawId), rpId: location.hostname });
+  state.lastUnlockTs = Date.now();
+}
+
+export function disable() {
+  save({ enabled: false, credentialId: null, rpId: location.hostname });
+  state.lastUnlockTs = 0;
+}
+
+/**
+ * Require a fresh biometric assertion. No-op if disabled. Throws on cancel.
+ * Cached for UNLOCK_TTL_MS.
+ */
+export async function require(forceFresh = false) {
+  const s = load();
+  if (!s.enabled || !s.credentialId) return;
+  if (!forceFresh && (Date.now() - state.lastUnlockTs) < UNLOCK_TTL_MS) return;
+  if (!isSupported()) throw new Error('Biometric enabled but not supported.');
+  const challenge = crypto.getRandomValues(new Uint8Array(32));
+  const assertion = await navigator.credentials.get({
+    publicKey: {
+      challenge,
+      rpId: s.rpId,
+      allowCredentials: [{ id: b64urlDecode(s.credentialId), type: 'public-key' }],
+      userVerification: 'required',
+      timeout: 60_000,
+    },
+  });
+  if (!assertion) throw new Error('Biometric unlock cancelled.');
+  state.lastUnlockTs = Date.now();
+}

--- a/tools/cb-control/web/icon.svg
+++ b/tools/cb-control/web/icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <radialGradient id="g" cx="50%" cy="42%" r="60%">
+      <stop offset="0%" stop-color="#7c9cff"/>
+      <stop offset="60%" stop-color="#3a5bd9"/>
+      <stop offset="100%" stop-color="#0b0d10"/>
+    </radialGradient>
+  </defs>
+  <rect width="512" height="512" rx="96" fill="#0b0d10"/>
+  <circle cx="256" cy="232" r="144" fill="url(#g)"/>
+  <rect x="128" y="372" width="256" height="24" rx="12" fill="#14171c" stroke="#262b34" stroke-width="3"/>
+  <rect x="152" y="396" width="208" height="16" rx="8" fill="#14171c" stroke="#262b34" stroke-width="3"/>
+</svg>

--- a/tools/cb-control/web/index.html
+++ b/tools/cb-control/web/index.html
@@ -17,6 +17,8 @@
 <header class="topbar">
   <button id="nav-back" class="icon-btn" aria-label="Back" hidden>&larr;</button>
   <h1 id="view-title">Sessions</h1>
+  <button id="nav-search" class="icon-btn" aria-label="Search">&#128269;</button>
+  <button id="nav-compose" class="icon-btn" aria-label="Compose">&#9998;</button>
   <button id="nav-settings" class="icon-btn" aria-label="Settings">&#9881;</button>
 </header>
 
@@ -30,15 +32,41 @@
 </main>
 
 <section id="view-terminal" class="view" hidden>
+  <div id="terminal-meta" class="terminal-meta"></div>
   <div id="terminal" class="terminal" aria-label="Session output"></div>
   <form id="input-form" class="input-bar">
     <textarea id="input-text" placeholder="Type a command…" rows="2" autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false"></textarea>
     <div class="input-actions">
       <button type="button" id="send-interrupt" class="secondary" title="Send Ctrl-C">^C</button>
       <button type="button" id="send-esc" class="secondary" title="Send Escape">Esc</button>
+      <button type="button" id="send-tab" class="secondary" title="Send Tab">Tab</button>
       <button type="submit" id="send-input" class="primary">Send</button>
     </div>
   </form>
+</section>
+
+<section id="view-compose" class="view" hidden>
+  <div class="compose-picker">
+    <h2>Relay to</h2>
+    <ul id="compose-list" class="compose-list"></ul>
+  </div>
+  <form id="compose-form" class="input-bar">
+    <textarea id="compose-text" placeholder="Command to relay to selected sessions…" rows="4" autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false"></textarea>
+    <div class="input-actions">
+      <label class="inline-check"><input type="checkbox" id="compose-enter" checked> Press Enter</label>
+      <button type="submit" class="primary">Relay to <span id="compose-count">0</span></button>
+    </div>
+    <p id="compose-status" class="status" aria-live="polite"></p>
+  </form>
+</section>
+
+<section id="view-search" class="view" hidden>
+  <form id="search-form" class="search-bar">
+    <input id="search-query" type="search" placeholder="Search transcripts…" autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false">
+    <button type="submit" class="primary">Search</button>
+  </form>
+  <ul id="search-results" class="search-results"></ul>
+  <p id="search-empty" class="empty" hidden>No matches.</p>
 </section>
 
 <section id="view-settings" class="view" hidden>
@@ -57,6 +85,14 @@
       <button type="button" id="test-connection" class="secondary">Test connection</button>
     </div>
     <p id="settings-status" class="status" aria-live="polite"></p>
+
+    <hr class="divider">
+    <h2 class="section-heading">Biometric unlock</h2>
+    <p class="hint" id="biometric-status">Disabled.</p>
+    <div class="settings-actions">
+      <button type="button" id="biometric-enable" class="primary">Enable Face ID / Touch ID</button>
+      <button type="button" id="biometric-disable" class="secondary">Disable</button>
+    </div>
   </form>
 </section>
 

--- a/tools/cb-control/web/index.html
+++ b/tools/cb-control/web/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="theme-color" content="#0b0d10">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="apple-mobile-web-app-title" content="cb-control">
+<link rel="manifest" href="/manifest.webmanifest">
+<link rel="apple-touch-icon" href="/icon.svg">
+<link rel="icon" href="/icon.svg" type="image/svg+xml">
+<link rel="stylesheet" href="/styles.css">
+<title>cb-control</title>
+</head>
+<body>
+<header class="topbar">
+  <button id="nav-back" class="icon-btn" aria-label="Back" hidden>&larr;</button>
+  <h1 id="view-title">Sessions</h1>
+  <button id="nav-settings" class="icon-btn" aria-label="Settings">&#9881;</button>
+</header>
+
+<main id="view-sessions" class="view">
+  <div class="toolbar">
+    <button id="new-session" class="primary">+ New session</button>
+    <button id="refresh" class="secondary">Refresh</button>
+  </div>
+  <ul id="session-list" class="session-list" aria-live="polite"></ul>
+  <p id="empty-state" class="empty" hidden>No sessions yet. Tap <b>+ New session</b> or start Claude CLI in a shell with the SessionStart hook installed.</p>
+</main>
+
+<section id="view-terminal" class="view" hidden>
+  <div id="terminal" class="terminal" aria-label="Session output"></div>
+  <form id="input-form" class="input-bar">
+    <textarea id="input-text" placeholder="Type a command…" rows="2" autocapitalize="off" autocomplete="off" autocorrect="off" spellcheck="false"></textarea>
+    <div class="input-actions">
+      <button type="button" id="send-interrupt" class="secondary" title="Send Ctrl-C">^C</button>
+      <button type="button" id="send-esc" class="secondary" title="Send Escape">Esc</button>
+      <button type="submit" id="send-input" class="primary">Send</button>
+    </div>
+  </form>
+</section>
+
+<section id="view-settings" class="view" hidden>
+  <form id="settings-form" class="settings">
+    <label>Server URL
+      <input id="server-url" type="url" placeholder="https://mac.your-tailnet.ts.net:46987" inputmode="url" autocomplete="off">
+    </label>
+    <label>Bearer token
+      <input id="server-token" type="password" placeholder="Paste from daemon startup log" autocomplete="off">
+    </label>
+    <label>Default working dir (for new sessions)
+      <input id="default-cwd" type="text" placeholder="/Users/you/developer/crystalball" autocomplete="off">
+    </label>
+    <div class="settings-actions">
+      <button type="submit" class="primary">Save</button>
+      <button type="button" id="test-connection" class="secondary">Test connection</button>
+    </div>
+    <p id="settings-status" class="status" aria-live="polite"></p>
+  </form>
+</section>
+
+<dialog id="new-session-dialog">
+  <form method="dialog">
+    <h2>Spawn Claude session</h2>
+    <label>Working directory
+      <input id="ns-cwd" type="text" required>
+    </label>
+    <label>Label (optional)
+      <input id="ns-label" type="text" placeholder="perf-review">
+    </label>
+    <label>Extra args (space-separated)
+      <input id="ns-args" type="text" placeholder="">
+    </label>
+    <menu>
+      <button value="cancel">Cancel</button>
+      <button id="ns-submit" value="confirm" class="primary">Spawn</button>
+    </menu>
+  </form>
+</dialog>
+
+<script type="module" src="/app.js"></script>
+</body>
+</html>

--- a/tools/cb-control/web/manifest.webmanifest
+++ b/tools/cb-control/web/manifest.webmanifest
@@ -1,0 +1,13 @@
+{
+  "name": "cb-control",
+  "short_name": "cb-control",
+  "description": "Remote control for Claude Code CLI sessions",
+  "start_url": "/",
+  "display": "standalone",
+  "orientation": "any",
+  "background_color": "#0b0d10",
+  "theme_color": "#0b0d10",
+  "icons": [
+    { "src": "/icon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any" }
+  ]
+}

--- a/tools/cb-control/web/styles.css
+++ b/tools/cb-control/web/styles.css
@@ -151,3 +151,53 @@ dialog input {
   padding: 10px; font: inherit;
 }
 dialog menu { display: flex; gap: 8px; justify-content: flex-end; padding: 0; margin: 8px 0 0; }
+
+/* Terminal metadata strip */
+.terminal-meta {
+  padding: 6px 12px; font-size: 12px; color: var(--text-dim);
+  background: var(--bg-elev); border-bottom: 1px solid var(--border);
+  font-family: var(--mono);
+  display: flex; gap: 10px; align-items: center; flex-wrap: wrap;
+}
+
+/* Compose */
+.compose-picker {
+  overflow-y: auto; flex: 1; min-height: 0;
+  border-bottom: 1px solid var(--border);
+}
+.compose-picker h2 { margin: 0; padding: 12px 14px 4px; font-size: 13px; color: var(--text-dim); font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+.compose-list { list-style: none; margin: 0; padding: 0; }
+.compose-list li {
+  padding: 10px 14px; border-bottom: 1px solid var(--border);
+  display: flex; align-items: center; gap: 10px;
+}
+.compose-list .meta { font-family: var(--mono); font-size: 11px; color: var(--text-dim); }
+.compose-list input[type="checkbox"] { width: 20px; height: 20px; accent-color: var(--accent); }
+.inline-check { display: inline-flex; align-items: center; gap: 6px; color: var(--text-dim); font-size: 13px; }
+.inline-check input { width: 18px; height: 18px; accent-color: var(--accent); }
+
+/* Search */
+.search-bar {
+  display: flex; gap: 8px; padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.search-bar input {
+  flex: 1; background: var(--bg-elev); color: var(--text);
+  border: 1px solid var(--border); border-radius: 10px;
+  padding: 10px 12px; font: inherit;
+}
+.search-results { list-style: none; margin: 0; padding: 0; overflow-y: auto; }
+.search-results li {
+  padding: 12px 14px; border-bottom: 1px solid var(--border);
+  cursor: pointer;
+}
+.search-results li:active { background: var(--bg-elev); }
+.search-results .snippet { font-family: var(--mono); font-size: 13px; white-space: pre-wrap; overflow-wrap: anywhere; }
+.search-results .snippet mark { background: #3a2d07; color: var(--warn); padding: 0 2px; border-radius: 3px; }
+.search-results .row { display: flex; gap: 8px; align-items: center; margin-bottom: 4px; }
+.search-results .row .label { font-weight: 600; }
+.search-results .row .meta { color: var(--text-dim); font-size: 11px; font-family: var(--mono); }
+
+.divider { border: 0; border-top: 1px solid var(--border); margin: 18px 0 6px; }
+.section-heading { margin: 4px 0; font-size: 14px; color: var(--text); font-weight: 600; }
+.hint { color: var(--text-dim); font-size: 13px; margin: 0; }

--- a/tools/cb-control/web/styles.css
+++ b/tools/cb-control/web/styles.css
@@ -1,0 +1,153 @@
+/* cb-control PWA styles — mobile-first, dark, iOS-safe */
+
+:root {
+  --bg: #0b0d10;
+  --bg-elev: #14171c;
+  --bg-elev-2: #1c2028;
+  --border: #262b34;
+  --text: #e6e9ef;
+  --text-dim: #9aa3b2;
+  --accent: #7c9cff;
+  --accent-fg: #0b0d10;
+  --danger: #ff6b6b;
+  --ok: #4ade80;
+  --warn: #facc15;
+  --mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+* { box-sizing: border-box; }
+html, body {
+  margin: 0; padding: 0; height: 100%;
+  background: var(--bg); color: var(--text);
+  font: 16px/1.4 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  overscroll-behavior: none;
+}
+body {
+  display: flex; flex-direction: column;
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
+.topbar {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-elev);
+  position: sticky; top: 0; z-index: 10;
+}
+.topbar h1 { flex: 1; margin: 0; font-size: 17px; font-weight: 600; }
+.icon-btn {
+  background: transparent; color: var(--text); border: 0;
+  font-size: 20px; padding: 6px 10px; cursor: pointer;
+}
+
+.view { flex: 1; overflow: hidden; display: flex; flex-direction: column; min-height: 0; }
+.view[hidden] { display: none; }
+
+.toolbar {
+  display: flex; gap: 8px; padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+button {
+  font: inherit;
+  border-radius: 10px; padding: 10px 14px;
+  border: 1px solid var(--border);
+  background: var(--bg-elev-2); color: var(--text);
+  cursor: pointer; transition: background 120ms;
+}
+button.primary { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); font-weight: 600; }
+button.primary:hover { filter: brightness(1.08); }
+button.secondary { background: var(--bg-elev-2); }
+button:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.session-list { list-style: none; margin: 0; padding: 0; overflow-y: auto; }
+.session-item {
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+  display: flex; flex-direction: column; gap: 4px;
+  cursor: pointer;
+}
+.session-item:active { background: var(--bg-elev); }
+.session-item .row { display: flex; align-items: center; gap: 8px; }
+.session-item .label { font-weight: 600; }
+.session-item .meta { font-size: 12px; color: var(--text-dim); font-family: var(--mono); }
+.session-item .cwd { font-size: 12px; color: var(--text-dim); font-family: var(--mono); overflow-wrap: anywhere; }
+.badge {
+  font-size: 11px; padding: 2px 7px; border-radius: 999px;
+  border: 1px solid var(--border); color: var(--text-dim);
+}
+.badge.live { color: var(--ok); border-color: #1f4f33; background: #0f2b1b; }
+.badge.ended { color: var(--text-dim); }
+.badge.external { color: var(--warn); border-color: #4a3d11; background: #2a2410; }
+
+.empty {
+  padding: 20px; color: var(--text-dim); text-align: center;
+}
+
+.terminal {
+  flex: 1; min-height: 0; overflow-y: auto;
+  background: #000; color: #e6e9ef;
+  font-family: var(--mono); font-size: 13px; line-height: 1.4;
+  padding: 12px; white-space: pre-wrap; word-break: break-word;
+}
+.terminal .ansi-red { color: #ff6b6b; }
+.terminal .ansi-green { color: #4ade80; }
+.terminal .ansi-yellow { color: #facc15; }
+.terminal .ansi-blue { color: #7c9cff; }
+.terminal .ansi-magenta { color: #f472b6; }
+.terminal .ansi-cyan { color: #67e8f9; }
+.terminal .ansi-dim { opacity: 0.6; }
+.terminal .ansi-bold { font-weight: 700; }
+
+.input-bar {
+  border-top: 1px solid var(--border);
+  background: var(--bg-elev);
+  padding: 10px 12px;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.input-bar textarea {
+  width: 100%; resize: none;
+  background: var(--bg); color: var(--text);
+  border: 1px solid var(--border); border-radius: 10px;
+  padding: 10px 12px; font: inherit;
+}
+.input-actions { display: flex; gap: 8px; justify-content: flex-end; }
+
+.settings {
+  padding: 16px; display: flex; flex-direction: column; gap: 14px;
+  overflow-y: auto;
+}
+.settings label {
+  display: flex; flex-direction: column; gap: 6px;
+  font-size: 13px; color: var(--text-dim);
+}
+.settings input {
+  background: var(--bg-elev); color: var(--text);
+  border: 1px solid var(--border); border-radius: 10px;
+  padding: 12px; font: inherit;
+}
+.settings-actions { display: flex; gap: 8px; }
+.status { font-size: 13px; color: var(--text-dim); min-height: 1.2em; }
+.status.ok { color: var(--ok); }
+.status.err { color: var(--danger); }
+
+dialog {
+  background: var(--bg-elev);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 16px;
+  max-width: 90vw;
+  width: 420px;
+}
+dialog::backdrop { background: rgba(0,0,0,0.6); }
+dialog h2 { margin: 0 0 12px; font-size: 16px; }
+dialog label { display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: var(--text-dim); margin-bottom: 10px; }
+dialog input {
+  background: var(--bg); color: var(--text);
+  border: 1px solid var(--border); border-radius: 8px;
+  padding: 10px; font: inherit;
+}
+dialog menu { display: flex; gap: 8px; justify-content: flex-end; padding: 0; margin: 8px 0 0; }

--- a/tools/cb-control/web/sw.js
+++ b/tools/cb-control/web/sw.js
@@ -1,8 +1,8 @@
 // Minimal service worker: shell caching so the PWA launches offline.
 // No API caching — we always go to network for session state.
 
-const CACHE = 'cb-control-v1';
-const SHELL = ['/', '/index.html', '/styles.css', '/app.js', '/api.js', '/ansi.js', '/manifest.webmanifest', '/icon.svg'];
+const CACHE = 'cb-control-v2';
+const SHELL = ['/', '/index.html', '/styles.css', '/app.js', '/api.js', '/ansi.js', '/biometric.js', '/manifest.webmanifest', '/icon.svg'];
 
 self.addEventListener('install', (e) => {
   e.waitUntil(caches.open(CACHE).then((c) => c.addAll(SHELL)).then(() => self.skipWaiting()));

--- a/tools/cb-control/web/sw.js
+++ b/tools/cb-control/web/sw.js
@@ -1,0 +1,28 @@
+// Minimal service worker: shell caching so the PWA launches offline.
+// No API caching — we always go to network for session state.
+
+const CACHE = 'cb-control-v1';
+const SHELL = ['/', '/index.html', '/styles.css', '/app.js', '/api.js', '/ansi.js', '/manifest.webmanifest', '/icon.svg'];
+
+self.addEventListener('install', (e) => {
+  e.waitUntil(caches.open(CACHE).then((c) => c.addAll(SHELL)).then(() => self.skipWaiting()));
+});
+self.addEventListener('activate', (e) => {
+  e.waitUntil(
+    caches.keys().then((keys) => Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k))))
+      .then(() => self.clients.claim())
+  );
+});
+self.addEventListener('fetch', (e) => {
+  const url = new URL(e.request.url);
+  if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/ws/') || url.pathname === '/health') return;
+  e.respondWith(
+    caches.match(e.request).then((hit) => hit || fetch(e.request).then((res) => {
+      if (res.ok && e.request.method === 'GET') {
+        const copy = res.clone();
+        caches.open(CACHE).then((c) => c.put(e.request, copy));
+      }
+      return res;
+    }).catch(() => caches.match('/index.html')))
+  );
+});


### PR DESCRIPTION
## Summary

Preserves `claude/review-cli-performance-RVsx6` (4 commits, 27 files) — entirely new `tools/cb-control/` subsystem for remote Claude CLI session coordination.

### Commits

- `feat(cb-control): iPhone PWA + daemon for remote Claude CLI sessions`
- `feat(cb-control): tmux bridge, compose, FTS5 search, biometric, launchd`
- `docs(cb-control): how-to for Claude sessions to coordinate via cb-control`
- `docs(cb-control): add HANDOFF.md as the canonical pointer for new sessions`

### What's in `tools/cb-control/`

- `server/{api,config,index,sessions}.mjs` — daemon
- `hooks/{session-start,session-stop}.mjs` — Claude session lifecycle hooks
- `scripts/install-hooks.mjs`, `install-launchd.mjs`, `setup-tailscale-https.sh`
- `CLAUDE.md`, `HANDOFF.md`, `README.md` — agent-oriented docs
- `.gitignore`, `package.json`

### Verdict — product decision needed

This is a **new feature**, not a fix. The entire `tools/cb-control/` directory is added from scratch. It's a remote-control tool for Claude CLI sessions (iPhone PWA + tailscale + biometric auth). Some traces of this subsystem appear on other branches too (`mcp-aggregate-filtering`, `sitrep-optimization`'s MCP changes).

**Decide whether cb-control is a feature you want before landing.** If yes, this is the canonical branch for it.

### Test plan

- [ ] Product decision: keep cb-control or drop?
- [ ] If keep: rebase onto main (low conflict risk — new directory, minimal src/ overlap)
- [ ] If drop: close this PR, `git push origin --delete claude/review-cli-performance-RVsx6`