### PR TITLE
fix(release): dispatch build-desktop at main with release_tag input

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -87,9 +87,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ steps.version.outputs.tag }}"
+          # Dispatch at main (the default ref) so the workflow always uses the
+          # latest automation code. Pass the tag via release_tag input; the
+          # workflow checks it out for the actual app build.
           gh workflow run build-desktop.yml \
             --repo "$GITHUB_REPOSITORY" \
-            --ref "$TAG" \
+            --ref main \
             -f variant=full \
-            -f publish_mode=publish
-          echo "Dispatched build-desktop.yml on tag $TAG in publish mode"
+            -f publish_mode=publish \
+            -f release_tag="$TAG"
+          echo "Dispatched build-desktop.yml at main with release_tag=$TAG"

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -7,11 +7,13 @@ on:
     #   publish — recovery path for tags whose push didn't fire this workflow
     #             (GitHub anti-loop: tags pushed by GITHUB_TOKEN inside
     #             auto-tag.yml don't trigger downstream workflows). Dispatch
-    #             with ref=<tag> and publish_mode=publish; release-context
-    #             treats it exactly like a tag push.
+    #             with publish_mode=publish and release_tag=<tag>. The workflow
+    #             runs at main (so it always uses the latest automation code),
+    #             then checks out release_tag for the actual build, and
+    #             release-context treats it exactly like a tag push.
     inputs:
       variant:
-        description: 'Variant to build (build mode only; publish mode derives variant from the tag)'
+        description: 'Variant to build (build mode only; publish mode derives variant from release_tag)'
         required: true
         default: full
         type: choice
@@ -20,13 +22,18 @@ on:
           - tech
           - finance
       publish_mode:
-        description: 'build = artifacts only, publish = cut a GitHub release from the dispatched ref'
+        description: 'build = artifacts only, publish = cut a GitHub release from release_tag'
         required: true
         default: build
         type: choice
         options:
           - build
           - publish
+      release_tag:
+        description: 'Tag to publish (only used when publish_mode=publish; e.g. v2.10.6)'
+        required: false
+        default: ''
+        type: string
   push:
     tags:
       - 'v*'
@@ -64,9 +71,14 @@ jobs:
         id: context
         shell: bash
         run: |
+          # For publish-mode workflow_dispatch, the tag comes from the
+          # release_tag input (because the workflow runs at main, not at the
+          # tag — see trigger comment). For everything else, github.ref_name
+          # is either the pushed tag or the dispatched branch.
+          REF_NAME="${{ inputs.release_tag || github.ref_name }}"
           node scripts/release-context.mjs \
             --event "${{ github.event_name }}" \
-            --ref "${{ github.ref_name }}" \
+            --ref "$REF_NAME" \
             --variant "${{ inputs.variant || 'full' }}" \
             --publish-mode "${{ inputs.publish_mode || 'build' }}" \
             --sha "${{ github.sha }}" \
@@ -112,6 +124,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          # In publish-mode workflow_dispatch the workflow runs at main so we
+          # always use the latest automation code — but the build must reflect
+          # the tagged release. The release-context job resolves the tag, so
+          # we reuse its output here.
+          ref: ${{ needs.release-context.outputs.tag || github.ref }}
 
       - name: Start job timer
         shell: bash
@@ -376,6 +394,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
+          ref: ${{ needs.release-context.outputs.tag || github.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f


### PR DESCRIPTION
## Summary

Follow-up to #74. Phase 1 dispatched `build-desktop.yml` with `--ref <tag>`, which makes GitHub use the workflow file **from the tag**. That's a bootstrap problem: tags created before the automation fix (like `v2.10.6`) don't have the new `publish_mode` input in their copy of `build-desktop.yml`, so the dispatch failed silently.

Phase 2 decouples workflow-file-ref from build-content-ref:

- **`build-desktop.yml`** gains a `release_tag` input. In publish-mode `workflow_dispatch`, the workflow runs at `main` (latest automation code) and uses `release_tag` for two things:
  - `release-context` parses it as the tag ref (so it returns `publish: true`).
  - The build matrix checkout + publish job checkout use it, so the build reflects the tagged content — not whatever's on `main`.
  - For tag-push events (future releases dispatched on the same commit as `main`), the tag equals `main` HEAD so this is a no-op.

- **`auto-tag.yml`** dispatches with `--ref main` and `-f release_tag=$TAG`. The in-force `build-desktop.yml` is always the latest, regardless of how old the tag's commit is.

- `release-context.mjs` already handled this shape (accepts `--ref <tag>` under `--publish-mode publish`), so the script needs no change.

### Why this fixes v2.10.6 retroactively

The new `auto-tag.yml` already ran on main when #74 merged. With phase-2 merged, its next trigger (the `.github/workflows/auto-tag.yml` path is in its own trigger list) re-runs the recovery path: detects the `v2.10.6` tag, sees no release, dispatches `build-desktop.yml` at `main` with `release_tag=v2.10.6`. This time the dispatched workflow file has the `release_tag` input and the `publish_mode` handling, so it publishes.

### Why this keeps future releases automatic

For the next release (e.g. `v2.10.7`):
1. `release:prepare` bumps version → PR → merge
2. `auto-tag.yml` fires on main, creates `v2.10.7` at `main` HEAD
3. `auto-tag.yml` dispatches `build-desktop.yml` at `main` with `release_tag=v2.10.7`
4. `build-desktop.yml` runs, checks out `v2.10.7` (same content as `main`), builds, publishes

No manual intervention.

## Test plan

- [x] `node scripts/release-context.mjs --event workflow_dispatch --publish-mode publish --ref v2.10.6 --sha … --no-enforce-main` → `publish: true` with full tag metadata
- [x] `npm run lint:yaml` passes
- [x] `npm run typecheck:all` passes
- [ ] After merge: `auto-tag.yml` re-runs on main (own path in trigger list) → detects `v2.10.6` stalled → dispatches correctly → release publishes
- [ ] Future release flow: version bump → merge → release publishes end-to-end with no manual step

https://claude.ai/code/session_0173fepKvSbBtkXwLDJz7dgg