### PR TITLE
weather-mission-bridge: skip suppressed + digest-tier + wire into data-loader

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -1396,6 +1396,21 @@ export class DataLoaderManager implements AppModule {
  console.warn('[data-loader] insights bridge failed:', error);
  }
 
+ // Wire weather alerts into the mission ledger (closed-loop ops PR 2).
+ // Each (alert × saved place) pair runs through polygon match +
+ // urgency engine + mission bridge so time-to-warn / near-miss /
+ // replay-fixture surfaces have real records to read from.
+ try {
+ const [{ routeAndBridgeWeatherAlerts }, { getPersonalProfile }] = await Promise.all([
+ import('@/services/ops/weather-mission-bridge'),
+ import('@/services/insights/insights-state'),
+ ]);
+ const places = getPersonalProfile().savedPlaces;
+ if (places.length > 0) routeAndBridgeWeatherAlerts(alerts, places);
+ } catch (error) {
+ console.warn('[data-loader] mission bridge failed:', error);
+ }
+
  // Wire weather into correlation matrix, anomaly detection, and convergence
  const severeCount = alerts.filter(a => a.severity === 'Extreme' || a.severity === 'Severe').length;
  ingestWeatherAnomalySignals(alerts.length, severeCount);

--- a/src/services/ops/__tests__/weather-mission-bridge.test.mts
+++ b/src/services/ops/__tests__/weather-mission-bridge.test.mts
@@ -11,7 +11,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { bridgeWeatherDecisionToMission } from '../weather-mission-bridge.ts';
+import { bridgeWeatherDecisionToMission, legacyAlertToNwsMinimal, routeAndBridgeWeatherAlerts } from '../weather-mission-bridge.ts';
 import { getMissionLedger, resetMissionState } from '../mission-state.ts';
 import { routeWeatherAlert } from '@/services/weather/weather-warning-router';
 import type { AlertPolygon, NwsAlertMinimal, SavedPlace } from '@/services/weather/weather-threat-types';
@@ -112,6 +112,97 @@ test('mission id includes alertId + placeId so two places see two missions for t
   assert.equal(all.length, 2);
   const placeIds = all.map((m) => m.placeId).sort();
   assert.deepEqual(placeIds, ['home', 'office']);
+});
+
+test('suppressed decision (e.g. quiet hours blocks non-bypass hazard) does NOT open a mission', () => {
+  // Winter Storm Warning is non-bypass + quiet hours active + bypass off
+  // → router returns shouldSuppress: true. The bridge must respect that
+  // contract; otherwise we'd record warnings the user never saw.
+  const decision = routeWeatherAlert(
+    alert({ event: 'Winter Storm Warning', severity: 'moderate' }),
+    [HOME],
+    { now: NOW, quietHoursActive: true, quietHoursBypassEnabled: false },
+  );
+  assert.equal(decision.shouldSuppress, true);
+  assert.notEqual(decision.match!.matchKind, 'no_match', 'sanity: it WAS a real match');
+  const result = bridgeWeatherDecisionToMission(decision, { now: NOW });
+  assert.equal(result, undefined, 'suppressed → no mission opened');
+  assert.equal(getMissionLedger().all().length, 0);
+});
+
+test('digest-tier alert opens mission (app_watch) but does NOT record user_notified', () => {
+  // Wind Advisory → priority 'digest' → queued for next morning/evening
+  // digest, NOT delivered now. user_notified must wait for digest render.
+  const decision = routeWeatherAlert(
+    alert({ event: 'Wind Advisory', severity: 'minor' }),
+    [HOME],
+    { now: NOW },
+  );
+  assert.equal(decision.urgency!.priority, 'digest');
+  assert.equal(decision.shouldSuppress, false, 'digest is NOT a suppression');
+  const result = bridgeWeatherDecisionToMission(decision, { now: NOW });
+  assert.ok(result, 'digest alert still opens an active mission');
+  const kinds = result!.mission.events.map((e) => e.kind).sort();
+  assert.ok(kinds.includes('app_watch'));
+  assert.ok(!kinds.includes('user_notified'),
+    'digest-tier user_notified should be deferred to digest-render time');
+});
+
+// ── Adapter + production orchestrator ──────────────────────────────────
+
+test('legacyAlertToNwsMinimal: lowercases severity + wraps single ring', () => {
+  const minimal = legacyAlertToNwsMinimal({
+    id: 'urn:legacy',
+    event: 'Severe Thunderstorm Warning',
+    severity: 'Severe',
+    onset: new Date(NOW),
+    expires: new Date(NOW + 60_000),
+    coordinates: [
+      [-87.0, 41.50], [-86.50, 41.50], [-86.50, 41.80], [-87.0, 41.80], [-87.0, 41.50],
+    ],
+  });
+  assert.equal(minimal.severity, 'severe');
+  assert.equal(minimal.polygon!.rings.length, 1);
+  assert.equal(minimal.polygon!.rings[0]!.length, 5);
+  assert.equal(minimal.messageType, 'alert');
+});
+
+test('legacyAlertToNwsMinimal: missing/short coordinates → no polygon (zone fallback)', () => {
+  const minimal = legacyAlertToNwsMinimal({
+    id: 'urn:no-poly',
+    event: 'Wind Advisory',
+    severity: 'Minor',
+    onset: new Date(NOW),
+    expires: new Date(NOW + 60_000),
+  });
+  assert.equal(minimal.polygon, undefined);
+});
+
+test('routeAndBridgeWeatherAlerts: opens missions for matched alerts only', () => {
+  resetMissionState();
+  const places = [{ placeId: 'home', label: 'La Porte, IN', latitude: 41.610, longitude: -86.722 }];
+  const matched = {
+    id: 'urn:matched',
+    event: 'Severe Thunderstorm Warning',
+    severity: 'Severe' as const,
+    onset: new Date(NOW),
+    expires: new Date(NOW + 30 * 60_000),
+    coordinates: ENVELOPING.rings[0]!.map(([lng, lat]) => [lng, lat] as [number, number]),
+  };
+  const farAway = {
+    id: 'urn:far',
+    event: 'Severe Thunderstorm Warning',
+    severity: 'Severe' as const,
+    onset: new Date(NOW),
+    expires: new Date(NOW + 30 * 60_000),
+    coordinates: FAR.rings[0]!.map(([lng, lat]) => [lng, lat] as [number, number]),
+  };
+  const results = routeAndBridgeWeatherAlerts([matched, farAway], places, { now: NOW });
+  assert.equal(results.length, 1, 'far alert is dropped (no matched place)');
+  assert.equal(results[0]!.alertId, 'urn:matched');
+  assert.equal(results[0]!.placeId, 'home');
+  assert.ok(results[0]!.mission, 'matched alert opened a mission');
+  assert.equal(getMissionLedger().all().length, 1);
 });
 
 test('bridge is JSON-serializable (audit-trail invariant)', () => {

--- a/src/services/ops/weather-mission-bridge.ts
+++ b/src/services/ops/weather-mission-bridge.ts
@@ -16,8 +16,55 @@
  */
 
 import type { WeatherDispatchDecision } from '@/services/weather/weather-warning-router';
+import { routeWeatherAlert } from '@/services/weather/weather-warning-router';
+import type { NwsAlertMinimal, SavedPlace, WeatherSeverity } from '@/services/weather/weather-threat-types';
 import type { MissionEvent, MissionRecord } from './mission-types';
 import { getMissionLedger } from './mission-state';
+
+// ── Adapter: legacy WeatherAlert → NwsAlertMinimal ──────────────────────
+// `src/services/weather.ts` `WeatherAlert` is the renderer's current
+// shape; the polygon-matching engine wants `NwsAlertMinimal`. This
+// adapter avoids forcing every caller to know the difference.
+
+interface LegacyWeatherAlertLike {
+  id: string;
+  event: string;
+  severity: 'Extreme' | 'Severe' | 'Moderate' | 'Minor' | 'Unknown';
+  headline?: string;
+  onset: Date | string;
+  expires: Date | string;
+  /** Single-ring polygon. The matcher accepts an array of rings; we
+   *  wrap the single ring before forwarding. */
+  coordinates?: readonly (readonly [number, number])[];
+}
+
+const SEVERITY_LOWER: Record<LegacyWeatherAlertLike['severity'], WeatherSeverity> = {
+  Extreme: 'extreme',
+  Severe: 'severe',
+  Moderate: 'moderate',
+  Minor: 'minor',
+  Unknown: 'unknown',
+};
+
+function toIsoString(d: Date | string): string {
+  return typeof d === 'string' ? d : d.toISOString();
+}
+
+export function legacyAlertToNwsMinimal(alert: LegacyWeatherAlertLike): NwsAlertMinimal {
+  const ring = alert.coordinates && alert.coordinates.length >= 3
+    ? alert.coordinates.map(([lng, lat]) => [lng, lat] as [number, number])
+    : undefined;
+  return {
+    id: alert.id,
+    event: alert.event,
+    polygon: ring ? { rings: [ring] } : undefined,
+    sent: toIsoString(alert.onset),
+    expires: toIsoString(alert.expires),
+    severity: SEVERITY_LOWER[alert.severity],
+    headline: alert.headline,
+    messageType: 'alert',
+  };
+}
 
 /**
  * Bridge a weather dispatch decision into the mission ledger.
@@ -33,6 +80,11 @@ export function bridgeWeatherDecisionToMission(
 ): { mission: MissionRecord; appendedEvents: MissionEvent[] } | undefined {
   const at = options.now ?? Date.now();
   if (!decision.match || decision.match.matchKind === 'no_match' || !decision.matchedPlaceId) return undefined;
+  // Suppressed decisions (quiet-hours blocked, dispatcher refused, etc.)
+  // intentionally weren't surfaced to the user. Recording them as
+  // active missions would pollute time-to-warn / near-miss data with
+  // alerts that the router deliberately silenced.
+  if (decision.shouldSuppress) return undefined;
 
   const ledger = getMissionLedger();
   const missionId = `weather-${decision.alertId}-${decision.matchedPlaceId}`;
@@ -66,8 +118,14 @@ export function bridgeWeatherDecisionToMission(
     }));
   }
 
-  // user_notified — only when the dispatcher would actually deliver.
-  if (decision.urgency && !decision.shouldSuppress) {
+  // user_notified — only when the dispatcher actually surfaced the
+  // alert to the user *now*. The 'digest' priority queues the alert
+  // for the next morning/evening digest; recording user_notified at
+  // routing time would skew time-to-warn metrics that read this
+  // event's timestamp as the warning moment. Digest delivery should
+  // emit user_notified at digest-render time instead (future PR).
+  const isDigestQueue = decision.urgency?.priority === 'digest';
+  if (decision.urgency && !isDigestQueue) {
     appendedEvents.push(ledger.recordEvent(missionId, {
       at,
       kind: 'user_notified',
@@ -82,4 +140,70 @@ export function bridgeWeatherDecisionToMission(
   }
 
   return { mission: ledger.get(missionId)!, appendedEvents };
+}
+
+// ── Production orchestrator ─────────────────────────────────────────────
+//
+// Single entry point the data-loader can call once weather alerts have
+// been fetched. Per (alert × place) pair, runs the polygon match +
+// urgency engine + mission bridge. Returns the mission records that
+// were opened or updated so callers can plumb them into the diagnostic
+// panel without re-querying the ledger.
+//
+// Plan invariant: this is the ONLY place that wires legacy weather
+// alerts into the closed-loop layer. Adding more downstream consumers
+// (notification dispatcher, time-to-warn calculator, etc.) means
+// reading from `getMissionLedger()`, not duplicating the routing call.
+
+export interface RouteAndBridgeResult {
+  /** Stable alert id this entry covers. */
+  alertId: string;
+  /** Stable place id matched against. */
+  placeId: string;
+  /** Underlying dispatch decision. */
+  decision: WeatherDispatchDecision;
+  /** Mission record (newly opened or already-existing) — `undefined`
+   *  when the bridge intentionally skipped (no_match / suppressed). */
+  mission?: MissionRecord;
+}
+
+/** SavedPlace shape that the personal-impact / insights-state layer
+ *  uses. The weather router wants a different shape; we convert. */
+export interface PersonalSavedPlaceLike {
+  placeId: string;
+  label: string;
+  latitude: number;
+  longitude: number;
+}
+
+function toWeatherSavedPlace(p: PersonalSavedPlaceLike): SavedPlace {
+  return { id: p.placeId, label: p.label, lat: p.latitude, lon: p.longitude };
+}
+
+export function routeAndBridgeWeatherAlerts(
+  alerts: readonly LegacyWeatherAlertLike[],
+  places: readonly PersonalSavedPlaceLike[],
+  options: { now?: number } = {},
+): RouteAndBridgeResult[] {
+  const at = options.now ?? Date.now();
+  const weatherPlaces = places.map((p) => toWeatherSavedPlace(p));
+  const out: RouteAndBridgeResult[] = [];
+  for (const alert of alerts) {
+    const minimal = legacyAlertToNwsMinimal(alert);
+    const decision = routeWeatherAlert(minimal, weatherPlaces, { now: at });
+    // Only emit a result when the alert actually concerned a saved
+    // place (real polygon match or zone match). routeWeatherAlert
+    // returns a matchedPlaceId even for no_match strongest-pick rows;
+    // we discard those here so the closed-loop layer doesn't see
+    // 5,000 daily NWS alerts the user has no relationship to.
+    if (!decision.matchedPlaceId || decision.match?.matchKind === 'no_match') continue;
+    const bridgeResult = bridgeWeatherDecisionToMission(decision, { now: at });
+    out.push({
+      alertId: alert.id,
+      placeId: decision.matchedPlaceId,
+      decision,
+      mission: bridgeResult?.mission,
+    });
+  }
+  return out;
 }


### PR DESCRIPTION
## Summary

Follow-up to #182. Codex review of #182 caught three real bugs:

### P2: Suppressed decisions opened missions anyway
Matched alerts with `shouldSuppress: true` (quiet-hours blocked, non-bypass hazards, dispatcher refused) opened active missions despite the contract saying "suppressed → undefined." Fixed by bailing on `decision.shouldSuppress` before opening the mission.

### P2: Digest-tier user_notified fired at routing time
`priority='digest'` means "queue for next digest, don't deliver now." The first `user_notified` timestamp is what time-to-warn / replay metrics consume as the warning moment, so digest-queued alerts would have shown impossibly early warnings. Fixed by gating the `user_notified` write on `urgency.priority !== 'digest'`. `app_watch` still fires for digest-tier matches so the polygon match is recorded; `user_notified` for digest delivery should fire at digest-render time (future PR).

### P2: Bridge wasn't wired into any live caller
The new mission ledger stayed empty in production. Fixed via:
- `legacyAlertToNwsMinimal(alert)` — adapter from the renderer's legacy `WeatherAlert` (single-ring + capitalized severity) to the `NwsAlertMinimal` shape the matcher consumes.
- `routeAndBridgeWeatherAlerts(alerts, places, options)` — production orchestrator that pairs each alert with saved places, runs polygon-match + urgency, and bridges to mission ledger.
- `data-loader.loadWeatherAlerts()` now calls the orchestrator after the existing insights bridge, using `getPersonalProfile().savedPlaces`. No-savedPlaces installs short-circuit.

Also drops `matchKind='no_match'` rows from the orchestrator result so the closed-loop layer doesn't see ~5,000 daily NWS alerts the user has no relationship to.

## Tests
3 new tests (legacy-shape adaptation, missing-polygon zone fallback, end-to-end orchestrator). All 13 weather-mission-bridge tests pass.

## Verification
- `npm run typecheck:all` clean
- `npm run lint:strict` (eslint on changed files clean)
- 13/13 weather-mission-bridge tests pass

Cross-agent review: Codex reviewed on 2026-04-28 (review of #182); 3 P2 findings, all addressed in this PR (commit 82195d8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
