### PR TITLE
feat(intelligence): PR 2 — situation clustering

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "test:providers": "tsx --test src/services/providers/__tests__/registry.test.mts src/services/providers/__tests__/health.test.mts src/services/providers/__tests__/fusion.test.mts",
     "test:shortage": "tsx --test src/services/shortage/__tests__/shortage-score.test.mts src/services/shortage/__tests__/commodity-playbooks.test.mts",
     "test:weather": "tsx --test src/services/weather/__tests__/nws-polygon-match.test.mts",
-    "test:intelligence": "tsx --test src/services/intelligence/__tests__/truth-score.test.mts src/services/intelligence/__tests__/evidence-graph.test.mts",
+    "test:intelligence": "tsx --test src/services/intelligence/__tests__/truth-score.test.mts src/services/intelligence/__tests__/evidence-graph.test.mts src/services/intelligence/__tests__/situation-clustering.test.mts",
     "test:feeds": "node scripts/validate-rss-feeds.mjs",
     "test:sidecar": "node --test src-tauri/sidecar/local-api-server.test.mjs api/_cors.test.mjs api/_api-key.test.mjs api/youtube/embed.test.mjs api/cyber-threats.test.mjs api/usni-fleet.test.mjs scripts/ais-relay-rss.test.cjs api/loaders-xml-wms-regression.test.mjs",
     "test:api": "node --test api/__tests__/*.test.mjs",

--- a/src/services/intelligence/__tests__/situation-clustering.test.mts
+++ b/src/services/intelligence/__tests__/situation-clustering.test.mts
@@ -1,0 +1,302 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { clusterFacts } from '../situation-clustering.ts';
+import type { NormalizedFact, SourceAttestation } from '../types.ts';
+
+const NOW = 1_745_000_000_000;
+
+function source(providerId: string): SourceAttestation {
+  return { providerId, observedAt: NOW };
+}
+
+function quakeFact(overrides: Partial<NormalizedFact> = {}): NormalizedFact {
+  return {
+    id: 'q-1',
+    domain: 'space',
+    eventType: 'earthquake',
+    claim: 'M5.5 quake',
+    severity: 'moderate',
+    occurredAt: NOW,
+    lat: 35.68,
+    lon: 139.69,
+    locationPrecision: 'point',
+    entities: ['JP'],
+    sources: [source('usgs')],
+    ...overrides,
+  };
+}
+
+function weatherFact(overrides: Partial<NormalizedFact> = {}): NormalizedFact {
+  return {
+    id: 'w-1',
+    domain: 'weather',
+    eventType: 'severe-thunderstorm',
+    claim: 'Severe TS warning',
+    severity: 'high',
+    occurredAt: NOW,
+    lat: 41.6,
+    lon: -86.7,
+    locationPrecision: 'local',
+    entities: ['US-IN'],
+    sources: [source('nws')],
+    ...overrides,
+  };
+}
+
+// ── Basic clustering ────────────────────────────────────────────────────
+
+test('cluster: two close facts in same domain merge into one situation', () => {
+  const a = quakeFact();
+  const b = quakeFact({
+    id: 'q-2',
+    claim: 'M5.4 aftershock',
+    occurredAt: NOW + 30 * 60 * 1000,
+    lat: 35.70,
+    lon: 139.71,
+    sources: [source('jma')],
+  });
+  const result = clusterFacts([a, b]);
+  assert.equal(result.length, 1);
+  assert.deepEqual(result[0]!.factIds.sort(), ['q-1', 'q-2']);
+});
+
+test('cluster: distant facts do not merge', () => {
+  const a = quakeFact();
+  const b = quakeFact({
+    id: 'q-2',
+    lat: -33.86, // Sydney — 7000+ km from Tokyo
+    lon: 151.21,
+    entities: ['AU'],
+  });
+  const result = clusterFacts([a, b]);
+  assert.equal(result.length, 2);
+});
+
+test('cluster: time-distant facts do not merge', () => {
+  const a = quakeFact();
+  const b = quakeFact({
+    id: 'q-2',
+    occurredAt: NOW + 24 * 60 * 60 * 1000, // a day later
+  });
+  const result = clusterFacts([a, b]);
+  assert.equal(result.length, 2);
+});
+
+test('cluster: different domains do not merge by default', () => {
+  // Even at the same coordinates: a quake and a weather event aren't
+  // the "same situation" unless they share an entity.
+  const a = quakeFact({ entities: ['XX-1'] });
+  const b = weatherFact({
+    lat: a.lat,
+    lon: a.lon,
+    entities: ['XX-2'], // no shared entity
+  });
+  const result = clusterFacts([a, b]);
+  assert.equal(result.length, 2);
+});
+
+test('cluster: cross-domain facts WITH shared entity DO merge (compound situations)', () => {
+  // Plan invariant: cross-domain situations are first-class.
+  const quake = quakeFact({ entities: ['JP'] });
+  const tsunami: NormalizedFact = {
+    id: 't-1',
+    domain: 'humanitarian',
+    eventType: 'tsunami-warning',
+    claim: 'Tsunami warning for east coast',
+    severity: 'critical',
+    occurredAt: NOW + 5 * 60 * 1000,
+    lat: 35.68,
+    lon: 139.69,
+    locationPrecision: 'country',
+    entities: ['JP'],
+    sources: [source('jma')],
+  };
+  const result = clusterFacts([quake, tsunami]);
+  assert.equal(result.length, 1);
+  const sit = result[0]!;
+  assert.deepEqual(sit.domains.sort(), ['humanitarian', 'space']);
+});
+
+// ── requireSameEventType option ────────────────────────────────────────
+
+test('cluster: requireSameEventType=true keeps different events apart even when close', () => {
+  const ts = weatherFact();
+  const tornado = weatherFact({
+    id: 'w-2',
+    eventType: 'tornado-warning',
+    claim: 'Tornado warning',
+    occurredAt: NOW + 10 * 60 * 1000,
+  });
+  const merged = clusterFacts([ts, tornado]);
+  assert.equal(merged.length, 1, 'default should merge same-domain near facts');
+  const split = clusterFacts([ts, tornado], { requireSameEventType: true });
+  assert.equal(split.length, 2);
+});
+
+// ── Title + drivers ─────────────────────────────────────────────────────
+
+test('title: single fact uses its claim verbatim', () => {
+  const result = clusterFacts([quakeFact()]);
+  assert.equal(result[0]!.title, 'M5.5 quake');
+});
+
+test('title: multi-member uses top severity claim + "+N more"', () => {
+  const a = quakeFact({ severity: 'low' });
+  const b = quakeFact({
+    id: 'q-2',
+    severity: 'critical',
+    claim: 'M7.1 mainshock',
+    occurredAt: NOW + 1000,
+  });
+  const result = clusterFacts([a, b]);
+  assert.equal(result[0]!.title, 'M7.1 mainshock (+1 more)');
+});
+
+test('topDrivers: sorted by severity then recency', () => {
+  const facts: NormalizedFact[] = [
+    quakeFact({ id: 'q-low', severity: 'low', claim: 'low-severity claim' }),
+    quakeFact({ id: 'q-crit', severity: 'critical', claim: 'critical claim', occurredAt: NOW - 60 * 1000 }),
+    quakeFact({ id: 'q-mod', severity: 'moderate', claim: 'moderate claim' }),
+  ];
+  const result = clusterFacts(facts);
+  assert.equal(result[0]!.topDrivers[0], 'critical claim');
+  assert.equal(result[0]!.topDrivers[1], 'moderate claim');
+});
+
+// ── Trend ───────────────────────────────────────────────────────────────
+
+test('trend: severity climbing over time → rising', () => {
+  const facts: NormalizedFact[] = [
+    quakeFact({ id: 'q-1', severity: 'info', occurredAt: NOW - 60 * 60 * 1000 }),
+    quakeFact({ id: 'q-2', severity: 'low', occurredAt: NOW - 30 * 60 * 1000 }),
+    quakeFact({ id: 'q-3', severity: 'high', occurredAt: NOW - 5 * 60 * 1000 }),
+    quakeFact({ id: 'q-4', severity: 'critical', occurredAt: NOW }),
+  ];
+  const result = clusterFacts(facts);
+  assert.equal(result[0]!.trend, 'rising');
+});
+
+test('trend: severity calming → falling', () => {
+  const facts: NormalizedFact[] = [
+    quakeFact({ id: 'q-1', severity: 'critical', occurredAt: NOW - 60 * 60 * 1000 }),
+    quakeFact({ id: 'q-2', severity: 'high', occurredAt: NOW - 30 * 60 * 1000 }),
+    quakeFact({ id: 'q-3', severity: 'low', occurredAt: NOW - 10 * 60 * 1000 }),
+    quakeFact({ id: 'q-4', severity: 'info', occurredAt: NOW }),
+  ];
+  const result = clusterFacts(facts);
+  assert.equal(result[0]!.trend, 'falling');
+});
+
+test('trend: flat severity → steady', () => {
+  const facts: NormalizedFact[] = [
+    quakeFact({ id: 'q-1', severity: 'moderate', occurredAt: NOW - 60 * 60 * 1000 }),
+    quakeFact({ id: 'q-2', severity: 'moderate', occurredAt: NOW - 30 * 60 * 1000 }),
+    quakeFact({ id: 'q-3', severity: 'moderate' }),
+  ];
+  const result = clusterFacts(facts);
+  assert.equal(result[0]!.trend, 'steady');
+});
+
+test('trend: single-member situation is steady (insufficient data)', () => {
+  const result = clusterFacts([quakeFact()]);
+  assert.equal(result[0]!.trend, 'steady');
+});
+
+// ── Centroid ────────────────────────────────────────────────────────────
+
+test('centroid: averages member coordinates', () => {
+  // Within 50 km of each other so they cluster into one situation.
+  const a = quakeFact({ id: 'q-1', lat: 35.50, lon: 139.50 });
+  const b = quakeFact({ id: 'q-2', lat: 35.70, lon: 139.70 });
+  const result = clusterFacts([a, b]);
+  assert.equal(result.length, 1);
+  assert.equal(result[0]!.centroid!.lat, 35.6);
+  assert.equal(result[0]!.centroid!.lon, 139.6);
+});
+
+test('centroid: undefined when no member has coords', () => {
+  const a: NormalizedFact = {
+    id: 'macro-1',
+    domain: 'macro',
+    eventType: 'rate-decision',
+    claim: 'Fed +25bp',
+    severity: 'moderate',
+    occurredAt: NOW,
+    locationPrecision: 'global',
+    entities: ['USD'],
+    sources: [source('fed')],
+  };
+  const result = clusterFacts([a]);
+  assert.equal(result[0]!.centroid, undefined);
+});
+
+// ── Time window ─────────────────────────────────────────────────────────
+
+test('timeWindow: spans earliest to latest member occurredAt', () => {
+  const a = quakeFact({ occurredAt: NOW - 60 * 60 * 1000 });
+  const b = quakeFact({ id: 'q-2', occurredAt: NOW });
+  const result = clusterFacts([a, b]);
+  assert.equal(result[0]!.timeWindow.from, NOW - 60 * 60 * 1000);
+  assert.equal(result[0]!.timeWindow.to, NOW);
+});
+
+// ── Confidence + providers ─────────────────────────────────────────────
+
+test('confidence: blended truth scores in 0-1', () => {
+  const result = clusterFacts([quakeFact()]);
+  assert.ok(result[0]!.confidence >= 0 && result[0]!.confidence <= 1);
+});
+
+test('contributingProviders: deduped across members', () => {
+  const a = quakeFact({ sources: [source('usgs')] });
+  const b = quakeFact({ id: 'q-2', sources: [source('usgs'), source('emsc')] });
+  const result = clusterFacts([a, b]);
+  assert.deepEqual(result[0]!.contributingProviders.sort(), ['emsc', 'usgs']);
+});
+
+// ── Contradictions surfaced, not averaged away ─────────────────────────
+
+test('contradictions: collected from member contradictedBy', () => {
+  const a = quakeFact({ contradictedBy: ['retraction-1'] });
+  const b = quakeFact({ id: 'q-2', contradictedBy: ['retraction-2'] });
+  const result = clusterFacts([a, b]);
+  assert.deepEqual(
+    result[0]!.contradictingFactIds.sort(),
+    ['retraction-1', 'retraction-2'],
+  );
+});
+
+// ── Custom score injection ─────────────────────────────────────────────
+
+test('option: scoreOf override is used for confidence', () => {
+  const result = clusterFacts([quakeFact()], { scoreOf: () => 0.42 });
+  assert.equal(result[0]!.confidence, 0.42);
+});
+
+// ── Sorting / determinism ──────────────────────────────────────────────
+
+test('output: sorted with strongest situation first', () => {
+  const big = quakeFact({
+    id: 'q-big',
+    severity: 'critical',
+    sources: [source('a'), source('b'), source('c')],
+  });
+  const small = quakeFact({
+    id: 'q-small',
+    severity: 'low',
+    occurredAt: NOW + 24 * 60 * 60 * 1000, // separate situation
+    lat: -10,
+    lon: 100,
+    entities: ['ID'],
+  });
+  const result = clusterFacts([big, small]);
+  assert.equal(result.length, 2);
+  assert.equal(result[0]!.factIds[0], 'q-big');
+});
+
+test('determinism: same input → same output', () => {
+  const a = clusterFacts([quakeFact(), weatherFact()]);
+  const b = clusterFacts([quakeFact(), weatherFact()]);
+  assert.deepEqual(a, b);
+});

--- a/src/services/intelligence/situation-clustering.ts
+++ b/src/services/intelligence/situation-clustering.ts
@@ -1,0 +1,307 @@
+/**
+ * Situation clustering — per
+ * docs/ALGORITHM_INTELLIGENCE_ENHANCEMENT_PLAN.md PR 2 (lines 508-523).
+ *
+ * Groups NormalizedFacts into Situations along four axes:
+ *   - space (within `spatialKm`)
+ *   - time (within `temporalMs`)
+ *   - source (provider overlap)
+ *   - type (eventType / domain)
+ *
+ * For each Situation we emit:
+ *   - canonical title
+ *   - timeline (member facts ordered by occurredAt)
+ *   - trend (rising / steady / falling severity over the window)
+ *   - blended confidence (mean of member truth scores)
+ *   - top drivers (highest-severity claims)
+ *
+ * Pure deterministic — no fetch, no DOM, no globals. Inputs are facts +
+ * an optional truth-score function; output is Situation[].
+ *
+ * Plan invariant: "Contradictions should be surfaced, not averaged away."
+ * Situations track contradicting fact ids separately from members so
+ * the UI can render dispute callouts without double-counting.
+ */
+
+import type { FactDomain, NormalizedFact, Severity } from './types';
+import { defaultContext, scoreFact, type TruthScoreContext } from './truth-score';
+
+// ── Public types ─────────────────────────────────────────────────────────
+
+export type SituationTrend = 'rising' | 'steady' | 'falling';
+
+export interface Situation {
+  id: string;
+  title: string;
+  /** Primary domain (the most-represented domain across members). */
+  domain: FactDomain;
+  /** All distinct domains touched by members — used to flag
+   *  cross-domain situations downstream (PR 5 compound risk). */
+  domains: FactDomain[];
+  factIds: string[];
+  /** Earliest occurredAt across members, latest across members. */
+  timeWindow: { from: number; to: number };
+  /** Mean lat/lon of geolocated members. Undefined when no member
+   *  has coordinates (e.g. all global/macro facts). */
+  centroid?: { lat: number; lon: number };
+  trend: SituationTrend;
+  /** Mean of member truthScores in 0-1. */
+  confidence: number;
+  /** Up to 5 top driver headlines, ordered by severity then recency. */
+  topDrivers: string[];
+  /** Distinct providers attesting to any member fact. */
+  contributingProviders: string[];
+  /** Fact ids that contradict at least one member (collected from each
+   *  member's contradictedBy list). Tracked separately so confidence
+   *  isn't averaged away. */
+  contradictingFactIds: string[];
+}
+
+// ── Options ──────────────────────────────────────────────────────────────
+
+export interface ClusterOptions {
+  /** Two facts cluster if their coords are within this km of each other.
+   *  Default 50. Set higher for slow-moving domains (markets/macro). */
+  spatialKm?: number;
+  /** Two facts cluster if their occurredAt timestamps are within this
+   *  many ms of each other. Default 6 hours. */
+  temporalMs?: number;
+  /** When true, facts must share their eventType (not just domain) to
+   *  cluster. Default false — so a "tornado warning" and a "severe TS
+   *  warning" near each other still cluster as one situation. */
+  requireSameEventType?: boolean;
+  /** Truth score context. Defaults to the truth-score defaultContext. */
+  truthCtx?: TruthScoreContext;
+  /** When supplied, used instead of scoreFact for member confidence —
+   *  lets callers inject pre-computed scores. */
+  scoreOf?: (fact: NormalizedFact) => number;
+}
+
+const DEFAULTS = {
+  spatialKm: 50,
+  temporalMs: 6 * 60 * 60 * 1000,
+};
+
+// ── Top-level clustering ─────────────────────────────────────────────────
+
+export function clusterFacts(
+  facts: readonly NormalizedFact[],
+  options: ClusterOptions = {},
+): Situation[] {
+  const opts = { ...DEFAULTS, ...options };
+  const ctx = options.truthCtx ?? defaultContext();
+  const scoreOf = options.scoreOf ?? ((f: NormalizedFact) => scoreFact(f, ctx).score);
+
+  // Union-find: each fact starts in its own cluster, merge when two
+  // facts pass the proximity test.
+  const parent = new Map<string, string>();
+  for (const f of facts) parent.set(f.id, f.id);
+  const find = (id: string): string => {
+    let cur = id;
+    while (parent.get(cur) !== cur) cur = parent.get(cur)!;
+    parent.set(id, cur);
+    return cur;
+  };
+  const union = (a: string, b: string): void => {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra !== rb) parent.set(ra, rb);
+  };
+
+  for (let i = 0; i < facts.length; i += 1) {
+    for (let j = i + 1; j < facts.length; j += 1) {
+      if (shouldCluster(facts[i]!, facts[j]!, opts)) {
+        union(facts[i]!.id, facts[j]!.id);
+      }
+    }
+  }
+
+  // Group facts by root.
+  const groups = new Map<string, NormalizedFact[]>();
+  for (const f of facts) {
+    const root = find(f.id);
+    if (!groups.has(root)) groups.set(root, []);
+    groups.get(root)!.push(f);
+  }
+
+  const situations: Situation[] = [];
+  for (const [root, members] of groups) {
+    situations.push(buildSituation(root, members, scoreOf));
+  }
+
+  // Order by confidence × member count so the most attention-worthy
+  // situations bubble up.
+  situations.sort(
+    (a, b) =>
+      b.confidence * Math.log2(b.factIds.length + 1) -
+      a.confidence * Math.log2(a.factIds.length + 1),
+  );
+  return situations;
+}
+
+// ── Cluster predicate ──────────────────────────────────────────────────
+
+function shouldCluster(
+  a: NormalizedFact,
+  b: NormalizedFact,
+  opts: Required<Pick<ClusterOptions, 'spatialKm' | 'temporalMs'>> & ClusterOptions,
+): boolean {
+  // Different domains never cluster, except when an entity is shared —
+  // a quake and a tsunami warning over the same country region SHOULD
+  // co-cluster as a single situation, but markets and weather should not.
+  const sameDomain = a.domain === b.domain;
+  const sharedEntity = a.entities.some((e) => b.entities.includes(e));
+  if (!sameDomain && !sharedEntity) return false;
+
+  if (opts.requireSameEventType && a.eventType !== b.eventType) return false;
+
+  if (Math.abs(a.occurredAt - b.occurredAt) > opts.temporalMs) return false;
+
+  // Spatial check: only enforced when both facts have coordinates.
+  // Facts with no coords (e.g. macro/global) cluster on time + entity
+  // alone.
+  if (a.lat !== undefined && a.lon !== undefined && b.lat !== undefined && b.lon !== undefined && haversineKm(a.lat, a.lon, b.lat, b.lon) > opts.spatialKm) return false;
+
+  return true;
+}
+
+// ── Situation construction ─────────────────────────────────────────────
+
+function buildSituation(
+  rootId: string,
+  members: readonly NormalizedFact[],
+  scoreOf: (fact: NormalizedFact) => number,
+): Situation {
+  const ordered = [...members].sort((a, b) => a.occurredAt - b.occurredAt);
+  const factIds = ordered.map((f) => f.id);
+  const earliest = ordered[0]!;
+  const latest = ordered[ordered.length - 1]!;
+
+  const domains = unique(ordered.map((f) => f.domain));
+  const domain = primaryDomain(ordered);
+  const centroid = computeCentroid(ordered);
+
+  const scores = ordered.map((f) => scoreOf(f));
+  const confidence = scores.length > 0
+    ? scores.reduce((s, v) => s + v, 0) / scores.length
+    : 0;
+
+  const trend = computeTrend(ordered);
+  const topDrivers = pickTopDrivers(ordered);
+  const contributingProviders = unique(
+    ordered.flatMap((f) => f.sources.map((s) => s.providerId)),
+  );
+  const contradictingFactIds = unique(
+    ordered.flatMap((f) => f.contradictedBy ?? []),
+  );
+
+  return {
+    id: `situation:${rootId}`,
+    title: titleFor(ordered, domain),
+    domain,
+    domains,
+    factIds,
+    timeWindow: { from: earliest.occurredAt, to: latest.occurredAt },
+    centroid,
+    trend,
+    confidence: round3(confidence),
+    topDrivers,
+    contributingProviders,
+    contradictingFactIds,
+  };
+}
+
+function primaryDomain(facts: readonly NormalizedFact[]): FactDomain {
+  const counts = new Map<FactDomain, number>();
+  for (const f of facts) counts.set(f.domain, (counts.get(f.domain) ?? 0) + 1);
+  let best: FactDomain = facts[0]!.domain;
+  let bestCount = 0;
+  for (const [d, c] of counts) {
+    if (c > bestCount) { best = d; bestCount = c; }
+  }
+  return best;
+}
+
+function computeCentroid(facts: readonly NormalizedFact[]): { lat: number; lon: number } | undefined {
+  let sumLat = 0;
+  let sumLon = 0;
+  let n = 0;
+  for (const f of facts) {
+    if (f.lat !== undefined && f.lon !== undefined) {
+      sumLat += f.lat;
+      sumLon += f.lon;
+      n += 1;
+    }
+  }
+  if (n === 0) return undefined;
+  return { lat: round3(sumLat / n), lon: round3(sumLon / n) };
+}
+
+const SEVERITY_RANK: Record<Severity, number> = {
+  info: 1,
+  low: 2,
+  moderate: 3,
+  high: 4,
+  critical: 5,
+};
+
+function computeTrend(facts: readonly NormalizedFact[]): SituationTrend {
+  if (facts.length < 2) return 'steady';
+  // Compare mean severity of first vs second half. >0.5 rank delta is
+  // meaningful.
+  const half = Math.floor(facts.length / 2);
+  const earlyMean = meanSeverity(facts.slice(0, half));
+  const lateMean = meanSeverity(facts.slice(half));
+  if (lateMean - earlyMean > 0.5) return 'rising';
+  if (earlyMean - lateMean > 0.5) return 'falling';
+  return 'steady';
+}
+
+function meanSeverity(facts: readonly NormalizedFact[]): number {
+  if (facts.length === 0) return 0;
+  return facts.reduce((s, f) => s + SEVERITY_RANK[f.severity], 0) / facts.length;
+}
+
+function pickTopDrivers(facts: readonly NormalizedFact[]): string[] {
+  const ranked = [...facts].sort((a, b) => {
+    const sevDiff = SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity];
+    if (sevDiff !== 0) return sevDiff;
+    return b.occurredAt - a.occurredAt;
+  });
+  return ranked.slice(0, 5).map((f) => f.claim);
+}
+
+// Canonical title: "<top severity claim>" + ", +N more" when applicable.
+// Plan section asks for a "canonical situation title" — keep it short
+// and stable across re-runs.
+function titleFor(facts: readonly NormalizedFact[], domain: FactDomain): string {
+  if (facts.length === 0) return `${domain} situation`;
+  const drivers = pickTopDrivers(facts);
+  const head = drivers[0]!;
+  if (facts.length === 1) return head;
+  return `${head} (+${facts.length - 1} more)`;
+}
+
+// ── Geometry helpers ────────────────────────────────────────────────────
+
+function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const R = 6371;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function toRad(d: number): number { return (d * Math.PI) / 180; }
+
+// ── Misc helpers ────────────────────────────────────────────────────────
+
+function unique<T>(items: readonly T[]): T[] {
+  return [...new Set(items)];
+}
+
+function round3(x: number): number {
+  return Math.round(x * 1000) / 1000;
+}


### PR DESCRIPTION
PR 2 of the algorithm intelligence layer per [docs/ALGORITHM_INTELLIGENCE_ENHANCEMENT_PLAN.md](docs/ALGORITHM_INTELLIGENCE_ENHANCEMENT_PLAN.md).

Builds on PR 1's NormalizedFact + truth-score. Groups facts into Situations along space / time / source / type axes with canonical title, timeline, trend, confidence, and top drivers.

## Highlights
- Union-find clustering across same-domain OR shared-entity, within `spatialKm` (default 50), within `temporalMs` (default 6h)
- **Cross-domain compound situations**: a quake + tsunami warning sharing entity 'JP' merge into one Situation with both domains tracked
- Trend classification (rising / steady / falling) by comparing mean severity of first vs second half
- **Contradictions surface, not averaged away** (plan invariant): `contradictingFactIds` tracked separately from member ids
- Output sorted by confidence × log2(member count) so the strongest situations bubble up

## Tests
22 new tests; `npm run test:intelligence` now runs 56 total. typecheck:all clean.

## Out of scope
- Negative evidence (PR 3)
- Baseline deviation (PR 4)
- Compound risk index (PR 5)
- Forecast calibration (PR 6)
- Watchlist relevance (PR 7)