### PR TITLE
feat(desktop): route critical alerts to iMessage via Messages app

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -918,6 +918,75 @@ fn send_notification(webview: Webview, title: String, body: String, sound: Optio
  }
 }
 
+/// Send an iMessage / SMS to a contact via the user's signed-in macOS Messages
+/// app. No-op on non-macOS. Reuses the same sanitization, length-cap, and
+/// trusted-window pattern as send_notification — recipient and body are
+/// stripped of AppleScript-meaningful characters before interpolation, so a
+/// hostile body string can't escape the quoted literal and run extra
+/// statements.
+///
+/// Rate-limited to 1 message per 30 seconds (shared with the notification
+/// limiter) so a runaway alert source can't burn through the user's Messages.
+#[tauri::command]
+fn send_imessage(webview: Webview, recipient: String, body: String) -> Result<(), String> {
+ require_trusted_window(webview.label())?;
+ #[cfg(not(target_os = "macos"))]
+ {
+ let _ = (recipient, body);
+ return Err("iMessage is only available on macOS".to_string());
+ }
+ #[cfg(target_os = "macos")]
+ {
+ {
+ let mut last = NOTIFICATION_LAST_SENT.lock().unwrap_or_else(|p| p.into_inner());
+ if let Some(t) = *last {
+ if t.elapsed() < NOTIFICATION_RATE_LIMIT {
+ return Err("Rate limit: too soon since the last alert".to_string());
+ }
+ }
+ *last = Some(Instant::now());
+ }
+
+ let recipient = truncate_to_bytes(&recipient, 64);
+ let body = truncate_to_bytes(&body, 512);
+ if recipient.trim().is_empty() {
+ return Err("Recipient is required".to_string());
+ }
+ if body.trim().is_empty() {
+ return Err("Message body is required".to_string());
+ }
+
+ let sanitize = |s: &str| -> String {
+ s.chars()
+ .filter(|c| !matches!(c, '"' | '\\' | '\n' | '\r' | '\x00'..='\x1f'))
+ .collect()
+ };
+ let safe_recipient = sanitize(&recipient);
+ let safe_body = sanitize(&body);
+
+ // Use the iMessage service explicitly — falls back gracefully if the
+ // recipient is only reachable via SMS by erroring inside Messages.
+ let script = format!(
+ r#"tell application "Messages"
+  set targetService to 1st service whose service type = iMessage
+  set targetBuddy to buddy "{safe_recipient}" of targetService
+  send "{safe_body}" to targetBuddy
+end tell"#
+ );
+
+ let status = Command::new("osascript")
+ .args(["-e", &script])
+ .stdout(Stdio::null())
+ .stderr(Stdio::null())
+ .status()
+ .map_err(|e| format!("osascript spawn failed: {e}"))?;
+ if !status.success() {
+ return Err("Messages app rejected the send (recipient unreachable, not signed in, or blocked)".to_string());
+ }
+ Ok(())
+ }
+}
+
 /// Download a macOS DMG release, mount it, copy the app bundle to /Applications, and relaunch.
 /// On non-macOS platforms returns an error immediately (no-op — only called on macOS).
 #[cfg(target_os = "macos")]
@@ -2205,6 +2274,7 @@ fn main() {
  open_youtube_logout,
  fetch_polymarket,
  send_notification,
+ send_imessage,
  install_update,
  update_mode_label
  ])

--- a/src/app/desktop-notifications.ts
+++ b/src/app/desktop-notifications.ts
@@ -3,6 +3,7 @@ import type { BreakingAlert } from '@/services/breaking-news-alerts';
 import { tryInvokeTauri } from '@/services/tauri-bridge';
 import { getAlertSettings } from '@/services/breaking-news-alerts';
 import { isGhostMode } from '@/services/mode-manager';
+import { getImessageSettings, sendImessage } from '@/services/imessage-bridge';
 
 /**
  * Routes breaking alerts to native macOS notifications on desktop (osascript
@@ -37,6 +38,7 @@ export class DesktopNotifications implements AppModule {
  document.removeEventListener('wm:breaking-news', this.boundHandler);
   }
 
+  // eslint-disable-next-line sonarjs/cognitive-complexity -- threshold gating + native + web + iMessage paths inline
   private async onBreakingNews(alert: BreakingAlert): Promise<void> {
  if (isGhostMode()) return;  // Ghost Mode: notifications suppressed
  const settings = getAlertSettings();
@@ -51,6 +53,22 @@ export class DesktopNotifications implements AppModule {
  body,
  sound,
  });
+ // Best-effort iMessage routing if the user has it configured. Threshold
+ // gating happens here so we never wake the user's phone for a 'high' if
+ // they only opted into 'critical'.
+ const imSettings = getImessageSettings();
+ if (imSettings.enabled && imSettings.recipient) {
+ const meetsThreshold = imSettings.threshold === 'critical'
+ ? alert.threatLevel === 'critical'
+ : alert.threatLevel === 'critical' || alert.threatLevel === 'high';
+ if (meetsThreshold) {
+ const result = await sendImessage(imSettings.recipient, `Crystal Ball: ${body}`);
+ if (!result.ok) {
+ // eslint-disable-next-line no-console -- best-effort relay; user-actionable failure
+ console.warn('[imessage] alert relay failed', result.reason);
+ }
+ }
+ }
  return;
  }
 

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -10,6 +10,7 @@ import type { PanelConfig } from '@/types';
 import { RuntimeConfigPanel } from './RuntimeConfigPanel';
 import type { StatusPanel } from './StatusPanel';
 import { isYouTubeConnected, signInToYouTube, signOutOfYouTube, initYouTubeAccountListeners } from '@/services/youtube-account';
+import { getImessageSettings, saveImessageSettings, sendImessage, type ImessageThreshold } from '@/services/imessage-bridge';
 import { getApiBaseUrl } from '@/services/runtime';
 import { tryInvokeTauri, invokeTauri } from '@/services/tauri-bridge';
 import {
@@ -261,6 +262,23 @@ export class UnifiedSettings {
  return;
  }
 
+ // iMessage relay test send + threshold change handled elsewhere.
+ if (target.id === 'us-imessage-test') {
+ const recipient = (this.overlay.querySelector<HTMLInputElement>('#us-imessage-recipient')?.value ?? '').trim();
+ const statusEl = this.overlay.querySelector<HTMLElement>('#us-imessage-status');
+ if (!recipient) {
+ if (statusEl) statusEl.textContent = 'Enter a recipient first.';
+ return;
+ }
+ if (statusEl) statusEl.textContent = 'Sending…';
+ const btn = target as HTMLButtonElement;
+ btn.disabled = true;
+ void sendImessage(recipient, 'Crystal Ball test message — alert routing is wired up.').then((result) => {
+ if (statusEl) statusEl.textContent = result.ok ? 'Sent.' : `Failed: ${result.reason ?? 'unknown error'}`;
+ }).finally(() => { btn.disabled = false; });
+ return;
+ }
+
  // Places tab actions
  const placesAction = target.closest<HTMLElement>('[data-places-action]')?.dataset.placesAction;
  if (placesAction) {
@@ -373,6 +391,16 @@ export class UnifiedSettings {
  localStorage.setItem('wm-debug-log', target.checked ? '1' : '0');
  } else if (target.id === 'us-auto-refresh') {
  if (target.checked) this._startDebugAutoRefresh(); else this._stopDebugAutoRefresh();
+ } else if (target.id === 'us-imessage-enabled') {
+ const cur = getImessageSettings();
+ saveImessageSettings({ ...cur, enabled: target.checked });
+ } else if (target.id === 'us-imessage-recipient') {
+ const cur = getImessageSettings();
+ saveImessageSettings({ ...cur, recipient: target.value });
+ } else if (target.id === 'us-imessage-threshold') {
+ const cur = getImessageSettings();
+ const next = target.value === 'high+critical' ? 'high+critical' : 'critical';
+ saveImessageSettings({ ...cur, threshold: next as ImessageThreshold });
  }
  });
 
@@ -663,6 +691,34 @@ export class UnifiedSettings {
  <div class="ai-flow-toggle-desc">${this.config.isDesktopApp ? desktopCopy : webCopy}</div>
  </div>
  <div class="yt-account-status">${this._renderYtStatus(connected)}</div>
+ </div>`;
+ }
+
+ // iMessage relay (macOS desktop only — Apple has no API for the web)
+ if (this.config.isDesktopApp) {
+ const im = getImessageSettings();
+ const recipientVal = escapeHtml(im.recipient);
+ const checkedAttr = im.enabled ? 'checked' : '';
+ const critSel = im.threshold === 'critical' ? ' selected' : '';
+ const highSel = im.threshold === 'high+critical' ? ' selected' : '';
+ html += `<div class="ai-flow-section-label">iMessage alerts</div>`;
+ html += `<div class="ai-flow-toggle-row imessage-row" style="flex-direction:column;align-items:flex-start;gap:6px">
+ <div class="ai-flow-toggle-label-wrap" style="width:100%;display:flex;align-items:center;justify-content:space-between;gap:8px;">
+ <div>
+ <div class="ai-flow-toggle-label">Route critical alerts to iMessage</div>
+ <div class="ai-flow-toggle-desc">Sends through your signed-in macOS Messages app. Rate-limited to 1 per 30s. Requires the Messages app to be open and signed in.</div>
+ </div>
+ <label class="ai-flow-switch"><input type="checkbox" id="us-imessage-enabled" ${checkedAttr}><span></span></label>
+ </div>
+ <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;width:100%;">
+ <input id="us-imessage-recipient" type="text" placeholder="Phone, email, or contact name" value="${recipientVal}" style="flex:1 1 220px;min-width:160px;padding:4px 6px;background:var(--bg-secondary);border:1px solid var(--border-color);border-radius:4px;color:var(--text-primary)">
+ <select id="us-imessage-threshold" style="padding:4px 6px;background:var(--bg-secondary);border:1px solid var(--border-color);border-radius:4px;color:var(--text-primary)">
+ <option value="critical"${critSel}>Critical only</option>
+ <option value="high+critical"${highSel}>High + Critical</option>
+ </select>
+ <button type="button" id="us-imessage-test" class="yt-account-btn connect" style="min-width:60px">Test</button>
+ <span id="us-imessage-status" style="font-size:11px;color:var(--text-muted);min-height:14px;"></span>
+ </div>
  </div>`;
  }
 

--- a/src/services/imessage-bridge.ts
+++ b/src/services/imessage-bridge.ts
@@ -1,0 +1,66 @@
+/**
+ * iMessage Bridge — desktop-only routing of breaking alerts to the user's
+ * signed-in macOS Messages app via the Tauri `send_imessage` command.
+ *
+ * Web builds can't fire iMessages (Apple has no public API; the route shells
+ * out to AppleScript on macOS only). All settings are stored in localStorage
+ * so the toggle survives reloads.
+ */
+
+import { tryInvokeTauri } from './tauri-bridge';
+import { isDesktopRuntime } from './runtime';
+
+const SETTINGS_KEY = 'crystalball-imessage-settings';
+
+export type ImessageThreshold = 'critical' | 'high+critical';
+
+export interface ImessageSettings {
+  enabled: boolean;
+  recipient: string;
+  threshold: ImessageThreshold;
+}
+
+const DEFAULTS: ImessageSettings = {
+  enabled: false,
+  recipient: '',
+  threshold: 'critical',
+};
+
+export function getImessageSettings(): ImessageSettings {
+  try {
+ const raw = localStorage.getItem(SETTINGS_KEY);
+ if (!raw) return { ...DEFAULTS };
+ const parsed = JSON.parse(raw) as Partial<ImessageSettings>;
+ return {
+ enabled: parsed.enabled === true,
+ recipient: typeof parsed.recipient === 'string' ? parsed.recipient : '',
+ threshold: parsed.threshold === 'high+critical' ? 'high+critical' : 'critical',
+ };
+  } catch {
+ return { ...DEFAULTS };
+  }
+}
+
+export function saveImessageSettings(s: ImessageSettings): void {
+  localStorage.setItem(SETTINGS_KEY, JSON.stringify(s));
+}
+
+/**
+ * Send a one-off iMessage. Returns `{ ok: true }` on success or
+ * `{ ok: false, reason }` on failure. Never throws — callers can ignore
+ * failures or surface them to the user.
+ */
+export async function sendImessage(recipient: string, body: string): Promise<{ ok: boolean; reason?: string }> {
+  if (!isDesktopRuntime()) return { ok: false, reason: 'iMessage routing requires the macOS desktop build' };
+  if (!recipient.trim()) return { ok: false, reason: 'Recipient is required' };
+  if (!body.trim()) return { ok: false, reason: 'Body is required' };
+  try {
+ const result = await tryInvokeTauri<void>('send_imessage', { recipient: recipient.trim(), body });
+ // tryInvokeTauri returns null on bridge unavailable. The native command
+ // returns Ok(()) on success or Err string on send failure (which becomes
+ // a thrown Error caught inside tryInvokeTauri).
+ return result === null ? { ok: false, reason: 'Tauri bridge unavailable' } : { ok: true };
+  } catch (error) {
+ return { ok: false, reason: error instanceof Error ? error.message : String(error) };
+  }
+}


### PR DESCRIPTION
macOS desktop-only — Apple has no public API for iMessage on the web, and reading `~/Library/Messages/chat.db` for a receive direction is too privacy-fraught to ship.

**Rust (`src-tauri/src/main.rs`).** New `send_imessage` Tauri command that shells out to `osascript` and tells Messages.app to send a single line to a configured iMessage contact. Reuses the existing `send_notification` hardening pattern verbatim:
- Trusted-window gating (`require_trusted_window`).
- Length caps: recipient ≤64 bytes, body ≤512 bytes.
- AppleScript-meta character stripping: `"`, `\`, newlines, all `\x00..\x1f` control chars.
- 30-second rate limit (shared with the notification limiter) so a runaway alert source can't burn through the user's Messages.
- Returns `Err(...)` strings instead of panicking on failure so the JS layer can surface what went wrong.

**Frontend.**
- `src/services/imessage-bridge.ts` persists settings (`enabled`, `recipient`, `threshold`) in localStorage. `sendImessage()` returns `{ ok, reason }` and never throws.
- `src/app/desktop-notifications.ts` `onBreakingNews()` now also fires an iMessage when configured. Threshold-gated: Critical-only (default) or High + Critical.
- `src/components/UnifiedSettings.ts` adds a desktop-only "iMessage alerts" section in Settings → General with a toggle, recipient field, threshold dropdown, and a Test button that fires a one-off message to confirm wiring before the user relies on it.

No web counterpart and none possible — the section just doesn't render in the browser build.

## Test plan
- [ ] macOS desktop: Settings → General → iMessage alerts visible. Web build: section absent.
- [ ] Enter a recipient (phone, email, or contact name), hit **Test** → Messages.app sends "Crystal Ball test message — alert routing is wired up." within seconds. Status field updates to "Sent."
- [ ] Bad recipient → Test surfaces "Failed: Messages app rejected the send (recipient unreachable, not signed in, or blocked)".
- [ ] Toggle off → no iMessage fires when a critical alert lands.
- [ ] Threshold = "Critical only" + a `high` alert → no iMessage. Switch to "High + Critical" → next high alert fires.
- [ ] Two critical alerts within 30s → only the first relays (rate-limited).
- [ ] Web build: no module errors at boot, `getImessageSettings()` returns defaults, `sendImessage()` returns `{ ok: false, reason: 'iMessage routing requires the macOS desktop build' }`.

https://claude.ai/code/session_01UFURjYqassFCPpT8FaWCLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFURjYqassFCPpT8FaWCLC)_