### PR TITLE
fix(web): revert desktop-shell auto-promotion + surface God's Vision button

### DIFF
--- a/src/app/layout/html.ts
+++ b/src/app/layout/html.ts
@@ -246,6 +246,9 @@ export function buildWebLayout(ctx: AppContext): string {
  </div>`}
  <button class="search-btn" id="searchBtn"><kbd>⌘K</kbd> ${t('header.search')}</button>
  ${ctx.isDesktopApp ? '' : `<button class="copy-link-btn" id="copyLinkBtn">${t('header.copyLink')}</button>`}
+ <button class="copy-link-btn" id="godsVisionBtn" title="God's Vision — 3D globe view (G)" style="display:inline-flex;align-items:center;gap:6px;">
+ 🌍 <span style="font-size:11px;">God's Vision</span>
+ </button>
  <button class="theme-toggle-btn" id="headerThemeToggle" title="${t('header.toggleTheme')}">
  ${buildThemeIcon()}
  </button>

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -355,18 +355,18 @@ export class PanelLayoutManager implements AppModule {
   }
 
   renderLayout(): void {
- // Use the desktop sidebar/toolbar shell whenever body.is-desktop-macos is
- // active — that includes wide-pointer web browsers, not just Tauri. The
- // earlier "isDesktopApp only" gate left web users on Windows/Linux/Mac
- // desktop with their .header hidden by macos-native.css and no sidebar
- // rendered, so the settings gear and version label vanished.
- const useDesktopShell = this.ctx.isDesktopApp || document.body.classList.contains('is-desktop-macos');
- this.ctx.container.innerHTML = useDesktopShell ? this.buildDesktopLayout() : this.buildWebLayout();
- if (useDesktopShell) {
+ // Tauri uses the macOS sidebar+toolbar shell; web (any browser) uses the
+ // header-bar layout that has its own settings gear and version display.
+ // Earlier attempts to put web on the desktop shell hit too many edge
+ // cases (hidden .header from is-desktop-macos, sidebar collapse from a
+ // stale localStorage flag, toolbar drag regions reading as "menu bars"),
+ // so we keep the two layouts strictly separated.
+ this.ctx.container.innerHTML = this.ctx.isDesktopApp ? this.buildDesktopLayout() : this.buildWebLayout();
+ if (this.ctx.isDesktopApp) {
  document.title = `Crystal Ball v${__APP_VERSION__}`;
  }
  this.createPanels();
- if (useDesktopShell) {
+ if (this.ctx.isDesktopApp) {
  this.renderSidebarUpdateBtn();
  }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -270,19 +270,11 @@ loadDesktopSecrets().then(async () => {
 // Apply stored theme preference before app initialization (safety net for inline script)
 applyStoredTheme();
 
-// Activate the desktop design system (sidebar chrome, wide layout, hover
-// affordances) whenever the client is a fine-pointer desktop-sized viewport,
-// not only in the Tauri build. The class name is historical — "macos" means
-// "the macOS-inspired chrome we use on any desktop browser". Mobile and
-// narrow-tablet browsers keep the default mobile layout.
-function shouldUseDesktopChrome(): boolean {
-  if (isDesktopRuntime() || FORCE_DESKTOP_GATE) return true;
-  if (typeof window === 'undefined') return false;
-  const finePointer = window.matchMedia?.('(pointer: fine)').matches ?? false;
-  const wideEnough = window.innerWidth >= 768;
-  return finePointer && wideEnough;
-}
-if (shouldUseDesktopChrome()) {
+// is-desktop-macos drives a macOS-specific design system that hides
+// .header and replaces it with a sidebar+toolbar shell. Only Tauri builds
+// (or the FORCE_DESKTOP_GATE override) render that shell, so only those
+// builds should set the class. Web browsers keep their own header layout.
+if (isDesktopRuntime() || FORCE_DESKTOP_GATE) {
   document.body.classList.add('is-desktop-macos');
 }
 


### PR DESCRIPTION
PR #89 added `body.is-desktop-macos` to wide-pointer web browsers and PR #93 followed up by routing those browsers to `buildDesktopLayout`. Both changes have caused too many regressions:

- Hidden web `.header` (settings gear lived there)
- Sidebar collapse from a stale `crystalball-sidebar-collapsed` flag carrying over to web
- The `mac-content-toolbar` reading as an unwanted "menu bar"
- Missing settings gear, missing version chip

Reverting both. Web browsers now keep `buildWebLayout` regardless of viewport / pointer type. `is-desktop-macos` is back to Tauri-only. The "web on Windows looks Android" complaint that motivated the original change can be addressed later with media-query CSS that doesn't fight with the layout switch.

**Bonus**: God's Vision had no visible affordance in web. The `#godsVisionBtn` was only rendered inside the desktop sidebar. The toggle already worked via the `G` key and Cmd+K palette (panel-layout delegates clicks on any `#godsVisionBtn` to the `cb:toggle-gods-vision` event), but users with no keyboard discoverability had no path. Added a small "🌍 God's Vision" button to the web header next to the theme toggle so the existing click delegation picks it up.

## Test plan
- [ ] Web on Windows/Mac/Linux desktop browser: header bar visible, settings gear (top-right), version chip visible, copy-link button visible.
- [ ] Web header now also shows "🌍 God's Vision" — clicking enters the 3D globe view.
- [ ] Press `G` from web — toggles God's Vision (already worked, regression check).
- [ ] Tauri desktop: no change — still uses sidebar+toolbar shell, settings in sidebar footer.
- [ ] Web on a phone (touch viewport): mobile layout unchanged.

https://claude.ai/code/session_01UFURjYqassFCPpT8FaWCLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFURjYqassFCPpT8FaWCLC)_