### PR TITLE
docs: web vault, desktop chrome activation, basemap files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,8 +80,9 @@ src/                        # TypeScript frontend (Vite)
     panels.ts               # FULL_PANELS, PANEL_CATEGORY_MAP, FULL_MAP_LAYERS
   services/
     mode-manager.ts         # AppMode: peace/finance/war/disaster/ghost
-    runtime-config.ts       # API key definitions, feature toggles
+    runtime-config.ts       # API key definitions, feature toggles, web verifySecret probes
     settings-constants.ts   # HUMAN_LABELS, KEY_DESCRIPTIONS, SIGNUP_URLS, SETTINGS_CATEGORIES
+    web-secret-store.ts     # browser-only passphrase-encrypted vault (see "Web key vault" below)
     analytics.ts            # PostHog (suppressed in Ghost Mode)
     # ── Analyst reasoning layer (see docs/reasoning-layer.md) ──
     analyst-loop.ts             # cross-domain hypothesis fusion + ranking
@@ -132,6 +133,37 @@ A persistent, renderer-side reasoning stack that fuses `situation-engine`, `anom
 - **LLM**: `llm-adapter.generateText()` is the single entry point; prefers Ollama / LM Studio via `/api/intel-generate` before falling back to `runClaudeAgent`. Daily cloud-call cap enforced by `llm-budget.reserveCloudCall()` (race-safe for parallel personas).
 - **MCP**: 4 read + 3 write + 2 diagnostic tools — see `tools/mcp-server/tools/analyst.mjs`.
 - **Memory**: IDB `reasoning_memory` store on the shared `crystalball_db` (versionchange handlers in alert-store and reasoning-memory let upgrades happen without blocking each other). LS bootstrap + writtenSinceLoad guard against IDB hydrate races.
+
+## Web Key Vault (`src/services/web-secret-store.ts`)
+
+The browser build can't reach the macOS keychain, so user-entered keys are persisted in a passphrase-encrypted IndexedDB vault. Architecture:
+
+- AES-GCM-256 over PBKDF2-SHA-256, **600,000 iterations** (OWASP 2023). Per-save random 12-byte IV, AAD pinned to `"crystalball-web-vault-v1"` so a future v2 needs an explicit migration.
+- Ciphertext stored in shared `crystalball_db` IDB at key `web-secret-vault/v1`. Derived key + plaintext `Map<string,string>` live only in module closure — **never** localStorage / sessionStorage / globalThis.
+- Auto-lock after 15 min of `document.visibilityState === 'hidden'`. Manual Lock and Destroy in the API Keys tab banner.
+- `setSecret` / `persistCurrent` snapshot the derived key before the async encrypt and re-verify after the await; concurrent auto-lock during a save throws cleanly instead of silently persisting with a wiped key.
+- `runtime-config.setSecretValue` routes to the vault when `!isDesktopRuntime() && isWebVaultUnlocked()`, otherwise routes to the desktop keychain via `invokeTauri('set_secret')`.
+- `runtime-config.isFeatureAvailable` gates on the vault's `requiredSecrets` once unlocked. Before unlock, web optimistically trusts server-managed credentials so users without a vault don't see a wall of red.
+- `runtime-config.verifyWebSecret` does direct CORS-friendly probes for Anthropic / Groq / OpenRouter / Cesium Ion / Mapbox / MapTiler with `referrerPolicy: 'no-referrer'` so bearer tokens don't leak via redirect Referer. Other providers fall through to a non-committal "Saved".
+- The API Keys tab in `UnifiedSettings` mounts the same `RuntimeConfigPanel` as desktop; the panel's `renderWebVaultBanner()` swaps the inputs for create/unlock/lock/destroy state when `!isDesktopRuntime()`.
+
+## Desktop Chrome Activation (`src/main.ts`)
+
+`body.is-desktop-macos` drives the entire sidebar + toolbar design system. Applied when:
+- `isDesktopRuntime()` is true (Tauri build), **OR**
+- `FORCE_DESKTOP_GATE` env override is on, **OR**
+- the browser has `(pointer: fine)` AND `window.innerWidth >= 768` (Windows / Linux / Mac web on a real monitor).
+
+Touch phones and narrow tablets get the mobile layout. The class name is historical; "macos" now means "the macOS-inspired chrome we use on any desktop browser."
+
+## Basemap Switcher (`src/components/DeckGLMap.ts`)
+
+Four basemaps (`dark | light | satellite | terrain`) selected by the `wm-basemap` localStorage key. Style URLs:
+- Dark/Light → self-hosted `/map-styles/{dark,light}.json` referencing CARTO raster tiles. The vector gl-style URL (`basemaps.cartocdn.com/gl/...`) is **not** used because it's cross-origin and not covered by the existing workbox `[abc].basemaps.cartocdn.com` cache rule.
+- Satellite → self-hosted `/map-styles/satellite.json` (NASA GIBS Blue Marble).
+- Terrain → self-hosted `/map-styles/terrain.json` (OpenTopoMap).
+
+`initMapLibre()` validates the persisted value against `validBasemaps` to prevent stale localStorage from leaving the UI in a stuck state. A MapLibre `'error'` listener logs failed style/tile fetches with `sourceId` so the next user report comes with diagnostics.
 
 ## App Modes (`src/services/mode-manager.ts`)
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,9 @@ All sounds are synthesized with Web Audio API -- no audio files in the repo:
 
 ## What Makes This Hard
 
-**Local-first security boundary** -- the renderer never sees API keys. Keys live in the macOS keychain, get injected into a Node.js sidecar at startup, and are proxied through a bearer-authenticated localhost port. The MCP server discovers the port and token from disk files with `0o600` permissions.
+**Local-first security boundary** -- the renderer never sees API keys on desktop. Keys live in the macOS keychain, get injected into a Node.js sidecar at startup, and are proxied through a bearer-authenticated localhost port. The MCP server discovers the port and token from disk files with `0o600` permissions.
+
+**Web key vault** -- the browser build has no keychain access, so user-entered keys are persisted in a passphrase-encrypted IndexedDB vault. AES-GCM-256 over PBKDF2-SHA-256 (600,000 iterations, OWASP 2023), per-save random 12-byte IV, AAD-bound ciphertext. The derived key and plaintext map live only in module closure -- never written to localStorage, sessionStorage, or globalThis -- and the vault auto-locks after 15 minutes of the tab being hidden. Lost passphrase = destroy and re-enter; there is no recovery.
 
 **CSP under real constraints** -- `script-src` requires `'unsafe-eval'` because Cesium compiles GLSL shaders dynamically. Removing it silently breaks God's Vision. Compensating controls: trusted-window IPC gating, sidecar bearer auth, no `'unsafe-inline'` on script-src, devtools disabled in production.
 

--- a/docs/API_KEYS.md
+++ b/docs/API_KEYS.md
@@ -1,8 +1,17 @@
 # Crystal Ball — API Keys & Data Sources
 
-Crystal Ball integrates with 40+ external data sources. Most features work out of the box with free public APIs, but some layers require API keys for full functionality. Keys are entered via **Settings (gear icon) > API Keys** and stored securely in your macOS keychain.
+Crystal Ball integrates with 40+ external data sources. Most features work out of the box with free public APIs, but some layers require API keys for full functionality. Keys are entered via **Settings (gear icon) → API Keys** in both the desktop and web builds.
 
 > **Each field in the in-app Settings overlay also shows a one-line description of what the key does, free vs paid, and a "Get key" link** — added in the v2.11 release as part of the documentation refresh.
+
+## Where keys are stored
+
+- **Desktop (Tauri)** — keys live in the macOS Keychain under service name `crystal-ball`. The renderer never sees them; they're injected into the Node.js sidecar at startup and proxied through a bearer-authenticated localhost port.
+- **Web (browser)** — keys live in a passphrase-encrypted vault in IndexedDB. AES-GCM-256 over PBKDF2-SHA-256 (600,000 iterations); ciphertext only, derived key + plaintext map held in module closure for the duration of the session. Auto-locks after 15 min of the tab being hidden. To set up:
+  1. Open Settings → API Keys.
+  2. Pick a passphrase you can remember (≥12 chars). There is no recovery — lost passphrase means destroying the vault and re-entering keys.
+  3. Once unlocked, the per-provider inputs accept and persist your keys across reloads.
+  4. **Save validation** — Anthropic, Groq, OpenRouter, Cesium Ion, Mapbox, and MapTiler keys are probed directly from the browser on save (no Referer leak via `referrerPolicy: 'no-referrer'`); a 401/403 surfaces immediately. Other providers don't accept browser CORS, so they fall through to a non-committal "Saved".
 
 ## Quick Start — Essential Free Keys
 


### PR DESCRIPTION
Catches the docs up to PRs #82–#89.

**README** — "What Makes This Hard" gains a *Web key vault* paragraph naming the crypto choice (PBKDF2-SHA-256 600k iters → AES-GCM-256), what's in memory vs IDB, the auto-lock window, and the no-recovery rule.

**CLAUDE.md** — three new architecture sections so the next agent session has the facts:
- *Web Key Vault* — file layout, runtime-config integration, verifyWebSecret probe table.
- *Desktop Chrome Activation* — the `pointer: fine` + `innerWidth ≥ 768px` rule that un-Android-ifies the web app on Windows / Linux.
- *Basemap Switcher* — self-hosted dark/light JSON, `validBasemaps` allowlist, MapLibre `error` listener for diagnostics.
- `services/` tree gets `web-secret-store.ts` listed.

**docs/API_KEYS.md** — "Where keys are stored" split into desktop (Keychain) and web (passphrase vault) flows. Create-and-unlock recipe and the verifyWebSecret behavior described inline.

`CHANGELOG.md` is auto-maintained by `release:prepare` so it already reflects v2.10.8 → v2.10.12.

## Test plan
- [ ] Read README §"What Makes This Hard" — web vault paragraph reads correctly.
- [ ] Read CLAUDE.md §"Web Key Vault" — file paths and crypto parameters match `src/services/web-secret-store.ts`.
- [ ] Read docs/API_KEYS.md §"Where keys are stored" — recipe matches the actual UI.

https://claude.ai/code/session_01UFURjYqassFCPpT8FaWCLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFURjYqassFCPpT8FaWCLC)_