### PR TITLE
feat(web): YouTube sign-in flow + Debug tab content in browser

### DIFF
--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -268,6 +268,16 @@ export class UnifiedSettings {
  }
 
  // Debug tab buttons
+ if (target.id === 'us-open-reasoning-overlay') {
+ document.dispatchEvent(new KeyboardEvent('keydown', {
+ key: 'D', code: 'KeyD', shiftKey: true, metaKey: true, bubbles: true,
+ }));
+ return;
+ }
+ if (target.id === 'us-reload-app') {
+ window.location.reload();
+ return;
+ }
  if (target.id === 'us-open-logs') {
  void tryInvokeTauri<string>('open_logs_folder');
  return;
@@ -415,7 +425,7 @@ export class UnifiedSettings {
  <button class="${this.tabClass('places')}" data-tab="places">Places</button>
  <button class="${this.tabClass('status')}" data-tab="status">${t('panels.status')}</button>
  <button class="${this.tabClass('help')}" data-tab="help">Help</button>
- ${this.config.isDesktopApp ? `<button class="${this.tabClass('debug')}" data-tab="debug">Debug</button>` : ''}
+ <button class="${this.tabClass('debug')}" data-tab="debug">Debug</button>
  </div>
  <div class="unified-settings-tab-panel${this.activeTab === 'general' ? ' active' : ''}" data-panel-id="general">
  ${this.renderGeneralContent()}
@@ -458,7 +468,7 @@ export class UnifiedSettings {
  <div class="unified-settings-tab-panel${this.activeTab === 'help' ? ' active' : ''}" data-panel-id="help">
  ${this.renderHelpContent()}
  </div>
- ${this.config.isDesktopApp ? `<div class="${debugPanelClass}" data-panel-id="debug">${this.renderDebugContent()}</div>` : ''}
+ <div class="${debugPanelClass}" data-panel-id="debug">${this.config.isDesktopApp ? this.renderDebugContent() : this.renderDebugContentWeb()}</div>
  </div>
  `;
 
@@ -502,9 +512,13 @@ export class UnifiedSettings {
  });
 
  if (tab === 'debug') {
+ if (this.config.isDesktopApp) {
  void this._refreshTrafficLog();
  void this._syncVerboseState();
  this._startDebugAutoRefresh();
+ } else {
+ void this._populateWebDebugStats();
+ }
  }
  if (tab === 'places') {
  this.placesDeleteConfirm = null;
@@ -1063,6 +1077,71 @@ export class UnifiedSettings {
   }
 
   // ── Debug tab ──────────────────────────────────────────────────────────────
+
+  // eslint-disable-next-line sonarjs/cognitive-complexity -- linear storage + SW probe, reads cleaner inline
+  private async _populateWebDebugStats(): Promise<void> {
+ const storageEl = this.overlay.querySelector<HTMLElement>('[data-web-debug="storage"]');
+ const swEl = this.overlay.querySelector<HTMLElement>('[data-web-debug="sw"]');
+ if (storageEl) {
+ try {
+ const nav = typeof navigator === 'undefined' ? undefined : navigator as Navigator & { storage?: { estimate?: () => Promise<{ usage?: number; quota?: number }> } };
+ const est = await nav?.storage?.estimate?.();
+ if (est?.usage === undefined || est?.quota === undefined) {
+ storageEl.textContent = 'unavailable';
+ } else {
+ const used = (est.usage / 1024 / 1024).toFixed(1);
+ const quota = (est.quota / 1024 / 1024).toFixed(0);
+ storageEl.textContent = `${used} MiB / ${quota} MiB`;
+ }
+ } catch {
+ storageEl.textContent = 'unavailable';
+ }
+ }
+ if (swEl) {
+ try {
+ const reg = await navigator.serviceWorker?.getRegistration();
+ if (!reg) {
+ swEl.textContent = 'not registered';
+ } else if (reg.waiting) {
+ swEl.textContent = 'update waiting (reload to activate)';
+ } else if (reg.installing) {
+ swEl.textContent = 'installing';
+ } else {
+ swEl.textContent = 'active';
+ }
+ } catch {
+ swEl.textContent = 'unavailable';
+ }
+ }
+  }
+
+  private renderDebugContentWeb(): string {
+ const fetchDebug = localStorage.getItem('wm-debug-log') === '1';
+ const ua = typeof navigator === 'undefined' ? 'n/a' : navigator.userAgent;
+ const variant = SITE_VARIANT || 'full';
+ const version = typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : 'dev';
+ return `
+ <div class="us-debug-content">
+ <div class="us-debug-section-label">Runtime</div>
+ <dl class="us-debug-kv">
+ <dt>Version</dt><dd>${escapeHtml(version)}</dd>
+ <dt>Variant</dt><dd>${escapeHtml(variant)}</dd>
+ <dt>User agent</dt><dd>${escapeHtml(ua)}</dd>
+ <dt>Storage</dt><dd><span data-web-debug="storage">computing…</span></dd>
+ <dt>Service worker</dt><dd><span data-web-debug="sw">checking…</span></dd>
+ </dl>
+ <div class="us-debug-section-label">Diagnostics</div>
+ <div class="us-debug-toggles">
+ <label class="us-debug-toggle-row"><input type="checkbox" id="us-fetch-debug" ${fetchDebug ? 'checked' : ''}> Frontend Fetch Debug</label>
+ </div>
+ <div class="us-debug-actions">
+ <button id="us-open-reasoning-overlay" class="us-debug-btn">Open Reasoning Overlay (⌘⇧D)</button>
+ <button id="us-reload-app" class="us-debug-btn">Reload app</button>
+ </div>
+ <p class="us-debug-empty" style="margin-top:12px;">Sidecar traffic logs and keychain tools are desktop-only. For browser-side issues, use DevTools + the Reasoning Overlay.</p>
+ </div>
+ `;
+  }
 
   private renderDebugContent(): string {
  const fetchDebug = localStorage.getItem('wm-debug-log') === '1';

--- a/src/services/youtube-account.ts
+++ b/src/services/youtube-account.ts
@@ -1,8 +1,12 @@
 import { tryInvokeTauri } from '@/services/tauri-bridge';
+import { isDesktopRuntime } from '@/services/runtime';
 
 const CONNECTED_KEY = 'wm-youtube-connected';
 
 export function isYouTubeConnected(): boolean {
+  // In a regular browser the user is already authenticated to YouTube via
+  // their cookie jar, so the in-app "connected" flag is always true in web.
+  if (!isDesktopRuntime()) return true;
   return localStorage.getItem(CONNECTED_KEY) === 'true';
 }
 
@@ -11,10 +15,20 @@ export function setYouTubeConnected(val: boolean): void {
 }
 
 export function signInToYouTube(): void {
+  if (!isDesktopRuntime()) {
+ // Web: YouTube auth is cookie-based in the browser; opening youtube.com
+ // in a new tab lets the user sign in there if they aren't already.
+ window.open('https://www.youtube.com/', '_blank', 'noopener');
+ return;
+  }
   void tryInvokeTauri('open_youtube_login');
 }
 
 export function signOutOfYouTube(): void {
+  if (!isDesktopRuntime()) {
+ window.open('https://www.youtube.com/logout', '_blank', 'noopener');
+ return;
+  }
   void tryInvokeTauri('open_youtube_logout');
 }
 


### PR DESCRIPTION
Closes the last two feasible web/desktop parity gaps from the audit.

**YouTube sign-in (`src/services/youtube-account.ts`)**
Web builds now open `https://www.youtube.com/` (or `/logout`) in a new tab instead of silently invoking a Tauri command that doesn't exist. Web users are already authenticated via their browser cookie jar, so `isYouTubeConnected()` returns true in web unconditionally — the in-app flag is purely for desktop where the auth webview is a separate window that has to signal back via `wm:youtube-signed-in`.

**Debug tab (`src/components/UnifiedSettings.ts`)**
Ungated the Debug tab button + panel for web. Added `renderDebugContentWeb()` showing Version / Variant / User agent / Storage (`navigator.storage.estimate`) / Service Worker state, plus "Open Reasoning Overlay (⌘⇧D)" and "Reload app" buttons. Populated live via `_populateWebDebugStats()` on tab-switch — sidecar traffic log + verbose toggle stay desktop-only.

**Intentionally skipped** (from the audit, because they're not actually fixable at the client layer):
- `cloudApiFallbackAuth` — the X-CrystalBall-Key header only exists because desktop relays through the cloud edge for trust validation. Web doesn't need it because it IS the edge.
- AIS relay key handoff — genuinely needs a server-side WebSocket proxy on `api.crystalball.app`.
- Variant switcher — variants are build-time bundles at different subdomains; a runtime toggle would swap to a non-existent asset.

## Test plan
- [ ] Web: Settings → Debug tab shows version, variant, user agent, storage usage, SW state.
- [ ] Web: "Open Reasoning Overlay" button opens the ⌘⇧D overlay.
- [ ] Web: "Reload app" refreshes the page.
- [ ] Web: Sign-in button in Settings opens youtube.com in a new tab.
- [ ] Desktop: Debug tab still shows traffic log, verbose toggle, sidecar log buttons.
- [ ] Desktop: YouTube sign-in still calls the Tauri webview.

https://claude.ai/code/session_01UFURjYqassFCPpT8FaWCLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFURjYqassFCPpT8FaWCLC)_