### PR TITLE
ci: pre-push stale-branch guard + main branch protection

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -10,5 +10,28 @@ npm run secrets:scan || exit 1
 REMOTE_NAME="${1:-}"
 PUSH_REFS="$(cat)"
 
+if [ "${SKIP_STALE_CHECK:-0}" != "1" ]; then
+  CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+  if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "main" ] && [ "$CURRENT_BRANCH" != "HEAD" ]; then
+    git fetch --quiet origin main 2>/dev/null || true
+    BEHIND="$(git rev-list --count HEAD..origin/main 2>/dev/null || echo 0)"
+    if [ "$BEHIND" -gt 0 ]; then
+      printf '\033[33m⚠  Branch is %s commits behind origin/main.\033[0m\n' "$BEHIND" >&2
+      echo "   Recommended: git fetch origin && git rebase origin/main" >&2
+      if [ -e /dev/tty ]; then
+        printf "Push anyway? [y/N] " >&2
+        read -r ANSWER < /dev/tty
+        case "$ANSWER" in
+          y|Y|yes|YES) echo "Continuing..." >&2 ;;
+          *) echo "Push aborted. (Bypass with SKIP_STALE_CHECK=1)" >&2; exit 1 ;;
+        esac
+      else
+        echo "Non-interactive shell; aborting. (Bypass with SKIP_STALE_CHECK=1)" >&2
+        exit 1
+      fi
+    fi
+  fi
+fi
+
 echo "Running release push guard..."
 printf '%s\n' "$PUSH_REFS" | node scripts/release-push-guard.mjs --remote "$REMOTE_NAME" || exit 1


### PR DESCRIPTION
## Summary

Locks in the workflow that keeps Codex and Claude PRs from clobbering each other's commits on `main`.

**Two pieces:**

1. **`.husky/pre-push`** — new interactive guard. If the branch is behind `origin/main`, prints how many commits behind and prompts `y/N`. Default declines. Bypass with `SKIP_STALE_CHECK=1`. Skips on `main` itself.
2. **GitHub branch protection on `main`** (applied directly via API, not in this diff):
   - Required status checks (strict): `typecheck`, `secret-scan`, `actionlint`, `integrity-checks`, `release-doctor`
   - `strict: true` → 'Require branches to be up to date before merging' is on
   - PR required (0 approving reviews — solo workflow)
   - Conversation resolution required
   - No force pushes, no deletions, admin-enforced
3. **Repo settings**: auto-merge enabled, delete-branch-on-merge enabled.

## Type of change

- [x] CI / Build / Infrastructure

## Affected areas

- [x] Other: git workflow / pre-push hook

## Checklist

- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors
- [x] Hook lints clean (`npm run lint:shell`)