### PR TITLE
fix(release): auto-dispatch build-desktop.yml after auto-tag pushes the tag

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,8 +1,15 @@
 name: Auto-tag on version bump
 
 # Watches for version changes in tauri.conf.json on main.
-# When the version changes, creates a vX.Y.Z tag which triggers build-desktop.yml.
-# This means: bump version + commit + push = release builds start automatically.
+# When the version changes, creates a vX.Y.Z tag AND dispatches build-desktop.yml
+# in publish mode. We cannot rely on the tag-push trigger alone because
+# GITHUB_TOKEN tag pushes do not fire downstream workflows (GitHub's anti-loop
+# protection). Explicit workflow_dispatch via the same token IS allowed, so we
+# use it as the always-on release driver.
+#
+# Recovery: if the tag already exists but no GitHub release has been published
+# yet, the dispatch still fires. That lets us unstick releases that were
+# created before this workflow gained the dispatch step.
 
 on:
   push:
@@ -11,9 +18,11 @@ on:
     paths:
       - 'src-tauri/tauri.conf.json'
       - 'package.json'
+      - '.github/workflows/auto-tag.yml'
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   auto-tag:
@@ -40,7 +49,7 @@ jobs:
           TAG="v${{ steps.version.outputs.version }}"
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Tag $TAG already exists — skipping"
+            echo "Tag $TAG already exists"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "Tag $TAG does not exist — will create"
@@ -57,4 +66,30 @@ jobs:
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
           echo "Created and pushed tag: $TAG"
-          echo "Build workflow will now start automatically."
+
+      - name: Check if release already published
+        id: release_check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "released=true" >> "$GITHUB_OUTPUT"
+            echo "Release for $TAG already exists — no dispatch needed"
+          else
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            echo "No release for $TAG yet — will dispatch build"
+          fi
+
+      - name: Dispatch build-desktop.yml in publish mode
+        if: steps.release_check.outputs.released == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          gh workflow run build-desktop.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$TAG" \
+            -f variant=full \
+            -f publish_mode=publish
+          echo "Dispatched build-desktop.yml on tag $TAG in publish mode"

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -2,11 +2,16 @@ name: Build Desktop App
 
 on:
   workflow_dispatch:
-    # Build-only variant dispatcher — picks a variant and runs the build
-    # without publishing a release. Tag pushes are the release publisher.
+    # Two modes:
+    #   build   — pick a variant, build artifacts, do NOT publish.
+    #   publish — recovery path for tags whose push didn't fire this workflow
+    #             (GitHub anti-loop: tags pushed by GITHUB_TOKEN inside
+    #             auto-tag.yml don't trigger downstream workflows). Dispatch
+    #             with ref=<tag> and publish_mode=publish; release-context
+    #             treats it exactly like a tag push.
     inputs:
       variant:
-        description: 'Variant to build (no release publish)'
+        description: 'Variant to build (build mode only; publish mode derives variant from the tag)'
         required: true
         default: full
         type: choice
@@ -14,6 +19,14 @@ on:
           - full
           - tech
           - finance
+      publish_mode:
+        description: 'build = artifacts only, publish = cut a GitHub release from the dispatched ref'
+        required: true
+        default: build
+        type: choice
+        options:
+          - build
+          - publish
   push:
     tags:
       - 'v*'
@@ -54,6 +67,8 @@ jobs:
           node scripts/release-context.mjs \
             --event "${{ github.event_name }}" \
             --ref "${{ github.ref_name }}" \
+            --variant "${{ inputs.variant || 'full' }}" \
+            --publish-mode "${{ inputs.publish_mode || 'build' }}" \
             --sha "${{ github.sha }}" \
             --github-output "$GITHUB_OUTPUT"
 

--- a/scripts/release-context.mjs
+++ b/scripts/release-context.mjs
@@ -14,6 +14,32 @@ import {
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, '..');
 
+const VALUE_FLAGS = new Map([
+  ['--event', 'event'],
+  ['--ref', 'ref'],
+  ['--variant', 'variant'],
+  ['--sha', 'sha'],
+  ['--github-output', 'githubOutput'],
+  ['--publish-mode', 'publishMode'],
+]);
+
+const BOOLEAN_FLAGS = new Map([
+  ['--no-enforce-main', { key: 'enforceMain', value: false }],
+]);
+
+function readValueFlag(arg, nextArg) {
+  if (VALUE_FLAGS.has(arg)) {
+ return { key: VALUE_FLAGS.get(arg), value: nextArg ?? '', consumedNext: true };
+  }
+  for (const [flag, key] of VALUE_FLAGS) {
+ const prefix = `${flag}=`;
+ if (arg.startsWith(prefix)) {
+ return { key, value: arg.slice(prefix.length), consumedNext: false };
+ }
+  }
+  return null;
+}
+
 function parseArgs(argv) {
   const options = {
  event: '',
@@ -22,77 +48,44 @@ function parseArgs(argv) {
  sha: '',
  githubOutput: '',
  enforceMain: true,
+ publishMode: 'build',
   };
 
   for (let i = 0; i < argv.length; i += 1) {
  const arg = argv[i];
- if (arg === '--event') {
- options.event = argv[i + 1] ?? '';
- i += 1;
+ const valueFlag = readValueFlag(arg, argv[i + 1]);
+ if (valueFlag) {
+ options[valueFlag.key] = valueFlag.value;
+ if (valueFlag.consumedNext) i += 1;
  continue;
  }
- if (arg.startsWith('--event=')) {
- options.event = arg.slice('--event='.length);
- continue;
- }
- if (arg === '--ref') {
- options.ref = argv[i + 1] ?? '';
- i += 1;
- continue;
- }
- if (arg.startsWith('--ref=')) {
- options.ref = arg.slice('--ref='.length);
- continue;
- }
- if (arg === '--variant') {
- options.variant = argv[i + 1] ?? '';
- i += 1;
- continue;
- }
- if (arg.startsWith('--variant=')) {
- options.variant = arg.slice('--variant='.length);
- continue;
- }
- if (arg === '--sha') {
- options.sha = argv[i + 1] ?? '';
- i += 1;
- continue;
- }
- if (arg.startsWith('--sha=')) {
- options.sha = arg.slice('--sha='.length);
- continue;
- }
- if (arg === '--github-output') {
- options.githubOutput = argv[i + 1] ?? '';
- i += 1;
- continue;
- }
- if (arg.startsWith('--github-output=')) {
- options.githubOutput = arg.slice('--github-output='.length);
- continue;
- }
- if (arg === '--no-enforce-main') {
- options.enforceMain = false;
+ const boolFlag = BOOLEAN_FLAGS.get(arg);
+ if (boolFlag) {
+ options[boolFlag.key] = boolFlag.value;
  continue;
  }
  throw new Error(`Unknown argument: ${arg}`);
   }
 
+  validateParsedOptions(options);
+  return options;
+}
+
+function validateParsedOptions(options) {
   if (!['push', 'workflow_dispatch'].includes(options.event)) {
  throw new Error(`Unsupported release event: ${options.event}`);
   }
-
   if (!options.sha) {
  throw new Error('Missing --sha');
   }
-
-  if (options.event === 'workflow_dispatch') {
- options.variant = 'full';
-  } else if (!options.ref) {
- throw new Error('Missing --ref for tag-driven release context');
+  if (options.event === 'workflow_dispatch' && options.publishMode !== 'publish') {
+ options.variant = options.variant || 'full';
+ return;
   }
-
-  return options;
+  if (!options.ref) {
+ const context = options.event === 'push' ? 'tag-driven release context' : 'publish-mode workflow_dispatch';
+ throw new Error(`Missing --ref for ${context}`);
+  }
 }
 
 function runCommand(command, args) {
@@ -132,8 +125,31 @@ export async function readSynchronizedVersions() {
   };
 }
 
-export function resolveReleaseContext({ event, refName, inputVariant, packageVersion, sha }) {
+export function resolveReleaseContext({ event, refName, inputVariant, packageVersion, sha, publishMode = 'build' }) {
   const shortSha = sha.slice(0, 12);
+
+  // Workflow dispatch with publish_mode=publish is the recovery path when the
+  // tag-push trigger was suppressed (e.g. tag pushed by GITHUB_TOKEN from
+  // auto-tag.yml, which per GitHub anti-loop rules does not fire downstream
+  // workflows). The workflow gets dispatched with --ref <tag> and
+  // -f publish_mode=publish; from here it's indistinguishable from a real
+  // tag push.
+  if (event === 'workflow_dispatch' && publishMode === 'publish') {
+ const parsed = parseReleaseRef(refName);
+ if (parsed.version !== packageVersion) {
+ throw new Error(`Tag ${parsed.tag} does not match package version ${packageVersion}`);
+ }
+ return {
+ publish: true,
+ variant: parsed.variant,
+ version: parsed.version,
+ tag: parsed.tag,
+ releaseName: buildReleaseName(parsed.version, parsed.variant),
+ productName: getReleaseProductName(parsed.variant),
+ commitSha: sha,
+ shortSha,
+ };
+  }
 
   if (event === 'workflow_dispatch') {
  const variant = inputVariant;
@@ -209,6 +225,7 @@ async function main() {
  inputVariant: options.variant,
  packageVersion: versions.packageVersion,
  sha: options.sha,
+ publishMode: options.publishMode,
   });
 
   if (options.enforceMain && context.publish) {
@@ -229,8 +246,10 @@ async function main() {
 const isCli = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 
 if (isCli) {
-  main().catch((error) => {
+  try {
+ await main();
+  } catch (error) {
  console.error(`[release-context] Failed: ${error instanceof Error ? error.message : String(error)}`);
  process.exit(1);
-  });
+  }
 }


### PR DESCRIPTION
## Summary

Fixes the release pipeline so `vX.Y.Z` tags created by `auto-tag.yml` actually trigger `build-desktop.yml` and publish a GitHub release — automatically, with no manual intervention.

### Root cause

GitHub's anti-loop protection suppresses downstream workflow triggers when a tag is pushed by `GITHUB_TOKEN`. `auto-tag.yml` creates and pushes `v*.*.*` tags with `GITHUB_TOKEN`, so `build-desktop.yml`'s `tags: 'v*'` trigger never fires. This left `v2.10.6` tagged but never published.

### Fix

After pushing the tag, `auto-tag.yml` explicitly dispatches `build-desktop.yml` via `gh workflow run`. `workflow_dispatch` via `GITHUB_TOKEN` **is** allowed under the anti-loop rules, so this is the sanctioned escape hatch.

**Recovery path:** If the tag already exists but no GitHub release is published yet, the dispatch still fires. This unsticks `v2.10.6` (and any future stalled release) the first time the new `auto-tag.yml` runs on main.

### Plumbing

- `build-desktop.yml`: new `publish_mode` input (`build` | `publish`). `build` is the existing variant-only path; `publish` tells release-context to treat the dispatch like a real tag push.
- `release-context.mjs`: new `--publish-mode` flag. When `event=workflow_dispatch` AND `publish-mode=publish`, parses `--ref` as a release tag and returns `publish=true` with tag-derived variant/version/release-name (same shape as a push-event tag). Flag parsing extracted into a table-driven helper to stay under the cognitive-complexity threshold.
- `auto-tag.yml`: added `actions: write` permission, a release-existence check, and the explicit dispatch step. The workflow's own path is now in its own trigger list, so this fix self-triggers on merge.

### Why this is safe

- Build-only `workflow_dispatch` (the existing developer path) is unchanged — defaults to `publish_mode=build`.
- `release-context.mjs` only flips to `publish=true` when explicitly dispatched with `publish_mode=publish` AND a matching tag ref.
- The existing `enforceMain` checks (`--no-enforce-main` only used in tests) continue to run: tagged commit must be on `origin/main`, tag must be annotated.

## Test plan

- [x] `node scripts/release-context.mjs --event workflow_dispatch --publish-mode publish --ref v2.10.6 --sha … --no-enforce-main` → returns `publish: true` with full tag metadata
- [x] `node scripts/release-context.mjs --event workflow_dispatch --variant tech --sha …` → still returns `publish: false` (unchanged behavior)
- [x] `npm run lint:yaml` passes for all 23 tracked YAML files
- [x] `npm run typecheck:all` passes
- [x] `eslint scripts/release-context.mjs` passes (cognitive complexity + prefer-top-level-await both resolved)
- [ ] After merge: `auto-tag.yml` re-runs because its own path is in the trigger list → detects `v2.10.6` tag exists but no release → dispatches `build-desktop.yml --ref v2.10.6 -f publish_mode=publish` → release gets published
- [ ] Future version bumps: tag creation + release publish happens end-to-end with no manual workflow_dispatch needed

https://claude.ai/code/session_0173fepKvSbBtkXwLDJz7dgg