### PR TITLE
fix(adsb): ADSB.fi uses 'aircraft' key, not 'ac'

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -5895,7 +5895,8 @@ async function dispatch(requestUrl, req, routes, context) {
  );
  if (!r.ok) throw new Error(`HTTP ${r.status}`);
  const data = await r.json();
- return (data?.ac ?? []).map(normalizeReadsb).filter(Boolean);
+ // ADSB.fi uses `aircraft` key (full readsb output), other readsb feeds use `ac`.
+ return (data?.aircraft ?? data?.ac ?? []).map(normalizeReadsb).filter(Boolean);
  }),
  runSource('adsbLol', async () => {
  const r = await fetchWithTimeout(


### PR DESCRIPTION
## Auto-generated PR from `claude/adsb-fi-shape-fix`

**Files changed:** 1

### Commits
```
ffde13ba fix(adsb): ADSB.fi uses 'aircraft' key, not 'ac'
```

---
> This PR was created automatically when the branch was pushed. Review and merge when ready, or close if superseded.
