### PR TITLE
fix(web): reset-cache button on staleness banner + honest auto-register UX

### DIFF
--- a/src/components/RuntimeConfigPanel.ts
+++ b/src/components/RuntimeConfigPanel.ts
@@ -487,7 +487,7 @@ export class RuntimeConfigPanel extends Panel {
  return `
  <details class="reg-profile-section">
  <summary class="reg-profile-summary">
- Registered as: ${escapeHtml(profile.firstName)} ${escapeHtml(profile.lastName)} (${escapeHtml(profile.email)})
+ Saved as: ${escapeHtml(profile.firstName)} ${escapeHtml(profile.lastName)} (${escapeHtml(profile.email)})
  <span class="reg-profile-edit-hint">— click to edit</span>
  </summary>
  <div class="reg-profile-form">
@@ -497,9 +497,11 @@ export class RuntimeConfigPanel extends Panel {
  <input type="text" class="reg-profile-input" data-reg-field="organization" placeholder="Organization (optional)" value="${escapeHtml(profile.organization)}">
  <div class="reg-profile-actions">
  <button type="button" class="reg-profile-save-btn" data-reg-save>Save Profile</button>
+ <button type="button" class="reg-profile-save-btn" data-reg-copy>Copy Email</button>
  <button type="button" class="reg-profile-clear-btn" data-reg-clear>Clear</button>
  </div>
  <span class="reg-profile-status"></span>
+ <p class="reg-profile-explainer">Cross-origin browsers block auto-fill into provider signup pages. We open the provider's tab and copy your email to your clipboard so you can paste it in seconds.</p>
  </div>
  </details>
  `;
@@ -507,7 +509,7 @@ export class RuntimeConfigPanel extends Panel {
  return `
  <details class="reg-profile-section">
  <summary class="reg-profile-summary">
- Save your info once to auto-register for API keys
+ Save your info once for faster API key signups
  <span class="reg-profile-edit-hint">— click to set up</span>
  </summary>
  <div class="reg-profile-form">
@@ -531,6 +533,7 @@ export class RuntimeConfigPanel extends Panel {
   private attachProfileListeners(): void {
  const saveBtn = this.content.querySelector<HTMLButtonElement>('[data-reg-save]');
  const clearBtn = this.content.querySelector<HTMLButtonElement>('[data-reg-clear]');
+ const copyBtn = this.content.querySelector<HTMLButtonElement>('[data-reg-copy]');
  const statusEl = this.content.querySelector<HTMLSpanElement>('.reg-profile-status');
 
  saveBtn?.addEventListener('click', () => {
@@ -547,6 +550,19 @@ export class RuntimeConfigPanel extends Panel {
  saveRegistrationProfile(profile);
  if (statusEl) statusEl.textContent = 'Profile saved';
  this.render();
+ });
+
+ copyBtn?.addEventListener('click', () => {
+ const profile = getRegistrationProfile();
+ if (!profile?.email) {
+ if (statusEl) statusEl.textContent = 'No email to copy';
+ return;
+ }
+ void navigator.clipboard?.writeText(profile.email).then(() => {
+ if (statusEl) statusEl.textContent = `Copied ${profile.email} to clipboard`;
+ }).catch(() => {
+ if (statusEl) statusEl.textContent = 'Clipboard write failed';
+ });
  });
 
  clearBtn?.addEventListener('click', () => {
@@ -709,6 +725,14 @@ export class RuntimeConfigPanel extends Panel {
  e.preventDefault();
  const url = link.dataset.signupUrl;
  if (!url) return;
+ // Best-effort: copy the saved registration email to the clipboard
+ // before opening the provider tab. Cross-origin browsers won't let
+ // us autofill the form, but a one-keystroke paste is the closest
+ // thing to "auto-register" we can deliver in a web build.
+ const profile = getRegistrationProfile();
+ if (profile?.email) {
+ void navigator.clipboard?.writeText(profile.email).catch(() => { /* no clipboard; ignore */ });
+ }
  if (isDesktopRuntime()) {
  void invokeTauri<void>('open_url', { url }).catch((error: unknown) => {
  // eslint-disable-next-line no-console -- user action failure diagnostics

--- a/src/components/StalenessBanner.ts
+++ b/src/components/StalenessBanner.ts
@@ -180,8 +180,26 @@ export class StalenessBanner {
  // safe-html: timeText comes from date formatting, message is built from constants
  this.el.innerHTML = `
  <div class="staleness-message">${message}</div>
+ <button class="staleness-reset" aria-label="Reset cache and reload" title="Clear local cache + service worker, then reload">Reset cache</button>
  <button class="staleness-dismiss" aria-label="Dismiss staleness banner">\u00D7</button>
  `;
+ // Recovery button: stuck-banner reports usually trace back to a stale
+ // service-worker bundle from before a deploy that fixed the underlying
+ // fetch failures. Unregister every SW + purge every cache + reload.
+ const resetBtn = this.el.querySelector<HTMLButtonElement>('.staleness-reset');
+ resetBtn?.addEventListener('click', () => {
+ void (async () => {
+ resetBtn.disabled = true;
+ resetBtn.textContent = 'Clearing\u2026';
+ try {
+ const regs = await navigator.serviceWorker?.getRegistrations();
+ await Promise.all((regs ?? []).map((r) => r.unregister()));
+ const keys = await caches.keys();
+ await Promise.all(keys.map((k) => caches.delete(k)));
+ } catch { /* best-effort */ }
+ location.reload();
+ })();
+ });
 
  // Update details if expanded
  if (this.expanded) {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -14811,6 +14811,27 @@ body.has-critical-banner .panels-grid {
   background: rgba(255, 255, 255, 0.3);
 }
 
+.staleness-reset {
+  background: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: inherit;
+  padding: 3px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+.staleness-reset:hover { background: rgba(255, 255, 255, 0.3); }
+.staleness-reset:disabled { opacity: 0.6; cursor: wait; }
+
+.reg-profile-explainer {
+  margin: 6px 0 0;
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
 .staleness-pulse-dot {
   display: inline-block;
   width: 8px;


### PR DESCRIPTION
Three open user complaints bundled into one PR.

**1. "Data feeds paused" stuck on screen + "Still no map in 2D mode."** Both regularly trace back to a stale service-worker bundle from before a deploy that fixed the underlying fetch failures. Added a **Reset cache** button right inside the banner — unregisters every active SW + purges every Cache Storage entry + reloads. One click recovery from anywhere on the page.

**2. "Auto API key registering doesn't work."** Cross-origin browsers block any auto-fill into a provider's signup page, so the previous "Save your info once to auto-register" copy was promising something we can't deliver. Reworded to "Save your info once for faster API key signups" and added an inline explainer that says exactly what's happening.

**3. Friction when signing up at provider sites.** When the user clicks "Open signup page" we now best-effort copy their saved email to the clipboard before opening the provider tab — paste in the email field with one keystroke. A standalone "Copy Email" button gives the same shortcut on demand from the profile section.

## Test plan
- [ ] Trigger the staleness banner → "Reset cache" button appears next to the dismiss × — clicking it unregisters SW, clears caches, reloads.
- [ ] Settings → API Keys with a saved profile: header reads "Saved as: …" not "Registered as: …"; "Copy Email" button works; explainer paragraph reads honestly.
- [ ] Click "Open signup page" with a saved profile email → tab opens AND clipboard has the email (verify with Cmd+V in any text field).
- [ ] No saved profile + click "Open signup page" → tab still opens, clipboard untouched.

https://claude.ai/code/session_01UFURjYqassFCPpT8FaWCLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFURjYqassFCPpT8FaWCLC)_