### PR TITLE
salvage: docs-update-apr14 (docs refresh + MCP pipeline doc, previously closed as PR #45)

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -16,5 +16,5 @@
  "MD039": true,
  "MD047": true
   },
-  "ignores": ["node_modules/**", "dist/**", "src-tauri/target/**", ".planning/**", ".worktrees/**"]
+  "ignores": ["node_modules/**", "dist/**", "src-tauri/target/**", ".planning/**", ".worktrees/**", "tools/**/node_modules/**", "mcp-server/**/node_modules/**", "docs/archive/**"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,77 @@
 
 All notable changes to Crystal Ball are documented here.
 
-## [Unreleased]
+## [2.10.5] - 2026-04-13
 
-### Changed
+### Added
 
-- Removed the Claude agent surface from desktop/web runtime configuration, UI exports, and API routes to avoid direct Anthropic API-cost exposure in default app flows.
-- Summarization provider chain now uses `Ollama -> Groq -> OpenRouter -> browser` without Anthropic dependencies in runtime settings or sidecar secret validation.
+- **MCP server** — 19+ tools exposing Crystal Ball intelligence feeds to Claude Code and MCP-compatible agents. Aggregate tools (sitrep, threats, markets, cyber, weather, infrastructure, military posture) and granular lookups (conflicts, news, IP, CVE, vessel, flight, sanctions, FRED, SEC, earthquakes, disease, region briefs). Auto-registered in Claude Code via `settings.json`. Feed health monitoring tool.
+- **Strike Package panel** — air formation clustering with importance scoring, route prediction engine (extrapolation + pattern matching), DeckGL map layers with predicted route paths, Cesium globe integration with icons and route polylines.
+- **Military intelligence enhancements** — multi-theater coordination detection, historical conflict pattern matching, strike group presence detection, conflict pattern type library.
+- **Correlation Engine v3 Phase 1** — unified event schema with controlled taxonomy, source-to-taxonomy mapper, UnifiedAlert-to-NormalizedEvent bridge.
+- **Navigation system** — 2D MapLibre navigation panel, 3D God's Vision integration, 4-tier routing engine (OSRM > GraphHopper > Valhalla > straight-line), 3-tier GPS (CoreLocation > browser > manual), street-level tile fallback chain, Navigation HUD overlay, GPS NMEA endpoint in sidecar.
+- **CoreLocation IPC** — native macOS GPS via ObjC FFI from Rust, bypassing WKWebView geolocation restrictions.
+- **cb-control daemon** — cross-session coordination for parallel Claude Code sessions. iPhone PWA for remote control, tmux bridge, FTS5 search, biometric auth, launchd integration.
+- **Apple design system** — design tokens (`design-system.css`), motion utilities, Toast notifications, EmptyState component, ContextualHint tooltips, Apple Maps-style glass card popups, segmented controls for map presets.
+- **WelcomeFlow** — 3-step onboarding modal with contextual hints wired into app init.
+- **Alert system overhaul** (18 waves) — unified alert inbox, composite relevance scoring, situation clustering, shift handoff, alert replay, story timelines, entity co-occurrence graphs, geofence alerts, silence anomaly detection, escalation predictor, pattern memory, source reliability tracking, annotations, bookmarks, briefing export, threat corridor detection, periodicity detector.
+- **Local IDS integration** — Suricata eve.json + fast.log, Zeek log paths, noise filtering for stream events and dev/CDN hits.
+- **God's Vision improvements** — cinematic entry/exit transitions, alert clustering on globe, SIGINT legend chip, map icon overhaul (15 dot layers replaced with realistic icons, Canvas 2D sprite sheet), fighter jet icons with operator colors.
+- **RIPE Atlas** internet connectivity measurements panel and map layer.
+- **World Bank** development indicators wired into periodic data-loader.
+- **LM Studio** as additional intel provider with LLM-validated correlations.
+- **Cmd+K command palette**, StatusOverlay (Cmd+Shift+S), Today view (Cmd+Shift+T).
+
+### Fixed
+
+- Performance death spiral — concurrency limits, circuit breaker fixes, retry cooldowns, exponential backoff with temporal-baseline circuit breaker.
+- God's Vision CPU/GPU burn when inactive — viewer now destroyed on exit, RAF loops paused.
+- Floating polylines — geodesic densification, correct EllipsoidTerrainProvider, proper ColorMaterialProperty wrapping.
+- Storage quota recovery and panic safety.
+- YouTube error 150 embed fallback chain, webcam autoplay, embed-restricted live channels.
+- Rust zombie-process leak in sidecar management.
+- 588/588 tests passing after comprehensive regression fix passes.
 
 ### Security
 
-- Tightened API key policy for trusted browser origins: keyless access now applies to read-only requests only; non-read requests require `X-CrystalBall-Key`.
-- Hardened RSS proxy ingress with explicit origin rejection, method allowlisting (`GET/OPTIONS`), and per-IP Upstash rate limiting.
-- Release workflow now hard-fails publish builds on macOS when Apple signing secrets are missing.
+- postMessage origin hardening, noopener enforcement, CSP-safe image error handling.
+- Vercel analytics guard, Iran events client fix, CSP tightening.
+- YouTube embed postMessage hardening.
+
+### Performance
+
+- LruCache utility for all bounded caches, mousemove throttling with rafSchedule.
+- Clock + sidebar-heat ticks skip when app is inactive.
+- Comprehensive bundle cleanup, regex caching, resource leak fixes.
 
 ---
+
+## [2.8.0] - 2026-04-07
+
+### Added
+
+- **Unified alert system foundation** — triage bar, multi-pronged reactions, IDS ingest, snooze with re-escalation, ghost-aware reactions, source grouping, watchlist editor, alerting presets, correlation synthesis.
+- **Alert intelligence layers** — sidebar heat auto-promote, Today view, activity log, map pulse beacons for hot alerts, debug ring buffer, quiet hours, watchlist quick-add, feed earthquakes and cyber into store.
+- **Correlation engine overhaul** — directional rules, haversine distance, causal chains, confidence scoring, UI feedback, source trust, entity dedup, causal-gated correlator, situation bridge, negative evidence guards, magnitude-aware radius, per-rule auto-disable.
+- **Forecast fusion** with silence detection and HUD display.
+- **Source feedback learning**, chat memory + activity tracking, proactive digest.
+- **Power-grid + comms-health** alert sources and blackout-signature detector.
+- **LM Studio intel provider** with LLM-validated correlations.
+- **Liveness indicators** — per-panel heartbeat, fresh-flash, just-in rail, LLM narratives, severity-tier sidebar.
+
+### Changed
+
+- Removed the Claude agent surface from desktop/web runtime configuration to avoid direct Anthropic API-cost exposure.
+- Default radar spatial ping set to OFF.
+
+### Security
+
+- Tightened API key policy: keyless access now read-only; non-read requests require `X-CrystalBall-Key`.
+- Hardened RSS proxy ingress with origin rejection, method allowlisting, per-IP rate limiting.
+
+---
+
+## [2.7.4] - 2026-03-25
 
 ## [2.7.2] - 2026-03-24
 
@@ -52,57 +109,6 @@ All notable changes to Crystal Ball are documented here.
 ### Changed
 
 - Version metadata was advanced to `2.7.3` across Node and Tauri release files to publish the repaired desktop release pipeline.
-
----
-
-## [2.7.2] - 2026-03-24
-
-### Fixed
-
-- CI typecheck compatibility for XML parser callbacks in aviation and arXiv ingestion paths, preventing release pipeline failures against stricter callback signatures.
-- Release docs no longer pin stale download/version strings in README and docs badges.
-
-### Changed
-
-- Added release-doc sync regression coverage so docs and changelog stay aligned with `package.json` version updates.
-
----
-
-## [2.7.4] - 2026-03-25
-
-### Fixed
-
-- Restored TypeScript QA gate compatibility by aligning `tsconfig.json` `ignoreDeprecations` with the shipped TypeScript compiler.
-- Repaired release push guard compatibility so `scripts/release-doctor.mjs` accepts and honors remote selection from guarded pre-push flows.
-
-### Changed
-
-- Advanced desktop release metadata to `2.7.4` across Node and Tauri versioned files for a clean tagged release after post-`2.7.3` hardening fixes.
-
----
-
-## [2.7.3] - 2026-03-25
-
-### Fixed
-
-- Release automation now triggers required pull request checks for the release branch before merge.
-
-### Changed
-
-- Version metadata was advanced to `2.7.3` across Node and Tauri release files to publish the repaired desktop release pipeline.
-
----
-
-## [2.7.2] - 2026-03-24
-
-### Fixed
-
-- CI typecheck compatibility for XML parser callbacks in aviation and arXiv ingestion paths, preventing release pipeline failures against stricter callback signatures.
-- Release docs no longer pin stale download/version strings in README and docs badges.
-
-### Changed
-
-- Added release-doc sync regression coverage so docs and changelog stay aligned with `package.json` version updates.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ src/                        # TypeScript frontend (Vite)
   config/
     panels.ts               # FULL_PANELS, PANEL_CATEGORY_MAP, FULL_MAP_LAYERS
   services/
-    mode-manager.ts         # AppMode: peace/finance/war/disaster/ghost
+    mode-manager.ts         # AppMode: ghost | gods-vision | null (default)
     alert-store.ts          # unified alert inbox, IndexedDB persistence
     correlation-engine.ts   # directional rules, causal chains, situation clustering
     navigation.ts           # GPS tracker, routing engine, tile provider
@@ -89,13 +89,11 @@ tools/cb-control/               # cross-session coordination daemon (port 46987)
 
 | Mode | Trigger |
 |------|---------|
-| Peace | default |
-| Finance | S&P500 ≥2.5% OR BTC ≥5% OR Oil ≥4% OR Gold ≥2% |
-| War | ≥2 war signals > confidence 0.6 (normalized by conflict baselines) |
-| Disaster | GDACS Red OR 3+ Orange OR M≥6.5 quake |
+| Default (`null`) | Normal state — no special mode active |
 | Ghost | Manual only — ⌘⇧G / sidebar / File menu |
+| God's Vision | `G` key or sidebar — full-viewport Cesium 3D globe |
 
-Ghost Mode: polling ×5, analytics suppressed, notifications suppressed, dark crimson sidebar.
+Ghost Mode: polling ×5, analytics suppressed, notifications suppressed, dark crimson sidebar. The old Peace/Finance/War/Disaster modes have been removed — their behaviors are inlined into the default state.
 
 ## CSP Posture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - **App name**: Crystal Ball
 - **Bundle ID**: `com.bradleybond.crystalball`
-- **Stack**: Tauri 2 + TypeScript + Vite + DeckGL + Node.js sidecar (port 46123)
+- **Stack**: Tauri 2 + TypeScript + Vite + DeckGL + Cesium.js + Node.js sidecar (port 46123) + MCP server
 
 ## Commands
 
@@ -68,6 +68,9 @@ src/                        # TypeScript frontend (Vite)
     panels.ts               # FULL_PANELS, PANEL_CATEGORY_MAP, FULL_MAP_LAYERS
   services/
     mode-manager.ts         # AppMode: peace/finance/war/disaster/ghost
+    alert-store.ts          # unified alert inbox, IndexedDB persistence
+    correlation-engine.ts   # directional rules, causal chains, situation clustering
+    navigation.ts           # GPS tracker, routing engine, tile provider
     runtime-config.ts       # API key definitions, feature toggles
     settings-constants.ts   # HUMAN_LABELS, SIGNUP_URLS, SETTINGS_CATEGORIES
     analytics.ts            # PostHog (suppressed in Ghost Mode)
@@ -75,6 +78,11 @@ src-tauri/
   sidecar/local-api-server.mjs  # Node.js API proxy, port 46123
   capabilities/default.json     # Tauri capability allowlist
   src/main.rs                   # SUPPORTED_SECRET_KEYS, keychain service "crystal-ball"
+mcp-server/                     # MCP server — 19+ tools for Claude Code integration
+  src/index.ts                  # server entry point, tool registration
+  src/tools/                    # aggregate + granular tool implementations
+  src/sidecar-client.ts         # port/token discovery, HTTP helpers
+tools/cb-control/               # cross-session coordination daemon (port 46987)
 ```
 
 ## App Modes (`src/services/mode-manager.ts`)
@@ -108,7 +116,7 @@ Ghost Mode: polling ×5, analytics suppressed, notifications suppressed, dark cr
 
 ## Settings / API Keys
 
-API keys entered via gear icon → API Keys tab. None embed the brand in their names; all 47 supported keys are generic API names (ANTHROPIC_API_KEY, GROQ_API_KEY, etc).
+API keys entered via gear icon → API Keys tab. None embed the brand in their names; all 49 supported keys are generic API names (ANTHROPIC_API_KEY, GROQ_API_KEY, etc).
 
 ## Secret Scan Guardrail
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,12 +74,14 @@ For release bundles and signing, use [docs/RELEASE_PACKAGING.md](docs/RELEASE_PA
 | `src/components/` | Dashboard panels, settings UI, maps, and modal flows |
 | `src/services/` | Data-fetching, summarization, runtime, analysis, and alert logic |
 | `src/config/` | Variant settings, feeds, map data, static datasets, and commands |
-| `src/locales/` | 18 language bundles and locale metadata |
+| `src/locales/` | 31 language bundles and locale metadata |
 | `src/generated/` | Generated Sebuf clients and server bindings. Do not hand-edit |
 | `proto/` | Protobuf service and message definitions |
 | `server/` | Sebuf handler implementations |
 | `api/` | Vercel routes, gateway entrypoints, and legacy non-RPC endpoints |
-| `src-tauri/` | Tauri desktop app, Rust shell, and local sidecar integration |
+| `src-tauri/` | Tauri desktop app, Rust shell, CoreLocation IPC, and local sidecar integration |
+| `mcp-server/` | MCP server — 19+ tools exposing intelligence feeds to Claude Code |
+| `tools/cb-control/` | Cross-session coordination daemon and iPhone PWA |
 | `docs/` | Public docs plus generated OpenAPI artifacts |
 | `research/` | Repeatable evaluation tracks and results history |
 | `tests/` and `e2e/` | Data tests, runtime tests, and Playwright coverage |

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The `happy` variant shares the default dev server (`npm run dev`). See [docs/API
 | [docs/API_KEYS.md](docs/API_KEYS.md) | All 49 API keys -- categories, signup URLs, free/paid |
 | [docs/DESKTOP_CONFIGURATION.md](docs/DESKTOP_CONFIGURATION.md) | Desktop secret keys, feature availability, fallback |
 | [docs/RELEASE_PACKAGING.md](docs/RELEASE_PACKAGING.md) | Desktop packaging and signing workflow |
+| [docs/MCP_PIPELINE.md](docs/MCP_PIPELINE.md) | How Claude Code gathers intelligence via MCP -- pipeline, auth, tools |
 | [docs/ALERTS_ENHANCEMENT_ROADMAP.md](docs/ALERTS_ENHANCEMENT_ROADMAP.md) | Alert system architecture and enhancement roadmap |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Contributor workflow, checks, PR expectations |
 | [SECURITY.md](SECURITY.md) | Vulnerability reporting and scope |

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Four product variants (Full, Tech, Finance, Happy) share one application shell. 
 **AI fallback chain**
 Summarization resolves at runtime: Ollama (local) > Groq > Claude > OpenRouter > browser inference. Each hop is an explicit boundary, not a catch-all try/catch. Works in air-gapped and privacy-sensitive environments.
 
-**App mode state machine**
-Five modes (Peace/Finance/War/Disaster/Ghost) trigger on live signal thresholds -- S&P >=2.5%, >=2 war signals above confidence 0.6 normalized by conflict baselines, GDACS Red events. Ghost Mode suppresses analytics, multiplies poll intervals x5, and changes UI chrome. Mode transitions are deterministic and testable.
+**Ghost Mode**
+Manual toggle (Cmd+Shift+G / sidebar / File menu) that suppresses analytics, multiplies poll intervals x5, suppresses notifications, and switches to dark crimson UI chrome. God's Vision is the other modal state -- a full-viewport Cesium 3D globe activated with `G`.
 
 **Native location via CoreLocation IPC**
 WKWebView blocks `navigator.geolocation` entirely. Crystal Ball bypasses this with native CLLocationManager via ObjC FFI from Rust, exposed as a Tauri IPC command. Requires hardened runtime entitlements for location access.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Crystal Ball
 
-Tauri 2 + TypeScript + Rust desktop app: 168+ live data panels across 4 product variants, a Cesium.js/DeckGL 3D globe with 74 geospatial layers, SGP4 orbital propagation in a Web Worker, AI summarization with Ollama/Groq/Claude/OpenRouter fallback chain, Protobuf/Buf contract-driven API layer, OS keychain secret storage, Node.js sidecar proxy on a bearer-authenticated local port, and a PostHog-instrumented Ghost Mode with analytics suppression.
+Tauri 2 + TypeScript + Rust desktop app: 180+ live data panels across 4 product variants, a Cesium.js/DeckGL 3D globe with 99 geospatial layers, SGP4 orbital propagation in a Web Worker, AI summarization with Ollama/Groq/Claude/OpenRouter fallback chain, an MCP server exposing 19+ tools for Claude Code integration, Protobuf/Buf contract-driven API layer, OS keychain secret storage, Node.js sidecar proxy on a bearer-authenticated local port, and a PostHog-instrumented Ghost Mode with analytics suppression.
 
 [![Version](https://img.shields.io/github/v/release/bradleybond512/crystal-ball?label=version)](https://github.com/bradleybond512/crystal-ball/releases/latest)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
@@ -15,9 +15,9 @@ Tauri 2 + TypeScript + Rust desktop app: 168+ live data panels across 4 product 
 
 Full-viewport Cesium.js 3D globe mode. Activate with `G` or the sidebar.
 
-**74 live data layers:** military bases, nuclear facilities, earthquakes, active conflicts, airstrikes, cyclones, fires, vessels, flights, cyber threats, submarines, cables, ports, satellites, ISS, and more.
+**99 live data layers:** military bases, nuclear facilities, earthquakes, active conflicts, airstrikes, cyclones, fires, vessels, flights, cyber threats, submarines, cables, ports, satellites, ISS, strike packages, navigation routes, RIPE Atlas probes, displacement flows, and more.
 
-**HUD overlay:** threat assessment card, mode badge, HOTSPOTS/ALT/CONFLICT/DISASTER stat pills, nearest hotspot (haversine), sun-phase badge (DAY/GOLDEN/CIVIL/NAUTICAL/ASTRO/NIGHT), local clock at camera longitude, scrolling LIVE alert ticker, top-5 alert list, layer-toggle bar.
+**HUD overlay:** threat assessment card, mode badge, HOTSPOTS/ALT/CONFLICT/DISASTER stat pills, nearest hotspot (haversine), sun-phase badge (DAY/GOLDEN/CIVIL/NAUTICAL/ASTRO/NIGHT), local clock at camera longitude, scrolling LIVE alert ticker, top-5 alert list, layer-toggle bar, navigation HUD with turn-by-turn routing.
 
 **Fly Mode:** game-style WASD/mouse first-person flight over the globe. Right-click drag for look, scroll for speed.
 
@@ -29,19 +29,27 @@ Full-viewport Cesium.js 3D globe mode. Activate with `G` or the sidebar.
 
 **Imagery:** Bing satellite (Cesium Ion token) > ArcGIS World Imagery fallback.
 
+**Navigation system:** 2D MapLibre panel + 3D God's Vision integration. 4-tier routing engine (OSRM > GraphHopper > Valhalla > straight-line), 3-tier GPS (CoreLocation > browser > manual), street-level tile fallback chain (Mapbox > Stadia > OSM).
+
 <!-- screenshot: God's Eye 3D globe with HUD overlay and active layers -->
+
+## MCP Server
+
+Crystal Ball ships an MCP (Model Context Protocol) server that exposes its intelligence feeds to Claude Code and other MCP-compatible AI agents. 19+ tools across aggregate situational awareness (sitrep, threats, markets, cyber, weather, infrastructure, military posture) and granular lookups (conflicts, news, IP, CVE, vessel, flight, sanctions, FRED economic data, SEC filings, earthquakes, disease outbreaks, region briefs). Registered automatically in Claude Code via `settings.json`.
 
 ## Intelligence Coverage
 
 | Domain | What's included |
 |--------|----------------|
-| **Conflict & Geopolitics** | Live conflict zones, airstrike tracking, ACLED events, military bases, nuclear facilities, theater polygons, kill chain, ORBAT, STIX/TAXII feeds |
+| **Conflict & Geopolitics** | Live conflict zones, airstrike tracking, ACLED events, military bases, nuclear facilities, theater polygons, kill chain, ORBAT, STIX/TAXII feeds, strike package detection with route prediction, multi-theater coordination detection, historical conflict pattern matching |
 | **Weather** | 7-day forecasts, RainViewer global radar, Blitzortung lightning, NOAA GOES/Himawari satellite imagery, tide predictions, pollen tracking, NWS severe alerts, SPC convective outlooks, tropical cyclone tracking, red flag fire warnings |
-| **Cyber & Threats** | ThreatFox IOCs, OpenPhish feeds, Spamhaus blocklists, CISA KEV, ICS/OT threats, network topology, 24-session EMA threat forecast, Palantir/Dragos-inspired intel panels |
-| **Markets & Finance** | S&P 500, BTC, oil, gold, commodities, macro signals, central bank feeds, sector heatmap (requires Finnhub key) |
+| **Cyber & Threats** | ThreatFox IOCs, OpenPhish feeds, Spamhaus blocklists, CISA KEV, ICS/OT threats, network topology, 24-session EMA threat forecast, Palantir/Dragos-inspired intel panels, local IDS integration (Suricata/Zeek) |
+| **Markets & Finance** | S&P 500, BTC, oil, gold, commodities, macro signals, central bank feeds, sector heatmap, World Bank development indicators, stablecoin depeg detection, elections tracking |
 | **Space & Satellites** | ISS + Starlink + weather satellite tracking, SGP4 propagation, real-time orbital positions, satellite ISR intelligence |
-| **Infrastructure** | Submarine cables, maritime vessels, flight tracking, port status, datacenter outages, internet exchange points, CCTV & webcams |
-| **Disasters** | GDACS Red/Orange events, M6.5+ earthquakes, wildfire perimeters (NASA FIRMS), cyclone paths |
+| **Infrastructure** | Submarine cables, maritime vessels, flight tracking, port status, datacenter outages, internet exchange points, CCTV & webcams, RIPE Atlas internet connectivity, power grid/comms health monitoring |
+| **Disasters** | GDACS Red/Orange events, M6.5+ earthquakes, wildfire perimeters (NASA FIRMS), cyclone paths, UNHCR displacement data |
+| **Alerts & Correlation** | Unified alert inbox with composite relevance scoring, 18-wave alert intelligence system, situation clustering, shift handoff, story timelines, entity co-occurrence graphs, geofence alerts, silence anomaly detection, escalation prediction |
+| **Navigation** | Turn-by-turn routing (OSRM/GraphHopper/Valhalla), native CoreLocation GPS, street-level tiles, 2D + 3D globe integration |
 
 ## What Makes This Hard
 
@@ -72,8 +80,10 @@ CSS `-webkit-app-region: drag` is silently ignored. Window dragging requires JS 
 |-------|-------|
 | Frontend | TypeScript, Vite, MapLibre GL, deck.gl, Cesium.js, D3, i18next |
 | Contracts | Buf, Protobuf, generated TypeScript clients + OpenAPI output |
-| Desktop shell | Tauri v2, Rust, OS keychain, Node.js sidecar (port 46123) |
-| AI layer | Ollama > Groq > Claude > OpenRouter > browser inference |
+| Desktop shell | Tauri v2, Rust, OS keychain, Node.js sidecar (port 46123), CoreLocation IPC |
+| AI layer | Ollama > Groq > Claude > OpenRouter > LM Studio > browser inference |
+| MCP server | @modelcontextprotocol/sdk, 19+ tools, sidecar port/token discovery |
+| Correlation | Unified event schema, controlled taxonomy, directional rules, causal chains |
 | Verification | TypeScript strict, Playwright e2e + visual, sidecar unit tests |
 | CI/CD | Tag-driven desktop publish, release manifest verification, CodeQL |
 
@@ -83,10 +93,11 @@ CSS `-webkit-app-region: drag` is silently ignored. Window dragging requires JS 
 |--------|-------|--------|
 | Product variants | 4 | `src/config/variant.ts` |
 | Desktop build targets | 3 | `package.json` |
-| Default panel inventory | 168 full / 35 tech / 31 finance / 10 happy | `src/config/panels.ts` |
-| God's Eye data layers | 74 | `src/config/panels.ts` |
-| Supported secret keys | 47 | `src-tauri/src/main.rs` |
-| Locales | 19 | `src/locales/` |
+| Default panel inventory | 180 full / 35 tech / 31 finance / 10 happy | `src/config/panels.ts` |
+| God's Eye data layers | 99 | `src/types/index.ts` MapLayers |
+| MCP tools | 19+ | `mcp-server/` |
+| Supported secret keys | 49 | `src-tauri/src/main.rs` |
+| Locales | 31 | `src/locales/` |
 | Generated OpenAPI specs | 21 | `docs/api/` |
 
 ## Variants
@@ -115,9 +126,10 @@ The `happy` variant shares the default dev server (`npm run dev`). See [docs/API
 
 | Guide | Purpose |
 |-------|---------|
-| [docs/API_KEYS.md](docs/API_KEYS.md) | All 47 API keys -- categories, signup URLs, free/paid |
+| [docs/API_KEYS.md](docs/API_KEYS.md) | All 49 API keys -- categories, signup URLs, free/paid |
 | [docs/DESKTOP_CONFIGURATION.md](docs/DESKTOP_CONFIGURATION.md) | Desktop secret keys, feature availability, fallback |
 | [docs/RELEASE_PACKAGING.md](docs/RELEASE_PACKAGING.md) | Desktop packaging and signing workflow |
+| [docs/ALERTS_ENHANCEMENT_ROADMAP.md](docs/ALERTS_ENHANCEMENT_ROADMAP.md) | Alert system architecture and enhancement roadmap |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Contributor workflow, checks, PR expectations |
 | [SECURITY.md](SECURITY.md) | Vulnerability reporting and scope |
 

--- a/docs/ALERTS_ENHANCEMENT_ROADMAP.md
+++ b/docs/ALERTS_ENHANCEMENT_ROADMAP.md
@@ -2,9 +2,9 @@
 # Crystal Ball — Alerts Enhancement Roadmap
 
 > **Created**: 2026-03-31
-> **Last updated**: 2026-03-31
-> **Branch**: `claude/enhance-alerts-sorting-rYp3l`
-> **Status**: Active
+> **Last updated**: 2026-04-14
+> **Branch**: multiple (see progress log)
+> **Status**: Active — Phase 0 and Phase 1 largely complete
 
 ---
 
@@ -42,12 +42,12 @@ Transform Crystal Ball's fragmented alert panels into a unified, intelligent ale
 
 ## Roadmap
 
-### Phase 0 — Foundation (P0) `[IN PROGRESS]`
+### Phase 0 — Foundation (P0) `[COMPLETE]`
 
 #### 0.1 Unified Alert Inbox
 
-- [ ] Create `UnifiedAlertInboxPanel` that ingests from all alert sources
-- [ ] Normalize all alert types into a common `UnifiedAlert` interface:
+- [x] Create `UnifiedAlertInboxPanel` that ingests from all alert sources
+- [x] Normalize all alert types into a common `UnifiedAlert` interface:
 
   ```typescript
   interface UnifiedAlert {
@@ -67,40 +67,40 @@ Transform Crystal Ball's fragmented alert panels into a unified, intelligent ale
   }
   ```
 
-- [ ] Sort controls: severity | time | distance | relevance score
-- [ ] Filter bar: by source type, severity level, acknowledged/unread
-- [ ] Acknowledge (dismiss) and pin (star) individual alerts
-- [ ] Badge count for unread alerts in sidebar
-- [ ] Keyboard shortcuts: `J/K` navigate, `A` acknowledge, `P` pin, `1-5` filter severity
+- [x] Sort controls: severity | time | distance | relevance score
+- [x] Filter bar: by source type, severity level, acknowledged/unread
+- [x] Acknowledge (dismiss) and pin (star) individual alerts
+- [x] Badge count for unread alerts in sidebar
+- [x] Keyboard shortcuts: `J/K` navigate, `A` acknowledge, `P` pin, `1-5` filter severity
 
 #### 0.2 Composite Relevance Scoring
 
-- [ ] Create `src/services/relevance-scoring.ts`
-- [ ] Score formula: `severity_weight * proximity_weight * freshness_weight * novelty_weight * source_trust_weight`
+- [x] Create `src/services/relevance-scoring.ts`
+- [x] Score formula: `severity_weight * proximity_weight * freshness_weight * novelty_weight * source_trust_weight`
   - **Severity**: critical=1.0, high=0.8, medium=0.5, low=0.25, info=0.1
   - **Proximity**: 1.0 at 0km, decays to 0.3 at radius limit, 0.2 for no-location alerts
   - **Freshness**: 1.0 at 0min, 0.7 at 1hr, 0.4 at 6hr, 0.2 at 24hr (exponential decay)
   - **Novelty**: 1.0 for first report, 0.5 for 2nd-3rd, 0.3 for 4th+
   - **Source trust**: tier1=1.0, tier2=0.8, tier3=0.6, tier4=0.4
-- [ ] Expose `computeRelevanceScore(alert: UnifiedAlert, userLocation?: UserLocation): number`
-- [ ] Default sort in unified inbox = relevance score descending
-- [ ] Visual indicator: relevance bar or heat dot next to each alert
+- [x] Expose `computeRelevanceScore(alert: UnifiedAlert, userLocation?: UserLocation): number`
+- [x] Default sort in unified inbox = relevance score descending
+- [x] Visual indicator: relevance bar or heat dot next to each alert
 
 ---
 
-### Phase 1 — Intelligence (P1) `[PLANNED]`
+### Phase 1 — Intelligence (P1) `[LARGELY COMPLETE]`
 
 #### 1.1 Cross-Source Proximity Filtering
 
-- [ ] Extend proximity scoring to GDACS earthquakes, NWS weather alerts, OREF sirens, ACLED conflict events, breaking news with coordinates
-- [ ] "Near Me" toggle in unified inbox — filters to alerts within user's chosen radius
-- [ ] Distance badge on every alert that has coordinates
-- [ ] Sort-by-distance option
+- [x] Extend proximity scoring to GDACS earthquakes, NWS weather alerts, OREF sirens, ACLED conflict events, breaking news with coordinates
+- [x] "Near Me" toggle in unified inbox — filters to alerts within user's chosen radius
+- [x] Distance badge on every alert that has coordinates
+- [x] Sort-by-distance option
 
 #### 1.2 Alert Grouping (Situations)
 
-- [ ] Create `src/services/situation-clustering.ts`
-- [ ] Group alerts by: geographic proximity (< 100km) + temporal proximity (< 6hr) + category overlap
+- [x] Create `src/services/situation-clustering.ts`
+- [x] Group alerts by: geographic proximity (< 100km) + temporal proximity (< 6hr) + category overlap
 - [ ] `Situation` interface:
 
   ```typescript
@@ -115,18 +115,18 @@ Transform Crystal Ball's fragmented alert panels into a unified, intelligent ale
   }
   ```
 
-- [ ] Collapsible situation cards in unified inbox
-- [ ] Situation summary: "3 NWS warnings + 1 GDACS red + 2 news articles"
-- [ ] Mini-timeline showing escalation/de-escalation within a situation
+- [x] Collapsible situation cards in unified inbox
+- [x] Situation summary: "3 NWS warnings + 1 GDACS red + 2 news articles"
+- [x] Mini-timeline showing escalation/de-escalation within a situation
 
 #### 1.3 Alert Persistence (IndexedDB)
 
-- [ ] Create `src/services/alert-store.ts` using existing `crystalball_db`
-- [ ] Object store: `unified_alerts` with indexes on `timestamp`, `severity`, `source`, `situationId`
-- [ ] Retain alerts for 30 days (configurable)
-- [ ] Migrate in-memory buffers (AlertCenterPanel's 100-item array, correlation signal history) to IndexedDB-backed
-- [ ] Alert history view: searchable, filterable archive panel
-- [ ] Basic trend stats: "12 critical alerts this week (up from 4 last week)"
+- [x] Create `src/services/alert-store.ts` using existing `crystalball_db`
+- [x] Object store: `unified_alerts` with indexes on `timestamp`, `severity`, `source`, `situationId`
+- [x] Retain alerts for 30 days (configurable)
+- [x] Migrate in-memory buffers (AlertCenterPanel's 100-item array, correlation signal history) to IndexedDB-backed
+- [x] Alert history view: searchable, filterable archive panel
+- [x] Basic trend stats: "12 critical alerts this week (up from 4 last week)"
 
 ---
 
@@ -234,7 +234,17 @@ Data Sources (RSS, NWS, GDACS, OREF, ACLED, ...)
 | Date | Phase | Item | Status | Notes |
 |------|-------|------|--------|-------|
 | 2026-03-31 | — | Roadmap created | Done | Initial analysis of current system |
-| | | | | |
+| 2026-04-07 | 0.1 | Unified alert inbox | Done | Triage bar, multi-pronged reactions, source grouping |
+| 2026-04-07 | 0.2 | Composite relevance scoring | Done | Severity × proximity × freshness × novelty × source trust |
+| 2026-04-07 | 0.1 | Watchlist editor + alerting presets | Done | Quick-add, per-source multipliers |
+| 2026-04-07 | — | Local IDS integration | Done | Suricata + Zeek log ingest with noise filtering |
+| 2026-04-08 | 1.2 | Situation clustering | Done | Directional correlation rules, haversine, causal chains |
+| 2026-04-08 | 1.1 | Cross-source proximity | Done | ~20 intel services bridged into unified alert store |
+| 2026-04-08 | — | LLM-validated correlations | Done | LM Studio provider, negative evidence guards |
+| 2026-04-09 | 1.2 | Story timelines + entity graph | Done | Waves 7-14: temporal chains, story grouping, lifecycle tracking |
+| 2026-04-09 | 1.3 | Alert persistence (IndexedDB) | Done | Alert replay, shift handoff, custom correlation rules |
+| 2026-04-10 | — | Waves 15-18 | Done | Pattern memory, escalation predictor, geofence alerts, threat corridors |
+| 2026-04-13 | — | Alert action animations + sound | Done | Web Audio API sound service, design system migration |
 
 ---
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -21,9 +21,12 @@ Crystal Ball currently ships:
 
 - `4` web variants
 - `3` desktop build targets
+- `180` panels (full variant)
+- `99` God's Eye map layers
+- `19+` MCP tools for Claude Code integration
 - `21` generated OpenAPI specs
-- `19` locale bundles
-- `46` desktop secret slots backed by the OS keychain
+- `31` locale bundles
+- `49` desktop secret slots backed by the OS keychain
 
 Those numbers come from the current codebase, not aspirational copy.
 
@@ -40,11 +43,17 @@ Those numbers come from the current codebase, not aspirational copy.
 
 | Guide | Focus |
 | --- | --- |
-| [API_KEYS.md](API_KEYS.md) | All 46 API keys — categories, signup URLs, free/paid status |
+| [API_KEYS.md](API_KEYS.md) | All 49 API keys — categories, signup URLs, free/paid status |
 | [DESKTOP_CONFIGURATION.md](DESKTOP_CONFIGURATION.md) | Desktop secret keys, feature availability, and degraded behavior |
 | [API_KEY_DEPLOYMENT.md](API_KEY_DEPLOYMENT.md) | Vercel API access rules, trusted origins, and key requirements |
 | [RELAY_PARAMETERS.md](RELAY_PARAMETERS.md) | Relay environment variables for AIS and OpenSky paths |
 | [RELEASE_PACKAGING.md](RELEASE_PACKAGING.md) | Tauri packaging, signing, and clean-machine validation |
+
+## Intelligence and Integration Docs
+
+| Guide | Focus |
+| --- | --- |
+| [ALERTS_ENHANCEMENT_ROADMAP.md](ALERTS_ENHANCEMENT_ROADMAP.md) | Alert system architecture, unified inbox, correlation, and enhancement roadmap |
 
 ## API and Extension Docs
 

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -53,6 +53,7 @@ Those numbers come from the current codebase, not aspirational copy.
 
 | Guide | Focus |
 | --- | --- |
+| [MCP_PIPELINE.md](MCP_PIPELINE.md) | How Claude Code gathers intelligence from Crystal Ball via MCP -- full pipeline, auth, tools, slash commands |
 | [ALERTS_ENHANCEMENT_ROADMAP.md](ALERTS_ENHANCEMENT_ROADMAP.md) | Alert system architecture, unified inbox, correlation, and enhancement roadmap |
 
 ## API and Extension Docs

--- a/docs/MCP_PIPELINE.md
+++ b/docs/MCP_PIPELINE.md
@@ -1,0 +1,199 @@
+# Crystal Ball MCP Pipeline
+
+How Claude Code gathers real-time intelligence from Crystal Ball.
+
+## Overview
+
+Crystal Ball exposes its intelligence feeds to Claude Code through a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server. When you type `/sitrep` or ask Claude about a conflict zone, Claude calls MCP tools that query Crystal Ball's running sidecar, which fans out to dozens of upstream APIs and returns structured intelligence.
+
+The pipeline has four layers:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Claude Code                                            │
+│  User types /sitrep or asks a question                  │
+│  Claude decides which MCP tools to call                 │
+└──────────────┬──────────────────────────────────────────┘
+               │ stdio (JSON-RPC)
+┌──────────────▼──────────────────────────────────────────┐
+│  MCP Server (tools/mcp-server/)                         │
+│  19 registered tools — aggregate + granular             │
+│  Discovers sidecar port & token from disk               │
+└──────────────┬──────────────────────────────────────────┘
+               │ HTTP GET/POST to 127.0.0.1:{port}
+               │ Authorization: Bearer {token}
+┌──────────────▼──────────────────────────────────────────┐
+│  Sidecar (src-tauri/sidecar/local-api-server.mjs)       │
+│  Node.js proxy on port 46123                            │
+│  Routes requests to upstream APIs, caches responses     │
+└──────────────┬──────────────────────────────────────────┘
+               │ HTTPS
+┌──────────────▼──────────────────────────────────────────┐
+│  Upstream APIs                                          │
+│  ACLED, ThreatFox, CISA, FRED, NWS, OpenSanctions,     │
+│  ADS-B, AIS, USGS, WHO, SEC EDGAR, NewsAPI, ...        │
+└─────────────────────────────────────────────────────────┘
+```
+
+## How Claude Code Discovers the Server
+
+The MCP server is registered in `.mcp.json` at the repo root:
+
+```json
+{
+  "mcpServers": {
+    "crystalball": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["tools/mcp-server/index.mjs"]
+    }
+  }
+}
+```
+
+When Claude Code starts a session in this repo, it launches the MCP server as a child process and communicates over stdin/stdout using JSON-RPC. No network ports are opened for this connection.
+
+## Authentication
+
+The sidecar requires a bearer token on every request. The token is generated per-session and never leaves the local machine.
+
+**Token lifecycle:**
+
+1. **Tauri generates token** -- `generate_local_token()` in `src-tauri/src/main.rs` produces a random string at app launch.
+2. **Token written to disk** -- saved to `~/Library/Logs/com.bradleybond.crystalball/sidecar.token` with `0o600` permissions (owner-only read/write).
+3. **Token passed to sidecar** -- injected as the `LOCAL_API_TOKEN` environment variable when Tauri spawns the sidecar process.
+4. **MCP server reads token from disk** -- `sidecar-client.mjs` reads the token file on each request (so it picks up restarts).
+5. **Every request includes the token** -- `Authorization: Bearer {token}` header. The sidecar validates with timing-safe comparison.
+6. **Token deleted on exit** -- Tauri removes the token file when the app closes.
+
+**Port discovery** follows the same pattern: the sidecar writes its port to `sidecar.port` in the same log directory.
+
+## MCP Tools
+
+### Aggregate Tools (broad awareness)
+
+These call multiple sidecar endpoints in parallel and return a combined picture.
+
+| Tool | What it returns | Sidecar endpoints |
+|------|----------------|-------------------|
+| `get_sitrep` | Top conflicts, market moves, weather alerts, service health | `market-quotes`, `acled-events`, `nws-alerts`, `service-status` |
+| `get_threat_landscape` | Active threats across conflict, cyber, and crisis domains | `acled-events`, `threatfox-iocs`, `cisa-kev`, `oref-alerts`, `liveuamap` |
+| `get_market_overview` | Indices, crypto, ETF flows, sentiment, macro signals | `market-quotes`, `crypto-quotes`, `btc-etf-flows`, `macro-signals`, `fear-greed`, `wsb-sentiment` |
+| `get_cyber_intel` | IOCs, KEVs, phishing, malware URLs, threat pulses | `threatfox-iocs`, `cisa-kev`, `openphish-feed`, `urlhaus`, `otx-pulses` |
+| `get_weather_environment` | Conditions for 28 cities, NWS alerts, space weather | `owm-current`, `nws-alerts`, `donki-events`, `space-weather-feeds` |
+| `get_infrastructure_status` | Power grid, water quality, radiation, outage alerts | `power-grid`, `grid-alerts`, `epa-sdwis-proxy`, `epa-radnet-proxy`, `usgs-water-proxy` |
+| `get_military_posture` | Tracked aircraft, naval vessels, theater posture, ISW analysis | `adsb-military`, `ais-snapshot`, `military/v1/get-theater-posture`, `isw-reports` |
+
+### Granular Tools (targeted lookups)
+
+| Tool | Parameters | Data source |
+|------|-----------|-------------|
+| `search_conflicts` | region, country, date_from, date_to, event_type | ACLED |
+| `search_news` | query, category, country | NewsAPI, NewsData, DoD, NATO |
+| `lookup_ip` | ip | GreyNoise + AbuseIPDB + IPinfo |
+| `lookup_cve` | query | Vulners |
+| `lookup_vessel` | mmsi, name | AIS |
+| `lookup_flight` | hex, callsign | ADS-B |
+| `get_sanctions` | name, country | OpenSanctions |
+| `get_economic_data` | series_ids (e.g., "FEDFUNDS,WALCL") | FRED |
+| `get_sec_filings` | query, type | SEC EDGAR |
+| `get_earthquakes` | min_magnitude, region | USGS |
+| `get_disease_outbreaks` | region | WHO, ReliefWeb |
+| `get_region_brief` | place_name, lat, lon | Multi-source regional synthesis |
+
+### Response Format
+
+Every tool returns the same envelope:
+
+```json
+{
+  "summary": "Human-readable summary of findings",
+  "data": { },
+  "sources": ["/api/acled-events", "/api/market-quotes"],
+  "warnings": ["threatfox-iocs: timed out"],
+  "timestamp": "2026-04-14T12:00:00.000Z",
+  "healthy": true
+}
+```
+
+Partial failures are non-blocking: if one endpoint times out, the remaining data is still returned with the failure noted in `warnings`.
+
+## Slash Commands
+
+Four slash commands compose MCP tool calls into intelligence products. These are defined in `.claude/commands/` and show up as `/sitrep`, `/watch`, `/threat-brief`, `/market-pulse` in Claude Code.
+
+### `/sitrep` -- Daily Intelligence Brief
+
+Calls `get_sitrep` + `get_threat_landscape` + `get_military_posture`. Claude synthesizes results into sections: Conflicts, Markets, Cyber, Military, Weather. Anything at elevated or critical levels is flagged.
+
+### `/watch <location>` -- Regional Brief
+
+Calls `get_region_brief` + `search_conflicts` + `search_news` + `get_weather_environment` for a specific location (e.g., `/watch Strait of Hormuz`). Output: security situation, recent events, infrastructure, weather, outlook.
+
+### `/threat-brief` -- Threat Assessment
+
+Calls `get_threat_landscape` + `get_cyber_intel` + `get_infrastructure_status`. Identifies top 5 threats by severity with trajectory (escalating/stable/de-escalating) and recommended watch items.
+
+### `/market-pulse` -- Markets Snapshot
+
+Calls `get_market_overview` + `get_economic_data` (FEDFUNDS, WALCL, T10Y2Y). Covers major indices, crypto, sentiment, yield curve, Fed balance sheet. Flags significant moves (>2% equity, >5% crypto).
+
+## Sidecar Client
+
+The MCP server talks to the sidecar through `tools/mcp-server/sidecar-client.mjs`:
+
+- **Port discovery**: reads `~/Library/Logs/com.bradleybond.crystalball/sidecar.port`
+- **Token discovery**: reads `~/Library/Logs/com.bradleybond.crystalball/sidecar.token`
+- **Request timeout**: 15 seconds per request
+- **Health check timeout**: 3 seconds
+- **Parallel fetching**: `getAll()` uses `Promise.allSettled()` so one slow endpoint doesn't block others
+- **Graceful degradation**: if Crystal Ball isn't running, tools return `{ error: "Crystal Ball is not running...", healthy: false }` instead of crashing
+
+## Sidecar Caching
+
+The sidecar caches upstream API responses in memory:
+
+| Endpoint type | Typical TTL |
+|--------------|-------------|
+| Market quotes | 1 min |
+| ACLED conflicts | 5 min |
+| Weather | 10 min |
+| Cyber IOCs | 15 min |
+| Static reference data | 60 min |
+
+Cache entries are evicted when stale or when the cache exceeds 200 entries.
+
+## End-to-End Example
+
+User types `/sitrep` in Claude Code:
+
+1. Claude Code reads `.claude/commands/sitrep.md` and expands the prompt.
+2. Claude decides to call three MCP tools: `get_sitrep`, `get_threat_landscape`, `get_military_posture`.
+3. The MCP server receives the tool invocations over stdio.
+4. For each tool, the sidecar client reads port and token from disk, then fires parallel HTTP GETs to `http://127.0.0.1:46123/api/...` with the bearer token.
+5. The sidecar validates the token, routes each request to its handler, which fetches from upstream APIs (ACLED, ThreatFox, ADS-B, etc.) or returns cached data.
+6. JSON responses flow back through the sidecar client to the MCP server, which wraps them in MCP text content.
+7. Claude receives all three tool results and synthesizes a brief: "SITREP -- 14 Apr 2026 -- Conflicts: ... Markets: ... Cyber: ... Military: ... Weather: ..."
+8. The user sees a formatted intelligence brief in their terminal.
+
+## Prerequisites
+
+- **Crystal Ball must be running.** The MCP server reads port/token files that only exist while the app is open. If the app is closed, tools return a clear error message.
+- **API keys must be configured.** The sidecar proxies requests to upstream APIs using keys stored in the macOS Keychain. Missing keys cause individual endpoints to return empty data (noted in `warnings`), but don't block the overall response.
+- **Node.js >= 20** is required by the MCP server.
+
+## File Reference
+
+| File | Role |
+|------|------|
+| `.mcp.json` | Registers the MCP server with Claude Code |
+| `tools/mcp-server/index.mjs` | Server entry point, 19 tool registrations |
+| `tools/mcp-server/sidecar-client.mjs` | Port/token discovery, HTTP client |
+| `tools/mcp-server/tools/aggregate.mjs` | 7 aggregate tool implementations |
+| `tools/mcp-server/tools/granular.mjs` | 12 granular tool implementations |
+| `src-tauri/sidecar/local-api-server.mjs` | Node.js sidecar, API proxy |
+| `src-tauri/src/main.rs` | Token generation, sidecar launch |
+| `.claude/commands/sitrep.md` | `/sitrep` slash command definition |
+| `.claude/commands/watch.md` | `/watch` slash command definition |
+| `.claude/commands/threat-brief.md` | `/threat-brief` slash command definition |
+| `.claude/commands/market-pulse.md` | `/market-pulse` slash command definition |

--- a/tools/cb-control/CLAUDE.md
+++ b/tools/cb-control/CLAUDE.md
@@ -127,17 +127,20 @@ curl -fsS -H "Authorization: Bearer $TOKEN" \
 ## When to use this vs. not
 
 **Use it when:**
+
 - The user asked to coordinate across sessions
 - The user asked what another session is doing
 - You need context another session built and you can search for it
 
 **Don't use it when:**
+
 - The user hasn't mentioned other sessions — don't freelance and start
   chattering at them
 - You'd be saying anything secret (tokens, keys, passwords) — the
   transcript is persisted to SQLite
 
 **Never:**
+
 - Mass-kill sessions (`DELETE /api/sessions/:id`) without explicit user approval
 - Spawn sessions with `--dangerously-skip-permissions` via the `args` field
 - Loop automated retries against another session — a human review gate

--- a/tools/cb-control/HANDOFF.md
+++ b/tools/cb-control/HANDOFF.md
@@ -42,6 +42,7 @@ The code exists but has not yet been installed or run on the user's Mac.
 actually use cb-control):**
 
 1. **Pull the branch to the Mac**
+
    ```bash
    cd ~/developer/crystalball
    git fetch origin
@@ -49,12 +50,14 @@ actually use cb-control):**
    ```
 
 2. **Install and run the daemon**
+
    ```bash
    cd tools/cb-control
    npm install
    npm run install-hooks
    npm run install-launchd        # or `npm start` for foreground
    ```
+
    After this, `curl http://127.0.0.1:46987/health` should return
    `{"ok":true,...}` and a bearer token lives at
    `~/.config/cb-control/token`.
@@ -62,6 +65,7 @@ actually use cb-control):**
 3. **Make it discoverable machine-wide** (optional but recommended)
    Add a section to `~/.claude/CLAUDE.md` so every Claude session on
    the Mac learns to check for the daemon, regardless of cwd:
+
    ```
    ## cb-control (machine-wide Claude session coordination)
    Local daemon at http://127.0.0.1:46987 for cross-session coordination.

--- a/tools/cb-control/README.md
+++ b/tools/cb-control/README.md
@@ -6,6 +6,7 @@ features from your phone, with full command relay into any running CLI
 session.
 
 **What it does:**
+
 - **Spawn Claude sessions from your phone** — they run on your Mac with your
   real env, keys, and tools.
 - **Attach to existing CLI sessions** you started in a terminal. As long as
@@ -16,6 +17,7 @@ session.
 - **Biometric gate** (Face ID / Touch ID) before any write from the phone.
 
 **Architecture:**
+
 - Node 20 daemon: HTTP + WebSocket + PTY + SQLite (~1000 LOC)
 - Vanilla-ESM PWA: no build step
 - Tailscale: secure transport, no public internet exposure
@@ -65,14 +67,17 @@ Copy the token into the PWA once and forget it.
 ## Using it
 
 ### Spawn from the phone
+
 **+ New session** → cwd + optional label + extra args. A managed `claude`
 process starts in a PTY; the terminal view opens.
 
 ### Attach to a terminal session (tmux)
+
 ```bash
 # in tmux
 claude
 ```
+
 The `SessionStart` hook registers it and captures `$TMUX_PANE`. Open the
 PWA — the session appears with a `live · tmux` badge and full I/O works.
 
@@ -80,6 +85,7 @@ Without tmux, the session still appears in the list but is **read-only**
 (metadata only; the daemon can't inject into a bare terminal's stdin).
 
 ### Compose (multi-session relay)
+
 Tap the pencil icon. Check the sessions to target, type a command, **Relay
 to N**. Each selected session receives the same input in parallel. Useful
 for: "rebase all feature branches onto main", "run the test suite
@@ -87,10 +93,12 @@ everywhere", "paste the same question into three branches to compare
 answers".
 
 ### Search
+
 Tap the magnifying-glass icon. Queries FTS5-indexed events across every
 session. Tap a hit to jump into that session's terminal view.
 
 ### Biometric unlock (optional but recommended)
+
 Settings → **Enable Face ID / Touch ID**. Once enabled, every write
 (spawn, input, compose) requires a platform-authenticator assertion. The
 unlock is cached for 60s to avoid re-prompting on every keystroke.
@@ -100,6 +108,7 @@ second wall that protects against scenarios where someone has physical
 access to your unlocked phone.
 
 ### Terminal keyboard
+
 - `Send` — relay the textarea + Enter
 - `^C` — SIGINT / Ctrl-C
 - `Esc` — Escape key (e.g. cancel a Claude thought)
@@ -165,6 +174,7 @@ npm run uninstall-launchd         # reverse
 ```
 
 The installed agent:
+
 - Runs at login and respawns on crash
 - Binds to `0.0.0.0:46987` (override with `CB_CONTROL_HOST` / `CB_CONTROL_PORT`)
 - Logs to `~/Library/Logs/cb-control.log` and `cb-control.err.log`


### PR DESCRIPTION
## Summary

Preserves `claude/docs-update-apr14` (3 commits, 11 files).

### Note — previously closed as PR #45

PR #45 with the same content was closed unmerged. Reopening for preservation. Some of these docs were likely superseded by later doc updates (including PR #52's own doc sweep which updated panel counts in README / CLAUDE.md / DOCUMENTATION.md).

### Commits

- `docs: update all documentation for Apr 7-14 work`
- `docs: add MCP pipeline documentation`
- `docs: remove stale Peace/Finance/War/Disaster mode references`

### Files

- `CLAUDE.md`, `CONTRIBUTING.md`, `README.md`, `CHANGELOG.md`
- `.markdownlint-cli2.jsonc`
- `docs/ALERTS_ENHANCEMENT_ROADMAP.md`
- `docs/DOCUMENTATION.md`
- `docs/MCP_PIPELINE.md` (new)
- `tools/cb-control/{CLAUDE,HANDOFF,README}.md`

### Test plan

- [ ] Cherry-pick just `docs/MCP_PIPELINE.md` (new doc) and the "remove stale Peace/Finance/War/Disaster mode references" commit — those are clearly additive.
- [ ] Discard README/CLAUDE.md/CHANGELOG changes (PR #52 already refreshed those).