### PR TITLE
fix: use stable alert ID for row click instead of positional index

### DIFF
--- a/src/components/UnifiedAlertInboxPanel.ts
+++ b/src/components/UnifiedAlertInboxPanel.ts
@@ -327,14 +327,11 @@ export class UnifiedAlertInboxPanel extends Panel {
  }
 
  // Row click: open link or show evidence drawer
- const row = target.closest('tr[data-alert-index]') as HTMLElement | null;
+ const row = target.closest('tr[data-alert-id]') as HTMLElement | null;
  if (row) {
- const idx = Number.parseInt(row.dataset.alertIndex!, 10);
- const alerts = this.getFilteredAlerts();
- const deduped = this.dedupByEntity(alerts);
- const group = deduped[idx];
- if (!group) return false;
- const alert = group.leader;
+ const alertId = row.dataset.alertId!;
+ const alert = unifiedAlertStore.getAll().find(a => a.id === alertId);
+ if (!alert) return false;
 
  // If alert has a link, open it
  const safeLink = alert.link?.startsWith('https://') ? alert.link : null;
@@ -579,7 +576,7 @@ export class UnifiedAlertInboxPanel extends Panel {
  .filter(Boolean)
  .join(' ');
 
- return `<tr class="${rowClasses}" data-alert-index="${index}">
+ return `<tr class="${rowClasses}" data-alert-index="${index}" data-alert-id="${esc(alert.id)}">
  <td class="ac-sev">${sevPill}</td>
  <td class="uai-src-cell">${srcTag}</td>
  <td class="uai-title-cell">

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -19286,8 +19286,8 @@ body.gods-vision-lock .replay-scrubber { display: none; }
 }
 
 /* ── Alert Inbox row interactivity ─────────────────────────────── */
-tr[data-alert-index] { cursor: pointer; }
-tr[data-alert-index]:hover { background: rgba(255,255,255,0.04); }
+tr[data-alert-id] { cursor: pointer; }
+tr[data-alert-id]:hover { background: rgba(255,255,255,0.04); }
 tr.uai-expanded .uai-body { max-height: none; white-space: normal; overflow: visible; }
 
 /* ── Related badge in Inbox ─────────────────────────────────────── */


### PR DESCRIPTION
## Auto-generated PR from `claude/stable-alert-row-id`

**Files changed:** 2

### Commits
```
ed4798c5 fix: use stable alert ID for row click instead of positional index
```

---
> This PR was created automatically when the branch was pushed. Review and merge when ready, or close if superseded.
