### PR TITLE
salvage: mcp-aggregate-filtering (cherry-picked + conflicts resolved against current main)

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -16,5 +16,5 @@
  "MD039": true,
  "MD047": true
   },
-  "ignores": ["node_modules/**", "dist/**", "src-tauri/target/**", ".planning/**", ".worktrees/**", "tools/**", "docs/archive/**"]
+  "ignores": ["node_modules/**", "**/node_modules/**", "dist/**", "src-tauri/target/**", ".planning/**", ".worktrees/**", "tools/**", "docs/archive/**"]
 }

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -6069,6 +6069,7 @@ export async function createLocalApiServer(options = {}) {
  }
  }
  const mem = process.memoryUsage();
+ const missing = wmMissingKeys();
  res.writeHead(200, { 'content-type': 'application/json', ...makeCorsHeaders(req) });
  res.end(JSON.stringify({
  ok: true,
@@ -6079,6 +6080,9 @@ export async function createLocalApiServer(options = {}) {
  heap_mb: Math.round(mem.heapUsed / 1024 / 1024),
  ais_connected: aisState.socket?.readyState === 1,
  ais_vessels: aisState.vessels.size,
+ keys_configured: EXPECTED_API_KEYS.length - missing.length,
+ keys_total: EXPECTED_API_KEYS.length,
+ keys_missing: missing,
  }));
  return;
  }

--- a/tools/cb-control/CLAUDE.md
+++ b/tools/cb-control/CLAUDE.md
@@ -127,17 +127,20 @@ curl -fsS -H "Authorization: Bearer $TOKEN" \
 ## When to use this vs. not
 
 **Use it when:**
+
 - The user asked to coordinate across sessions
 - The user asked what another session is doing
 - You need context another session built and you can search for it
 
 **Don't use it when:**
+
 - The user hasn't mentioned other sessions — don't freelance and start
   chattering at them
 - You'd be saying anything secret (tokens, keys, passwords) — the
   transcript is persisted to SQLite
 
 **Never:**
+
 - Mass-kill sessions (`DELETE /api/sessions/:id`) without explicit user approval
 - Spawn sessions with `--dangerously-skip-permissions` via the `args` field
 - Loop automated retries against another session — a human review gate

--- a/tools/cb-control/HANDOFF.md
+++ b/tools/cb-control/HANDOFF.md
@@ -42,6 +42,7 @@ The code exists but has not yet been installed or run on the user's Mac.
 actually use cb-control):**
 
 1. **Pull the branch to the Mac**
+
    ```bash
    cd ~/developer/crystalball
    git fetch origin
@@ -49,12 +50,14 @@ actually use cb-control):**
    ```
 
 2. **Install and run the daemon**
+
    ```bash
    cd tools/cb-control
    npm install
    npm run install-hooks
    npm run install-launchd        # or `npm start` for foreground
    ```
+
    After this, `curl http://127.0.0.1:46987/health` should return
    `{"ok":true,...}` and a bearer token lives at
    `~/.config/cb-control/token`.
@@ -62,6 +65,7 @@ actually use cb-control):**
 3. **Make it discoverable machine-wide** (optional but recommended)
    Add a section to `~/.claude/CLAUDE.md` so every Claude session on
    the Mac learns to check for the daemon, regardless of cwd:
+
    ```
    ## cb-control (machine-wide Claude session coordination)
    Local daemon at http://127.0.0.1:46987 for cross-session coordination.

--- a/tools/cb-control/README.md
+++ b/tools/cb-control/README.md
@@ -6,6 +6,7 @@ features from your phone, with full command relay into any running CLI
 session.
 
 **What it does:**
+
 - **Spawn Claude sessions from your phone** — they run on your Mac with your
   real env, keys, and tools.
 - **Attach to existing CLI sessions** you started in a terminal. As long as
@@ -16,6 +17,7 @@ session.
 - **Biometric gate** (Face ID / Touch ID) before any write from the phone.
 
 **Architecture:**
+
 - Node 20 daemon: HTTP + WebSocket + PTY + SQLite (~1000 LOC)
 - Vanilla-ESM PWA: no build step
 - Tailscale: secure transport, no public internet exposure
@@ -65,14 +67,17 @@ Copy the token into the PWA once and forget it.
 ## Using it
 
 ### Spawn from the phone
+
 **+ New session** → cwd + optional label + extra args. A managed `claude`
 process starts in a PTY; the terminal view opens.
 
 ### Attach to a terminal session (tmux)
+
 ```bash
 # in tmux
 claude
 ```
+
 The `SessionStart` hook registers it and captures `$TMUX_PANE`. Open the
 PWA — the session appears with a `live · tmux` badge and full I/O works.
 
@@ -80,6 +85,7 @@ Without tmux, the session still appears in the list but is **read-only**
 (metadata only; the daemon can't inject into a bare terminal's stdin).
 
 ### Compose (multi-session relay)
+
 Tap the pencil icon. Check the sessions to target, type a command, **Relay
 to N**. Each selected session receives the same input in parallel. Useful
 for: "rebase all feature branches onto main", "run the test suite
@@ -87,10 +93,12 @@ everywhere", "paste the same question into three branches to compare
 answers".
 
 ### Search
+
 Tap the magnifying-glass icon. Queries FTS5-indexed events across every
 session. Tap a hit to jump into that session's terminal view.
 
 ### Biometric unlock (optional but recommended)
+
 Settings → **Enable Face ID / Touch ID**. Once enabled, every write
 (spawn, input, compose) requires a platform-authenticator assertion. The
 unlock is cached for 60s to avoid re-prompting on every keystroke.
@@ -100,6 +108,7 @@ second wall that protects against scenarios where someone has physical
 access to your unlocked phone.
 
 ### Terminal keyboard
+
 - `Send` — relay the textarea + Enter
 - `^C` — SIGINT / Ctrl-C
 - `Esc` — Escape key (e.g. cancel a Claude thought)
@@ -165,6 +174,7 @@ npm run uninstall-launchd         # reverse
 ```
 
 The installed agent:
+
 - Runs at login and respawns on crash
 - Binds to `0.0.0.0:46987` (override with `CB_CONTROL_HOST` / `CB_CONTROL_PORT`)
 - Logs to `~/Library/Logs/cb-control.log` and `cb-control.err.log`

--- a/tools/mcp-server/index.mjs
+++ b/tools/mcp-server/index.mjs
@@ -30,40 +30,52 @@ function textResult(data) {
 
 // ---- Aggregate Tools ----
 
+const aggregateOpts = {
+  summary_only: z.boolean().optional().describe('Return only the summary and counts, omit raw data arrays. Dramatically reduces output size.'),
+  limit: z.number().optional().describe('Max items to return per data source (default: unlimited). Use 10-20 for a concise overview.'),
+};
+
 server.registerTool('get_sitrep', {
-  description: 'Full situational report: top conflicts, market moves, weather alerts, service health. Start here for broad awareness.',
-  inputSchema: z.object({}),
-}, async () => textResult(await aggregate.get_sitrep()));
+  description: 'Full situational report: top conflicts, market moves, weather alerts, service health. Start here for broad awareness. Use summary_only=true for a compact brief.',
+  inputSchema: z.object({ ...aggregateOpts }),
+}, async (args) => textResult(await aggregate.get_sitrep(args)));
 
 server.registerTool('get_threat_landscape', {
-  description: 'Active threats across conflict, cyber, and crisis domains. Includes ACLED conflicts, ThreatFox IOCs, CISA KEVs, and crisis alerts.',
-  inputSchema: z.object({}),
-}, async () => textResult(await aggregate.get_threat_landscape()));
+  description: 'Active threats across conflict, cyber, and crisis domains. Includes ACLED conflicts, ThreatFox IOCs, CISA KEVs, and crisis alerts. Use summary_only=true for a compact brief.',
+  inputSchema: z.object({ ...aggregateOpts }),
+}, async (args) => textResult(await aggregate.get_threat_landscape(args)));
 
 server.registerTool('get_market_overview', {
-  description: 'Financial markets snapshot: indices, crypto, BTC ETF flows, Fear & Greed, WSB sentiment, FRED macro signals.',
-  inputSchema: z.object({}),
-}, async () => textResult(await aggregate.get_market_overview()));
+  description: 'Financial markets snapshot: indices, crypto, BTC ETF flows, Fear & Greed, WSB sentiment, FRED macro signals. Use summary_only=true for a compact brief.',
+  inputSchema: z.object({ ...aggregateOpts }),
+}, async (args) => textResult(await aggregate.get_market_overview(args)));
 
 server.registerTool('get_cyber_intel', {
-  description: 'Cyber threat intelligence: ThreatFox IOCs, CISA KEVs, OpenPhish, URLhaus malware URLs, OTX threat pulses.',
-  inputSchema: z.object({}),
-}, async () => textResult(await aggregate.get_cyber_intel()));
+  description: 'Cyber threat intelligence: ThreatFox IOCs, CISA KEVs, OpenPhish, URLhaus malware URLs, OTX threat pulses. Use summary_only=true for a compact brief.',
+  inputSchema: z.object({ ...aggregateOpts }),
+}, async (args) => textResult(await aggregate.get_cyber_intel(args)));
 
 server.registerTool('get_weather_environment', {
-  description: 'Weather and environment: conditions for 28 global cities, NWS alerts, NASA DONKI space weather, NOAA SWPC.',
-  inputSchema: z.object({}),
-}, async () => textResult(await aggregate.get_weather_environment()));
+  description: 'Weather and environment: conditions for 28 global cities, NWS alerts, NASA DONKI space weather, NOAA SWPC. Use summary_only=true for a compact brief.',
+  inputSchema: z.object({ ...aggregateOpts }),
+}, async (args) => textResult(await aggregate.get_weather_environment(args)));
 
 server.registerTool('get_infrastructure_status', {
-  description: 'Critical infrastructure: power grid status, grid outage alerts, EPA water quality, RadNet radiation, USGS water.',
-  inputSchema: z.object({}),
-}, async () => textResult(await aggregate.get_infrastructure_status()));
+  description: 'Critical infrastructure: power grid status, grid outage alerts, EPA water quality, RadNet radiation, USGS water. Use summary_only=true for a compact brief.',
+  inputSchema: z.object({ ...aggregateOpts }),
+}, async (args) => textResult(await aggregate.get_infrastructure_status(args)));
 
 server.registerTool('get_military_posture', {
-  description: 'Military activity: tracked aircraft (ADS-B), naval vessels (AIS), theater posture, ISW analysis reports.',
+  description: 'Military activity: tracked aircraft (ADS-B), naval vessels (AIS), theater posture, ISW analysis reports. Use summary_only=true for a compact brief.',
+  inputSchema: z.object({ ...aggregateOpts }),
+}, async (args) => textResult(await aggregate.get_military_posture(args)));
+
+// ---- Diagnostic Tools ----
+
+server.registerTool('check_feed_health', {
+  description: 'Pre-flight check: probes the sidecar and key data feeds. Returns which feeds are healthy vs erroring, sidecar memory/uptime, and AIS connection status. Run this before aggregate tools to know what data is available.',
   inputSchema: z.object({}),
-}, async () => textResult(await aggregate.get_military_posture()));
+}, async () => textResult(await granular.check_feed_health()));
 
 // ---- Granular Tools ----
 

--- a/tools/mcp-server/tools/aggregate.mjs
+++ b/tools/mcp-server/tools/aggregate.mjs
@@ -1,3 +1,10 @@
+function toArray(...candidates) {
+  for (const c of candidates) {
+    if (Array.isArray(c)) return c;
+  }
+  return [];
+}
+
 function makeResponse(summary, data, sources, warnings = []) {
   return {
     summary,
@@ -17,8 +24,25 @@ function extractWarnings(results) {
   return warnings;
 }
 
+function parseOpts(opts = {}) {
+  const summaryOnly = opts.summary_only === true;
+  const limit = typeof opts.limit === 'number' && opts.limit > 0 ? opts.limit : Infinity;
+  const cap = (arr) => (limit === Infinity ? arr : arr.slice(0, limit));
+  return { summaryOnly, cap };
+}
+
+function summarizeData(data, summaryOnly) {
+  if (!summaryOnly) return data;
+  const out = {};
+  for (const [key, value] of Object.entries(data)) {
+    out[key] = Array.isArray(value) ? { count: value.length } : value;
+  }
+  return out;
+}
+
 export function makeAggregateTools(client) {
-  async function get_sitrep() {
+  async function get_sitrep(opts) {
+    const { summaryOnly, cap } = parseOpts(opts);
     const routes = ['/api/market-quotes', '/api/acled-events', '/api/nws-alerts', '/api/service-status'];
     const results = await client.getAll(routes);
     const warnings = extractWarnings(results);
@@ -34,15 +58,18 @@ export function makeAggregateTools(client) {
 
     const summary = `Situational report: ${conflictCount} conflict events, ${alertCount} weather alerts. Markets: ${quoteSummary}.${warnings.length ? ` (${warnings.length} source(s) unavailable)` : ''}`;
 
-    return makeResponse(summary, {
-      conflicts: conflicts?.events || [],
-      markets: markets?.quotes || [],
-      alerts: Array.isArray(alerts) ? alerts : [],
+    const data = {
+      conflicts: cap(conflicts?.events || []),
+      markets: cap(markets?.quotes || []),
+      alerts: cap(Array.isArray(alerts) ? alerts : []),
       serviceHealth: status || {},
-    }, routes.filter(r => !results.get(r)?.error), warnings);
+    };
+
+    return makeResponse(summary, summarizeData(data, summaryOnly), routes.filter(r => !results.get(r)?.error), warnings);
   }
 
-  async function get_threat_landscape() {
+  async function get_threat_landscape(opts) {
+    const { summaryOnly, cap } = parseOpts(opts);
     const routes = ['/api/acled-events', '/api/threatfox-iocs', '/api/cisa-kev', '/api/oref-alerts', '/api/liveuamap'];
     const results = await client.getAll(routes);
     const warnings = extractWarnings(results);
@@ -59,18 +86,21 @@ export function makeAggregateTools(client) {
 
     const summary = `Threat landscape: ${conflictCount} conflict events, ${iocCount} IOCs, ${kevCount} KEVs.${warnings.length ? ` (${warnings.length} source(s) unavailable)` : ''}`;
 
-    return makeResponse(summary, {
-      conflicts: conflicts?.events || [],
-      cyberThreats: iocs?.data || iocs || [],
-      kevs: kevs?.vulnerabilities || kevs || [],
-      crisisAlerts: [
-        ...(oref?.alerts || oref || []),
-        ...(uamap?.events || uamap || []),
-      ],
-    }, routes.filter(r => !results.get(r)?.error), warnings);
+    const data = {
+      conflicts: cap(conflicts?.events || []),
+      cyberThreats: cap(toArray(iocs?.data, iocs)),
+      kevs: cap(toArray(kevs?.vulnerabilities, kevs)),
+      crisisAlerts: cap([
+        ...toArray(oref?.alerts, oref),
+        ...toArray(uamap?.events, uamap),
+      ]),
+    };
+
+    return makeResponse(summary, summarizeData(data, summaryOnly), routes.filter(r => !results.get(r)?.error), warnings);
   }
 
-  async function get_market_overview() {
+  async function get_market_overview(opts) {
+    const { summaryOnly, cap } = parseOpts(opts);
     const routes = ['/api/market-quotes', '/api/crypto-quotes', '/api/btc-etf-flows', '/api/macro-signals', '/api/fear-greed', '/api/wsb-sentiment'];
     const results = await client.getAll(routes);
     const warnings = extractWarnings(results);
@@ -87,16 +117,19 @@ export function makeAggregateTools(client) {
 
     const summary = `Markets overview: Fear & Greed at ${fgValue} (${fgLabel}).${warnings.length ? ` (${warnings.length} source(s) unavailable)` : ''}`;
 
-    return makeResponse(summary, {
-      indices: quotes?.quotes || [],
-      crypto: crypto?.prices || crypto || [],
+    const data = {
+      indices: cap(quotes?.quotes || []),
+      crypto: cap(toArray(crypto?.prices, crypto)),
       etfFlows: etf?.flows || etf || {},
       sentiment: { fearGreed: fg, wsb: wsb },
       macroRegime: macro?.signals || macro || {},
-    }, routes.filter(r => !results.get(r)?.error), warnings);
+    };
+
+    return makeResponse(summary, summarizeData(data, summaryOnly), routes.filter(r => !results.get(r)?.error), warnings);
   }
 
-  async function get_cyber_intel() {
+  async function get_cyber_intel(opts) {
+    const { summaryOnly, cap } = parseOpts(opts);
     const routes = ['/api/threatfox-iocs', '/api/cisa-kev', '/api/openphish-feed', '/api/urlhaus', '/api/otx-pulses'];
     const results = await client.getAll(routes);
     const warnings = extractWarnings(results);
@@ -112,16 +145,19 @@ export function makeAggregateTools(client) {
 
     const summary = `Cyber intel: ${iocCount} IOCs, ${kevCount} KEVs.${warnings.length ? ` (${warnings.length} source(s) unavailable)` : ''}`;
 
-    return makeResponse(summary, {
-      iocs: iocs?.data || [],
-      kevs: kevs?.vulnerabilities || kevs || [],
-      phishing: phishing || [],
-      malwareUrls: malware || [],
-      threatPulses: pulses?.results || pulses || [],
-    }, routes.filter(r => !results.get(r)?.error), warnings);
+    const data = {
+      iocs: cap(iocs?.data || []),
+      kevs: cap(toArray(kevs?.vulnerabilities, kevs)),
+      phishing: cap(toArray(phishing)),
+      malwareUrls: cap(toArray(malware)),
+      threatPulses: cap(toArray(pulses?.results, pulses)),
+    };
+
+    return makeResponse(summary, summarizeData(data, summaryOnly), routes.filter(r => !results.get(r)?.error), warnings);
   }
 
-  async function get_weather_environment() {
+  async function get_weather_environment(opts) {
+    const { summaryOnly, cap } = parseOpts(opts);
     const routes = ['/api/owm-current', '/api/nws-alerts', '/api/donki-events', '/api/space-weather-feeds'];
     const results = await client.getAll(routes);
     const warnings = extractWarnings(results);
@@ -135,14 +171,17 @@ export function makeAggregateTools(client) {
 
     const summary = `Environment: ${alertCount} weather alerts active.${warnings.length ? ` (${warnings.length} source(s) unavailable)` : ''}`;
 
-    return makeResponse(summary, {
-      weather: weather?.cities || weather || [],
-      alerts: Array.isArray(alerts) ? alerts : [],
+    const data = {
+      weather: cap(toArray(weather?.cities, weather)),
+      alerts: cap(Array.isArray(alerts) ? alerts : []),
       spaceWeather: { donki: donki || [], feeds: space || {} },
-    }, routes.filter(r => !results.get(r)?.error), warnings);
+    };
+
+    return makeResponse(summary, summarizeData(data, summaryOnly), routes.filter(r => !results.get(r)?.error), warnings);
   }
 
-  async function get_infrastructure_status() {
+  async function get_infrastructure_status(opts) {
+    const { summaryOnly, cap } = parseOpts(opts);
     const routes = ['/api/power-grid', '/api/grid-alerts', '/api/epa-sdwis-proxy', '/api/epa-radnet-proxy', '/api/usgs-water-proxy'];
     const results = await client.getAll(routes);
     const warnings = extractWarnings(results);
@@ -157,16 +196,19 @@ export function makeAggregateTools(client) {
 
     const summary = `Infrastructure: ${alertCount} grid alerts.${warnings.length ? ` (${warnings.length} source(s) unavailable)` : ''}`;
 
-    return makeResponse(summary, {
+    const data = {
       powerGrid: grid || {},
-      gridAlerts: gridAlerts?.alerts || gridAlerts || [],
+      gridAlerts: cap(toArray(gridAlerts?.alerts, gridAlerts)),
       waterQuality: water || {},
       radiation: radiation || {},
       waterResources: usgs || {},
-    }, routes.filter(r => !results.get(r)?.error), warnings);
+    };
+
+    return makeResponse(summary, summarizeData(data, summaryOnly), routes.filter(r => !results.get(r)?.error), warnings);
   }
 
-  async function get_military_posture() {
+  async function get_military_posture(opts) {
+    const { summaryOnly, cap } = parseOpts(opts);
     const routes = ['/api/adsb-military', '/api/ais-snapshot', '/api/military/v1/get-theater-posture', '/api/isw-reports'];
     const results = await client.getAll(routes);
     const warnings = extractWarnings(results);
@@ -181,12 +223,14 @@ export function makeAggregateTools(client) {
 
     const summary = `Military posture: ${flightCount} tracked aircraft, ${vesselCount} tracked vessels.${warnings.length ? ` (${warnings.length} source(s) unavailable)` : ''}`;
 
-    return makeResponse(summary, {
-      militaryFlights: flights?.aircraft || flights || [],
-      navalVessels: vessels?.vessels || vessels || [],
+    const data = {
+      militaryFlights: cap(toArray(flights?.aircraft, flights)),
+      navalVessels: cap(toArray(vessels?.vessels, vessels)),
       theaterPosture: posture || {},
-      iswAnalysis: isw?.reports || isw || [],
-    }, routes.filter(r => !results.get(r)?.error), warnings);
+      iswAnalysis: cap(toArray(isw?.reports, isw)),
+    };
+
+    return makeResponse(summary, summarizeData(data, summaryOnly), routes.filter(r => !results.get(r)?.error), warnings);
   }
 
   return {

--- a/tools/mcp-server/tools/granular.mjs
+++ b/tools/mcp-server/tools/granular.mjs
@@ -211,6 +211,56 @@ export function makeGranularTools(client) {
     );
   }
 
+  async function check_feed_health() {
+    const health = await client.get('/api/health');
+    const status = await client.get('/api/service-status');
+
+    const probeRoutes = [
+      '/api/acled-events',
+      '/api/market-quotes',
+      '/api/nws-alerts',
+      '/api/threatfox-iocs',
+      '/api/cisa-kev',
+      '/api/adsb-military',
+      '/api/ais-snapshot',
+      '/api/isw-reports',
+      '/api/owm-current',
+      '/api/fear-greed',
+    ];
+    const results = await client.getAll(probeRoutes);
+
+    const feeds = [];
+    let healthy = 0;
+    let degraded = 0;
+    for (const route of probeRoutes) {
+      const data = results.get(route);
+      const ok = data && !data.error;
+      feeds.push({ route, status: ok ? 'ok' : 'error', error: data?.error || null });
+      if (ok) healthy++; else degraded++;
+    }
+
+    const sidecarOk = health && !health.error;
+    const keyInfo = sidecarOk ? `${health.keys_configured}/${health.keys_total} API keys configured` : 'unknown';
+    const missingKeys = sidecarOk && health.keys_missing?.length ? health.keys_missing : [];
+
+    const summary = `Sidecar ${sidecarOk ? 'up' : 'DOWN'}. Feeds: ${healthy} healthy, ${degraded} degraded out of ${probeRoutes.length}. Keys: ${keyInfo}.${missingKeys.length ? ` Missing: ${missingKeys.join(', ')}.` : ''}`;
+
+    return makeResponse(summary, {
+      sidecar: sidecarOk ? {
+        pid: health.pid,
+        uptime_ms: health.uptime_ms,
+        rss_mb: health.rss_mb,
+        ais_connected: health.ais_connected,
+        ais_vessels: health.ais_vessels,
+        keys_configured: health.keys_configured,
+        keys_total: health.keys_total,
+        keys_missing: missingKeys,
+      } : { error: health?.error || 'unreachable' },
+      serviceStatus: status || {},
+      feeds,
+    }, ['/api/health', '/api/service-status', ...probeRoutes]);
+  }
+
   return {
     search_conflicts,
     search_news,
@@ -224,5 +274,6 @@ export function makeGranularTools(client) {
     get_earthquakes,
     get_disease_outbreaks,
     get_region_brief,
+    check_feed_health,
   };
 }


### PR DESCRIPTION
## Summary

Cherry-pick of `claude/mcp-aggregate-filtering` onto current main (commit `9a818354`), with conflicts resolved.

The original PR #56 was unmergeable after PR #52 landed (conflicts in `.markdownlint-cli2.jsonc` and `.claude/commands/sitrep.md`). This branch resolves both:

- `.markdownlint-cli2.jsonc`: kept main's `tools/**` exclusion AND added the branch's `**/node_modules/**` (union of both)
- `.claude/commands/sitrep.md`: gitignored, took main's content

### What's in this PR

`mcp: add aggregate filtering, feed health tool, fix threat_landscape bug`:
- `summary_only` and `limit` params on all 7 aggregate tools to control output size
- `get_threat_landscape` crash fix (spread on non-iterable when oref/liveuamap returns error)
- New `check_feed_health` diagnostic tool (probes sidecar + 10 key feeds)
- Surface `keys_configured`/`keys_missing` in sidecar `/api/health`

### Verification
- typecheck: clean
- test:sidecar: 78/78

PR #56 will be closed in favor of this cherry-pick.