### PR TITLE
fix(map): satellite basemap broken — wrong tile-matrix-set for EPSG:3857

### DIFF
--- a/public/map-styles/satellite.json
+++ b/public/map-styles/satellite.json
@@ -5,7 +5,7 @@
  "esri-satellite": {
  "type": "raster",
  "tiles": [
- "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/BlueMarble_NextGeneration/default/500m/{z}/{y}/{x}.jpeg"
+ "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/BlueMarble_NextGeneration/default/GoogleMapsCompatible_Level8/{z}/{y}/{x}.jpeg"
  ],
  "tileSize": 256,
  "maxzoom": 8,


### PR DESCRIPTION
## Auto-generated PR from `claude/fix-satellite-tile-matrix`

**Files changed:** 1

### Commits
```
b4e0d4cd fix(map): satellite basemap tile-matrix-set was 500m, must be GoogleMapsCompatible_Level8 for EPSG:3857
```

---
> This PR was created automatically when the branch was pushed. Review and merge when ready, or close if superseded.
