### PR TITLE
Restore PR ESLint signal

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -9,9 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: 22
           cache: npm
       - run: npm ci
-      - run: npm run lint
+      - run: npm run lint:ci

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "secrets:scan": "node scripts/secret-scan.mjs",
     "secrets:scan:staged": "node scripts/secret-scan.mjs --staged",
     "lint": "eslint .",
+    "lint:ci": "node scripts/lint-changed.mjs",
     "lint:fix": "eslint . --fix",
     "lockfile:check": "node scripts/check-package-lock.mjs",
     "bundle:check": "node scripts/check-bundle-size.mjs",

--- a/scripts/lint-changed.mjs
+++ b/scripts/lint-changed.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+
+const eslintFilePattern = /\.(?:[cm]?[jt]sx?)$/u;
+const ignoredPrefixes = [
+  'node_modules/',
+  'dist/',
+  'src-tauri/target/',
+  '.agent/',
+  '.agents/',
+  '.claude/',
+  '.worktrees/',
+  'convex/',
+];
+
+const runCapture = (command, args) =>
+  spawnSync(command, args, {
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  });
+
+const baseCandidates = [
+  process.env.GITHUB_BASE_REF ? `origin/${process.env.GITHUB_BASE_REF}` : '',
+  process.env.GITHUB_BASE_REF || '',
+  'origin/main',
+  'main',
+].filter(Boolean);
+
+const findBaseRef = () => {
+  for (const candidate of baseCandidates) {
+    const result = runCapture('git', ['rev-parse', '--verify', candidate]);
+    if ((result.status ?? 1) === 0) return candidate;
+  }
+  return '';
+};
+
+const isLintableFile = (filePath) =>
+  eslintFilePattern.test(filePath) && !ignoredPrefixes.some((prefix) => filePath.startsWith(prefix));
+
+const baseRef = findBaseRef();
+
+if (baseRef) {
+  const diff = runCapture('git', ['diff', '--name-only', '--diff-filter=ACMRTUXB', `${baseRef}...HEAD`]);
+  if ((diff.status ?? 1) === 0) {
+    const files = diff.stdout
+      .split(/\r?\n/u)
+      .filter(Boolean)
+      .filter((filePath) => isLintableFile(filePath));
+    if (files.length === 0) {
+      console.log('[lint:ci] No changed JavaScript or TypeScript files to lint.');
+    } else {
+      console.log(`[lint:ci] Linting ${files.length} changed file(s).`);
+      const eslint = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+      const result = spawnSync(eslint, ['eslint', ...files], {
+        stdio: 'inherit',
+        shell: process.platform === 'win32',
+      });
+      process.exitCode = result.status ?? 1;
+    }
+  } else {
+    console.error((diff.stderr || diff.stdout || '').trim() || '[lint:ci] Failed to list changed files.');
+    process.exitCode = diff.status ?? 1;
+  }
+} else {
+  console.error('[lint:ci] Unable to find a base ref for changed-file linting.');
+  process.exitCode = 1;
+}


### PR DESCRIPTION
Restores a useful PR ESLint gate by linting changed JavaScript and TypeScript files against the pull request base. Full `npm run lint` remains available as the strict repo-wide audit backlog, but CI no longer fails every PR on the existing 1,500+ legacy violations.

Verification:
- git diff --cached --check
- npm run secrets:scan:staged
- npm run lint:yaml
- npx eslint scripts/lint-changed.mjs
- npm run typecheck
- commit hook: lint:conflicts, secrets:scan:staged, lint:json, lint:yaml, typecheck:all, lint-staged