### PR TITLE
fix: reduce diagnostic noise and fix edge-case crashes

### DIFF
--- a/src/app/refresh-scheduler.ts
+++ b/src/app/refresh-scheduler.ts
@@ -98,7 +98,7 @@ export class RefreshScheduler implements AppModule {
  const elapsed = performance.now() - refreshStart;
  // eslint-disable-next-line no-console
  console.error(`[App] Refresh ${name} failed after ${Math.round(elapsed)}ms:`, error);
- currentMultiplier = 1;
+ currentMultiplier = Math.min(currentMultiplier * 2, MAX_BACKOFF_MULTIPLIER);
  } finally {
  this.ctx.inFlight.delete(name);
  scheduleNext(computeDelay(intervalMs * currentMultiplier, isHidden));

--- a/src/bootstrap/chunk-reload.ts
+++ b/src/bootstrap/chunk-reload.ts
@@ -30,19 +30,21 @@ export function installChunkReloadGuard(
   const reload = options.reload ?? (() => window.location.reload());
 
   eventTarget.addEventListener(eventName, (event: Event) => {
- // Log the underlying failure so we can see what chunk/URL failed to preload.
- // Without this, we only see the symptom (a reload) and never the cause.
  const detail = (event as Event & { payload?: { message?: string } }).payload;
  const message = detail?.message ?? (event as unknown as { message?: string }).message ?? 'unknown';
- console.error(`[chunk-reload] vite:preloadError: ${message}`, event);
 
- // In Tauri, all chunks are bundled into the binary at build time. A reload
- // cannot fix a missing/broken chunk — it just re-runs vault intro and
- // leaves the user staring at a dead app. Skip the reload entirely.
+ // In Tauri, all chunks are bundled into the binary — a reload can't fix
+ // a missing chunk. Optional dynamic imports (e.g. @tauri-apps/plugin-notification)
+ // trigger this harmlessly; demote to warn so it doesn't flood error logs.
  const isTauri =
  typeof window !== 'undefined' &&
  ('__TAURI_INTERNALS__' in window || '__TAURI__' in window);
- if (isTauri) return;
+ if (isTauri) {
+ console.warn(`[chunk-reload] preload skipped (Tauri): ${message}`);
+ return;
+ }
+
+ console.error(`[chunk-reload] vite:preloadError: ${message}`, event);
 
  if (storage.getItem(storageKey)) return;
  storage.setItem(storageKey, '1');

--- a/src/services/financial-contagion.ts
+++ b/src/services/financial-contagion.ts
@@ -377,10 +377,15 @@ export async function getContagionModel(): Promise<ContagionModel> {
 
   // Compute measured channels
   for (const def of CHANNEL_DEFS) {
+ try {
  const { stress, dataPoints } = def.compute(ecoData);
  const trend = computeTrend(def.id, stress, history);
  channels.push({ channel: def.label, stressLevel: Math.round(stress), trend, dataPoints });
  stressMap.set(def.id, stress);
+ } catch {
+ channels.push({ channel: def.label, stressLevel: 0, trend: 'stable' as const, dataPoints: [] });
+ stressMap.set(def.id, 0);
+ }
   }
 
   // Compute synthetic channels

--- a/src/services/maritime/index.ts
+++ b/src/services/maritime/index.ts
@@ -30,10 +30,10 @@ function toDisruptionEvent(proto: ProtoDisruption): AisDisruptionEvent {
   return {
  id: proto.id,
  name: proto.name,
- type: DISRUPTION_TYPE_REVERSE[proto.type] || 'gap_spike',
+ type: DISRUPTION_TYPE_REVERSE[proto.type] ?? 'gap_spike',
  lat: proto.location?.latitude ?? 0,
  lon: proto.location?.longitude ?? 0,
- severity: SEVERITY_REVERSE[proto.severity] || 'low',
+ severity: SEVERITY_REVERSE[proto.severity] ?? 'low',
  changePct: proto.changePct,
  windowHours: proto.windowHours,
  darkShips: proto.darkShips,
@@ -135,13 +135,13 @@ const MAX_CALLBACK_TRACKED_VESSELS = 20_000;
 // ---- Raw Relay URL (for candidate reports path) ----
 
 const SNAPSHOT_PROXY_URL = '/api/ais-snapshot';
-const wsRelayUrl = import.meta.env.VITE_WS_RELAY_URL || '';
+const wsRelayUrl = (import.meta.env.VITE_WS_RELAY_URL as string | undefined) ?? '';
 const DIRECT_RAILWAY_SNAPSHOT_URL = wsRelayUrl
   ? wsRelayUrl.replace('wss://', 'https://').replace('ws://', 'http://').replace(/\/$/, '') + '/ais/snapshot'
   : '';
 const LOCAL_SNAPSHOT_FALLBACK = 'http://127.0.0.1:3004/ais/snapshot';
-// eslint-disable-next-line no-restricted-syntax -- intentional: runtime detection, localhost never reached in WKWebView
-const isLocalhost = isClientRuntime && window.location.hostname === 'localhost';
+// eslint-disable-next-line no-restricted-syntax -- intentional: runtime detection for dev fallback
+const isLocalhost = isClientRuntime && ['localhost', '127.0.0.1'].includes(window.location.hostname);
 
 // ---- Internal Helpers ----
 
@@ -161,7 +161,7 @@ function parseSnapshot(data: unknown): {
 
   if (!Array.isArray(raw.disruptions) || !Array.isArray(raw.density)) return null;
 
-  const status = raw.status || {};
+  const status = raw.status ?? {};
   return {
  sequence: Number.isFinite(raw.sequence as number) ? Number(raw.sequence) : 0,
  status: {
@@ -220,8 +220,8 @@ async function fetchSnapshotPayload(includeCandidates: boolean): Promise<unknown
  return {
  sequence: 0, // Proto payload does not include relay sequence.
  status: { connected: true, vessels: 0, messages: 0 },
- disruptions: response.snapshot.disruptions.map(toDisruptionEvent),
- density: response.snapshot.densityZones.map(toDensityZone),
+ disruptions: response.snapshot.disruptions.map((d) => toDisruptionEvent(d)),
+ density: response.snapshot.densityZones.map((z) => toDensityZone(z)),
  candidateReports: [],
  };
  }
@@ -266,7 +266,7 @@ function emitCandidateReports(reports: SnapshotCandidateReport[]): void {
  if (!report?.mmsi || !Number.isFinite(report.lat) || !Number.isFinite(report.lon)) continue;
 
  const reportTs = Number.isFinite(report.timestamp) ? Number(report.timestamp) : now;
- const lastTs = lastCallbackTimestampByMmsi.get(report.mmsi) || 0;
+ const lastTs = lastCallbackTimestampByMmsi.get(report.mmsi) ?? 0;
  if (reportTs <= lastTs) continue;
 
  lastCallbackTimestampByMmsi.set(report.mmsi, reportTs);
@@ -315,10 +315,7 @@ async function pollSnapshot(force = false): Promise<void> {
  lastPollAt = Date.now();
 
  if (includeCandidates) {
- if (snapshot.sequence > lastSequence) {
- emitCandidateReports(snapshot.candidateReports);
- lastSequence = snapshot.sequence;
- } else if (lastSequence === 0) {
+ if (snapshot.sequence > lastSequence || lastSequence === 0) {
  emitCandidateReports(snapshot.candidateReports);
  lastSequence = snapshot.sequence;
  }

--- a/src/services/telegram-intel.ts
+++ b/src/services/telegram-intel.ts
@@ -1,6 +1,11 @@
 import { proxyUrl } from '@/utils';
 import { isDesktopRuntime } from '@/services/runtime';
 
+const DISABLED_RESPONSE: TelegramFeedResponse = {
+  source: 'telegram', earlySignal: false, enabled: false,
+  count: 0, updatedAt: null, items: [],
+};
+
 export interface TelegramItem {
   id: string;
   source: 'telegram';
@@ -43,12 +48,15 @@ function telegramFeedUrl(limit: number): string {
 }
 
 export async function fetchTelegramFeed(limit = 50): Promise<TelegramFeedResponse> {
+  // No sidecar route for telegram-feed on desktop — skip to avoid 60s error spam
+  if (isDesktopRuntime()) return DISABLED_RESPONSE;
+
   if (cachedResponse && Date.now() - cachedAt < CACHE_TTL) return cachedResponse;
 
   const res = await fetch(telegramFeedUrl(limit));
   if (!res.ok) throw new Error(`Telegram feed ${res.status}`);
 
-  const json: TelegramFeedResponse = await res.json();
+  const json = (await res.json()) as TelegramFeedResponse;
   cachedResponse = json;
   cachedAt = Date.now();
   return json;


### PR DESCRIPTION
## Changes

- **Telegram intel**: Gate fetch on desktop (no sidecar route exists) — eliminates 60s error spam
- **Chunk reload**: Demote `vite:preloadError` to warn in Tauri context — `@tauri-apps/plugin-notification` dynamic import is expected to fail
- **Refresh scheduler**: Back off on errors (x2 up to 4x) instead of resetting multiplier to 1 — stops hammering failing endpoints
- **Financial contagion**: Wrap individual channel `.compute()` calls so one failure doesn't crash the whole model
- **Maritime**: Fix localhost detection to include `127.0.0.1` for WKWebView + clean up pre-existing lint errors

## Impact
Significantly reduces log noise from expected failures (missing API keys, unavailable upstream services, desktop-only gaps). Failing fetches now back off progressively instead of retrying at minimum interval.