### PR TITLE
Algorithm Plan PR 2: wire recordEvaluation into live call sites

### DIFF
--- a/src/services/algorithms/__tests__/algorithm-registry.test.mts
+++ b/src/services/algorithms/__tests__/algorithm-registry.test.mts
@@ -22,7 +22,7 @@ test.beforeEach(() => resetAlgorithmRegistry());
 
 // ── Initial registry coverage ──────────────────────────────────────────
 
-test('initial: registers all 20 plan-listed algorithms', () => {
+test('initial: registers all 21 plan-listed algorithms', () => {
   const ids = listAlgorithms().map((a) => a.id).sort();
   const expected = [
     'baseline-deviation', 'big-event-detector', 'compound-risk',
@@ -30,8 +30,8 @@ test('initial: registers all 20 plan-listed algorithms', () => {
     'forecast-calibration', 'hypothesis-accuracy', 'negative-evidence',
     'nws-polygon-match', 'personal-storm-mode', 'relevance-learner',
     'shortage-diesel', 'shortage-wheat', 'situation-clustering',
-    'source-feedback', 'truth-score', 'watchlist-relevance',
-    'weather-urgency', 'what-changed-digest',
+    'source-feedback', 'threat-classifier', 'truth-score',
+    'watchlist-relevance', 'weather-urgency', 'what-changed-digest',
   ];
   assert.deepEqual(ids, expected);
 });

--- a/src/services/algorithms/__tests__/tracked-algorithms.test.mts
+++ b/src/services/algorithms/__tests__/tracked-algorithms.test.mts
@@ -1,0 +1,108 @@
+/**
+ * Coverage for `tracked-algorithms.ts` — verifies that each tracked
+ * wrapper:
+ *   1. Returns the same value the underlying pure function returns.
+ *   2. Emits exactly one ledger record per call.
+ *   3. Populates score/label/detail with the right fields.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { trackedScoreFact, trackedComputeCompoundRisk, trackedEvaluateNegativeEvidence } from '../tracked-algorithms.ts';
+import { getAlgorithmEvaluationLedger, resetAlgorithmsState } from '../algorithms-state.ts';
+import type { NormalizedFact } from '@/services/intelligence/types';
+import type { CompoundRiskInput } from '@/services/intelligence/compound-risk';
+import type { ExpectedSignal } from '@/services/intelligence/negative-evidence';
+
+test.beforeEach(() => resetAlgorithmsState());
+
+const fact = (id: string, sourceCount: number = 2): NormalizedFact => ({
+  id,
+  domain: 'weather',
+  eventType: 'earthquake',
+  claim: 'M6.2 near Tokyo',
+  severity: 'medium',
+  occurredAt: Date.now() - 60_000,
+  ingestedAt: Date.now(),
+  precision: 'point',
+  entities: ['JP'],
+  sources: Array.from({ length: sourceCount }, (_, i) => ({
+    providerId: `provider-${i}`,
+    reliability: 0.8,
+    observedAt: Date.now() - 30_000,
+    rawId: `raw-${i}`,
+  })),
+});
+
+test('trackedScoreFact: emits one record with score+label+detail', () => {
+  const ledger = getAlgorithmEvaluationLedger();
+  const result = trackedScoreFact(fact('f1'));
+  assert.equal(typeof result.score, 'number', 'pure result returned');
+  const records = ledger.byAlgorithm('truth-score');
+  assert.equal(records.length, 1);
+  const r = records[0]!;
+  assert.equal(r.score, result.score);
+  assert.equal(r.label, result.label);
+  assert.equal(r.detail?.sourceCount, 2);
+  assert.equal(r.detail?.domain, 'weather');
+});
+
+test('trackedScoreFact: 5 calls emit 5 records', () => {
+  const ledger = getAlgorithmEvaluationLedger();
+  for (let i = 0; i < 5; i++) trackedScoreFact(fact(`f${i}`));
+  assert.equal(ledger.byAlgorithm('truth-score').length, 5);
+});
+
+test('trackedComputeCompoundRisk: emits one record with the top-scoring cluster surfaced', () => {
+  const ledger = getAlgorithmEvaluationLedger();
+  const inputs: CompoundRiskInput[] = [
+    {
+      id: 's1', title: 'Heat wave', domain: 'weather', domains: ['weather'],
+      severityScore: 80, confidence: 0.9, latitude: 35, longitude: 139,
+      entities: ['JP'], occurredAt: Date.now(),
+    },
+    {
+      id: 's2', title: 'Power grid stress', domain: 'energy', domains: ['energy'],
+      severityScore: 70, confidence: 0.8, latitude: 35.5, longitude: 139.5,
+      entities: ['JP'], occurredAt: Date.now(),
+    },
+  ];
+  const results = trackedComputeCompoundRisk(inputs);
+  assert.ok(Array.isArray(results), 'pure result returned');
+  const records = ledger.byAlgorithm('compound-risk');
+  assert.equal(records.length, 1, 'one record per call regardless of cluster count');
+  const r = records[0]!;
+  assert.equal(r.detail?.inputCount, 2);
+  if (results.length > 0) {
+    assert.equal(r.score, results.reduce((m, x) => Math.max(m, x.score), 0));
+  }
+});
+
+test('trackedEvaluateNegativeEvidence: records totalAbsencePenalty as score', () => {
+  const ledger = getAlgorithmEvaluationLedger();
+  const parent = fact('parent');
+  const expected: ExpectedSignal[] = [
+    { id: 'aftershock', label: 'Aftershock within 1h', windowMs: 60 * 60 * 1000, weight: 0.3, predicate: () => false },
+  ];
+  const result = trackedEvaluateNegativeEvidence(parent, expected, [], 0.7, { now: parent.occurredAt + 2 * 60 * 60 * 1000 });
+  const records = ledger.byAlgorithm('negative-evidence');
+  assert.equal(records.length, 1);
+  const r = records[0]!;
+  assert.equal(r.score, result.totalAbsencePenalty);
+  assert.equal(r.detail?.expected, 1);
+  assert.equal(r.detail?.adjustedConfidence, result.adjustedConfidence);
+});
+
+test('determinism: same call twice produces same record fields (modulo id+at)', () => {
+  const ledger = getAlgorithmEvaluationLedger();
+  const f = fact('repro', 3);
+  trackedScoreFact(f);
+  trackedScoreFact(f);
+  const records = ledger.byAlgorithm('truth-score');
+  assert.equal(records.length, 2);
+  assert.equal(records[0]!.score, records[1]!.score);
+  assert.equal(records[0]!.label, records[1]!.label);
+  assert.deepEqual(records[0]!.detail, records[1]!.detail);
+  assert.notEqual(records[0]!.id, records[1]!.id);
+});

--- a/src/services/algorithms/algorithm-registry.ts
+++ b/src/services/algorithms/algorithm-registry.ts
@@ -297,6 +297,17 @@ const REGISTRY_INITIAL: readonly AlgorithmDefinition[] = [
     criticality: 'low',
   },
   {
+    id: 'threat-classifier',
+    label: 'AI threat classifier',
+    version: '1.0.0',
+    domain: 'classification',
+    healthDomain: 'reasoning_hypothesis',
+    ownerFeature: 'threat_classifier',
+    dependencies: { sources: [], providers: ['anthropic', 'groq', 'openrouter'], services: [] },
+    outputs: ['ranking', 'notification_decision'],
+    criticality: 'medium',
+  },
+  {
     id: 'hypothesis-accuracy',
     label: 'Hypothesis accuracy tracker',
     version: '1.0.0',

--- a/src/services/algorithms/tracked-algorithms.ts
+++ b/src/services/algorithms/tracked-algorithms.ts
@@ -1,0 +1,116 @@
+/**
+ * Tracked wrappers for the pure intelligence algorithms.
+ *
+ * The pure modules (`truth-score.ts`, `compound-risk.ts`,
+ * `negative-evidence.ts`) stay free of side effects. This file
+ * provides opt-in facades that:
+ *   1. Call the pure algorithm.
+ *   2. Time the call.
+ *   3. Record one evaluation into the singleton ledger.
+ *   4. Return the result unchanged.
+ *
+ * Use these from orchestrator-level code (situation engines, briefing
+ * pipelines, planners). Do NOT use them inside hot per-fact loops
+ * like `situation-clustering`'s member scorer — that would emit one
+ * record per cluster member and drown the ledger. The pure functions
+ * remain importable for those cases.
+ */
+
+import { scoreFact, type TruthScoreContext, defaultContext } from '@/services/intelligence/truth-score';
+import { computeCompoundRisk, type CompoundRiskResult, type CompoundRiskInput, type CompoundRiskOptions } from '@/services/intelligence/compound-risk';
+import { evaluateNegativeEvidence, type NegativeEvidenceResult, type ExpectedSignal, type NegativeEvidenceOptions } from '@/services/intelligence/negative-evidence';
+import type { NormalizedFact, TruthScore } from '@/services/intelligence/types';
+import { recordAlgorithmEvaluation } from './record-evaluation';
+
+/**
+ * Score a single fact and record the call in the ledger.
+ *
+ * Use sparingly — calling once per fact in a tight loop will emit one
+ * record per fact. Prefer recording at the situation/decision level
+ * (one record per fused situation, not per member).
+ */
+export function trackedScoreFact(
+  fact: NormalizedFact,
+  ctx: TruthScoreContext = defaultContext(),
+): TruthScore {
+  const startedAt = Date.now();
+  const result = scoreFact(fact, ctx);
+  recordAlgorithmEvaluation('truth-score', {
+    durationMs: Date.now() - startedAt,
+    score: result.score,
+    label: result.label,
+    detail: {
+      sourceCount: fact.sources?.length ?? 0,
+      domain: fact.domain ?? 'unknown',
+      corroboration: result.components?.corroboration,
+      disputed: result.disputed,
+    },
+  });
+  return result;
+}
+
+/**
+ * Run the compound-risk computation and record the call. Records one
+ * evaluation per call regardless of how many cluster results come
+ * back, with the highest-scoring cluster's score+level surfaced as
+ * the headline.
+ */
+export function trackedComputeCompoundRisk(
+  inputs: readonly CompoundRiskInput[],
+  options?: CompoundRiskOptions,
+): CompoundRiskResult[] {
+  const startedAt = Date.now();
+  const results = computeCompoundRisk(inputs, options);
+  const top = results.reduce<CompoundRiskResult | undefined>(
+    (best, curr) => (best === undefined || curr.score > best.score ? curr : best),
+    undefined,
+  );
+  recordAlgorithmEvaluation('compound-risk', {
+    durationMs: Date.now() - startedAt,
+    score: top?.score,
+    label: top?.level,
+    detail: {
+      inputCount: inputs.length,
+      resultCount: results.length,
+      memberIds: top?.memberIds?.length ?? 0,
+      affectedDomains: top?.affectedDomains?.length ?? 0,
+    },
+  });
+  return results;
+}
+
+function negEvidenceLabel(result: NegativeEvidenceResult): 'missing_signals' | 'pending' | 'all_observed' {
+  if (result.missing.length > 0) return 'missing_signals';
+  if (result.pending.length > 0) return 'pending';
+  return 'all_observed';
+}
+
+/**
+ * Run the negative-evidence engine and record the call. The
+ * absence-penalty + missing-signal count is the headline value for
+ * the ledger; downstream calibration grades whether the missing
+ * signals actually never arrived.
+ */
+export function trackedEvaluateNegativeEvidence(
+  parent: NormalizedFact,
+  expected: readonly ExpectedSignal[],
+  candidates: readonly NormalizedFact[],
+  baseConfidence: number,
+  options?: NegativeEvidenceOptions,
+): NegativeEvidenceResult {
+  const startedAt = Date.now();
+  const result = evaluateNegativeEvidence(parent, expected, candidates, baseConfidence, options);
+  recordAlgorithmEvaluation('negative-evidence', {
+    durationMs: Date.now() - startedAt,
+    score: result.totalAbsencePenalty,
+    label: negEvidenceLabel(result),
+    detail: {
+      expected: expected.length,
+      observed: result.observed.length,
+      missing: result.missing.length,
+      pending: result.pending.length,
+      adjustedConfidence: result.adjustedConfidence,
+    },
+  });
+  return result;
+}

--- a/src/services/threat-classifier.ts
+++ b/src/services/threat-classifier.ts
@@ -389,6 +389,7 @@ import {
   ApiError,
   type ClassifyEventResponse,
 } from '@/generated/client/crystalball/intelligence/v1/service_client';
+import { recordAlgorithmEvaluation } from '@/services/algorithms/record-evaluation';
 
 const classifyClient = new IntelligenceServiceClient('', { fetch: (...args) => globalThis.fetch(...args) });
 
@@ -466,13 +467,41 @@ function flushBatch(): void {
 
  await waitForGap();
 
+ const callStartedAt = Date.now();
  try {
  const resp = await classifyClient.classifyEvent({
  title: job.title, description: '', source: '', country: '',
  });
- job.resolve(toThreat(resp));
+ const result = toThreat(resp);
+ // Record one evaluation per AI classification. Pure-keyword
+ // classifications skip the queue entirely, so this only fires
+ // when the cloud AI was actually consulted.
+ recordAlgorithmEvaluation('threat-classifier', {
+ durationMs: Date.now() - callStartedAt,
+ score: result?.confidence,
+ label: result ? `${result.level}/${result.category}` : 'null',
+ detail: {
+ variant: job.variant,
+ attempts: job.attempts ?? 0,
+ source: result?.source ?? 'llm',
+ },
+ });
+ job.resolve(result);
  consecutivePauses = 0;
  } catch (error) {
+ // Record the failure so the health aggregator sees errors,
+ // not just successes. Use label='error' (matches timeAndRecord's
+ // convention) so the closed-loop layer can reason about hit rate.
+ recordAlgorithmEvaluation('threat-classifier', {
+ durationMs: Date.now() - callStartedAt,
+ label: 'error',
+ detail: {
+ variant: job.variant,
+ attempts: job.attempts ?? 0,
+ statusCode: error instanceof ApiError ? error.statusCode : undefined,
+ },
+ notes: error instanceof Error ? error.message : String(error),
+ });
  if (error instanceof ApiError && (error.statusCode === 429 || error.statusCode >= 500)) {
  batchPaused = true;
  consecutivePauses++;

--- a/src/services/weather/__tests__/weather-warning-router.test.mts
+++ b/src/services/weather/__tests__/weather-warning-router.test.mts
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import { routeWeatherAlert } from '../weather-warning-router.ts';
 import type { AlertPolygon, NwsAlertMinimal, SavedPlace } from '../weather-threat-types.ts';
+import { getAlgorithmEvaluationLedger, resetAlgorithmsState } from '@/services/algorithms/algorithms-state';
 
 const NOW = 1_745_000_000_000;
 
@@ -299,4 +300,28 @@ test('integration: tornado warning inside polygon during quiet hours bypasses + 
   assert.ok(decision.dispatchActions.includes('imessage'));
   assert.ok(decision.dispatchActions.includes('request_acknowledgment'));
   assert.equal(decision.diagnostic.verdict, 'delivered');
+});
+
+// ── Ledger wiring (closed-loop algorithm plan PR 2) ─────────────────────
+
+test('ledger wiring: routing a matched alert records one weather-urgency evaluation', () => {
+  resetAlgorithmsState();
+  const ledger = getAlgorithmEvaluationLedger();
+  routeWeatherAlert(alert(), [HOME], { now: NOW });
+  const records = ledger.byAlgorithm('weather-urgency');
+  assert.equal(records.length, 1);
+  const r = records[0]!;
+  assert.equal(r.label, 'persistent_critical', 'records the urgency priority as the label');
+  assert.equal(r.detail?.matchKind, 'inside_polygon');
+  assert.equal(typeof r.detail?.threatLevel, 'string');
+  assert.equal(typeof r.detail?.persistentInApp, 'boolean');
+});
+
+test('ledger wiring: no_match alerts do NOT emit a weather-urgency record', () => {
+  resetAlgorithmsState();
+  const ledger = getAlgorithmEvaluationLedger();
+  routeWeatherAlert(alert({ polygon: FAR }), [HOME], { now: NOW });
+  // Skipping urgency for no_match keeps the ledger noise-free; the
+  // diagnostic trace already explains why nothing fired.
+  assert.equal(ledger.byAlgorithm('weather-urgency').length, 0);
 });

--- a/src/services/weather/weather-warning-router.ts
+++ b/src/services/weather/weather-warning-router.ts
@@ -33,6 +33,36 @@ import {
   type DiagnosticTrace,
   type WeatherDiagnostic,
 } from './weather-warning-diagnostics';
+import { recordAlgorithmEvaluation } from '@/services/algorithms/record-evaluation';
+
+/**
+ * Time the urgency call and emit one evaluation record into the
+ * algorithm ledger. Records the priority + acknowledgement-required
+ * flag + match kind as compact detail; ground-truth outcome (warning
+ * landed before impact / dismissed by user / etc.) is appended later
+ * by the closed-loop layer once the mission resolves.
+ */
+function recordWeatherUrgency(
+  match: PolygonMatchResult,
+  invoke: () => WeatherUrgencyDecision,
+  now: number,
+): WeatherUrgencyDecision {
+  const startedAt = Date.now();
+  const decision = invoke();
+  const durationMs = Date.now() - startedAt;
+  recordAlgorithmEvaluation('weather-urgency', {
+    durationMs,
+    at: now,
+    label: decision.priority,
+    detail: {
+      matchKind: match.matchKind,
+      threatLevel: match.threatLevel,
+      hazardKind: match.hazardKind,
+      persistentInApp: decision.persistentInApp,
+    },
+  });
+  return decision;
+}
 
 // ── Public types ─────────────────────────────────────────────────────────
 
@@ -112,12 +142,20 @@ export function routeWeatherAlert(
   // Step 1: find the strongest match across all saved places.
   const strongest = pickStrongestMatch(alert, places, now);
 
-  // Step 2: when we have any match, derive urgency.
+  // Step 2: when we have any match, derive urgency. Recording the
+  // urgency decision into the algorithm-evaluation ledger lets the
+  // closed-loop diagnostics surface "weather-urgency fired N times,
+  // mean priority X, last-seen at T" without coupling the pure
+  // urgency engine to the ledger.
   const urgency = strongest && strongest.match.matchKind !== 'no_match'
-    ? urgencyFor(strongest.match, options.previousDelivery, {
+    ? recordWeatherUrgency(
+        strongest.match,
+        () => urgencyFor(strongest.match, options.previousDelivery, {
+          now,
+          quietHoursBypassHazards: options.quietHoursBypassHazards,
+        }),
         now,
-        quietHoursBypassHazards: options.quietHoursBypassHazards,
-      })
+      )
     : undefined;
 
   // Step 3: when urgency is at banner+, build the Storm Mode payload.


### PR DESCRIPTION
## Summary

Per [`docs/CLAUDE_ALGORITHM_SYSTEM_ENHANCEMENTS_2026-04-28.md`](docs/CLAUDE_ALGORITHM_SYSTEM_ENHANCEMENTS_2026-04-28.md) Enhancement 1. PR #179 (now merged) added the registry-derived ledger and the `recordAlgorithmEvaluation` helper. This PR brings two real call sites into the closed loop and ships an opt-in `tracked-algorithms` module for the three algorithms that don't have live callers yet.

## Live call sites wired

### 1. `weather-warning-router.ts`
`recordWeatherUrgency()` wraps `urgencyFor()` and emits one ledger record per matched alert. Records the priority as the label, plus `matchKind` / `threatLevel` / `hazardKind` / `persistentInApp` as detail. No-match alerts intentionally skip recording so the ledger stays noise-free.

### 2. `threat-classifier.ts`
`flushBatch()` records one evaluation per AI classification (success or error). Records confidence as score and `level/category` as label on success; `label='error'` with `statusCode` in detail on failure. Pure-keyword fallbacks skip the queue entirely so they don't pollute the AI-classifier's calibration.

### 3. New `tracked-algorithms.ts` module
Opt-in wrappers for the three intelligence algorithms that don't have live callers yet:
- `trackedScoreFact` (truth-score)
- `trackedComputeCompoundRisk` (compound-risk)
- `trackedEvaluateNegativeEvidence` (negative-evidence)

These let downstream PR-3+ work (mission-ledger, situation-engine wiring, etc.) get metrics for free without re-plumbing every call site.

## Registry update

Added `threat-classifier` (criticality medium, `healthDomain: reasoning_hypothesis`). Registered count: 20 → 21.

## Verification

- `npm run typecheck:all` green
- `npm run lint:strict` green
- 91/91 algorithm + weather tests pass:
  - 5 new tracked-algorithms tests (one record per call, score/label/detail correct, return value matches pure function)
  - 2 new router-wiring tests (record on match, skip on no_match)
  - 12 existing record-evaluation + algorithms-state tests
  - 17 algorithm-registry tests (count updated 20 → 21)
  - 55 weather + ledger + health tests

Cross-agent review: pending Codex review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)