### PR TITLE
release-doctor: accept just-shipped tag-at-HEAD with a published release

### DIFF
--- a/scripts/release-doctor.mjs
+++ b/scripts/release-doctor.mjs
@@ -122,13 +122,23 @@ export function findReleaseStateIssues({
   remoteTags,
   releases,
   allowExistingTargetRelease = false,
+  // When the strict-mode caller can prove the existing tag points at the
+  // current HEAD AND a non-draft release exists for it, that's the
+  // healthy "we just shipped this version" state, not a stale-tag
+  // failure. The flag stays opt-in so older callers don't change shape.
+  tagPointsAtHead = false,
 }) {
   const issues = [];
   const hasRemoteTargetTag = remoteTags.has(targetTag);
   const releasesForTarget = releases.filter((release) => release?.tagName === targetTag);
+  const hasPublishedReleaseForTarget = releasesForTarget.some((release) => release && release.isDraft !== true);
   const duplicateDraftTags = findDuplicateDraftReleaseTags(releases);
 
-  if (hasRemoteTargetTag && !allowExistingTargetRelease) {
+  // The just-shipped state: tag exists AND points at HEAD AND a published
+  // (non-draft) GitHub release for that tag exists. Treat as healthy.
+  const justShipped = hasRemoteTargetTag && tagPointsAtHead && hasPublishedReleaseForTarget;
+
+  if (hasRemoteTargetTag && !allowExistingTargetRelease && !justShipped) {
  issues.push(`Remote tag already exists for target release: ${targetTag}`);
   }
 
@@ -215,8 +225,33 @@ async function fetchRemoteReleaseState(targetTag, remoteName = 'origin') {
   const repoSlug = process.env.GITHUB_REPOSITORY
  || normalizeRepoSlug(runCommand('git', ['remote', 'get-url', resolvedRemote]));
 
-  const remoteTagOutput = runCommand('git', ['ls-remote', '--tags', resolvedRemote, `refs/tags/${targetTag}`]);
+  // ls-remote also dereferences annotated tags via `--tags --refs`. The
+  // first column is the SHA; the second is the ref. For an annotated
+  // tag we ask for `refs/tags/<tag>^{}` (the dereferenced commit), which
+  // tells us the commit the tag actually labels.
+  const remoteTagOutput = runCommand('git', ['ls-remote', '--tags', resolvedRemote, `refs/tags/${targetTag}`, `refs/tags/${targetTag}^{}`]);
   const remoteTags = new Set(remoteTagOutput ? [targetTag] : []);
+
+  // Pick the dereferenced (peeled) SHA when present; otherwise the
+  // lightweight-tag SHA (which already points at the commit).
+  let tagCommitSha = '';
+  for (const line of remoteTagOutput.split('\n')) {
+ const trimmed = line.trim();
+ if (!trimmed) continue;
+ const [sha, ref] = trimmed.split(/\s+/, 2);
+ if (ref === `refs/tags/${targetTag}^{}`) {
+ tagCommitSha = sha;
+ break;
+ }
+ if (ref === `refs/tags/${targetTag}` && !tagCommitSha) {
+ tagCommitSha = sha;
+ }
+  }
+
+  // Resolve the SHA we're auditing against. CI sets GITHUB_SHA on push
+  // events; locally we fall back to HEAD.
+  const headSha = (process.env.GITHUB_SHA?.trim() || runCommand('git', ['rev-parse', 'HEAD'])).trim();
+  const tagPointsAtHead = Boolean(tagCommitSha) && tagCommitSha === headSha;
 
   const releases = JSON.parse(
  runCommand('gh', ['api', `repos/${repoSlug}/releases?per_page=100`])
@@ -225,7 +260,7 @@ async function fetchRemoteReleaseState(targetTag, remoteName = 'origin') {
  isDraft: release.draft === true,
   }));
 
-  return { remoteTags, releases };
+  return { remoteTags, releases, tagPointsAtHead };
 }
 
 async function main() {
@@ -238,13 +273,14 @@ async function main() {
  ...findVersionMismatches(versionsByFile),
   ];
 
-  const { remoteTags, releases } = await fetchRemoteReleaseState(targetTag, options.remote || 'origin');
+  const { remoteTags, releases, tagPointsAtHead } = await fetchRemoteReleaseState(targetTag, options.remote || 'origin');
   issues.push(
  ...findReleaseStateIssues({
  targetTag,
  remoteTags,
  releases,
  allowExistingTargetRelease: options.allowExistingTargetRelease,
+ tagPointsAtHead,
  }),
   );
 

--- a/tests/release-doctor.test.mjs
+++ b/tests/release-doctor.test.mjs
@@ -61,6 +61,57 @@ test('findReleaseStateIssues rejects a target tag that already exists remotely w
   ]);
 });
 
+test('findReleaseStateIssues accepts a just-shipped tag that points at HEAD with a published release', () => {
+  // The tag-driven release flow leaves the most recent release tag
+  // pointing at the same commit as `main`. Strict mode used to flag
+  // this as "tag already exists," which broke release-integrity on
+  // every successful release until the next bump shipped.
+  const issues = findReleaseStateIssues({
+ targetTag: 'v2.6.1',
+ remoteTags: new Set(['v2.6.1']),
+ releases: [
+ { tagName: 'v2.6.1', isDraft: false },
+ ],
+ tagPointsAtHead: true,
+  });
+
+  assert.deepEqual(issues, []);
+});
+
+test('findReleaseStateIssues still rejects a just-shipped tag when the release is only a draft', () => {
+  const issues = findReleaseStateIssues({
+ targetTag: 'v2.6.1',
+ remoteTags: new Set(['v2.6.1']),
+ releases: [
+ { tagName: 'v2.6.1', isDraft: true },
+ ],
+ tagPointsAtHead: true,
+  });
+
+  assert.deepEqual(issues, [
+ 'Remote tag already exists for target release: v2.6.1',
+  ]);
+});
+
+test('findReleaseStateIssues still rejects a stale tag that points at a different commit even with a release', () => {
+  // Tag exists, release exists, but the tag does NOT point at HEAD —
+  // this means main has commits past the release that haven't been
+  // tagged. Strict mode should keep flagging this as "you forgot to
+  // bump."
+  const issues = findReleaseStateIssues({
+ targetTag: 'v2.6.1',
+ remoteTags: new Set(['v2.6.1']),
+ releases: [
+ { tagName: 'v2.6.1', isDraft: false },
+ ],
+ tagPointsAtHead: false,
+  });
+
+  assert.deepEqual(issues, [
+ 'Remote tag already exists for target release: v2.6.1',
+  ]);
+});
+
 test('findReleaseStateIssues rejects duplicate drafts for the target tag', () => {
   const issues = findReleaseStateIssues({
  targetTag: 'v2.6.1',


### PR DESCRIPTION
## Auto-generated PR from `claude/release-doctor-tag-at-head`

**Files changed:** 2

### Commits
```
68dbdc54 release-doctor: accept just-shipped tag-at-HEAD with a published release
```

---
> This PR was created automatically when the branch was pushed. Review and merge when ready, or close if superseded.
