### PR TITLE
fix(dashboard): Test button collapse + recover orphaned iMessage/probe fixes

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -1601,14 +1601,57 @@ async function validateSecretAgainstProvider(key, rawValue, context = {}) {
  }
 
  case 'GOOGLE_MAPS_API_KEY': {
- const response = await fetchWithTimeout(`https://maps.googleapis.com/maps/api/geocode/json?address=Mountain+View&key=${encodeURIComponent(value)}`, {
- headers: { Accept: 'application/json' },
- });
+ // Probe the Directions API specifically — that's one of the two APIs the
+ // setup steps tell users to enable. Previously this probe hit Geocoding,
+ // which most users haven't enabled, so REQUEST_DENIED returned for keys
+ // that worked fine for Map Tiles + Directions.
+ const url = `https://maps.googleapis.com/maps/api/directions/json?origin=NY&destination=LA&key=${encodeURIComponent(value)}`;
+ const response = await fetchWithTimeout(url, { headers: { Accept: 'application/json' } });
  const text = await response.text();
  let payload = null; try { payload = JSON.parse(text); } catch { /* ignore */ }
- if (payload?.status === 'REQUEST_DENIED') return fail(`Google Maps rejected this key (${payload?.error_message ?? 'denied'})`);
+ if (payload?.status === 'REQUEST_DENIED') {
+ const msg = String(payload?.error_message ?? 'denied');
+ // If the key works but Directions isn't enabled, surface that hint.
+ if (/not authorized|API not activated|API has not been used/i.test(msg)) {
+ return fail(`Google Maps key valid but Directions API isn't enabled — see APIs & Services → Library`);
+ }
+ return fail(`Google Maps rejected this key (${msg})`);
+ }
  if (!response.ok) return fail(`Google Maps probe failed (${response.status})`);
- return ok('Google Maps key verified');
+ return ok('Google Maps key verified (Directions API)');
+ }
+
+ case 'MAPBOX_API_KEY': {
+ // Mapbox Geocoding endpoint — 200 = ok, 401 = bad token, 429 = rate limit (still valid).
+ const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/SanFrancisco.json?access_token=${encodeURIComponent(value)}&limit=1`;
+ const response = await fetchWithTimeout(url, { headers: { Accept: 'application/json' } });
+ if (response.status === 401 || response.status === 403) return fail('Mapbox rejected this token');
+ if (response.status === 429) return ok('Mapbox token accepted (rate limited)');
+ if (!response.ok) return fail(`Mapbox probe failed (${response.status})`);
+ return ok('Mapbox token verified');
+ }
+
+ case 'MAPTILER_API_KEY': {
+ // MapTiler returns the streets-v2 style JSON when the key is valid, 403 otherwise.
+ const url = `https://api.maptiler.com/maps/streets-v2/style.json?key=${encodeURIComponent(value)}`;
+ const response = await fetchWithTimeout(url, { headers: { Accept: 'application/json' } });
+ if (response.status === 401 || response.status === 403) return fail('MapTiler rejected this key');
+ if (!response.ok) return fail(`MapTiler probe failed (${response.status})`);
+ return ok('MapTiler key verified');
+ }
+
+ case 'CESIUM_ION_TOKEN': {
+ // Cesium ion exposes /v1/me which returns the authenticated user's profile.
+ const response = await fetchWithTimeout('https://api.cesium.com/v1/me', {
+ method: 'GET',
+ headers: {
+ Authorization: `Bearer ${value}`,
+ Accept: 'application/json',
+ },
+ });
+ if (response.status === 401 || response.status === 403) return fail('Cesium ion rejected this token');
+ if (!response.ok) return fail(`Cesium ion probe failed (${response.status})`);
+ return ok('Cesium ion token verified');
  }
 
  case 'GEONAMES_USERNAME': {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -90,6 +90,10 @@ const SUPPORTED_SECRET_KEYS: [&str; 47] = [
 // Rate-limit native notifications: no more than 1 per 30 seconds across all threads.
 static NOTIFICATION_LAST_SENT: Mutex<Option<Instant>> = Mutex::new(None);
 const NOTIFICATION_RATE_LIMIT: Duration = Duration::from_secs(30);
+
+// iMessage has its own rate-limit state so user-initiated Test sends aren't
+// blocked by background native notifications. Same 30s window between iMessages.
+static IMESSAGE_LAST_SENT: Mutex<Option<Instant>> = Mutex::new(None);
 const MIN_CACHE_FLUSH_INTERVAL: Duration = Duration::from_secs(2);
 
 struct LocalApiState {
@@ -936,10 +940,10 @@ fn send_imessage(webview: Webview, recipient: String, body: String) -> Result<()
  #[cfg(target_os = "macos")]
  {
  {
- let mut last = NOTIFICATION_LAST_SENT.lock().unwrap_or_else(|p| p.into_inner());
+ let mut last = IMESSAGE_LAST_SENT.lock().unwrap_or_else(|p| p.into_inner());
  if let Some(t) = *last {
  if t.elapsed() < NOTIFICATION_RATE_LIMIT {
- return Err("Rate limit: too soon since the last alert".to_string());
+ return Err("Rate limit: too soon since the last iMessage".to_string());
  }
  }
  *last = Some(Instant::now());

--- a/src/components/KeyDashboard.ts
+++ b/src/components/KeyDashboard.ts
@@ -226,7 +226,22 @@ export class KeyDashboard {
       setKeyStatus(key, { state: 'invalid', lastChecked: Date.now(), lastError: result.message });
       this.setFeedback(key, '✗ ' + result.message, 'err');
     }
-    this.render();
+    // Update only the affected card's status glyph + dataset in place. Calling
+    // the full this.render() rebuilds every <details class="key-tier"> element;
+    // tiers where every key is set lose their `open` attribute (because the
+    // render code only sets det.open=true when !allSet) and visibly collapse,
+    // making the user think the panel is closing on Test.
+    this.updateCardStatus(key);
+  }
+
+  private updateCardStatus(key: RuntimeSecretKey): void {
+    const card = this.root.querySelector<HTMLElement>(`.key-card[data-key="${key}"]`);
+    if (!card) return;
+    const stored = this.opts.getValue(key);
+    const status = getKeyStatus(key)?.state ?? (stored ? 'unvalidated' : 'unset');
+    card.dataset.status = status;
+    const glyph = card.querySelector('.key-card-glyph');
+    if (glyph) glyph.textContent = STATUS_GLYPH[status];
   }
 
   private async handleClear(key: RuntimeSecretKey): Promise<void> {

--- a/src/services/imessage-bridge.ts
+++ b/src/services/imessage-bridge.ts
@@ -7,7 +7,7 @@
  * so the toggle survives reloads.
  */
 
-import { tryInvokeTauri } from './tauri-bridge';
+import { invokeTauri, hasTauriInvokeBridge } from './tauri-bridge';
 import { isDesktopRuntime } from './runtime';
 
 const SETTINGS_KEY = 'crystalball-imessage-settings';
@@ -54,12 +54,14 @@ export async function sendImessage(recipient: string, body: string): Promise<{ o
   if (!isDesktopRuntime()) return { ok: false, reason: 'iMessage routing requires the macOS desktop build' };
   if (!recipient.trim()) return { ok: false, reason: 'Recipient is required' };
   if (!body.trim()) return { ok: false, reason: 'Body is required' };
+  // Distinguish 'bridge truly unavailable' from 'Rust command threw'. tryInvokeTauri
+  // collapses both to null, hiding the real reason — users saw a misleading
+  // 'Tauri bridge unavailable' for what was actually a rate-limit or
+  // recipient-unreachable error from Messages.app.
+  if (!hasTauriInvokeBridge()) return { ok: false, reason: 'Tauri bridge unavailable' };
   try {
- const result = await tryInvokeTauri<void>('send_imessage', { recipient: recipient.trim(), body });
- // tryInvokeTauri returns null on bridge unavailable. The native command
- // returns Ok(()) on success or Err string on send failure (which becomes
- // a thrown Error caught inside tryInvokeTauri).
- return result === null ? { ok: false, reason: 'Tauri bridge unavailable' } : { ok: true };
+ await invokeTauri<void>('send_imessage', { recipient: recipient.trim(), body });
+ return { ok: true };
   } catch (error) {
  return { ok: false, reason: error instanceof Error ? error.message : String(error) };
   }


### PR DESCRIPTION
## Auto-generated PR from `claude/fix-test-button-collapse`

**Files changed:** 4

### Commits
```
e6dcee4b fix(dashboard): Test button no longer collapses tier sections
55621b8f fix(imessage): re-apply lost PR #110 fixes — bridge resolver + separate rate limit
9c5c502a fix(probes): correct Google Maps probe + add Mapbox / MapTiler / Cesium probes
```

---
> This PR was created automatically when the branch was pushed. Review and merge when ready, or close if superseded.
