### PR TITLE
fix(web): activate desktop chrome on fine-pointer wide viewports

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -270,10 +270,19 @@ loadDesktopSecrets().then(async () => {
 // Apply stored theme preference before app initialization (safety net for inline script)
 applyStoredTheme();
 
-// Mark body with macOS-native class so CSS design system activates on desktop
-if (isDesktopRuntime()) {
-  document.body.classList.add('is-desktop-macos');
-} else if (FORCE_DESKTOP_GATE) {
+// Activate the desktop design system (sidebar chrome, wide layout, hover
+// affordances) whenever the client is a fine-pointer desktop-sized viewport,
+// not only in the Tauri build. The class name is historical — "macos" means
+// "the macOS-inspired chrome we use on any desktop browser". Mobile and
+// narrow-tablet browsers keep the default mobile layout.
+function shouldUseDesktopChrome(): boolean {
+  if (isDesktopRuntime() || FORCE_DESKTOP_GATE) return true;
+  if (typeof window === 'undefined') return false;
+  const finePointer = window.matchMedia?.('(pointer: fine)').matches ?? false;
+  const wideEnough = window.innerWidth >= 768;
+  return finePointer && wideEnough;
+}
+if (shouldUseDesktopChrome()) {
   document.body.classList.add('is-desktop-macos');
 }
 


### PR DESCRIPTION
User reports the web app looks "very Android styled" from a Windows 11 PC. Root cause: `body.is-desktop-macos` — which activates the entire sidebar + toolbar design system — was only added when `isDesktopRuntime()` was true (Tauri only). Every desktop browser user (Windows, Linux, Mac web) fell back to the mobile layout meant for 320px phones.

Fixed by also applying the class when the client is a **fine-pointer** (mouse, not touch) **desktop-sized** (`window.innerWidth >= 768`) viewport. Touch devices and narrow viewports still get the mobile layout. Class name stays as-is (historical — "macos" now means "the macOS-inspired chrome we use on any desktop browser"); renaming would churn ~200 CSS selectors for zero user value.

## Test plan
- [ ] Web on Windows/Linux desktop (Chrome, Firefox, Edge): sidebar appears, toolbar uses the desktop design system — matches the Tauri build.
- [ ] Web on a phone (Chrome on Android, Safari iOS): mobile layout stays unchanged.
- [ ] Web on iPad landscape: desktop chrome if pointer:fine (Apple Pencil / Magic Keyboard), mobile otherwise.
- [ ] Tauri build: no change.

https://claude.ai/code/session_01UFURjYqassFCPpT8FaWCLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFURjYqassFCPpT8FaWCLC)_