### PR TITLE
fix(web): black map screen + workbox json glob + Ctrl+K + extra tile caches

### DIFF
--- a/public/map-styles/dark.json
+++ b/public/map-styles/dark.json
@@ -5,9 +5,9 @@
     "carto-dark": {
       "type": "raster",
       "tiles": [
-        "https://a.basemaps.cartocdn.com/rastertiles/dark_all/{z}/{x}/{y}@2x.png",
-        "https://b.basemaps.cartocdn.com/rastertiles/dark_all/{z}/{x}/{y}@2x.png",
-        "https://c.basemaps.cartocdn.com/rastertiles/dark_all/{z}/{x}/{y}@2x.png"
+        "https://a.basemaps.cartocdn.com/rastertiles/dark_all/{z}/{x}/{y}.png",
+        "https://b.basemaps.cartocdn.com/rastertiles/dark_all/{z}/{x}/{y}.png",
+        "https://c.basemaps.cartocdn.com/rastertiles/dark_all/{z}/{x}/{y}.png"
       ],
       "tileSize": 256,
       "maxzoom": 19,

--- a/public/map-styles/light.json
+++ b/public/map-styles/light.json
@@ -5,9 +5,9 @@
     "carto-voyager": {
       "type": "raster",
       "tiles": [
-        "https://a.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png",
-        "https://b.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png",
-        "https://c.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png"
+        "https://a.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png",
+        "https://b.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png",
+        "https://c.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
       ],
       "tileSize": 256,
       "maxzoom": 19,

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -384,8 +384,8 @@ export class EventHandlerManager implements AppModule {
  e.preventDefault();
  document.dispatchEvent(new CustomEvent('cb:toggle-today'));
  }
- // Cmd+K — toggle command palette
- if (e.metaKey && e.key === 'k' && !e.shiftKey && !e.altKey) {
+ // Cmd+K (mac) / Ctrl+K (windows / linux) — toggle command palette
+ if ((e.metaKey || e.ctrlKey) && e.key === 'k' && !e.shiftKey && !e.altKey) {
  const active = document.activeElement;
  if (active?.tagName === 'INPUT' || active?.tagName === 'TEXTAREA') return;
  e.preventDefault();

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -5628,6 +5628,15 @@ export class DeckGLMap {
 
   private applyDarkMapEnhancements(): void {
  if (!this.maplibreMap || this.activeBaseMap !== 'dark') return;
+ // The hillshade DEM expects a vector style with symbol layers underneath
+ // for the hillshade to overlay through. Our self-hosted dark.json is a
+ // raster-only style (single CARTO tile layer), so adding a hillshade on
+ // top occludes the basemap and produces a black map. Bail when there's
+ // no vector source to enhance.
+ const styleSpec = this.maplibreMap.getStyle();
+ const hasVectorSource = Object.values(styleSpec?.sources ?? {})
+ .some((src) => (src as { type?: string }).type === 'vector');
+ if (!hasVectorSource) return;
  try {
  // Add terrain DEM source for hillshade (Mapzen terrarium — free, no API key)
  if (!this.maplibreMap.getSource('wm-terrain-dem')) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -695,7 +695,7 @@ export default defineConfig({
  },
 
  workbox: {
- globPatterns: ['**/*.{js,css,ico,png,svg,woff2}'],
+ globPatterns: ['**/*.{js,css,ico,png,svg,woff2,json}'],
  globIgnores: ['**/ml*.js', '**/onnx*.wasm', '**/locale-*.js'],
  maximumFileSizeToCacheInBytes: 6 * 1024 * 1024, // 6 MiB — CesiumJS adds ~2.4 MiB to panels bundle
  navigateFallback: null,
@@ -762,6 +762,24 @@ export default defineConfig({
  handler: 'CacheFirst',
  options: {
  cacheName: 'carto-tiles',
+ expiration: { maxEntries: 500, maxAgeSeconds: 30 * 24 * 60 * 60 },
+ cacheableResponse: { statuses: [0, 200] },
+ },
+ },
+ {
+ urlPattern: /^https:\/\/[abc]\.tile\.opentopomap\.org\//,
+ handler: 'CacheFirst',
+ options: {
+ cacheName: 'opentopomap-tiles',
+ expiration: { maxEntries: 500, maxAgeSeconds: 30 * 24 * 60 * 60 },
+ cacheableResponse: { statuses: [0, 200] },
+ },
+ },
+ {
+ urlPattern: /^https:\/\/gibs\.earthdata\.nasa\.gov\//,
+ handler: 'CacheFirst',
+ options: {
+ cacheName: 'gibs-tiles',
  expiration: { maxEntries: 500, maxAgeSeconds: 30 * 24 * 60 * 60 },
  cacheableResponse: { statuses: [0, 200] },
  },


### PR DESCRIPTION
User reported a black map screen on the web build after the recent basemap refactor. Two compounding causes:

**1.** `applyDarkMapEnhancements()` unconditionally added a hillshade layer on top of the dark style. It expects a vector style with symbol layers underneath so the hillshade slots in below labels — but the new self-hosted `dark.json` is raster-only (a single CARTO tile layer with a `#0b0e12` background fallback). With no vector source, `firstSymbolId` is undefined, the hillshade is added on top, and DEM tile failures (Mapzen terrarium S3 occasionally lags) leave a black layer occluding the basemap. Now bails early when the active style has no vector source.

**2.** Dark/Light styles requested `@2x` retina tiles. CARTO's `@2x` endpoint is real but slower and occasionally 4xx in regions; non-`@2x` tiles are universally fast and identical 256×256 logical units. The slight retina-crispness loss is invisible compared to a black map.

Quick wins from the parallel bug scan, batched in:

- `vite.config.ts` `globPatterns` now includes `.json` so `/map-styles/*.json` precaches into the service worker (otherwise an offline first-load serves nothing for basemap styles).
- Added `runtimeCaching` rules for OpenTopoMap (terrain) and NASA GIBS (satellite) so those modes survive offline once warm.
- Cmd+K command palette now also triggers on Ctrl+K so Windows/Linux users have keyboard access (was `metaKey`-only).

## Test plan
- [ ] Web dark basemap renders the CARTO dark raster, no black overlay.
- [ ] Web light basemap renders voyager raster.
- [ ] Web satellite/terrain unchanged.
- [ ] Service worker precaches `/map-styles/dark.json` and friends; reload offline → basemap still loads.
- [ ] Ctrl+K opens command palette on Windows/Linux web.
- [ ] Desktop dark basemap still gets the hillshade enhancement (because the desktop's CARTO vector style still has vector sources).

https://claude.ai/code/session_01UFURjYqassFCPpT8FaWCLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFURjYqassFCPpT8FaWCLC)_