### PR TITLE
Fix macOS LaunchServices packaging

### DIFF
--- a/scripts/desktop-package.mjs
+++ b/scripts/desktop-package.mjs
@@ -193,6 +193,24 @@ const verifyMacCodeSignature = (artifactPath, label, args = ['--verify', '--deep
   }
 };
 
+const ensureModernMacLaunchServicesPlist = (appPath, allowMutation) => {
+  if (process.platform !== 'darwin') return;
+  const plistPath = path.join(appPath, 'Contents', 'Info.plist');
+  const printResult = runCapture('/usr/libexec/PlistBuddy', ['-c', 'Print :LSRequiresCarbon', plistPath]);
+  const currentValue = (printResult.stdout || '').trim();
+  if (currentValue === 'false' || currentValue === '') return;
+  if (!allowMutation) {
+    throw new Error('App bundle Info.plist still has LSRequiresCarbon=true; fix src-tauri/Info.plist before signing.');
+  }
+  let result = runCapture('/usr/libexec/PlistBuddy', ['-c', 'Set :LSRequiresCarbon false', plistPath]);
+  if ((result.status ?? 1) !== 0) {
+    result = runCapture('/usr/libexec/PlistBuddy', ['-c', 'Add :LSRequiresCarbon bool false', plistPath]);
+  }
+  if ((result.status ?? 1) !== 0) {
+    throw new Error((result.stderr || result.stdout || '').trim() || 'Failed to clear LSRequiresCarbon in app bundle');
+  }
+};
+
 if (targetOs === 'macos') {
   const bundleRoot = path.join('src-tauri', 'target', 'release', 'bundle');
   const appDir = path.join(bundleRoot, 'macos');
@@ -210,6 +228,7 @@ if (targetOs === 'macos') {
   const bundleVersion = env.npm_package_version;
   const archSuffix = process.arch === 'arm64' ? 'aarch64' : process.arch;
   const dmgPath = path.join(dmgDir, `${variantProductName}_${bundleVersion}_${archSuffix}.dmg`);
+  ensureModernMacLaunchServicesPlist(appPath, !sign);
 
   try {
  verifyMacCodeSignature(appPath, 'App bundle');

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -18,5 +18,9 @@
   <!-- Required for macOS Core Location permission prompt -->
   <key>NSLocationWhenInUseUsageDescription</key>
   <string>Crystal Ball uses your location to center panels and weather data on your home.</string>
+
+  <!-- Modern macOS LaunchServices should treat Crystal Ball as a Cocoa app. -->
+  <key>LSRequiresCarbon</key>
+  <false/>
 </dict>
 </plist>

--- a/tests/desktop-package-signing.test.mjs
+++ b/tests/desktop-package-signing.test.mjs
@@ -40,6 +40,11 @@ test('macOS desktop packaging signs and verifies the app bundle before creating 
   );
   assert.match(
  desktopPackageScript,
+ /Set :LSRequiresCarbon false/,
+ 'local macOS packaging should clear the obsolete Carbon launch flag before ad-hoc signing',
+  );
+  assert.match(
+ desktopPackageScript,
  /hdiutil["']?,?\s*\[[^\]]*create/s,
  'macOS packaging should create the dmg after the app bundle has been signed and verified',
   );


### PR DESCRIPTION
Fixes macOS app bundle LaunchServices metadata so downloaded builds do not advertise the obsolete Carbon requirement.

Verification:
- npm run secrets:scan:staged
- npm run typecheck
- npx eslint scripts/desktop-package.mjs tests/desktop-package-signing.test.mjs
- npx tsx --test tests/desktop-package-signing.test.mjs tests/install-built-app.test.mjs
- commit hook: lint:conflicts, secrets:scan:staged, typecheck:all, lint-staged

Notes:
- npm run lint currently fails on pre-existing repo-wide baseline issues unrelated to this commit.
- npm run build is blocked locally by sandbox EPERM on node_modules/.vite-temp; GitHub should run it in a normal workspace.