### PR TITLE
feat(shortage): batch 1 — shared types, scoring, wheat + diesel models

### DIFF
--- a/docs/SHORTAGE_AND_COMMODITY_FORECAST_PLAN.md
+++ b/docs/SHORTAGE_AND_COMMODITY_FORECAST_PLAN.md
@@ -1,0 +1,271 @@
+# Shortage and Commodity Forecast Plan
+
+Use this plan to make Crystal Ball more predictive around food shortages, crop failures, oil/fuel shortages, and broader commodity stress.
+
+The goal is to predict shortage risk before it is obvious in headlines.
+
+## Core Forecast Pattern
+
+Most shortage forecasts can use the same structure:
+
+```text
+production risk + inventory risk + transport risk + demand shock + price confirmation + conflict/weather overlay = forecast
+```
+
+Crystal Ball should not only collect the raw data. It should explain which part of the shortage chain is breaking.
+
+## Food Shortage Forecast Engine
+
+Track crop failure and food security risk before food prices spike.
+
+Core signals:
+
+- Crop condition
+- Drought
+- Heat
+- Frost
+- Flood
+- Soil moisture
+- NDVI and vegetation stress
+- Weather anomaly vs crop calendar stage
+- Planting delays
+- Harvest disruption
+- Fertilizer prices
+- Fuel prices
+- Export bans
+- Port disruption
+- Conflict corridors
+- Refugee flows
+- Currency collapse
+- Local food price inflation
+- IPC, FEWS NET, WFP, and humanitarian confirmation
+
+Useful sources:
+
+- USDA Quick Stats: <https://www.nass.usda.gov/quick_stats/>
+- FAOSTAT: <https://www.fao.org/statistics/databases/en/>
+- FEWS NET Data Center: <https://fews.net/data>
+- FEWS NET API help: <https://help.fews.net/fde/fews-net-api>
+- USGS Water APIs: <https://api.waterdata.usgs.gov/>
+- NOAA Climate Data Online API: <https://www.ncdc.noaa.gov/cdo-web/webservices/v2>
+- Drought.gov data downloads: <https://www.drought.gov/data-download>
+
+Example forecast:
+
+```text
+Wheat shortage risk rising in Region X:
+- rainfall 42% below normal during key growth window
+- soil moisture below 10th percentile
+- fertilizer prices rising
+- export corridor disrupted
+- local wheat prices up 18% month-over-month
+- FEWS NET classification deteriorating nearby
+```
+
+## Oil Shortage and Fuel Stress Forecast Engine
+
+Oil shortages are usually visible through inventory drawdown, refinery disruption, shipping chokepoints, conflict risk, sanctions, and demand spikes.
+
+Core signals:
+
+- Crude inventories
+- Product inventories
+- Days of supply
+- Refinery utilization
+- Refinery outages
+- Imports
+- Exports
+- Strategic reserve releases
+- Tanker traffic and rerouting
+- Port closures
+- Sanctions
+- Conflict
+- Crack spreads
+- Product prices
+- Weather disruption to Gulf/refinery regions
+
+Useful sources:
+
+- EIA petroleum data: <https://www.eia.gov/petroleum/data.php>
+- EIA Open Data petroleum API: <https://www.eia.gov/opendata/index.php/browser/petroleum/>
+- JODI Oil: <https://www.jodidata.org/oil/>
+- JODI Oil user guide: <https://www.jodidata.org/oil/support/user-guide.aspx>
+- IEA Oil Information: <https://www.iea.org/data-and-statistics/data-product/oil-information>
+- World Bank commodity markets/Pink Sheet: <https://www.worldbank.org/en/research/commodity-markets>
+
+Example forecast:
+
+```text
+Diesel stress risk rising:
+- distillate inventories below 5-year range
+- refinery utilization falling
+- imports down week-over-week
+- port weather risk increasing
+- freight demand stable/rising
+- diesel crack spread widening
+```
+
+## Commodity Playbooks
+
+Do not build one generic shortage model. Build commodity playbooks with shared scoring primitives.
+
+Food commodities:
+
+- Wheat
+- Corn
+- Rice
+- Soybeans
+- Sugar
+- Coffee
+- Cocoa
+- Fertilizer
+
+Energy commodities:
+
+- Crude oil
+- Gasoline
+- Diesel
+- Jet fuel
+- Natural gas
+- Propane
+- Electricity capacity
+
+Each playbook should define:
+
+- Leading indicators
+- Confirming indicators
+- Invalidating indicators
+- Normal seasonal cycle
+- Known chokepoints
+- Affected countries
+- Affected sectors
+- Forecast horizon
+
+## Leading Indicator Scores
+
+For each commodity, compute:
+
+- Production Risk: 0-100
+- Inventory Risk: 0-100
+- Transport Risk: 0-100
+- Policy Risk: 0-100
+- Demand Shock: 0-100
+- Price Confirmation: 0-100
+- Overall Shortage Risk: weighted score
+
+Example:
+
+```text
+Global Wheat Shortage Risk: 71
+Production risk: 82
+Transport risk: 65
+Policy risk: 58
+Price confirmation: 49
+Confidence: medium
+Watch window: 30-90 days
+```
+
+## Watch Windows
+
+For every shortage forecast, define what should happen next if the forecast is right.
+
+Example:
+
+```text
+If wheat shortage risk is real, expect within 30 days:
+- crop condition downgrade
+- local wheat prices rising
+- export restriction rumors or policy moves
+- WFP/FEWS NET deterioration
+- futures curve tightening
+```
+
+If those signals do not appear, confidence should decay.
+
+## Cross-Domain Insight Engine
+
+Shortages are almost never single-domain. Crystal Ball should combine:
+
+```text
+weather + crop calendar + river levels + fertilizer + conflict + port status + prices + humanitarian data
+```
+
+Examples:
+
+- Drought + low river levels + fertilizer spike = crop failure risk
+- Conflict + Black Sea port disruption + wheat futures rise = grain export risk
+- Hurricane + refinery corridor + low distillate stocks = diesel/gasoline shortage risk
+- Heat wave + grid demand + low natural gas storage = electricity/fuel stress
+- Cyberattack + pipeline/refinery target + fuel price movement = supply disruption risk
+
+## Insight Products
+
+Build these user-facing intelligence surfaces after the model exists:
+
+- Shortage Radar: ranked list of commodities at risk
+- Food Security Map: crop stress + IPC/FEWS NET + price pressure
+- Energy Stress Map: inventories + refinery/port/weather/conflict chokepoints
+- Commodity Watch Cards: what changed, why it matters, what to watch
+- Cascade Forecasts: crop failure -> food prices -> unrest risk
+- Confidence Timeline: how the forecast strengthened or weakened over time
+- Data Gap Warnings: low confidence because current inventory data is missing
+
+## First Implementation Batch
+
+Add a shared shortage forecast framework first.
+
+Suggested type:
+
+```ts
+type ShortageDomain = 'food' | 'energy' | 'fertilizer' | 'water';
+
+interface ShortageForecast {
+  commodity: string;
+  domain: ShortageDomain;
+  region: string;
+  horizonDays: number;
+  riskScore: number;
+  confidence: 'low' | 'medium' | 'high';
+  drivers: ShortageDriver[];
+  confirmingIndicators: string[];
+  invalidatingIndicators: string[];
+  dataGaps: string[];
+  lastUpdated: string;
+}
+```
+
+Then implement two initial deterministic models:
+
+- `wheat-shortage-risk`
+- `diesel-shortage-risk`
+
+Suggested files:
+
+- `src/services/shortage/shortage-types.ts`
+- `src/services/shortage/shortage-score.ts`
+- `src/services/shortage/commodity-playbooks.ts`
+- `src/services/shortage/wheat-shortage-risk.ts`
+- `src/services/shortage/diesel-shortage-risk.ts`
+- `src/services/shortage/__tests__/shortage-score.test.mts`
+- `src/services/shortage/__tests__/commodity-playbooks.test.mts`
+
+## Guardrails
+
+- Start deterministic.
+- Do not add opaque ML in the first batch.
+- Every shortage score must include drivers and data gaps.
+- Every forecast must include confirming and invalidating indicators.
+- Use source provenance for all inputs.
+- Make stale or missing data reduce confidence.
+- Keep model outputs stable enough for unit tests.
+- Do not overfit to one country or one data provider.
+
+## Claude Instruction
+
+Claude should read this plan before implementation.
+
+Recommended prompt:
+
+```text
+Read docs/SHORTAGE_AND_COMMODITY_FORECAST_PLAN.md. Implement the first batch only: shared shortage forecast types, scoring helpers, commodity playbooks, and deterministic wheat/diesel risk models with unit tests. Do not build broad UI yet.
+```

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:reasoning": "tsx --test src/services/__tests__/hypothesis-dedupe.test.mts src/services/__tests__/hypothesis-entities.test.mts src/services/__tests__/hypothesis-feedback.test.mts src/services/__tests__/pressure-baselines.test.mts src/services/__tests__/llm-budget.test.mts src/services/__tests__/action-memory.test.mts",
     "test:settings": "tsx --test src/services/__tests__/key-categories.test.mts src/services/__tests__/key-feature-index.test.mts src/services/__tests__/key-shape-registry.test.mts src/services/__tests__/wizard-state.test.mts",
     "test:providers": "tsx --test src/services/providers/__tests__/registry.test.mts src/services/providers/__tests__/health.test.mts src/services/providers/__tests__/fusion.test.mts",
+    "test:shortage": "tsx --test src/services/shortage/__tests__/shortage-score.test.mts src/services/shortage/__tests__/commodity-playbooks.test.mts",
     "test:feeds": "node scripts/validate-rss-feeds.mjs",
     "test:sidecar": "node --test src-tauri/sidecar/local-api-server.test.mjs api/_cors.test.mjs api/_api-key.test.mjs api/youtube/embed.test.mjs api/cyber-threats.test.mjs api/usni-fleet.test.mjs scripts/ais-relay-rss.test.cjs api/loaders-xml-wms-regression.test.mjs",
     "test:api": "node --test api/__tests__/*.test.mjs",

--- a/src/services/shortage/__tests__/commodity-playbooks.test.mts
+++ b/src/services/shortage/__tests__/commodity-playbooks.test.mts
@@ -1,0 +1,233 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  ALL_PLAYBOOKS,
+  WHEAT_PLAYBOOK,
+  DIESEL_PLAYBOOK,
+  getPlaybook,
+  isSeasonalRisk,
+} from '../commodity-playbooks.ts';
+import { computeWheatShortageRisk } from '../wheat-shortage-risk.ts';
+import { computeDieselShortageRisk } from '../diesel-shortage-risk.ts';
+import type { ShortageInput } from '../shortage-types.ts';
+
+const NOW = Date.UTC(2026, 3, 27, 12, 0, 0); // 2026-04-27 — wheat in-season, diesel out-of-season
+
+function input(value: number, source = 'src1', ageMs = 0): ShortageInput {
+  return { value, observedAt: NOW - ageMs, source };
+}
+
+// ── Playbook hygiene ────────────────────────────────────────────────────
+
+test('ALL_PLAYBOOKS: has wheat and diesel', () => {
+  const commodities = ALL_PLAYBOOKS.map((p) => p.commodity);
+  assert.ok(commodities.includes('wheat'));
+  assert.ok(commodities.includes('diesel'));
+});
+
+test('getPlaybook: case-insensitive lookup', () => {
+  assert.equal(getPlaybook('WHEAT')?.commodity, 'wheat');
+  assert.equal(getPlaybook('Diesel')?.commodity, 'diesel');
+  assert.equal(getPlaybook('unknown'), undefined);
+});
+
+test('isSeasonalRisk: respects month membership', () => {
+  assert.equal(isSeasonalRisk(WHEAT_PLAYBOOK, 4), true);  // April: in season
+  assert.equal(isSeasonalRisk(WHEAT_PLAYBOOK, 1), false); // January: out
+  assert.equal(isSeasonalRisk(DIESEL_PLAYBOOK, 8), true); // August: hurricane season
+});
+
+test('every playbook has nonempty leading + confirming + invalidating + chokepoints', () => {
+  for (const p of ALL_PLAYBOOKS) {
+    assert.ok(p.leadingIndicators.length > 0, `${p.commodity} leading`);
+    assert.ok(p.confirmingIndicators.length > 0, `${p.commodity} confirming`);
+    assert.ok(p.invalidatingIndicators.length > 0, `${p.commodity} invalidating`);
+    assert.ok(p.chokepoints.length > 0, `${p.commodity} chokepoints`);
+    assert.ok(p.affectedCountries.length > 0, `${p.commodity} countries`);
+    assert.ok(p.forecastHorizonDays > 0);
+  }
+});
+
+// ── Wheat model ─────────────────────────────────────────────────────────
+
+test('wheat: drought + corridor disruption + price spike → high risk', () => {
+  const f = computeWheatShortageRisk(
+    {
+      rainfall_pct_of_normal: input(45, 'noaa'),
+      soil_moisture_percentile: input(8, 'usda'),
+      ndvi_anomaly: input(-0.18, 'usgs'),
+      fertilizer_price_yoy: input(40, 'worldbank'),
+      export_corridor_status: input(75, 'gdacs'),
+      local_wheat_price_mom: input(18, 'fao'),
+      futures_curve_tightness: input(4, 'cme'),
+      fews_net_stage: input(3, 'fewsnet'),
+    },
+    { region: 'Black Sea Basin', now: NOW },
+  );
+  assert.equal(f.commodity, 'wheat');
+  assert.equal(f.region, 'Black Sea Basin');
+  assert.ok(f.riskScore >= 60, `expected high risk, got ${f.riskScore}`);
+  assert.ok(['medium', 'high'].includes(f.confidence));
+  assert.ok(f.drivers.some((d) => d.kind === 'production'));
+  assert.ok(f.drivers.some((d) => d.kind === 'transport'));
+  assert.ok(f.drivers.some((d) => d.kind === 'price'));
+});
+
+test('wheat: deterministic for same inputs', () => {
+  const inputs = {
+    rainfall_pct_of_normal: input(60),
+    soil_moisture_percentile: input(20),
+    fertilizer_price_yoy: input(15),
+    export_corridor_status: input(0),
+    local_wheat_price_mom: input(2),
+  };
+  const a = computeWheatShortageRisk(inputs, { region: 'X', now: NOW });
+  const b = computeWheatShortageRisk(inputs, { region: 'X', now: NOW });
+  assert.equal(a.riskScore, b.riskScore);
+  assert.deepEqual(a.drivers, b.drivers);
+});
+
+test('wheat: missing inputs become data gaps, confidence drops', () => {
+  const f = computeWheatShortageRisk(
+    { rainfall_pct_of_normal: input(60, 'noaa') }, // only one input
+    { region: 'X', now: NOW },
+  );
+  assert.ok(f.dataGaps.length >= 4);
+  assert.equal(f.confidence, 'low');
+});
+
+test('wheat: stale inputs reduce confidence (do not silently disappear)', () => {
+  const week = 7 * 24 * 60 * 60 * 1000;
+  const f = computeWheatShortageRisk(
+    {
+      rainfall_pct_of_normal: input(45, 'noaa', 4 * week), // very stale
+      soil_moisture_percentile: input(10, 'usda', 4 * week),
+      fertilizer_price_yoy: input(30, 'worldbank', 4 * week),
+      export_corridor_status: input(60, 'gdacs', 4 * week),
+      local_wheat_price_mom: input(15, 'fao', 4 * week),
+    },
+    { region: 'X', now: NOW },
+  );
+  // Should still produce a forecast with the drivers, but confidence
+  // should reflect the staleness either via gaps or worstFreshness.
+  assert.notEqual(f.confidence, 'high');
+  assert.ok(f.drivers.length > 0);
+});
+
+test('wheat: in-season production stress is amplified vs out-of-season', () => {
+  const inSeason = Date.UTC(2026, 3, 15); // April
+  const outSeason = Date.UTC(2026, 0, 15); // January
+  const inputs = {
+    rainfall_pct_of_normal: input(50, 'noaa'),
+    fertilizer_price_yoy: input(20, 'worldbank'),
+  };
+  const a = computeWheatShortageRisk(inputs, { region: 'X', now: inSeason });
+  const b = computeWheatShortageRisk(inputs, { region: 'X', now: outSeason });
+  const aProduction = a.drivers.find((d) => d.kind === 'production');
+  const bProduction = b.drivers.find((d) => d.kind === 'production');
+  assert.ok(aProduction!.score > bProduction!.score);
+});
+
+test('wheat: forecast preserves confirming + invalidating indicators from playbook', () => {
+  const f = computeWheatShortageRisk(
+    { rainfall_pct_of_normal: input(50) },
+    { region: 'X', now: NOW },
+  );
+  assert.deepEqual(f.confirmingIndicators, [...WHEAT_PLAYBOOK.confirmingIndicators]);
+  assert.deepEqual(f.invalidatingIndicators, [...WHEAT_PLAYBOOK.invalidatingIndicators]);
+  assert.equal(f.horizonDays, WHEAT_PLAYBOOK.forecastHorizonDays);
+});
+
+// ── Diesel model ────────────────────────────────────────────────────────
+
+test('diesel: low inventory + falling utilization + crack widening → high risk', () => {
+  const f = computeDieselShortageRisk(
+    {
+      distillate_inventory_vs_5yr: input(-18, 'eia'),
+      refinery_utilization_pct: input(82, 'eia'),
+      crude_imports_wow: input(-15, 'eia'),
+      crack_spread_distillate: input(45, 'cme'),
+      refinery_outage_capacity_pct: input(8, 'eia'),
+      gulf_weather_risk: input(70, 'noaa'),
+      diesel_retail_price_wow: input(6, 'eia'),
+      freight_demand_index: input(72, 'industry'),
+      futures_curve_distillate: input(3, 'cme'),
+    },
+    { region: 'PADD3 (Gulf Coast)', now: NOW },
+  );
+  assert.equal(f.commodity, 'diesel');
+  assert.ok(f.riskScore >= 60, `expected high risk, got ${f.riskScore}`);
+  assert.ok(f.drivers.some((d) => d.kind === 'inventory'));
+  assert.ok(f.drivers.some((d) => d.kind === 'price'));
+});
+
+test('diesel: SPR release announcement applies a protective driver', () => {
+  const baseInputs = {
+    distillate_inventory_vs_5yr: input(-15, 'eia'),
+    refinery_utilization_pct: input(85, 'eia'),
+    crack_spread_distillate: input(40, 'cme'),
+    diesel_retail_price_wow: input(4, 'eia'),
+  };
+  const without = computeDieselShortageRisk(baseInputs, { region: 'US', now: NOW });
+  const withRelease = computeDieselShortageRisk(
+    { ...baseInputs, spr_release_announcement: input(1, 'whitehouse') },
+    { region: 'US', now: NOW },
+  );
+  assert.ok(
+    withRelease.riskScore <= without.riskScore,
+    `SPR release should not increase risk (${without.riskScore} → ${withRelease.riskScore})`,
+  );
+  assert.ok(withRelease.drivers.some((d) => d.polarity === 'protective'));
+});
+
+test('diesel: deterministic for same inputs', () => {
+  const inputs = {
+    distillate_inventory_vs_5yr: input(-10),
+    refinery_utilization_pct: input(88),
+    crack_spread_distillate: input(30),
+    diesel_retail_price_wow: input(2),
+  };
+  const a = computeDieselShortageRisk(inputs, { region: 'US', now: NOW });
+  const b = computeDieselShortageRisk(inputs, { region: 'US', now: NOW });
+  assert.equal(a.riskScore, b.riskScore);
+});
+
+test('diesel: lastUpdated is ISO and reflects `now`', () => {
+  const f = computeDieselShortageRisk(
+    { distillate_inventory_vs_5yr: input(0) },
+    { region: 'US', now: NOW },
+  );
+  assert.equal(f.lastUpdated, new Date(NOW).toISOString());
+});
+
+test('diesel: empty inputs produce a low-confidence forecast with all data gaps', () => {
+  const f = computeDieselShortageRisk({}, { region: 'US', now: NOW });
+  assert.equal(f.confidence, 'low');
+  assert.ok(f.dataGaps.length >= 4);
+  assert.equal(f.drivers.length, 0);
+});
+
+// ── Plan invariants ─────────────────────────────────────────────────────
+//
+// Per the plan's "Guardrails" (lines 252-261), every shortage score
+// must include drivers + data gaps and every forecast must include
+// confirming + invalidating indicators.
+
+test('invariant: every forecast has drivers (or empty), gaps, confirming, invalidating, lastUpdated', () => {
+  const cases = [
+    computeWheatShortageRisk({ rainfall_pct_of_normal: input(60) }, { region: 'X', now: NOW }),
+    computeDieselShortageRisk({ distillate_inventory_vs_5yr: input(-5) }, { region: 'US', now: NOW }),
+    computeWheatShortageRisk({}, { region: 'X', now: NOW }),
+    computeDieselShortageRisk({}, { region: 'US', now: NOW }),
+  ];
+  for (const f of cases) {
+    assert.ok(Array.isArray(f.drivers));
+    assert.ok(Array.isArray(f.dataGaps));
+    assert.ok(f.confirmingIndicators.length > 0);
+    assert.ok(f.invalidatingIndicators.length > 0);
+    assert.ok(typeof f.lastUpdated === 'string' && f.lastUpdated.length > 0);
+    assert.ok(['low', 'medium', 'high'].includes(f.confidence));
+    assert.ok(f.riskScore >= 0 && f.riskScore <= 100);
+  }
+});

--- a/src/services/shortage/__tests__/shortage-score.test.mts
+++ b/src/services/shortage/__tests__/shortage-score.test.mts
@@ -1,0 +1,209 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  scoreOverallShortage,
+  deriveConfidence,
+  freshnessFor,
+  buildDriver,
+  inverseLinear,
+  directLinear,
+  detectGaps,
+  uniqueSourceCount,
+} from '../shortage-score.ts';
+import type { ShortageDriver, ShortageInput } from '../shortage-types.ts';
+
+const NOW = 1_745_000_000_000;
+
+function driver(kind: ShortageDriver['kind'], score: number, source = 'src'): ShortageDriver {
+  return { kind, score, label: `${kind}=${score}`, sources: [source] };
+}
+
+// ── Bucket math ─────────────────────────────────────────────────────────
+
+test('scoreOverallShortage: weights buckets per defaults', () => {
+  // 100 in production (weight 0.25) + nothing else → 100 normalized.
+  const r = scoreOverallShortage([driver('production', 100)]);
+  assert.equal(r.riskScore, 100);
+  assert.equal(r.weightUsed, 0.25);
+});
+
+test('scoreOverallShortage: averages within a bucket', () => {
+  const r = scoreOverallShortage([
+    driver('production', 80),
+    driver('production', 40),
+  ]);
+  // Bucket avg = 60; only one bucket used → normalized = 60.
+  assert.equal(r.riskScore, 60);
+});
+
+test('scoreOverallShortage: protective drivers subtract', () => {
+  const r = scoreOverallShortage([
+    driver('inventory', 80),
+    { ...driver('inventory', 60), polarity: 'protective' },
+  ]);
+  // (80 - 60) / 2 = 10
+  assert.equal(r.riskScore, 10);
+});
+
+test('scoreOverallShortage: missing buckets reduce weightUsed but do not zero score', () => {
+  // Only inventory and price provided; no production. Score stays
+  // representative of the inputs given.
+  const r = scoreOverallShortage([
+    driver('inventory', 80),
+    driver('price', 60),
+  ]);
+  // weight used = 0.2 + 0.15 = 0.35
+  assert.equal(Math.round(r.weightUsed * 100) / 100, 0.35);
+  // weighted = 80*0.2 + 60*0.15 = 16 + 9 = 25; normalized = 25/0.35 ≈ 71.4 → 71
+  assert.equal(r.riskScore, 71);
+});
+
+test('scoreOverallShortage: clamps to 0-100', () => {
+  // Force a custom weight so a runaway score can be tested.
+  const r = scoreOverallShortage(
+    [driver('production', 100)],
+    { weights: { production: 1, inventory: 0, transport: 0, policy: 0, demand: 0, price: 0, cross_domain: 0 } },
+  );
+  assert.equal(r.riskScore, 100);
+  assert.ok(r.riskScore <= 100);
+});
+
+// ── Driver building ─────────────────────────────────────────────────────
+
+test('buildDriver: applies toRisk and rounds + clamps', () => {
+  const d = buildDriver({
+    kind: 'production',
+    value: 50,
+    toRisk: inverseLinear(40, 100),
+    label: 'rainfall',
+  });
+  // (100 - 50) / (100 - 40) * 100 = 83.33 → 83
+  assert.equal(d.score, 83);
+  assert.equal(d.kind, 'production');
+});
+
+test('buildDriver: clamps below 0 and above 100', () => {
+  const lo = buildDriver({ kind: 'price', value: 0, toRisk: inverseLinear(0, 100), label: 'x' });
+  assert.equal(lo.score, 100);
+  const hi = buildDriver({ kind: 'price', value: 200, toRisk: directLinear(0, 100), label: 'y' });
+  assert.equal(hi.score, 100);
+});
+
+test('inverseLinear: at edges returns extremes', () => {
+  const f = inverseLinear(40, 100);
+  assert.equal(f(40), 100);
+  assert.equal(f(100), 0);
+  assert.equal(f(20), 100); // below low: still 100
+  assert.equal(f(120), 0);  // above high: still 0
+});
+
+test('directLinear: at edges returns extremes', () => {
+  const f = directLinear(0, 30);
+  assert.equal(f(0), 0);
+  assert.equal(f(30), 100);
+  assert.equal(f(-5), 0);
+  assert.equal(f(60), 100);
+});
+
+// ── Freshness ───────────────────────────────────────────────────────────
+
+test('freshnessFor: 1.0 fresh, 0.5 at window, 0 at 2× window', () => {
+  const week = 7 * 24 * 60 * 60 * 1000;
+  const fresh: ShortageInput = { value: 1, observedAt: NOW };
+  assert.equal(freshnessFor(fresh, week, NOW), 1);
+  const atWindow: ShortageInput = { value: 1, observedAt: NOW - week };
+  assert.equal(freshnessFor(atWindow, week, NOW), 0.5);
+  const stale: ShortageInput = { value: 1, observedAt: NOW - 3 * week };
+  assert.equal(freshnessFor(stale, week, NOW), 0);
+});
+
+test('freshnessFor: undefined input returns 0', () => {
+  assert.equal(freshnessFor(undefined, 1000, NOW), 0);
+});
+
+// ── Confidence ──────────────────────────────────────────────────────────
+
+test('deriveConfidence: low when weightUsed < 0.5', () => {
+  assert.equal(
+    deriveConfidence({ gapCount: 0, uniqueSourceCount: 3, worstFreshness: 1, weightUsed: 0.3 }),
+    'low',
+  );
+});
+
+test('deriveConfidence: low when 4+ data gaps', () => {
+  assert.equal(
+    deriveConfidence({ gapCount: 4, uniqueSourceCount: 3, worstFreshness: 1, weightUsed: 0.9 }),
+    'low',
+  );
+});
+
+test('deriveConfidence: low with zero sources', () => {
+  assert.equal(
+    deriveConfidence({ gapCount: 0, uniqueSourceCount: 0, worstFreshness: 1, weightUsed: 0.9 }),
+    'low',
+  );
+});
+
+test('deriveConfidence: medium with single source even if everything else is good', () => {
+  assert.equal(
+    deriveConfidence({ gapCount: 0, uniqueSourceCount: 1, worstFreshness: 1, weightUsed: 0.9 }),
+    'medium',
+  );
+});
+
+test('deriveConfidence: medium with stale data', () => {
+  assert.equal(
+    deriveConfidence({ gapCount: 0, uniqueSourceCount: 3, worstFreshness: 0.2, weightUsed: 0.9 }),
+    'medium',
+  );
+});
+
+test('deriveConfidence: high requires diverse sources, fresh data, and ≥75% weight coverage', () => {
+  assert.equal(
+    deriveConfidence({ gapCount: 0, uniqueSourceCount: 3, worstFreshness: 0.8, weightUsed: 0.85 }),
+    'high',
+  );
+});
+
+// ── Data gaps ───────────────────────────────────────────────────────────
+
+test('detectGaps: returns missing keys', () => {
+  const gaps = detectGaps(
+    { a: { value: 1, observedAt: NOW } },
+    [{ key: 'a', label: 'A' }, { key: 'b', label: 'B' }, { key: 'c', label: 'C' }],
+    NOW,
+  );
+  assert.deepEqual(gaps, ['Missing B', 'Missing C']);
+});
+
+test('detectGaps: flags stale inputs', () => {
+  const week = 7 * 24 * 60 * 60 * 1000;
+  const gaps = detectGaps(
+    { a: { value: 1, observedAt: NOW - 2 * week } },
+    [{ key: 'a', label: 'A', staleAfterMs: week }],
+    NOW,
+  );
+  assert.equal(gaps.length, 1);
+  assert.match(gaps[0]!, /Stale A/);
+});
+
+test('detectGaps: clean when everything is fresh', () => {
+  const gaps = detectGaps(
+    { a: { value: 1, observedAt: NOW } },
+    [{ key: 'a', label: 'A', staleAfterMs: 1000 }],
+    NOW,
+  );
+  assert.deepEqual(gaps, []);
+});
+
+// ── Source counting ─────────────────────────────────────────────────────
+
+test('uniqueSourceCount: dedupes across drivers', () => {
+  const ds: ShortageDriver[] = [
+    { kind: 'production', score: 50, label: 'a', sources: ['src1', 'src2'] },
+    { kind: 'price', score: 50, label: 'b', sources: ['src1'] },
+    { kind: 'inventory', score: 50, label: 'c' }, // no sources
+  ];
+  assert.equal(uniqueSourceCount(ds), 2);
+});

--- a/src/services/shortage/commodity-playbooks.ts
+++ b/src/services/shortage/commodity-playbooks.ts
@@ -1,0 +1,103 @@
+/**
+ * Commodity playbooks — plan section "Commodity Playbooks" (lines 108-142).
+ *
+ * Each playbook is a static fact sheet describing a commodity's:
+ *   - leading / confirming / invalidating indicators
+ *   - seasonal exposure
+ *   - chokepoints and most-affected geographies/sectors
+ *   - default forecast horizon
+ *
+ * The first batch covers wheat (food) and diesel (energy). Adding a
+ * new commodity = adding a new entry plus a model file that reads from
+ * the same indicator key namespace.
+ *
+ * Playbooks are intentionally NOT models. They define what to look at;
+ * the per-commodity *-shortage-risk.ts files do the math.
+ */
+
+import type { CommodityPlaybook } from './shortage-types';
+
+export const WHEAT_PLAYBOOK: CommodityPlaybook = {
+  commodity: 'wheat',
+  domain: 'food',
+  leadingIndicators: [
+    'rainfall_pct_of_normal',
+    'soil_moisture_percentile',
+    'ndvi_anomaly',
+    'fertilizer_price_yoy',
+    'planting_progress_pct',
+    'export_corridor_status',
+  ],
+  confirmingIndicators: [
+    'local_wheat_price_mom',
+    'futures_curve_tightness',
+    'export_ban_count',
+    'fews_net_stage',
+  ],
+  invalidatingIndicators: [
+    'late_season_rainfall_recovery',
+    'export_ban_lifted',
+    'inventory_release_announced',
+  ],
+  // Northern Hemisphere planting Sep-Nov, growth Mar-May, harvest Jun-Aug.
+  // Markets care most when those windows overlap with stress signals.
+  seasonalRiskMonths: [3, 4, 5, 6, 7, 8],
+  chokepoints: ['Black Sea ports', 'Bosphorus Strait', 'Suez Canal', 'Mississippi River'],
+  // Top exporters/importers most exposed to disruption.
+  affectedCountries: ['UA', 'RU', 'US', 'CA', 'AU', 'FR', 'EG', 'TR', 'ID', 'BD'],
+  affectedSectors: ['food retail', 'humanitarian aid', 'livestock feed', 'baking'],
+  forecastHorizonDays: 60,
+};
+
+export const DIESEL_PLAYBOOK: CommodityPlaybook = {
+  commodity: 'diesel',
+  domain: 'energy',
+  leadingIndicators: [
+    'distillate_inventory_vs_5yr',
+    'refinery_utilization_pct',
+    'crude_imports_wow',
+    'crack_spread_distillate',
+    'refinery_outage_capacity_pct',
+    'gulf_weather_risk',
+  ],
+  confirmingIndicators: [
+    'diesel_retail_price_wow',
+    'freight_demand_index',
+    'futures_curve_distillate',
+    'spr_release_announcement',
+  ],
+  invalidatingIndicators: [
+    'refinery_back_online',
+    'inventory_build_consecutive',
+    'crack_spread_normalizing',
+  ],
+  // US winter heating + summer freight peak. Hurricane season Jun-Nov
+  // hits the Gulf refining corridor.
+  seasonalRiskMonths: [6, 7, 8, 9, 10, 11, 12, 1, 2],
+  chokepoints: [
+    'US Gulf Coast refineries',
+    'Strait of Hormuz',
+    'Rotterdam ARA hub',
+    'Singapore distillate hub',
+  ],
+  affectedCountries: ['US', 'CA', 'MX', 'NL', 'DE', 'IN', 'BR', 'SG'],
+  affectedSectors: ['trucking', 'farming', 'rail', 'mining', 'maritime', 'construction'],
+  forecastHorizonDays: 30,
+};
+
+export const ALL_PLAYBOOKS: readonly CommodityPlaybook[] = [
+  WHEAT_PLAYBOOK,
+  DIESEL_PLAYBOOK,
+];
+
+/** Lookup helper — preferred over reaching into ALL_PLAYBOOKS directly. */
+export function getPlaybook(commodity: string): CommodityPlaybook | undefined {
+  const lc = commodity.toLowerCase();
+  return ALL_PLAYBOOKS.find((p) => p.commodity === lc);
+}
+
+/** True if `month` (1-12) is inside the playbook's seasonal risk window.
+ *  Handles wrap-around (e.g. diesel's Sep-Feb window). */
+export function isSeasonalRisk(playbook: CommodityPlaybook, month: number): boolean {
+  return playbook.seasonalRiskMonths.includes(month);
+}

--- a/src/services/shortage/diesel-shortage-risk.ts
+++ b/src/services/shortage/diesel-shortage-risk.ts
@@ -1,0 +1,180 @@
+/**
+ * Deterministic diesel shortage risk model.
+ *
+ * Per the plan's worked example (lines 99-106):
+ *
+ *   Diesel stress risk rising:
+ *   - distillate inventories below 5-year range
+ *   - refinery utilization falling
+ *   - imports down week-over-week
+ *   - port weather risk increasing
+ *   - freight demand stable/rising
+ *   - diesel crack spread widening
+ *
+ * Same compositional pattern as the wheat model — provenance-aware
+ * inputs in, drivers + data gaps + confidence out. No fetch.
+ */
+
+import type { ShortageDriver, ShortageForecast, ShortageInput, ShortageInputBag } from './shortage-types';
+import {
+  buildDriver,
+  deriveConfidence,
+  detectGaps,
+  directLinear,
+  freshnessFor,
+  inverseLinear,
+  scoreOverallShortage,
+  uniqueSourceCount,
+} from './shortage-score';
+import { DIESEL_PLAYBOOK, isSeasonalRisk } from './commodity-playbooks';
+
+export interface DieselModelInputs extends ShortageInputBag {
+  /** Distillate inventory % deviation from 5-year average. Negative = below. */
+  distillate_inventory_vs_5yr?: ShortageInput;
+  /** Refinery utilization % (national or region). 90+ healthy. */
+  refinery_utilization_pct?: ShortageInput;
+  /** Crude imports week-over-week % change. Negative = falling. */
+  crude_imports_wow?: ShortageInput;
+  /** Distillate crack spread (USD/bbl). Wide = stress. */
+  crack_spread_distillate?: ShortageInput;
+  /** Capacity offline as % of total refining capacity. */
+  refinery_outage_capacity_pct?: ShortageInput;
+  /** Gulf weather risk index 0-100. */
+  gulf_weather_risk?: ShortageInput;
+  /** Diesel retail price week-over-week % change. */
+  diesel_retail_price_wow?: ShortageInput;
+  /** Freight demand index (0-100, 50 = baseline). */
+  freight_demand_index?: ShortageInput;
+  /** Distillate futures curve (positive = backwardation). */
+  futures_curve_distillate?: ShortageInput;
+  /** Strategic Petroleum Reserve release flag (0 = none, 1 = announced). */
+  spr_release_announcement?: ShortageInput;
+}
+
+export interface DieselModelOptions {
+  region: string;
+  /** Defaults to Date.now(). Inject for deterministic tests. */
+  now?: number;
+}
+
+const REQUIRED_INPUTS = [
+  { key: 'distillate_inventory_vs_5yr', label: 'distillate inventory', staleAfterMs: 8 * 24 * 60 * 60 * 1000 },
+  { key: 'refinery_utilization_pct', label: 'refinery utilization', staleAfterMs: 8 * 24 * 60 * 60 * 1000 },
+  { key: 'crack_spread_distillate', label: 'crack spread', staleAfterMs: 3 * 24 * 60 * 60 * 1000 },
+  { key: 'diesel_retail_price_wow', label: 'retail diesel price', staleAfterMs: 8 * 24 * 60 * 60 * 1000 },
+];
+
+interface DriverSpec<K extends keyof DieselModelInputs> {
+  key: K;
+  kind: ShortageDriver['kind'];
+  toRisk: (v: number) => number;
+  label: (v: number) => string;
+  when?: (v: number) => boolean;
+  polarity?: 'risk' | 'protective';
+}
+
+const DIESEL_DRIVER_SPECS: DriverSpec<keyof DieselModelInputs>[] = [
+  { key: 'distillate_inventory_vs_5yr', kind: 'inventory', toRisk: inverseLinear(-25, 10),
+    label: (v) => `Distillate inventory ${signedPct(v)} vs 5-yr avg` },
+  { key: 'refinery_utilization_pct', kind: 'production', toRisk: inverseLinear(75, 95),
+    label: (v) => `Refinery utilization ${Math.round(v)}%` },
+  { key: 'refinery_outage_capacity_pct', kind: 'production', toRisk: directLinear(0, 15),
+    label: (v) => `${v.toFixed(1)}% capacity offline` },
+  { key: 'crude_imports_wow', kind: 'transport', toRisk: inverseLinear(-25, 5),
+    label: (v) => `Crude imports ${signedPct(v)} WoW` },
+  { key: 'gulf_weather_risk', kind: 'transport', toRisk: (v) => v,
+    label: (v) => `Gulf weather risk ${Math.round(v)}/100` },
+  { key: 'freight_demand_index', kind: 'demand', toRisk: directLinear(50, 80),
+    label: (v) => `Freight demand index ${Math.round(v)}` },
+  { key: 'crack_spread_distillate', kind: 'price', toRisk: directLinear(20, 50),
+    label: (v) => `Distillate crack spread $${v.toFixed(1)}/bbl` },
+  { key: 'diesel_retail_price_wow', kind: 'price', toRisk: directLinear(0, 10),
+    label: (v) => `Retail diesel ${signedPct(v)} WoW` },
+  { key: 'futures_curve_distillate', kind: 'price', toRisk: directLinear(0, 10),
+    label: (v) => `Distillate futures curve ${v.toFixed(1)}` },
+  { key: 'spr_release_announcement', kind: 'policy', toRisk: () => 100,
+    label: () => 'SPR release announced — partially protective',
+    when: (v) => v > 0, polarity: 'protective' },
+];
+
+function buildDriversFromSpecs(
+  inputs: DieselModelInputs,
+  specs: readonly DriverSpec<keyof DieselModelInputs>[],
+): ShortageDriver[] {
+  const drivers: ShortageDriver[] = [];
+  for (const spec of specs) {
+    const input = inputs[spec.key];
+    if (!input) continue;
+    if (spec.when && !spec.when(input.value)) continue;
+    drivers.push(
+      buildDriver({
+        kind: spec.kind,
+        value: input.value,
+        toRisk: spec.toRisk,
+        label: spec.label(input.value),
+        source: input.source,
+        polarity: spec.polarity,
+      }),
+    );
+  }
+  return drivers;
+}
+
+export function computeDieselShortageRisk(
+  inputs: DieselModelInputs,
+  options: DieselModelOptions,
+): ShortageForecast {
+  const now = options.now ?? Date.now();
+  const drivers = buildDriversFromSpecs(inputs, DIESEL_DRIVER_SPECS);
+
+  // Hurricane-season bump for transport and production drivers.
+  const month = new Date(now).getUTCMonth() + 1;
+  if (isSeasonalRisk(DIESEL_PLAYBOOK, month)) {
+    for (const d of drivers) {
+      if (d.kind === 'transport' || d.kind === 'production') {
+        d.score = Math.min(100, Math.round(d.score * 1.1));
+      }
+    }
+  }
+
+  const overall = scoreOverallShortage(drivers);
+  const dataGaps = detectGaps(inputs, REQUIRED_INPUTS, now);
+  const worstFreshness = computeWorstFreshness(inputs, now);
+  const confidence = deriveConfidence({
+    gapCount: dataGaps.length,
+    uniqueSourceCount: uniqueSourceCount(drivers),
+    worstFreshness,
+    weightUsed: overall.weightUsed,
+  });
+
+  return {
+    commodity: DIESEL_PLAYBOOK.commodity,
+    domain: DIESEL_PLAYBOOK.domain,
+    region: options.region,
+    horizonDays: DIESEL_PLAYBOOK.forecastHorizonDays,
+    riskScore: overall.riskScore,
+    confidence,
+    drivers,
+    confirmingIndicators: [...DIESEL_PLAYBOOK.confirmingIndicators],
+    invalidatingIndicators: [...DIESEL_PLAYBOOK.invalidatingIndicators],
+    dataGaps,
+    lastUpdated: new Date(now).toISOString(),
+  };
+}
+
+function computeWorstFreshness(inputs: DieselModelInputs, now: number): number {
+  // EIA weekly publishes Wed; markets refresh daily. 7 days is a fair
+  // worst-case refresh window for the slowest input.
+  const week = 7 * 24 * 60 * 60 * 1000;
+  let worst = 1;
+  for (const v of Object.values(inputs)) {
+    if (!v) continue;
+    const f = freshnessFor(v, week, now);
+    if (f < worst) worst = f;
+  }
+  return worst;
+}
+
+function signedPct(n: number): string {
+  return n >= 0 ? `+${n.toFixed(1)}%` : `${n.toFixed(1)}%`;
+}

--- a/src/services/shortage/shortage-score.ts
+++ b/src/services/shortage/shortage-score.ts
@@ -1,0 +1,251 @@
+/**
+ * Shortage scoring helpers — pure deterministic functions that the
+ * commodity models compose into a final ShortageForecast.
+ *
+ * Per the plan's invariants:
+ *   - every score must include drivers + data gaps
+ *   - stale or missing data must reduce confidence (not silently drop)
+ *   - protective signals subtract from risk; they don't get averaged in
+ *
+ * The math here is intentionally simple — weighted means, freshness
+ * decay, threshold mappings. No ML; the plan explicitly says "Start
+ * deterministic. Do not add opaque ML in the first batch."
+ */
+
+import type {
+  ShortageConfidence,
+  ShortageDriver,
+  ShortageDriverKind,
+  ShortageInput,
+  ShortageInputBag,
+} from './shortage-types';
+
+// ── Default weights for the six driver buckets ────────────────────────────
+//
+// Plan example weights (line 154-166): production/inventory dominate,
+// price confirmation is a moderate weight, transport/policy/demand fill
+// the middle. cross_domain is the catch-all, weighted lower so a single
+// overlay doesn't swamp the structured signals.
+
+export const DEFAULT_DRIVER_WEIGHTS: Record<ShortageDriverKind, number> = {
+  production: 0.25,
+  inventory: 0.2,
+  transport: 0.15,
+  policy: 0.1,
+  demand: 0.1,
+  price: 0.15,
+  cross_domain: 0.05,
+};
+
+// ── Overall score ────────────────────────────────────────────────────────
+
+export interface OverallScoreOptions {
+  /** Per-bucket weights override. Missing keys fall through to default. */
+  weights?: Partial<Record<ShortageDriverKind, number>>;
+  /** Reduces score by this fraction per data gap, capped at 0.4 so even
+   *  many gaps can't zero out a strong structural signal. */
+  gapPenaltyPerItem?: number;
+}
+
+export interface OverallScoreResult {
+  /** 0-100 weighted overall risk score. */
+  riskScore: number;
+  /** Weighted contribution by driver kind, useful for explanation UI. */
+  contributionByKind: Record<ShortageDriverKind, number>;
+  /** Sum of weights actually used (drops missing buckets). The UI
+   *  renders this as the denominator: "65/85 — 20 pts of inputs missing". */
+  weightUsed: number;
+}
+
+/** Average drivers within each bucket, then weight-average across buckets.
+ *  Protective drivers (polarity:'protective') subtract within their bucket.
+ *  Buckets with no drivers are dropped from the denominator — that's how
+ *  "missing data reduces confidence" propagates. */
+export function scoreOverallShortage(
+  drivers: readonly ShortageDriver[],
+  options: OverallScoreOptions = {},
+): OverallScoreResult {
+  const weights = { ...DEFAULT_DRIVER_WEIGHTS, ...options.weights };
+  const byKind = new Map<ShortageDriverKind, ShortageDriver[]>();
+  for (const d of drivers) {
+    if (!byKind.has(d.kind)) byKind.set(d.kind, []);
+    byKind.get(d.kind)!.push(d);
+  }
+
+  const contribution: Record<ShortageDriverKind, number> = {
+    production: 0, inventory: 0, transport: 0, policy: 0,
+    demand: 0, price: 0, cross_domain: 0,
+  };
+  let weighted = 0;
+  let weightUsed = 0;
+
+  for (const [kind, bucketDrivers] of byKind) {
+    const weight = weights[kind] ?? 0;
+    if (weight <= 0) continue;
+    const bucketScore = averageBucket(bucketDrivers);
+    contribution[kind] = bucketScore * weight;
+    weighted += contribution[kind];
+    weightUsed += weight;
+  }
+
+  // Renormalize against weight actually used so partial coverage
+  // doesn't artificially shrink the score.
+  const normalized = weightUsed > 0 ? weighted / weightUsed : 0;
+  return {
+    riskScore: clamp(0, 100, Math.round(normalized)),
+    contributionByKind: contribution,
+    weightUsed,
+  };
+}
+
+function averageBucket(drivers: readonly ShortageDriver[]): number {
+  if (drivers.length === 0) return 0;
+  let sum = 0;
+  for (const d of drivers) {
+    const signed = d.polarity === 'protective' ? -d.score : d.score;
+    sum += signed;
+  }
+  return clamp(0, 100, sum / drivers.length);
+}
+
+// ── Confidence ───────────────────────────────────────────────────────────
+
+export interface ConfidenceOptions {
+  /** Number of data gaps; each one drops confidence one rung. */
+  gapCount: number;
+  /** Number of distinct sources backing the drivers. Used to penalize
+   *  single-provider conclusions even when their signal is strong. */
+  uniqueSourceCount: number;
+  /** Worst freshness fraction (0 = stale, 1 = fresh) across critical
+   *  inputs. Stale inputs cap confidence at 'medium'. */
+  worstFreshness: number;
+  /** Sum of weights actually used by scoreOverallShortage. ≤0.5 means
+   *  more than half the model is missing — confidence cannot be high. */
+  weightUsed: number;
+}
+
+export function deriveConfidence(opts: ConfidenceOptions): ShortageConfidence {
+  if (opts.weightUsed < 0.5 || opts.gapCount >= 4 || opts.uniqueSourceCount === 0) {
+    return 'low';
+  }
+  if (opts.uniqueSourceCount === 1 || opts.worstFreshness < 0.4 || opts.gapCount >= 2) {
+    return 'medium';
+  }
+  if (opts.weightUsed >= 0.75 && opts.uniqueSourceCount >= 2 && opts.worstFreshness >= 0.6) {
+    return 'high';
+  }
+  return 'medium';
+}
+
+// ── Freshness ────────────────────────────────────────────────────────────
+
+/** 1.0 at observation, 0.5 at the model's expected refresh window,
+ *  0.0 at ≥2× the window. Mirrors the truth-score freshness curve so
+ *  the two layers tell consistent stories. */
+export function freshnessFor(
+  input: ShortageInput | undefined,
+  expectedRefreshMs: number,
+  now: number,
+): number {
+  if (!input) return 0;
+  const age = Math.max(0, now - input.observedAt);
+  if (age <= 0) return 1;
+  if (age >= 2 * expectedRefreshMs) return 0;
+  return clamp(0, 1, 1 - age / (2 * expectedRefreshMs));
+}
+
+// ── Driver builders — small helpers so models stay readable ─────────────
+
+export interface BuildDriverArgs {
+  kind: ShortageDriverKind;
+  /** Raw indicator value, e.g. "rainfall pct of normal", "inventory pct
+   *  of 5-year average". */
+  value: number;
+  /** Function that maps the raw value into a 0-100 risk score. */
+  toRisk: (v: number) => number;
+  label: string;
+  source?: string;
+  polarity?: 'risk' | 'protective';
+  factId?: string;
+}
+
+export function buildDriver(args: BuildDriverArgs): ShortageDriver {
+  return {
+    kind: args.kind,
+    score: clamp(0, 100, Math.round(args.toRisk(args.value))),
+    label: args.label,
+    sources: args.source ? [args.source] : undefined,
+    polarity: args.polarity,
+    factId: args.factId,
+  };
+}
+
+// ── Common toRisk mappings the models reuse ─────────────────────────────
+
+/** Linear inverse: lowValue → 100 risk, highValue → 0 risk.
+ *  e.g. rainfall % of normal: 50% → high risk, 100% → low risk. */
+export function inverseLinear(low: number, high: number): (v: number) => number {
+  return (v) => {
+    if (v <= low) return 100;
+    if (v >= high) return 0;
+    return ((high - v) / (high - low)) * 100;
+  };
+}
+
+/** Linear: lowValue → 0 risk, highValue → 100 risk.
+ *  e.g. price increase %: 0% → 0 risk, 30% → 100 risk. */
+export function directLinear(low: number, high: number): (v: number) => number {
+  return (v) => {
+    if (v <= low) return 0;
+    if (v >= high) return 100;
+    return ((v - low) / (high - low)) * 100;
+  };
+}
+
+// ── Data gap helper ──────────────────────────────────────────────────────
+
+/** Walks a known-key list against the input bag and returns a list of
+ *  human-readable "missing X" strings for any absent keys. Models pass
+ *  this directly into ShortageForecast.dataGaps. */
+export function detectGaps(
+  inputs: ShortageInputBag,
+  required: readonly { key: string; label: string; staleAfterMs?: number }[],
+  now: number,
+): string[] {
+  const gaps: string[] = [];
+  for (const { key, label, staleAfterMs } of required) {
+    const v = inputs[key];
+    if (!v) {
+      gaps.push(`Missing ${label}`);
+      continue;
+    }
+    if (staleAfterMs !== undefined && now - v.observedAt > staleAfterMs) {
+      gaps.push(`Stale ${label} (last update ${formatAge(now - v.observedAt)})`);
+    }
+  }
+  return gaps;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function clamp(min: number, max: number, x: number): number {
+  return Math.max(min, Math.min(max, x));
+}
+
+function formatAge(ms: number): string {
+  const days = Math.floor(ms / (24 * 60 * 60 * 1000));
+  if (days >= 1) return `${days}d ago`;
+  const hours = Math.floor(ms / (60 * 60 * 1000));
+  if (hours >= 1) return `${hours}h ago`;
+  const minutes = Math.floor(ms / (60 * 1000));
+  return `${minutes}m ago`;
+}
+
+/** Count distinct source ids across drivers (used by deriveConfidence). */
+export function uniqueSourceCount(drivers: readonly ShortageDriver[]): number {
+  const set = new Set<string>();
+  for (const d of drivers) {
+    for (const s of d.sources ?? []) set.add(s);
+  }
+  return set.size;
+}

--- a/src/services/shortage/shortage-types.ts
+++ b/src/services/shortage/shortage-types.ts
@@ -1,0 +1,130 @@
+/**
+ * Crystal Ball shortage/commodity forecast layer — shared types.
+ *
+ * Per docs/SHORTAGE_AND_COMMODITY_FORECAST_PLAN.md "First Implementation
+ * Batch" (lines 213-251): a shared shortage framework first, then two
+ * deterministic models (wheat + diesel). UI surfaces come later.
+ *
+ * Plan invariants this file encodes:
+ *   - every shortage score must include drivers + data gaps
+ *   - every forecast must include confirming + invalidating indicators
+ *   - source provenance is required for all inputs
+ *   - stale or missing data must reduce confidence (not silently drop)
+ *
+ * No DOM, no fetch, no globals. Plain TypeScript so the models can be
+ * tested with static fixtures and reused across the app.
+ */
+
+export type ShortageDomain = 'food' | 'energy' | 'fertilizer' | 'water';
+
+export type ShortageConfidence = 'low' | 'medium' | 'high';
+
+/** The six universal driver buckets from the plan's "Leading Indicator
+ *  Scores" section (lines 144-166). Each model fills the buckets that
+ *  apply to its commodity; missing buckets reduce confidence rather
+ *  than silently zero out (see scoreOverallShortage). */
+export type ShortageDriverKind =
+  | 'production'
+  | 'inventory'
+  | 'transport'
+  | 'policy'
+  | 'demand'
+  | 'price'
+  /** Catch-all for cross-domain overlays (weather × crop calendar,
+   *  conflict × port chokepoints) that don't fit a single bucket. */
+  | 'cross_domain';
+
+export interface ShortageDriver {
+  kind: ShortageDriverKind;
+  /** 0-100 risk contribution from this driver. Higher = worse. */
+  score: number;
+  /** Free-text — what the user sees in the explanation. e.g.
+   *  "Distillate inventories below 5-year range". */
+  label: string;
+  /** Optional source ids (provider registry keys) backing this driver. */
+  sources?: string[];
+  /** Polarity. 'risk' = adds to shortage; 'protective' = reduces it.
+   *  Defaults to 'risk' on read; protective drivers subtract instead
+   *  of add when computing the overall score. */
+  polarity?: 'risk' | 'protective';
+  /** Optional pointer back to a NormalizedFact id (PR 1 evidence
+   *  graph) so the UI can drill from a driver into its provenance. */
+  factId?: string;
+}
+
+export interface ShortageForecast {
+  /** Commodity name as used in the playbook ("wheat", "diesel"). */
+  commodity: string;
+  domain: ShortageDomain;
+  /** Free-form region label — country code, region name, "global". */
+  region: string;
+  /** Forward-looking horizon for the forecast. Models pick from their
+   *  playbook's `forecastHorizonDays`. */
+  horizonDays: number;
+  /** 0-100 weighted overall score. Computed by scoreOverallShortage. */
+  riskScore: number;
+  confidence: ShortageConfidence;
+  drivers: ShortageDriver[];
+  /** Plain-language signals the user should expect to see if the
+   *  forecast is right (the plan's "Watch Windows" section). */
+  confirmingIndicators: string[];
+  /** Signals that, if observed, should weaken confidence and could
+   *  flip the call. */
+  invalidatingIndicators: string[];
+  /** Inputs the model wanted but didn't have. Each item drops
+   *  confidence and explains *why* it dropped — never silently
+   *  swallowed. */
+  dataGaps: string[];
+  /** ISO-8601 timestamp. Models that consume stale inputs should
+   *  reflect that here so the UI can render an "as of" line. */
+  lastUpdated: string;
+}
+
+// ── Inputs the models accept ─────────────────────────────────────────────
+
+/** Provenance-aware numeric input. The model reads `value` for math
+ *  and uses `observedAt` + `source` to compute freshness/confidence. */
+export interface ShortageInput {
+  value: number;
+  /** Epoch ms when this value was measured/published. */
+  observedAt: number;
+  /** Provider id matching the registry. Optional but expected for
+   *  anything that should appear in `dataGaps` when stale. */
+  source?: string;
+  /** Optional unit (USD/bbl, % of capacity, mm rainfall). Models
+   *  ignore the string but pass it through to driver labels. */
+  unit?: string;
+}
+
+/** A complete-or-partial set of inputs handed to a model. The model is
+ *  responsible for noting which inputs were missing as data gaps. */
+export type ShortageInputBag = Record<string, ShortageInput | undefined>;
+
+// ── Playbook definition ──────────────────────────────────────────────────
+
+/** Per the plan's "Commodity Playbooks" section (lines 108-142): each
+ *  commodity defines its leading/confirming/invalidating signals and
+ *  known constants. Playbooks live in `commodity-playbooks.ts`. */
+export interface CommodityPlaybook {
+  commodity: string;
+  domain: ShortageDomain;
+  /** Inputs the model considers leading (move first). */
+  leadingIndicators: string[];
+  /** Inputs the model considers confirming (move with the price). */
+  confirmingIndicators: string[];
+  /** Inputs that, if present, should weaken or invalidate the call. */
+  invalidatingIndicators: string[];
+  /** Months of the year (1-12) when the commodity is most exposed.
+   *  Empty array means "no clear seasonality". */
+  seasonalRiskMonths: number[];
+  /** Free-text geographic chokepoints. Wheat: "Black Sea ports".
+   *  Diesel: "Strait of Hormuz", "US Gulf Coast refineries". */
+  chokepoints: string[];
+  /** Country codes most exposed (ISO 3166-1 alpha-2). */
+  affectedCountries: string[];
+  /** Sectors materially impacted by a sustained shortage. */
+  affectedSectors: string[];
+  /** Days into the future this playbook's forecasts target. Models
+   *  may use a shorter horizon if their inputs are stale. */
+  forecastHorizonDays: number;
+}

--- a/src/services/shortage/wheat-shortage-risk.ts
+++ b/src/services/shortage/wheat-shortage-risk.ts
@@ -1,0 +1,186 @@
+/**
+ * Deterministic wheat shortage risk model.
+ *
+ * Per the plan's worked example (lines 53-63):
+ *
+ *   Wheat shortage risk rising in Region X:
+ *   - rainfall 42% below normal during key growth window
+ *   - soil moisture below 10th percentile
+ *   - fertilizer prices rising
+ *   - export corridor disrupted
+ *   - local wheat prices up 18% month-over-month
+ *   - FEWS NET classification deteriorating nearby
+ *
+ * The model takes a `ShortageInputBag` of those indicators (provenance-
+ * aware), maps each to a 0-100 driver in the right bucket, runs the
+ * shared scorer, and reports drivers + data gaps + confidence.
+ *
+ * No fetch, no globals. Tests pass synthetic inputs.
+ */
+
+import type { ShortageDriver, ShortageForecast, ShortageInput, ShortageInputBag } from './shortage-types';
+import {
+  buildDriver,
+  deriveConfidence,
+  detectGaps,
+  directLinear,
+  freshnessFor,
+  inverseLinear,
+  scoreOverallShortage,
+  uniqueSourceCount,
+} from './shortage-score';
+import { WHEAT_PLAYBOOK, isSeasonalRisk } from './commodity-playbooks';
+
+export interface WheatModelInputs extends ShortageInputBag {
+  /** Seasonal rainfall as % of normal. 50 = drought. */
+  rainfall_pct_of_normal?: ShortageInput;
+  /** Soil moisture percentile (0-100). 10 = severely dry. */
+  soil_moisture_percentile?: ShortageInput;
+  /** NDVI anomaly vs 10y baseline (negative = stressed). */
+  ndvi_anomaly?: ShortageInput;
+  /** Fertilizer price YoY % change (positive = rising costs). */
+  fertilizer_price_yoy?: ShortageInput;
+  /** Planting progress as % of typical pace at this date. */
+  planting_progress_pct?: ShortageInput;
+  /** Export corridor status: 0 = open, 100 = fully blocked. */
+  export_corridor_status?: ShortageInput;
+  /** Local wheat price month-over-month % change. */
+  local_wheat_price_mom?: ShortageInput;
+  /** Futures curve "tightness" (positive = backwardation). */
+  futures_curve_tightness?: ShortageInput;
+  /** Number of recent export bans by major producers. */
+  export_ban_count?: ShortageInput;
+  /** FEWS NET food-security stage 1-5 (5 = famine). */
+  fews_net_stage?: ShortageInput;
+}
+
+export interface WheatModelOptions {
+  region: string;
+  /** Defaults to Date.now(). Inject for deterministic tests. */
+  now?: number;
+}
+
+const REQUIRED_INPUTS = [
+  { key: 'rainfall_pct_of_normal', label: 'rainfall vs normal', staleAfterMs: 7 * 24 * 60 * 60 * 1000 },
+  { key: 'soil_moisture_percentile', label: 'soil moisture percentile', staleAfterMs: 7 * 24 * 60 * 60 * 1000 },
+  { key: 'fertilizer_price_yoy', label: 'fertilizer prices', staleAfterMs: 30 * 24 * 60 * 60 * 1000 },
+  { key: 'export_corridor_status', label: 'export corridor status', staleAfterMs: 14 * 24 * 60 * 60 * 1000 },
+  { key: 'local_wheat_price_mom', label: 'local wheat price', staleAfterMs: 14 * 24 * 60 * 60 * 1000 },
+];
+
+// Each spec maps a single input key to a driver. Spec list is walked
+// once in computeWheatShortageRisk so the function stays small.
+interface DriverSpec<K extends keyof WheatModelInputs> {
+  key: K;
+  kind: ShortageDriver['kind'];
+  toRisk: (v: number) => number;
+  label: (v: number) => string;
+  /** Optional gate — driver is skipped when the predicate returns false. */
+  when?: (v: number) => boolean;
+  polarity?: 'risk' | 'protective';
+}
+
+const WHEAT_DRIVER_SPECS: DriverSpec<keyof WheatModelInputs>[] = [
+  { key: 'rainfall_pct_of_normal', kind: 'production', toRisk: inverseLinear(40, 100),
+    label: (v) => `Rainfall ${Math.round(v)}% of normal` },
+  { key: 'soil_moisture_percentile', kind: 'production', toRisk: inverseLinear(0, 50),
+    label: (v) => `Soil moisture ${Math.round(v)}th percentile` },
+  { key: 'ndvi_anomaly', kind: 'production', toRisk: inverseLinear(-0.25, 0.05),
+    label: (v) => `NDVI anomaly ${v.toFixed(2)} vs baseline` },
+  { key: 'planting_progress_pct', kind: 'production', toRisk: inverseLinear(40, 100),
+    label: (v) => `Planting progress ${Math.round(v)}% of typical` },
+  { key: 'fertilizer_price_yoy', kind: 'policy', toRisk: directLinear(0, 60),
+    label: (v) => `Fertilizer prices +${Math.round(v)}% YoY` },
+  { key: 'export_ban_count', kind: 'policy', toRisk: directLinear(0, 5),
+    label: (v) => `${v} active export ban(s) by major producers`,
+    when: (v) => v > 0 },
+  { key: 'export_corridor_status', kind: 'transport', toRisk: (v) => v,
+    label: (v) => `Export corridor status ${Math.round(v)}/100 disrupted` },
+  { key: 'local_wheat_price_mom', kind: 'price', toRisk: directLinear(0, 30),
+    label: (v) => `Local wheat price ${signed(v)}% MoM` },
+  { key: 'futures_curve_tightness', kind: 'price', toRisk: directLinear(0, 10),
+    label: (v) => `Futures curve tightness ${v.toFixed(1)}` },
+  { key: 'fews_net_stage', kind: 'cross_domain', toRisk: directLinear(1, 5),
+    label: (v) => `FEWS NET stage ${v.toFixed(0)}` },
+];
+
+function buildDriversFromSpecs(
+  inputs: WheatModelInputs,
+  specs: readonly DriverSpec<keyof WheatModelInputs>[],
+): ShortageDriver[] {
+  const drivers: ShortageDriver[] = [];
+  for (const spec of specs) {
+    const input = inputs[spec.key];
+    if (!input) continue;
+    if (spec.when && !spec.when(input.value)) continue;
+    drivers.push(
+      buildDriver({
+        kind: spec.kind,
+        value: input.value,
+        toRisk: spec.toRisk,
+        label: spec.label(input.value),
+        source: input.source,
+        polarity: spec.polarity,
+      }),
+    );
+  }
+  return drivers;
+}
+
+export function computeWheatShortageRisk(
+  inputs: WheatModelInputs,
+  options: WheatModelOptions,
+): ShortageForecast {
+  const now = options.now ?? Date.now();
+  const drivers = buildDriversFromSpecs(inputs, WHEAT_DRIVER_SPECS);
+
+  // Seasonal multiplier: in-window stress is more meaningful than out-of-
+  // window noise. We bump production drivers by +10% when in-season.
+  const month = new Date(now).getUTCMonth() + 1;
+  if (isSeasonalRisk(WHEAT_PLAYBOOK, month)) {
+    for (const d of drivers) {
+      if (d.kind === 'production') d.score = Math.min(100, Math.round(d.score * 1.1));
+    }
+  }
+
+  const overall = scoreOverallShortage(drivers);
+  const dataGaps = detectGaps(inputs, REQUIRED_INPUTS, now);
+  const worstFreshness = computeWorstFreshness(inputs, now);
+  const confidence = deriveConfidence({
+    gapCount: dataGaps.length,
+    uniqueSourceCount: uniqueSourceCount(drivers),
+    worstFreshness,
+    weightUsed: overall.weightUsed,
+  });
+
+  return {
+    commodity: WHEAT_PLAYBOOK.commodity,
+    domain: WHEAT_PLAYBOOK.domain,
+    region: options.region,
+    horizonDays: WHEAT_PLAYBOOK.forecastHorizonDays,
+    riskScore: overall.riskScore,
+    confidence,
+    drivers,
+    confirmingIndicators: [...WHEAT_PLAYBOOK.confirmingIndicators],
+    invalidatingIndicators: [...WHEAT_PLAYBOOK.invalidatingIndicators],
+    dataGaps,
+    lastUpdated: new Date(now).toISOString(),
+  };
+}
+
+function computeWorstFreshness(inputs: WheatModelInputs, now: number): number {
+  // 14 days = expected refresh window for the model's bread-and-butter
+  // weekly indicators (rainfall, prices, FEWS NET).
+  const week = 7 * 24 * 60 * 60 * 1000;
+  let worst = 1;
+  for (const v of Object.values(inputs)) {
+    if (!v) continue;
+    const f = freshnessFor(v, week, now);
+    if (f < worst) worst = f;
+  }
+  return worst;
+}
+
+function signed(n: number): string {
+  return n >= 0 ? `+${Math.round(n)}` : `${Math.round(n)}`;
+}


### PR DESCRIPTION
First batch of the shortage/commodity forecast layer per [docs/SHORTAGE_AND_COMMODITY_FORECAST_PLAN.md](docs/SHORTAGE_AND_COMMODITY_FORECAST_PLAN.md).

Pure deterministic, fixture-tested — **no UI changes**.

## What's in
- \`shortage-types.ts\` — \`ShortageDomain\`, \`ShortageDriver\`, \`ShortageInput\`, \`ShortageInputBag\`, \`ShortageForecast\`, \`CommodityPlaybook\`
- \`shortage-score.ts\` — weighted scorer, freshness, confidence derivation, data-gap detection. Seven driver buckets (production / inventory / transport / policy / demand / price / cross_domain) with the plan's example weights. Missing buckets drop from the denominator (no silent zeroing).
- \`commodity-playbooks.ts\` — \`WHEAT_PLAYBOOK\` (food, 60d horizon, Black Sea + Bosphorus + Suez) and \`DIESEL_PLAYBOOK\` (energy, 30d horizon, US Gulf + Hormuz + Rotterdam) with leading / confirming / invalidating indicators
- \`wheat-shortage-risk.ts\` — spec-driven model matching the plan's worked example (rainfall / soil moisture / NDVI / fertilizer / corridor / local price / FEWS NET). Seasonal multiplier amplifies in-window production stress.
- \`diesel-shortage-risk.ts\` — EIA inventory / refinery utilization / crack spread / freight / SPR (protective). Hurricane-season multiplier on transport + production.

## Tests
37 deterministic unit tests covering score math, freshness curves, confidence derivation, data-gap detection, and end-to-end wheat/diesel forecasts with the plan's exact scenarios.

\`\`\`bash
npm run test:shortage      # 37/37 passing
npm run typecheck:all      # clean
\`\`\`

## Plan invariants honored
- ✅ Every shortage score includes drivers + data gaps
- ✅ Every forecast includes confirming + invalidating indicators
- ✅ Source provenance for all inputs
- ✅ Stale or missing data reduces confidence (does not silently disappear)
- ✅ Outputs stable for unit tests
- ✅ Deterministic (no opaque ML in batch 1)

## Out of scope
- Insight Products (Shortage Radar, Food Security Map, etc.) — come after the model layer is settled
- Live data wiring to USDA / EIA / FAO / FEWS NET / EIA Open Data
- Additional commodities (corn, rice, soybeans, gas, jet fuel, …)