### PR TITLE
FAA cams: switch to weathercams.faa.gov + lazy-load image URLs

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -3297,33 +3297,97 @@ async function dispatch(requestUrl, req, routes, context) {
 
   // ── FAA Aviation Weather Cameras (public, no auth) ───────────────────────────
   if (requestUrl.pathname === '/api/faa-cameras') {
+ // Old `avcams.faa.gov` host has been decommissioned (DNS no longer
+ // resolves). The active service is `weathercams.faa.gov` whose
+ // `/api/sites` endpoint requires Origin + Referer headers but no
+ // auth key. Each site groups multiple cameras; we surface one row
+ // per camera so the panel's selection table can drill into the
+ // specific viewpoint.
  const CACHE_KEY = 'faa-cameras';
  const CACHE_TTL = 15 * 60 * 1000;
  const cached = getCached(CACHE_KEY, CACHE_TTL);
  if (cached) return json(cached);
  try {
  const resp = await fetchWithTimeout(
- 'https://avcams.faa.gov/api/cameras',
- { headers: { Accept: 'application/json', 'User-Agent': 'CrystalBall/1.0' } },
+ 'https://weathercams.faa.gov/api/sites',
+ {
+ headers: {
+ Accept: 'application/json',
+ Origin: 'https://weathercams.faa.gov',
+ Referer: 'https://weathercams.faa.gov/',
+ 'User-Agent': 'CrystalBall/1.0',
+ },
+ },
  15000,
  );
  if (!resp.ok) return json(getCachedStale(CACHE_KEY) ?? [], 200);
  const raw = await resp.json();
- const cameras = (Array.isArray(raw) ? raw : raw?.cameras ?? []).map(c => ({
- id: String(c.id ?? c.cameraId ?? ''),
- name: String(c.name ?? c.cameraName ?? ''),
- lat: Number(c.lat ?? c.latitude ?? 0),
- lon: Number(c.lon ?? c.longitude ?? 0),
- state: String(c.state ?? ''),
- category: String(c.category ?? 'weather').toLowerCase(),
- imageUrl: String(c.imageUrl ?? c.image_url ?? ''),
- isOnline: Boolean(c.isOnline ?? c.active ?? true),
- lastUpdated: String(c.lastUpdated ?? c.last_updated ?? new Date().toISOString()),
- })).filter(c => c.id && c.lat !== 0 && c.lon !== 0);
+ const sites = Array.isArray(raw?.payload) ? raw.payload : [];
+ const cameras = [];
+ for (const site of sites) {
+ if (!site?.siteActive) continue;
+ const cams = Array.isArray(site.cameras) ? site.cameras : [];
+ for (const cam of cams) {
+ if (cam?.cameraInMaintenance || cam?.cameraOutOfOrder) continue;
+ const id = String(cam.cameraId ?? '');
+ if (!id) continue;
+ const lat = Number(cam.latitude ?? site.latitude ?? 0);
+ const lon = Number(cam.longitude ?? site.longitude ?? 0);
+ if (lat === 0 || lon === 0) continue;
+ cameras.push({
+ id,
+ name: `${site.siteName ?? site.siteIdentifier ?? 'Site'} — ${cam.cameraName ?? cam.cameraDirection ?? 'Camera'}`,
+ lat,
+ lon,
+ state: String(site.state ?? site.country ?? ''),
+ category: site.thirdParty ? 'remote' : 'weather',
+ // Per-image URL is resolved lazily by /api/faa-camera-image
+ // — pre-fetching 1000+ jpg metadata calls would melt the
+ // 15s timeout. The panel calls the resolver on click.
+ imageUrl: `/api/faa-camera-image?cameraId=${id}`,
+ isOnline: !cam.cameraInMaintenance && !cam.cameraOutOfOrder,
+ lastUpdated: String(cam.cameraLastSuccess ?? new Date().toISOString()),
+ });
+ }
+ }
  setCached(CACHE_KEY, cameras);
  return json(cameras);
  } catch {
  return json(getCachedStale(CACHE_KEY) ?? [], 200);
+ }
+  }
+
+  // Resolve the latest image URL for a single FAA weathercam. The
+  // weathercams.faa.gov `/api/cameras/{id}/images/last/N` endpoint
+  // returns metadata + an `imageUri` pointing at the
+  // images.wcams-static.faa.gov CDN.
+  if (requestUrl.pathname === '/api/faa-camera-image') {
+ const cameraId = (requestUrl.searchParams.get('cameraId') ?? '').replace(/\D/g, '');
+ if (!cameraId) return json({ error: 'cameraId required' }, 400);
+ try {
+ const resp = await fetchWithTimeout(
+ `https://weathercams.faa.gov/api/cameras/${cameraId}/images/last/1`,
+ {
+ headers: {
+ Accept: 'application/json',
+ Origin: 'https://weathercams.faa.gov',
+ Referer: 'https://weathercams.faa.gov/',
+ 'User-Agent': 'CrystalBall/1.0',
+ },
+ },
+ 10000,
+ );
+ if (!resp.ok) return json({ imageUrl: null, degraded: true, reason: `weathercams returned ${resp.status}` });
+ const raw = await resp.json();
+ const item = Array.isArray(raw?.payload) ? raw.payload[0] : null;
+ if (!item?.imageUri) return json({ imageUrl: null, degraded: true, reason: 'No recent image for this camera' });
+ return json({
+ imageUrl: item.imageUri,
+ imageDatetime: item.imageDatetime,
+ cameraId,
+ });
+ } catch (error) {
+ return json({ imageUrl: null, degraded: true, reason: `image lookup failed: ${error?.message ?? error}` });
  }
   }
 

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -1535,9 +1535,35 @@ test('service-status reports bound fallback port after EADDRINUSE recovery', asy
 });
 
 test('/api/faa-cameras — returns cached response on second call', async () => {
-  const mockCameras = [
- { id: '1', name: 'Anchorage Cam', lat: 61.2, lon: -149.9, state: 'AK', category: 'weather', imageUrl: 'https://example.com/cam1.jpg', isOnline: true, lastUpdated: '2024-01-01T00:00:00Z' },
-  ];
+  // The handler upstream is now weathercams.faa.gov/api/sites which
+  // returns {success, count, payload: [{siteId, ..., cameras: [...]}]}.
+  // Each site contributes one row per camera; we use a single
+  // single-camera site here to keep the assertion simple.
+  const mockSites = {
+ success: true,
+ count: 1,
+ payload: [{
+ siteId: 477,
+ siteName: 'Anchorage',
+ siteIdentifier: 'PANC',
+ latitude: 61.2,
+ longitude: -149.9,
+ state: 'AK',
+ country: 'US',
+ siteActive: true,
+ thirdParty: false,
+ cameras: [{
+ cameraId: 11_483,
+ cameraName: 'Camera 1',
+ cameraDirection: 'North',
+ latitude: 61.2,
+ longitude: -149.9,
+ cameraInMaintenance: false,
+ cameraOutOfOrder: false,
+ cameraLastSuccess: '2024-01-01T00:00:00Z',
+ }],
+ }],
+  };
 
   let httpsCallCount = 0;
   const originalHttpsRequest = https.request;
@@ -1554,7 +1580,7 @@ test('/api/faa-cameras — returns cached response on second call', async () => 
  res.statusMessage = '';
  res.headers = { 'content-type': 'application/json' };
  onResponse(res);
- res.emit('data', Buffer.from(JSON.stringify(mockCameras)));
+ res.emit('data', Buffer.from(JSON.stringify(mockSites)));
  res.emit('end');
  });
  };
@@ -1574,13 +1600,15 @@ test('/api/faa-cameras — returns cached response on second call', async () => 
  assert.equal(res1.status, 200);
  const body1 = await res1.json();
  assert.equal(body1.length, 1);
- assert.equal(body1[0].name, 'Anchorage Cam');
+ assert.match(body1[0].name, /Anchorage/);
+ assert.equal(body1[0].id, '11483');
+ assert.match(body1[0].imageUrl, /\/api\/faa-camera-image\?cameraId=11483/);
 
  const res2 = await authFetch(`http://127.0.0.1:${port}/api/faa-cameras`);
  assert.equal(res2.status, 200);
  const body2 = await res2.json();
  assert.equal(body2.length, 1);
- assert.equal(body2[0].name, 'Anchorage Cam');
+ assert.equal(body2[0].id, '11483');
 
  assert.equal(httpsCallCount, 1, 'FAA endpoint should only be hit once; second call should use cache');
   } finally {

--- a/src/components/FAAWeatherCamsPanel.ts
+++ b/src/components/FAAWeatherCamsPanel.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-async-constructor, sonarjs/cognitive-complexity */
 import { Panel } from './Panel';
 import { fetchFAACameras, scoreCamerasAgainstAlerts } from '@/services/faa-cameras';
 import type { ScoredFAACamera } from '@/services/faa-cameras';
@@ -13,7 +14,7 @@ export class FAAWeatherCamsPanel extends Panel {
 
   constructor() {
  super({ id: 'faa-weather-cams', title: 'FAA Weather Cams', className: 'panel-wide' });
- this.load();
+ void this.load();
   }
 
   private async load(): Promise<void> {
@@ -27,7 +28,7 @@ export class FAAWeatherCamsPanel extends Panel {
   }
 
   public refresh(): void {
- this.load();
+ void this.load();
   }
 
   private get displayed(): ScoredFAACamera[] {
@@ -38,7 +39,7 @@ export class FAAWeatherCamsPanel extends Panel {
 
   private render(): void {
  const el = this.getContentElement();
- while (el.firstChild) el.removeChild(el.firstChild);
+ while (el.firstChild) el.firstChild.remove();
  el.className = 'panel-content faa-cams-content';
 
  const alertCams = this.cameras.filter(c => c.alertProximityMi !== null);
@@ -46,7 +47,7 @@ export class FAAWeatherCamsPanel extends Panel {
  const banner = document.createElement('div');
  banner.className = 'faa-digest-banner';
  banner.textContent = this.digestText;
- el.appendChild(banner);
+ el.append(banner);
  }
 
  // Toolbar
@@ -58,16 +59,16 @@ export class FAAWeatherCamsPanel extends Panel {
  cb.type = 'checkbox';
  cb.checked = this.alertOnly;
  cb.addEventListener('change', () => { this.alertOnly = cb.checked; this.render(); });
- label.appendChild(cb);
- label.appendChild(document.createTextNode(' Alert-proximate only'));
+ label.append(cb);
+ label.append(document.createTextNode(' Alert-proximate only'));
  const countEl = document.createElement('span');
  countEl.className = 'faa-cam-count';
  countEl.textContent = `${this.displayed.length} cameras`;
- toolbar.appendChild(label);
- toolbar.appendChild(countEl);
- el.appendChild(toolbar);
+ toolbar.append(label);
+ toolbar.append(countEl);
+ el.append(toolbar);
 
- if (this.selectedCam) el.appendChild(this._buildViewer(this.selectedCam));
+ if (this.selectedCam) el.append(this._buildViewer(this.selectedCam));
 
  // Table
  const table = document.createElement('table');
@@ -78,31 +79,31 @@ export class FAAWeatherCamsPanel extends Panel {
  for (const col of ['Camera', 'Location', 'Alert', 'Score', 'Updated']) {
  const th = document.createElement('th');
  th.textContent = col;
- headerRow.appendChild(th);
+ headerRow.append(th);
  }
- thead.appendChild(headerRow);
- table.appendChild(thead);
+ thead.append(headerRow);
+ table.append(thead);
 
  const tbody = document.createElement('tbody');
  for (const cam of this.displayed) {
  const tr = document.createElement('tr');
- tr.className = `eq-row${cam.alertProximityMi !== null ? ' eq-moderate' : ''}`;
+ tr.className = `eq-row${cam.alertProximityMi === null ? '' : ' eq-moderate'}`;
  if (this.selectedCam?.id === cam.id) tr.classList.add('faa-cam-selected');
 
  const tdName = document.createElement('td');
  tdName.textContent = cam.name;
 
  const tdLoc = document.createElement('td');
- tdLoc.textContent = cam.category !== 'weather'
- ? `${cam.state} · ${cam.category}`
- : cam.state;
+ tdLoc.textContent = cam.category === 'weather'
+ ? cam.state
+ : `${cam.state} · ${cam.category}`;
 
  const tdAlert = document.createElement('td');
  if (cam.alertLabel) {
  const badge = document.createElement('span');
  badge.className = 'faa-alert-badge';
  badge.textContent = cam.alertLabel;
- tdAlert.appendChild(badge);
+ tdAlert.append(badge);
  } else {
  tdAlert.textContent = '—';
  }
@@ -113,16 +114,24 @@ export class FAAWeatherCamsPanel extends Panel {
  const tdTime = document.createElement('td');
  tdTime.textContent = this._relativeTime(cam.lastUpdated);
 
- for (const td of [tdName, tdLoc, tdAlert, tdScore, tdTime]) tr.appendChild(td);
+ for (const td of [tdName, tdLoc, tdAlert, tdScore, tdTime]) tr.append(td);
 
  tr.addEventListener('click', () => {
  this.selectedCam = this.selectedCam?.id === cam.id ? null : cam;
+ // The sidecar returns imageUrl='/api/faa-camera-image?...' as a
+ // resolver pointer, not a direct CDN URL. Lazy-resolve here so
+ // each click only spends one upstream call (the 927-camera
+ // catalog has 4–8 images per site; pre-fetching them all is
+ // wasteful + timeouts the catalog response).
+ if (this.selectedCam?.imageUrl.startsWith('/api/faa-camera-image')) {
+ void this._resolveImageUrl(this.selectedCam);
+ }
  this.render();
  });
- tbody.appendChild(tr);
+ tbody.append(tr);
  }
- table.appendChild(tbody);
- el.appendChild(table);
+ table.append(tbody);
+ el.append(table);
 
  if (this.displayed.length === 0) {
  const empty = document.createElement('p');
@@ -130,7 +139,7 @@ export class FAAWeatherCamsPanel extends Panel {
  empty.textContent = this.alertOnly
  ? 'No cameras near active alerts.'
  : 'No camera data available.';
- el.appendChild(empty);
+ el.append(empty);
  }
   }
 
@@ -142,17 +151,17 @@ export class FAAWeatherCamsPanel extends Panel {
  header.className = 'faa-cam-viewer-header';
  const nameEl = document.createElement('strong');
  nameEl.textContent = cam.name;
- header.appendChild(nameEl);
+ header.append(nameEl);
  if (cam.alertLabel) {
  const badge = document.createElement('span');
  badge.className = 'faa-alert-badge';
  badge.textContent = cam.alertLabel;
- header.appendChild(badge);
+ header.append(badge);
  }
  const updatedEl = document.createElement('span');
  updatedEl.className = 'faa-cam-updated';
  updatedEl.textContent = this._relativeTime(cam.lastUpdated);
- header.appendChild(updatedEl);
+ header.append(updatedEl);
 
  const img = document.createElement('img');
  img.className = 'faa-cam-image';
@@ -165,11 +174,11 @@ export class FAAWeatherCamsPanel extends Panel {
  analyzeBtn.className = 'faa-analyze-btn';
  analyzeBtn.textContent = cam.aiConditions ?? 'Analyze conditions';
  analyzeBtn.disabled = !!cam.aiConditions;
- analyzeBtn.addEventListener('click', () => this._analyzeCamera(cam, analyzeBtn));
+ analyzeBtn.addEventListener('click', () => { void this._analyzeCamera(cam, analyzeBtn); });
 
- div.appendChild(header);
- div.appendChild(img);
- div.appendChild(analyzeBtn);
+ div.append(header);
+ div.append(img);
+ div.append(analyzeBtn);
  return div;
   }
 
@@ -185,7 +194,7 @@ export class FAAWeatherCamsPanel extends Panel {
  cameraName: cam.name,
  alertLabel: cam.alertLabel,
  }),
- signal: AbortSignal.timeout(30000),
+ signal: AbortSignal.timeout(30_000),
  });
  const data = await res.json() as { conditions?: string; error?: string };
  if (data.conditions) {
@@ -209,9 +218,35 @@ export class FAAWeatherCamsPanel extends Panel {
  }
   }
 
+  /**
+   * Replace the panel's `/api/faa-camera-image?cameraId=X` resolver
+   * pointer with the actual CDN URL the FAA weathercams API returns.
+   * Idempotent — second call short-circuits when the URL already
+   * looks like a real CDN URL.
+   */
+  private async _resolveImageUrl(cam: ScoredFAACamera): Promise<void> {
+ if (!cam.imageUrl.startsWith('/api/faa-camera-image')) return;
+ try {
+ const res = await fetch(`${getApiBaseUrl()}${cam.imageUrl}`, { signal: AbortSignal.timeout(10_000) });
+ if (!res.ok) return;
+ const data = await res.json() as { imageUrl?: string | null; imageDatetime?: string };
+ if (!data.imageUrl) return;
+ const idx = this.cameras.findIndex(c => c.id === cam.id);
+ if (idx === -1) return;
+ this.cameras[idx]!.imageUrl = data.imageUrl;
+ if (data.imageDatetime) this.cameras[idx]!.lastUpdated = data.imageDatetime;
+ if (this.selectedCam?.id === cam.id) this.selectedCam = this.cameras[idx] ?? null;
+ this.render();
+ } catch {
+ // Silent failure leaves the resolver pointer in place; the
+ // viewer's <img> will 404 and the analyze button stays
+ // disabled, but the panel itself stays usable.
+ }
+  }
+
   private _relativeTime(iso: string): string {
  const diff = Date.now() - new Date(iso).getTime();
- const min = Math.floor(diff / 60000);
+ const min = Math.floor(diff / 60_000);
  if (min < 1) return 'just now';
  if (min < 60) return `${min}m ago`;
  return `${Math.floor(min / 60)}h ago`;
@@ -223,7 +258,7 @@ export class FAAWeatherCamsPanel extends Panel {
  this.alertOnly = true;
  } else if (!active) {
  this.alertOnly = false;
- this.load();
+ void this.load();
  }
  this.render();
   }


### PR DESCRIPTION
## Summary

User reported the FAA Weather Cams panel was empty — couldn't select a camera anywhere. Root cause: the sidecar `/api/faa-cameras` handler was hitting `avcams.faa.gov`, which has been decommissioned. DNS no longer resolves, so the catalog returned `[]` and the click table had no rows to click.

## Fix

- Sidecar now calls `https://weathercams.faa.gov/api/sites` with the `Origin` + `Referer` headers the upstream's CORS gate requires (no auth key needed; live probe returns 200 + 927 active sites).
- Each site's `cameras[]` is flattened into the `FAACamera` row shape so the panel sees one row per camera/viewpoint.
- Image URLs aren't pre-fetched (catalog has 4–8 cameras per site × 927 sites; pre-resolving would melt the 15s catalog timeout). Sidecar emits a resolver pointer `/api/faa-camera-image?cameraId=X` + adds a new sidecar route that calls `/api/cameras/{id}/images/last/1` on demand.
- Panel lazy-resolves imageUrl on click; resolver short-circuits if the URL is already a CDN URL.

## Verification
- Live: `curl https://weathercams.faa.gov/api/sites` → 200, 927 sites; `/api/cameras/11483/images/last/1` → 200, `imageUri` populated.
- 77/77 sidecar tests pass (existing cache test updated for the new sites response shape).
- `typecheck:all` + eslint clean for changed files.

Cross-agent review: pending Codex review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
