### PR TITLE
fix(web): restore settings gear + version + add build-info to Debug tab

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -355,12 +355,18 @@ export class PanelLayoutManager implements AppModule {
   }
 
   renderLayout(): void {
- this.ctx.container.innerHTML = this.ctx.isDesktopApp ? this.buildDesktopLayout() : this.buildWebLayout();
- if (this.ctx.isDesktopApp) {
+ // Use the desktop sidebar/toolbar shell whenever body.is-desktop-macos is
+ // active — that includes wide-pointer web browsers, not just Tauri. The
+ // earlier "isDesktopApp only" gate left web users on Windows/Linux/Mac
+ // desktop with their .header hidden by macos-native.css and no sidebar
+ // rendered, so the settings gear and version label vanished.
+ const useDesktopShell = this.ctx.isDesktopApp || document.body.classList.contains('is-desktop-macos');
+ this.ctx.container.innerHTML = useDesktopShell ? this.buildDesktopLayout() : this.buildWebLayout();
+ if (useDesktopShell) {
  document.title = `Crystal Ball v${__APP_VERSION__}`;
  }
  this.createPanels();
- if (this.ctx.isDesktopApp) {
+ if (useDesktopShell) {
  this.renderSidebarUpdateBtn();
  }
   }

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -1167,11 +1167,18 @@ export class UnifiedSettings {
  const ua = typeof navigator === 'undefined' ? 'n/a' : navigator.userAgent;
  const variant = SITE_VARIANT || 'full';
  const version = typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : 'dev';
+ // These build macros are stamped at vite build time so they identify
+ // exactly which Vercel deployment / commit the user is running.
+ const commitSha = typeof __BUILD_COMMIT_SHA__ === 'string' ? __BUILD_COMMIT_SHA__.slice(0, 12) : 'dev';
+ const buildTag = typeof __BUILD_TAG__ === 'string' ? __BUILD_TAG__ : '';
+ const buildTime = typeof __BUILD_TIMESTAMP__ === 'string' ? __BUILD_TIMESTAMP__ : '';
  return `
  <div class="us-debug-content">
  <div class="us-debug-section-label">Runtime</div>
  <dl class="us-debug-kv">
- <dt>Version</dt><dd>${escapeHtml(version)}</dd>
+ <dt>Version</dt><dd>${escapeHtml(version)}${buildTag && buildTag !== `v${version}` ? ` (${escapeHtml(buildTag)})` : ''}</dd>
+ <dt>Build commit</dt><dd><code>${escapeHtml(commitSha)}</code></dd>
+ <dt>Built at</dt><dd>${escapeHtml(buildTime)}</dd>
  <dt>Variant</dt><dd>${escapeHtml(variant)}</dd>
  <dt>User agent</dt><dd>${escapeHtml(ua)}</dd>
  <dt>Storage</dt><dd><span data-web-debug="storage">computing…</span></dd>


### PR DESCRIPTION
**Regression fix.** PR #89 added `body.is-desktop-macos` to wide-pointer web browsers. `macos-native.css:78` hides `.header` whenever that class is set — but `.header` is where the web build's settings gear and version label live. The desktop sidebar / toolbar (which has its *own* gear and version) was still gated to `isDesktopApp` (Tauri only), so web users on Windows/Linux/Mac desktop browsers ended up with no settings access, no version display, and no update widget.

`renderLayout()` now renders `buildDesktopLayout` whenever the body has `.is-desktop-macos`, not only when the runtime is Tauri. The desktop HTML contains `data-tauri-drag-region` attributes which are inert in web browsers, so it renders cleanly in both contexts.

**Bonus** (you asked for this): build-info on the Debug tab. Surfaces `__BUILD_COMMIT_SHA__` (short), `__BUILD_TAG__`, and `__BUILD_TIMESTAMP__` which were already stamped at build time by `vite.config.ts` but never displayed. After this PR + a Vercel rebuild, the Debug tab → Runtime section shows exactly which deployment the user is on, so you can confirm the served bundle matches `main` HEAD.

## Test plan
- [ ] Web on Chrome/Edge/Firefox desktop: sidebar visible, gear icon clickable, version chip shows v2.10.X.
- [ ] Web on a phone (touch / narrow viewport): keeps the original web header layout (no `.is-desktop-macos`).
- [ ] Settings → Debug shows Build commit (12-char SHA) + Built at (ISO timestamp).
- [ ] Tauri desktop: no change — `isDesktopApp || is-desktop-macos` is true the same way it was before.

https://claude.ai/code/session_01UFURjYqassFCPpT8FaWCLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFURjYqassFCPpT8FaWCLC)_