### PR TITLE
fix(desktop): update widget always clickable; don't lie when GitHub is unreachable

### DIFF
--- a/src/app/desktop-updater.ts
+++ b/src/app/desktop-updater.ts
@@ -79,7 +79,10 @@ export class DesktopUpdater implements AppModule {
  );
  if (!res.ok) {
  this.logUpdaterOutcome('fetch_failed', { status: res.status });
- this.setUpdateState({ phase: 'up-to-date' });
+ // Don't claim up-to-date on a server error — that hides real
+ // failures behind a false green check. Reset to null so the sidebar
+ // falls back to just the version label and the user can retry.
+ this.setUpdateState(null);
  if (manual) this.showInfoToast('Could not reach update server. Check your connection.');
  return;
  }
@@ -117,8 +120,11 @@ export class DesktopUpdater implements AppModule {
  this.logUpdaterOutcome('fetch_failed', {
  error: error instanceof Error ? error.message : String(error),
  });
- this.setUpdateState({ phase: 'up-to-date' });
- }
+ // Network or parsing failure — same as the !res.ok branch, don't pretend
+ // the user is current.
+ this.setUpdateState(null);
+ if (manual) this.showInfoToast('Could not reach update server. Check your connection.');
+  }
   }
 
   private isNewerVersion(remote: string, current: string): boolean {

--- a/src/app/layout/html.ts
+++ b/src/app/layout/html.ts
@@ -52,20 +52,28 @@ export function buildThemeIcon(): string {
 export function buildSidebarUpdateBtnHtml(ctx: AppContext): string {
   const versionLabel = escapeHtml(`v${__APP_VERSION__}${BETA_MODE ? ' β' : ''}`);
   const state = ctx.updateState;
-  if (!state || state.phase === 'checking') {
+  // While a check is in flight, render an inert label.
+  if (state?.phase === 'checking') {
  return `<span class="mac-sidebar-version">${versionLabel}</span>`;
   }
-  if (state.phase === 'up-to-date') {
- return `<span class="mac-sidebar-version mac-sidebar-version--ok">${versionLabel} ✓</span>`;
-  }
-  if (state.phase === 'available' && state.version) {
+  // A new release is out — primary action: install.
+  if (state?.phase === 'available' && state.version) {
  const remoteLabel = escapeHtml(`v${state.version}`);
- return `<button class="mac-sidebar-update-btn" id="sidebarUpdateInstall">${versionLabel} → ${remoteLabel}</button>`;
+ return `<button class="mac-sidebar-update-btn" id="sidebarUpdateInstall" title="Install ${remoteLabel}">${versionLabel} → ${remoteLabel}</button>`;
   }
-  if (state.phase === 'installing') {
+  // Auto-installer is downloading + replacing the .app bundle.
+  if (state?.phase === 'installing') {
  return `<span class="mac-sidebar-version mac-sidebar-version--installing">Installing…</span>`;
   }
-  return `<span class="mac-sidebar-version">${versionLabel}</span>`;
+  // Up-to-date OR initial pre-check OR a previous fetch failed (state === null).
+  // All three render the same clickable widget so the user can always trigger
+  // a manual re-check; the ✓ only renders when we know the result is fresh.
+  const okMark = state?.phase === 'up-to-date' ? ' ✓' : '';
+  const okClass = state?.phase === 'up-to-date' ? ' mac-sidebar-version--ok' : '';
+  const titleAttr = state?.phase === 'up-to-date'
+ ? 'Click to check for updates'
+ : 'Check for updates';
+  return `<button class="mac-sidebar-version mac-sidebar-update-recheck${okClass}" id="sidebarUpdateRecheck" title="${titleAttr}">${versionLabel}${okMark}</button>`;
 }
 
 export function buildSidebarNav(ctx: AppContext): string {

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -372,6 +372,16 @@ export class PanelLayoutManager implements AppModule {
  // Only other content is hardcoded markup (class names, "Installing…", "✓", button structure).
  container.innerHTML = this.buildSidebarUpdateBtnHtml(); // safe-html: escapeHtml applied to all dynamic strings
 
+ // Re-check button: rendered when state is null (initial / after fetch
+ // failure) or 'up-to-date'. Dispatches the same event the macOS Help
+ // menu uses so the desktop-updater module owns the actual fetch.
+ const recheckBtn = container.querySelector<HTMLButtonElement>('#sidebarUpdateRecheck');
+ if (recheckBtn) {
+ recheckBtn.addEventListener('click', () => {
+ document.dispatchEvent(new CustomEvent('wm:check-for-updates'));
+ });
+ }
+
  const installBtn = container.querySelector<HTMLButtonElement>('#sidebarUpdateInstall');
  if (!installBtn) return;
 

--- a/src/styles/macos-native.css
+++ b/src/styles/macos-native.css
@@ -653,6 +653,20 @@ body.is-desktop-macos[data-app-mode="ghost"] .mac-mode-section {
   background: rgba(245, 158, 11, 0.2);
 }
 
+/* When .mac-sidebar-version is rendered as a <button> (the re-check
+   variant), strip the default browser chrome so it matches the inert
+   <span> case. The .mac-sidebar-update-recheck class signals it's
+   interactive — give it a faint hover affordance. */
+button.mac-sidebar-version {
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font: inherit;
+}
+.mac-sidebar-update-recheck:hover {
+  color: var(--mac-label);
+}
 .mac-sidebar-version {
   margin-left: auto;
   font-size: 11px;


### PR DESCRIPTION
User reports the desktop sidebar update widget never shows. Two compounding bugs traced from `desktop-updater.ts` → `buildSidebarUpdateBtnHtml()`:

**1.** `checkForUpdate()` set state to `{ phase: 'up-to-date' }` on both the `!res.ok` branch and the network-error catch. That painted a green ✓ next to the version even when the GitHub API was unreachable, hiding real failures behind false reassurance. Both error paths now set state to `null` so the sidebar falls back to the plain version label, and a toast surfaces on manual checks.

**2.** The 'up-to-date' / null states rendered an inert `<span>`, so a user who saw a ✓ (or saw nothing after a network error) had no way to re-check. Added an `#sidebarUpdateRecheck` `<button>` for those states; clicking dispatches `wm:check-for-updates` — the same event the macOS Help → "Check for Updates…" menu fires.

CSS strips the default button chrome when `.mac-sidebar-version` is rendered as a `<button>`, so the inert and interactive variants are visually identical.

## Test plan
- [ ] Desktop on the latest version: sidebar shows `v2.10.12 ✓`, click triggers a fresh check that completes back to ✓.
- [ ] Desktop on an older version: sidebar shows `v2.10.7 → v2.10.12` button, click installs.
- [ ] Desktop offline: sidebar shows `v2.10.12` (no ✓), click triggers a check that lands back null with a "Could not reach update server" toast.
- [ ] Desktop while a check is in flight: sidebar shows plain `v2.10.12` (inert span).
- [ ] Web: no change — sidebar isn't rendered in web layouts.

https://claude.ai/code/session_01UFURjYqassFCPpT8FaWCLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFURjYqassFCPpT8FaWCLC)_