### PR TITLE
Failure Prediction: pure deterministic per-capability risk classifier

### DIFF
--- a/docs/CLAUDE_NEXT_LEVEL_SELF_LEARNING_ROADMAP_2026-04-28.md
+++ b/docs/CLAUDE_NEXT_LEVEL_SELF_LEARNING_ROADMAP_2026-04-28.md
@@ -1,0 +1,573 @@
+# Claude Next-Level Self-Learning Roadmap - 2026-04-28
+
+## Purpose
+
+This document describes what to build after the baseline diagnostics, self-learning, and self-correction gaps are closed.
+
+The next level is to move Crystal Ball from:
+
+```text
+self-diagnosing app
+```
+
+to:
+
+```text
+local intelligence operations system
+```
+
+That means Crystal Ball should not only know what failed. It should predict likely failures, test better algorithm versions in shadow mode, generate counterfactuals, and recommend safe repairs with evidence.
+
+## Build Order
+
+### 1. Failure Prediction
+
+Goal:
+
+Predict capability degradation before the user depends on the capability.
+
+Example:
+
+```text
+Weather warning capability is likely to become unsafe in the next hour because NWS latency is rising, sidecar retries are up, and notification permission is missing.
+```
+
+Inputs:
+
+- provider health trend
+- source freshness trend
+- sidecar reachability
+- notification permission and dispatch trace
+- panel health
+- mission ledger activity
+- algorithm evaluation latency/error trend
+- user configuration gaps, such as missing saved places
+
+Files to inspect first:
+
+- `src/services/diagnostics/system-health.ts`
+- `src/services/diagnostics/provider-redundancy.ts`
+- `src/services/diagnostics/sentinel-feed-audit.ts`
+- `src/services/diagnostics/notification-trace.ts`
+- `src/services/ops/capability-readiness.ts`
+- `src/services/algorithms/algorithm-health.ts`
+
+Implementation idea:
+
+- Add `src/services/diagnostics/failure-prediction.ts`.
+- Compute per-capability risk of failure over the next time window.
+- Start with simple deterministic rules, not ML:
+  - provider latency rising + recent failures = elevated risk
+  - critical source stale + active hazard context = unsafe risk
+  - notification permission denied + severe weather risk = unsafe
+  - sidecar unreachable + desktop-only source = failing
+- Emit recommendations and diagnostic events.
+
+Validation:
+
+```bash
+npm run lint:strict
+npm run typecheck:all
+npx vitest run src/services/diagnostics/__tests__/system-health.test.mts src/services/diagnostics/__tests__/provider-redundancy.test.mts
+```
+
+Add tests for healthy, degraded, failing, and unsafe prediction cases.
+
+### 2. Counterfactual Replay
+
+Goal:
+
+For every missed or late warning, ask:
+
+```text
+What setting or algorithm behavior would have changed the outcome?
+```
+
+Current replay checks mission timelines. Counterfactual replay should evaluate "what if" settings against historical fixtures.
+
+Examples:
+
+- What if weather urgency threshold had been lower?
+- What if polygon buffer had been wider?
+- What if digest-tier alert had been banner-tier?
+- What if source confidence penalty had been stronger?
+- What if a noisy source had been ignored?
+
+Files to inspect first:
+
+- `src/services/ops/replay-harness.ts`
+- `src/services/ops/replay-fixtures.ts`
+- `src/services/ops/replay-fixtures-catalog.ts`
+- `src/services/algorithms/safe-adjustment.ts`
+- `src/services/weather/weather-warning-router.ts`
+- `src/services/weather/weather-urgency.ts`
+
+Implementation idea:
+
+- Add `src/services/ops/counterfactual-replay.ts`.
+- Add a `CounterfactualScenario` shape:
+  - fixture id
+  - baseline settings
+  - candidate settings
+  - expected improvement
+  - safety gates
+  - verdict
+- Start with weather urgency because weather has the clearest mission bridge.
+- Do not use counterfactuals to auto-apply settings. Use them to produce evidence for a human-reviewed proposal.
+
+Validation:
+
+```bash
+npm run lint:strict
+npm run typecheck:all
+npx vitest run src/services/ops/__tests__/replay-harness.test.mts src/services/ops/__tests__/replay-fixtures-catalog.test.mts
+```
+
+Add tests proving a candidate can be eligible, blocked, or inconclusive.
+
+### 3. Shadow-Mode Algorithms
+
+Goal:
+
+Run new algorithm versions silently beside current versions, compare decisions, and promote only after evidence accumulates.
+
+Example:
+
+```text
+weather-urgency-v1 sent digest
+weather-urgency-v2 would have sent banner
+outcome: v2 was right
+```
+
+Files to inspect first:
+
+- `src/services/algorithms/algorithm-registry.ts`
+- `src/services/algorithms/record-evaluation.ts`
+- `src/services/algorithms/algorithm-evaluation-ledger.ts`
+- `src/services/algorithms/algorithm-health.ts`
+- `src/services/weather/weather-urgency.ts`
+- `src/services/weather/weather-warning-router.ts`
+
+Implementation idea:
+
+- Add `src/services/algorithms/shadow-mode.ts`.
+- Add a `ShadowDecisionRecord` or reuse evaluation records with `version` and `label`.
+- Run candidate algorithm versions without dispatch side effects.
+- Record:
+  - production decision
+  - shadow decision
+  - divergence reason
+  - outcome once known
+- Add health summary by algorithm version.
+
+Safety rules:
+
+- shadow algorithms must never dispatch notifications directly
+- no user-visible actions from shadow runs
+- no promotion without minimum sample size
+- safety-critical promotion requires replay pass and no worse no-warning/after-event outcomes
+
+Validation:
+
+```bash
+npm run lint:strict
+npm run typecheck:all
+npx vitest run src/services/algorithms/__tests__/algorithm-evaluation-ledger.test.mts src/services/algorithms/__tests__/algorithm-health.test.mts
+```
+
+### 4. Domain-Specific Mission Scorecards
+
+Goal:
+
+Each mission domain should have a scorecard that answers whether Crystal Ball is doing its job.
+
+Domains:
+
+- weather safety
+- cyber exposure
+- conflict escalation
+- food/commodity shortage
+- energy/fuel stress
+- travel disruption
+- market/portfolio risk
+- local infrastructure
+
+Scorecard dimensions:
+
+- time-to-warn
+- false positives
+- false negatives
+- data quality
+- user acknowledgement
+- user action/follow-through
+- confidence debt
+- open near-misses
+- provider redundancy
+- algorithm health
+
+Files to inspect first:
+
+- `src/services/ops/effectiveness.ts`
+- `src/services/ops/time-to-warn.ts`
+- `src/services/ops/near-miss.ts`
+- `src/services/ops/mission-ledger.ts`
+- `src/services/diagnostics/system-health.ts`
+- `src/services/algorithms/algorithm-health.ts`
+
+Implementation idea:
+
+- Add `src/services/ops/mission-scorecard.ts`.
+- Compute one scorecard per `MissionDomain`.
+- Feed scorecards into diagnostics export and a panel later.
+
+Validation:
+
+```bash
+npm run lint:strict
+npm run typecheck:all
+npx vitest run src/services/ops/__tests__/time-to-warn.test.mts src/services/ops/__tests__/closed-loop-batch.test.mts
+```
+
+### 5. Active Learning Queue
+
+Goal:
+
+When Crystal Ball lacks evidence, it should identify the most valuable next data point.
+
+Examples:
+
+```text
+Need confirmation source for this cyber exposure.
+Need official outage confirmation.
+Need user feedback: was this alert useful?
+Need saved place to personalize weather warnings.
+Need provider key to close aviation blind spot.
+```
+
+Files to inspect first:
+
+- `src/services/intelligence/confidence-explanation.ts`
+- `src/services/intelligence/negative-evidence.ts`
+- `src/services/ops/capability-readiness.ts`
+- `src/services/diagnostics/system-health.ts`
+- `src/services/relevance-learner.ts`
+- `src/services/source-feedback.ts`
+
+Implementation idea:
+
+- Add `src/services/learning/active-learning-queue.ts`.
+- Queue items should include:
+  - id
+  - reason
+  - expected value
+  - domain
+  - action type
+  - expiresAt
+  - privacy/sensitivity level
+- Start with deterministic ranking:
+  - safety-critical gaps first
+  - gaps blocking multiple capabilities next
+  - stale/unknown evidence next
+  - optional user-feedback prompts last
+
+Safety rules:
+
+- never interrupt during urgent alerts
+- user feedback can tune relevance/noise, not factual truth by itself
+- privacy-sensitive asks must be explicit
+
+Validation:
+
+```bash
+npm run lint:strict
+npm run typecheck:all
+```
+
+Add targeted tests for ranking, expiry, and privacy classification.
+
+### 6. Safety Case Dashboard
+
+Goal:
+
+Show why Crystal Ball is currently safe or unsafe to trust for critical warnings.
+
+Core question:
+
+```text
+Can I trust Crystal Ball for critical warnings right now?
+```
+
+Dashboard should show:
+
+- critical capability readiness
+- notification path status
+- provider redundancy
+- saved-place coverage
+- algorithm health
+- recent unsafe suppressions
+- open blind spots
+- current confidence debt
+- last self-test result
+- recommended operator actions
+
+Files to inspect first:
+
+- `src/services/diagnostics/system-health.ts`
+- `src/services/ops/capability-readiness.ts`
+- `src/services/diagnostics/self-test.ts`
+- `src/services/diagnostics/export-bundle.ts`
+- `src/components/AlgorithmDiagnosticPanel.ts`
+- `src/components/SystemDiagnosticPanel.ts` if present
+
+Implementation idea:
+
+- Add a pure `safety-case.ts` service first.
+- UI can come later.
+- The service should output:
+  - `safe_to_trust`
+  - `degraded_but_usable`
+  - `unsafe_do_not_rely`
+  - reasons
+  - required actions
+
+Validation:
+
+```bash
+npm run lint:strict
+npm run typecheck:all
+npx vitest run src/services/diagnostics/__tests__/system-health.test.mts src/services/diagnostics/__tests__/self-test.test.mts
+```
+
+### 7. Autonomous Repair Recommendations
+
+Goal:
+
+Recommend concrete repairs, not vague warnings.
+
+Examples:
+
+- re-enable provider
+- request notification permission
+- add saved place
+- refresh sidecar
+- lower relevance threshold
+- widen polygon buffer
+- disable noisy source
+- queue provider key setup
+- rebuild stale cache
+
+Files to inspect first:
+
+- `src/services/diagnostics/system-health.ts`
+- `src/services/ops/capability-readiness.ts`
+- `src/services/algorithms/safe-adjustment.ts`
+- `src/services/source-feedback.ts`
+- `src/services/correlation-feedback.ts`
+
+Implementation idea:
+
+- Add `src/services/diagnostics/repair-recommendations.ts`.
+- Normalize all recommendations into one shape:
+  - id
+  - severity
+  - confidence
+  - action type
+  - target
+  - reason
+  - expected impact
+  - risk
+  - rollback
+- Separate user actions from code/config actions.
+
+Safety rules:
+
+- recommendations are allowed
+- automatic repair should be limited to low-risk local actions
+- safety-critical algorithm changes require human approval and replay evidence
+
+Validation:
+
+```bash
+npm run lint:strict
+npm run typecheck:all
+```
+
+Add targeted tests for recommendation sorting and deduplication.
+
+### 8. Multi-Agent Review Loop
+
+Goal:
+
+Have Crystal Ball generate evidence bundles that agents can inspect and turn into targeted PRs.
+
+Flow:
+
+```text
+diagnostic bundle -> agent review -> proposed repair plan -> PR -> replay/backtest -> merge
+```
+
+Files to inspect first:
+
+- `src/services/diagnostics/export-bundle.ts`
+- `src/services/diagnostics/diagnostic-events.ts`
+- `docs/CLAUDE_SYSTEM_DIAGNOSTICS_SELF_LEARNING_GAP_SCAN_2026-04-28.md`
+- `docs/CLAUDE_BACKTEST_SELF_IMPROVEMENT_HANDOFF_2026-04-28.md`
+
+Implementation idea:
+
+- Add an "agent handoff bundle" export mode.
+- Include:
+  - system health
+  - recent diagnostic events
+  - algorithm health
+  - recent evaluations
+  - missions and near-misses
+  - replay report summary
+  - pending repair recommendations
+  - reproduction hints
+- Keep it redacted and capped.
+
+Validation:
+
+```bash
+npm run lint:strict
+npm run typecheck:all
+npx vitest run src/services/diagnostics/__tests__/export-bundle.test.mts
+```
+
+## Highest-Value Moonshot
+
+The most valuable advanced build is:
+
+```text
+shadow-mode algorithms + counterfactual replay
+```
+
+Why:
+
+- Shadow mode lets Crystal Ball test better versions without risking user-facing behavior.
+- Counterfactual replay lets it prove whether a settings change would have prevented a miss.
+- Together, they turn "we should tune this" into evidence-backed proposals.
+
+Recommended first moonshot slice:
+
+1. Add weather urgency v2 in shadow mode.
+2. Record production vs shadow decisions.
+3. Link decisions to weather missions.
+4. Resolve outcomes with time-to-warn.
+5. Generate a promotion report:
+   - sample size
+   - divergences
+   - v1 wins
+   - v2 wins
+   - safety regressions
+   - recommendation
+
+Do not auto-promote. Produce a recommendation only.
+
+## Suggested PR Sequence
+
+### PR 1 - Failure Prediction
+
+Add deterministic capability failure prediction based on current health trends.
+
+### PR 2 - Counterfactual Replay
+
+Add scenario comparison for missed/late warnings.
+
+### PR 3 - Shadow-Mode Algorithms
+
+Run candidate algorithm versions silently and compare outcomes.
+
+### PR 4 - Mission Scorecards
+
+Add per-domain scorecards with time-to-warn, false positives, false negatives, and confidence debt.
+
+### PR 5 - Active Learning Queue
+
+Rank the next best evidence, user feedback, or configuration ask.
+
+### PR 6 - Safety Case
+
+Add a pure safety-case service answering whether critical warnings are trustworthy right now.
+
+### PR 7 - Repair Recommendations
+
+Normalize system, algorithm, provider, and user-action repairs into one ranked queue.
+
+### PR 8 - Agent Handoff Bundle
+
+Generate a redacted, capped bundle designed for Claude/Codex repair sessions.
+
+## Full Verification
+
+Before claiming any PR complete:
+
+```bash
+npm run lint:strict
+npm run typecheck:all
+npm run secrets:scan
+npm run test:api
+npm run test:sidecar
+npm run build
+```
+
+Also run targeted tests for every touched module.
+
+## Claude Prompt
+
+```text
+You are working in /Users/bradleybond/Developer/crystalball.
+
+Goal: push Crystal Ball beyond baseline self-diagnostics into a local intelligence operations system using docs/CLAUDE_NEXT_LEVEL_SELF_LEARNING_ROADMAP_2026-04-28.md.
+
+Read first:
+- AGENTS.md
+- docs/CLAUDE_NEXT_LEVEL_SELF_LEARNING_ROADMAP_2026-04-28.md
+- docs/CLAUDE_SYSTEM_DIAGNOSTICS_SELF_LEARNING_GAP_SCAN_2026-04-28.md
+- docs/CLAUDE_BACKTEST_SELF_IMPROVEMENT_HANDOFF_2026-04-28.md
+- docs/CLOSED_LOOP_INTELLIGENCE_OPERATIONS_PLAN.md
+
+Do not commit to main. Do not push to upstream/origin. Stage files by explicit path only.
+
+Start with PR 1: Failure Prediction.
+Implement a pure deterministic service that predicts capability degradation before it becomes a user-facing miss.
+
+Suggested first files:
+- src/services/diagnostics/failure-prediction.ts
+- src/services/diagnostics/__tests__/failure-prediction.test.mts
+
+The first implementation should:
+1. Take system health, provider health, source freshness, notification trace summary, algorithm health, and capability readiness as inputs.
+2. Return per-capability predicted failure risk.
+3. Classify risk as low/elevated/high/unsafe.
+4. Explain each prediction with compact reasons.
+5. Recommend concrete next actions.
+6. Emit no side effects from the pure function.
+
+After PR 1, continue with:
+- counterfactual replay
+- shadow-mode algorithms
+- mission scorecards
+- active learning queue
+- safety case service
+- repair recommendation queue
+- agent handoff bundle
+
+Safety rules:
+- no automatic safety-critical setting changes
+- no user-facing action from shadow algorithms
+- no private raw payloads in replay fixtures or handoff bundles
+- user feedback tunes relevance/noise, not factual truth by itself
+- promotion of any algorithm version requires sample-size and replay gates
+
+Before claiming done, run:
+npm run lint:strict
+npm run typecheck:all
+npm run secrets:scan
+npm run test:api
+npm run test:sidecar
+npm run build
+
+Also run targeted tests for every touched module and report exact files changed, tests run, remaining risks, and which PR stage you completed.
+```

--- a/docs/CLAUDE_SYSTEM_DIAGNOSTICS_SELF_LEARNING_GAP_SCAN_2026-04-28.md
+++ b/docs/CLAUDE_SYSTEM_DIAGNOSTICS_SELF_LEARNING_GAP_SCAN_2026-04-28.md
@@ -1,0 +1,801 @@
+# Claude System Diagnostics And Self-Learning Gap Scan - 2026-04-28
+
+## Purpose
+
+This document is a handoff for Claude to continue hardening Crystal Ball into a system that is:
+
+- diagnosable when something breaks
+- self-observing while it runs
+- self-learning from outcomes and user response
+- self-correcting through bounded, reviewable setting proposals
+- safe enough that critical alert paths do not silently degrade
+
+This is based on an overall repo scan after the recent algorithm and weather-mission work through PR `#183`.
+
+## Current State
+
+Crystal Ball has many of the right primitives now.
+
+Diagnostics primitives:
+
+- `src/services/diagnostics/diagnostic-events.ts`
+- `src/services/diagnostics/system-health.ts`
+- `src/services/diagnostics/system-health-types.ts`
+- `src/services/diagnostics/feature-health-registry.ts`
+- `src/services/diagnostics/panel-health-registry.ts`
+- `src/services/diagnostics/provider-redundancy.ts`
+- `src/services/diagnostics/sentinel-feed-audit.ts`
+- `src/services/diagnostics/notification-trace.ts`
+- `src/services/diagnostics/self-test.ts`
+- `src/services/diagnostics/export-bundle.ts`
+- `src/services/data-freshness.ts`
+- `src/services/data-health.ts`
+- `src/services/providers/health.ts`
+
+Algorithm self-observation primitives:
+
+- `src/services/algorithms/algorithm-registry.ts`
+- `src/services/algorithms/record-evaluation.ts`
+- `src/services/algorithms/algorithm-evaluation-ledger.ts`
+- `src/services/algorithms/algorithm-health.ts`
+- `src/services/algorithms/tracked-algorithms.ts`
+- `src/services/algorithms/safe-adjustment.ts`
+- `src/services/algorithms/algorithms-state.ts`
+- `src/components/AlgorithmDiagnosticPanel.ts`
+
+Closed-loop operations primitives:
+
+- `src/services/ops/mission-ledger.ts`
+- `src/services/ops/mission-state.ts`
+- `src/services/ops/weather-mission-bridge.ts`
+- `src/services/ops/time-to-warn.ts`
+- `src/services/ops/effectiveness.ts`
+- `src/services/ops/near-miss.ts`
+- `src/services/ops/replay-fixtures.ts`
+- `src/services/ops/replay-harness.ts`
+- `src/services/ops/replay-fixtures-catalog.ts`
+- `src/services/ops/capability-readiness.ts`
+
+Recent improvements:
+
+- Algorithm ids are now registry-driven instead of duplicated by diagnostics state.
+- `recordAlgorithmEvaluation` can record compact live decisions and rejects oversized details.
+- `trackedScoreFact`, `trackedComputeCompoundRisk`, and `trackedEvaluateNegativeEvidence` keep pure algorithms pure while allowing opt-in ledger recording.
+- Weather urgency and threat classifier paths now emit algorithm evaluation records.
+- Weather alerts can now open mission records through `weather-mission-bridge`.
+- PR `#183` correctly avoids opening missions for suppressed weather decisions and avoids fake `user_notified` events for digest-tier alerts.
+
+## Executive Gap Summary
+
+The system can now observe some decisions, but it still cannot consistently close the loop.
+
+Main missing capabilities:
+
+1. Evaluation records are not reliably linked to mission outcomes.
+2. Algorithm decisions are recorded, but most are not graded later.
+3. Mission ledgers and algorithm ledgers are in-memory only.
+4. Diagnostics export does not include algorithm/mission/replay/self-learning state.
+5. Replay checks mission timelines, but does not rerun algorithms over historical input snapshots.
+6. Safe-adjustment has an engine, but no live tunable registry or backtest-before-apply gate.
+7. Weather has mission wiring; most other critical domains do not.
+8. Digest delivery does not yet complete mission timelines.
+9. Diagnostic events do not cover all important lifecycle transitions.
+10. Capability readiness is defined, but not fully hydrated from live runtime state.
+
+## Missing Diagnostics Abilities
+
+### 1. Diagnostics Export Does Not Include The New Closed-Loop State
+
+Current export bundle:
+
+- system health
+- notification summary
+- notification traces
+- diagnostic event ring
+- optional self-test report
+- app/env metadata
+
+Missing from `src/services/diagnostics/export-bundle.ts`:
+
+- recent algorithm evaluation records
+- algorithm health report
+- pending algorithm adjustment proposals
+- mission ledger snapshot
+- time-to-warn summary
+- effectiveness report
+- near-miss reports
+- replay fixture summary
+- replay harness report
+- capability readiness report
+- ledger persistence status
+
+Why it matters:
+
+When the user asks "why did this not self-correct?" or "why did Crystal Ball miss this?", the copy/paste diagnostics bundle does not yet include the evidence needed to answer.
+
+Recommended implementation:
+
+- Extend `DiagnosticsExportBundle` with optional closed-loop sections.
+- Add caps for each section so the bundle remains paste-friendly.
+- Redact mission/event details using the existing `redactDetail` rules.
+- Add tests covering truncation and redaction for the new fields.
+
+Primary files:
+
+- `src/services/diagnostics/export-bundle.ts`
+- `src/services/diagnostics/__tests__/export-bundle.test.mts`
+- `src/services/algorithms/algorithms-state.ts`
+- `src/services/ops/mission-state.ts`
+
+### 2. No Durable Ledger Health Diagnostics
+
+The algorithm and mission ledgers have `toJson` / `loadJson`, but the live singleton state is not persisted. A restart loses the evidence needed for learning.
+
+Missing:
+
+- storage adapter for algorithm evaluations
+- storage adapter for mission records
+- last load/save status
+- trim policy visibility
+- export of persisted count vs in-memory count
+- corruption recovery diagnostics
+
+Why it matters:
+
+Self-learning requires history. In-memory ledgers can prove logic in tests, but not learn across sessions.
+
+Recommended implementation:
+
+- Add `src/services/algorithms/algorithm-ledger-persistence.ts`.
+- Add `src/services/ops/mission-ledger-persistence.ts`.
+- Use existing `src/services/persistent-cache.ts` where appropriate.
+- Persist compact redacted records.
+- Trim old records by max count and age.
+- Emit diagnostic events on load/save/failure/trim.
+
+Primary files:
+
+- `src/services/persistent-cache.ts`
+- `src/services/algorithms/algorithms-state.ts`
+- `src/services/algorithms/algorithm-evaluation-ledger.ts`
+- `src/services/ops/mission-state.ts`
+- `src/services/ops/mission-ledger.ts`
+- `src/services/diagnostics/diagnostic-events.ts`
+
+### 3. Capability Readiness Exists But Is Not Hydrated
+
+`src/services/ops/capability-readiness.ts` defines a useful readiness matrix, but the default catalog uses `satisfied: undefined` placeholders. The host needs to hydrate those checkpoints from live diagnostics.
+
+Missing live inputs:
+
+- saved places configured
+- mission ledger active
+- algorithm ledger active
+- notification trace active
+- provider registry loaded
+- NWS provider health
+- panel health registry mounted
+- self-test runner availability
+- storage availability
+- sidecar status
+
+Why it matters:
+
+The app should be able to answer: "Can Crystal Ball learn and warn correctly right now?"
+
+Recommended implementation:
+
+- Add a readiness hydration service.
+- Convert system health, panel health, provider health, sidecar health, and storage self-test output into readiness checkpoint values.
+- Include readiness in diagnostics export and a diagnostic panel.
+
+Primary files:
+
+- `src/services/ops/capability-readiness.ts`
+- `src/services/diagnostics/system-health.ts`
+- `src/services/diagnostics/self-test.ts`
+- `src/services/diagnostics/export-bundle.ts`
+
+### 4. Diagnostic Event Bus Is Not Used Everywhere It Matters
+
+The diagnostic event bus exists, but many important lifecycle events are not emitted.
+
+Missing events:
+
+- algorithm evaluation recorded
+- algorithm outcome graded
+- algorithm detail rejected for size
+- mission opened
+- mission event appended
+- mission resolved
+- near-miss detected
+- replay fixture generated
+- replay run completed
+- adjustment proposal generated
+- adjustment blocked by safety/backtest
+- adjustment accepted/rejected by user
+- ledger persisted/loaded/trimmed
+- digest notification delivered
+
+Why it matters:
+
+Without chronology, debugging becomes archaeology.
+
+Recommended implementation:
+
+- Add lightweight diagnostic emission at the boundary services, not inside pure modules.
+- Keep event payloads compact and redacted.
+- Add tests proving event emission for key transitions.
+
+Primary files:
+
+- `src/services/diagnostics/diagnostic-events.ts`
+- `src/services/algorithms/record-evaluation.ts`
+- `src/services/ops/mission-ledger.ts`
+- `src/services/ops/weather-mission-bridge.ts`
+- `src/services/ops/replay-fixtures.ts`
+- `src/services/ops/replay-harness.ts`
+- `src/services/algorithms/safe-adjustment.ts`
+
+### 5. Self-Test Does Not Probe Closed-Loop Learning
+
+The self-test runner has core checks, but it does not yet verify the self-learning loop.
+
+Missing self-tests:
+
+- algorithm registry can derive health definitions
+- evaluation ledger can record and grade a fixture
+- algorithm health changes from unknown to healthy/degraded with fixture data
+- mission ledger can open/append/resolve a fixture
+- time-to-warn can score a fixture
+- near-miss detection produces a fixture
+- replay harness runs the catalog
+- export bundle includes closed-loop state
+- persistent cache can save/load ledgers
+- safe-adjustment refuses unsafe auto-apply
+
+Recommended implementation:
+
+- Add closed-loop self-test definitions.
+- Keep tests pure and fast; use fixtures, not network calls.
+- Add these to readiness and export.
+
+Primary files:
+
+- `src/services/diagnostics/self-test.ts`
+- `src/services/diagnostics/__tests__/self-test.test.mts`
+- `src/services/ops/replay-fixtures-catalog.ts`
+
+## Missing Self-Learning Abilities
+
+### 1. Recorded Decisions Are Not Reliably Graded Later
+
+The app records some algorithm evaluations, but no general resolver maps later mission outcomes back to those evaluations.
+
+Missing:
+
+- evaluation id stored on mission events
+- mission resolution updates related evaluation records
+- automatic outcome labels from time-to-warn/near-miss results
+- inconclusive handling when no outcome appears before expiration
+
+Recommended implementation:
+
+- Add `evaluationRecordId` or `evaluationRecordIds` to mission event detail where a model decision opened/escalated a mission.
+- Add an outcome resolver that:
+  - reads active/resolved missions
+  - computes time-to-warn
+  - detects near-misses
+  - records `hit`, `miss`, `partial`, or `inconclusive` on linked evaluations
+- Ensure it refuses to overwrite already graded records.
+
+Primary files:
+
+- `src/services/algorithms/record-evaluation.ts`
+- `src/services/ops/mission-types.ts`
+- `src/services/ops/weather-mission-bridge.ts`
+- `src/services/ops/time-to-warn.ts`
+- `src/services/ops/near-miss.ts`
+- new `src/services/ops/outcome-resolver.ts`
+
+### 2. Forecast Calibration Is Not Unified With Algorithm Health
+
+`src/services/intelligence/forecast-calibration.ts` tracks prediction records, Brier score, domain accuracy, and source multipliers. The algorithm evaluation ledger tracks generic algorithm outcomes. They are parallel.
+
+Missing:
+
+- common adapter between forecast predictions and algorithm evaluations
+- shared algorithm id/version naming
+- algorithm health using Brier/calibration error, not only hit-rate
+- source multipliers feeding truth/source confidence in a controlled way
+
+Recommended implementation:
+
+- Add a forecast-to-evaluation adapter.
+- Add calibration summaries to algorithm health.
+- Use source multipliers as proposals, not direct unreviewed changes.
+
+Primary files:
+
+- `src/services/intelligence/forecast-calibration.ts`
+- `src/services/algorithms/algorithm-evaluation-ledger.ts`
+- `src/services/algorithms/algorithm-health.ts`
+- `src/services/source-trust.ts`
+- `src/services/source-reliability.ts`
+
+### 3. User Feedback Loops Are Fragmented
+
+Existing feedback/learning services:
+
+- `src/services/source-feedback.ts`
+- `src/services/correlation-feedback.ts`
+- `src/services/relevance-learner.ts`
+- `src/services/hypothesis-feedback.ts`
+- `src/services/hypothesis-accuracy.ts`
+- `src/services/severity-recalibration.ts`
+- `src/services/snooze-learning.ts`
+
+Missing:
+
+- unified feedback event taxonomy
+- clear separation between "user found it irrelevant" and "the fact was false"
+- joins from user feedback to mission/evaluation records
+- sample-size gates before changing algorithm behavior
+- diagnostics showing which feedback changed which setting
+
+Recommended implementation:
+
+- Add a shared feedback-event adapter.
+- Store feedback references on missions/evaluations.
+- Treat user feedback as relevance/noise evidence, not truth evidence unless paired with real outcome.
+- Add diagnostic export for recent feedback-derived adjustments.
+
+Primary files:
+
+- feedback services listed above
+- `src/services/algorithms/safe-adjustment.ts`
+- `src/services/algorithms/algorithm-health.ts`
+
+### 4. No Drift Detector For Algorithm Behavior
+
+The system can compute health from graded records, but it does not explicitly detect drift.
+
+Missing drift checks:
+
+- hit-rate trend degradation
+- latency trend degradation
+- provider source drift
+- domain volume drift
+- false-positive pressure rising
+- false-negative / near-miss pressure rising
+- user follow-through decline
+- data-quality dependency decline
+
+Recommended implementation:
+
+- Add `src/services/algorithms/algorithm-drift.ts`.
+- Compare recent window vs baseline window.
+- Emit status and recommendation.
+- Feed drift into algorithm health and diagnostics export.
+
+Primary files:
+
+- `src/services/algorithms/algorithm-evaluation-ledger.ts`
+- `src/services/algorithms/algorithm-health.ts`
+- `src/services/ops/effectiveness.ts`
+- `src/services/diagnostics/export-bundle.ts`
+
+## Missing Self-Correction Abilities
+
+### 1. Safe Adjustment Has No Live Tunable Registry
+
+`safe-adjustment.ts` can propose bounded changes, but `AlgorithmDiagnosticPanel` still passes `tunings: []`.
+
+Missing:
+
+- tunable registry
+- current setting source
+- min/max/step per parameter
+- safety class per parameter
+- sample-size gates per parameter
+- last applied/rejected proposal history
+
+Recommended implementation:
+
+- Add `src/services/algorithms/tunable-registry.ts`.
+- Start with low-risk tunables only:
+  - relevance threshold
+  - digest ranking weight
+  - stale data penalty
+  - source confidence multiplier bounds
+- Add safety-critical tunables later:
+  - weather urgency threshold
+  - polygon buffer
+  - critical notification bypass threshold
+- Show proposals in Algorithm Diagnostic Panel with rollback values.
+
+Primary files:
+
+- `src/services/algorithms/safe-adjustment.ts`
+- `src/services/algorithms/algorithms-state.ts`
+- `src/components/AlgorithmDiagnosticPanel.ts`
+- new `src/services/algorithms/tunable-registry.ts`
+
+### 2. No Backtest-Before-Apply Gate
+
+The app should never apply or recommend high-risk tuning without proving it against replay fixtures.
+
+Missing:
+
+- baseline replay report
+- candidate replay report
+- comparison verdict
+- safety regression gates
+- block reasons
+
+Recommended implementation:
+
+- Add `src/services/algorithms/backtest-adjustment.ts`.
+- Compare current settings vs proposed settings over replay fixtures.
+- Gate proposals:
+  - no new safety-critical failures
+  - no worse weather time-to-warn
+  - no increase in no-warning/after-event cases
+  - no increase in unsafe suppressions
+  - improved or equal weighted hit rate
+- Add `blocked_by_backtest` or equivalent verdict.
+
+Primary files:
+
+- `src/services/ops/replay-harness.ts`
+- `src/services/ops/replay-fixtures.ts`
+- `src/services/algorithms/safe-adjustment.ts`
+- new `src/services/algorithms/backtest-adjustment.ts`
+
+### 3. Replay Does Not Rerun Real Algorithms
+
+Current replay checks mission-event expectations. That is useful, but it does not rerun the algorithm with historical inputs and proposed settings.
+
+Missing:
+
+- input snapshot schema
+- fixture input payloads for algorithms
+- algorithm runner registry
+- old-settings vs new-settings comparison
+- output diffing
+
+Recommended implementation:
+
+- Extend replay fixtures with optional `algorithmInputs`.
+- Add algorithm replay runners for selected algorithms.
+- Start with weather urgency because it has clear mission outcomes.
+- Keep all replay runners pure and deterministic.
+
+Primary files:
+
+- `src/services/ops/replay-fixtures.ts`
+- `src/services/ops/replay-harness.ts`
+- `src/services/weather/weather-warning-router.ts`
+- `src/services/weather/weather-urgency.ts`
+
+### 4. Critical Domains Other Than Weather Do Not Open Missions
+
+Weather now has a mission bridge. Other domains still need equivalent bridges.
+
+Priority mission bridges:
+
+- cyber exposure
+- compound risk
+- local infrastructure
+- travel disruption
+- market/portfolio risk
+- food/commodity shortage
+- conflict escalation
+
+Recommended pattern:
+
+- one bridge per domain
+- record `app_watch` when the app starts tracking
+- record `user_notified` only when actually delivered
+- record `official_confirmed` when an authoritative source confirms
+- record `actual_impact` when outcome is known
+- link origin algorithm id and evaluation record id
+
+Primary files:
+
+- `src/services/ops/weather-mission-bridge.ts` as template
+- `src/services/cyber/*`
+- `src/services/compound-risk*`
+- `src/services/infrastructure/*`
+- `src/services/shortage/*`
+- `src/services/market/*`
+
+### 5. Digest Delivery Does Not Complete Mission Timelines
+
+PR `#183` correctly avoids writing `user_notified` for digest-tier weather alerts at routing time. However, when digest delivery actually happens, the mission should receive `user_notified`.
+
+Missing:
+
+- digest delivery hook
+- mission lookup by alert/place
+- `user_notified` event at actual digest render/send time
+- user acknowledgement/follow-through tracking for digest items
+
+Primary files:
+
+- `src/services/insights/notification-ladder.ts`
+- `src/services/notification-digest.ts`
+- `src/services/ops/weather-mission-bridge.ts`
+- `src/services/ops/mission-state.ts`
+
+## Recommended PR Sequence
+
+### PR 1 - Closed-Loop Diagnostics Export
+
+Goal:
+
+Make one export bundle answer "what happened and why?"
+
+Tasks:
+
+- Extend diagnostics export with algorithm health, recent evaluations, missions, time-to-warn, near-misses, replay summary, readiness, and pending proposals.
+- Add caps and redaction.
+- Add tests for redaction/truncation.
+
+Validation:
+
+```bash
+npm run lint:strict
+npm run typecheck:all
+npx vitest run src/services/diagnostics/__tests__/export-bundle.test.mts
+```
+
+### PR 2 - Durable Ledgers
+
+Goal:
+
+Make learning survive app restarts.
+
+Tasks:
+
+- Persist algorithm evaluation ledger.
+- Persist mission ledger.
+- Add load/save/trim diagnostics.
+- Add corruption recovery tests.
+
+Validation:
+
+```bash
+npm run lint:strict
+npm run typecheck:all
+npx vitest run src/services/algorithms/__tests__/algorithm-evaluation-ledger.test.mts src/services/ops/__tests__/mission-ledger.test.mts
+```
+
+### PR 3 - Outcome Resolver
+
+Goal:
+
+Make recorded decisions grade themselves from mission outcomes.
+
+Tasks:
+
+- Link mission events to evaluation record ids.
+- Add resolver that grades evaluations from time-to-warn and near-miss results.
+- Add tests for hit/miss/partial/inconclusive and no-overwrite.
+
+Validation:
+
+```bash
+npm run lint:strict
+npm run typecheck:all
+npx vitest run src/services/ops/__tests__/time-to-warn.test.mts src/services/ops/__tests__/closed-loop-batch.test.mts src/services/algorithms/__tests__/algorithm-evaluation-ledger.test.mts
+```
+
+### PR 4 - Diagnostic Event Coverage
+
+Goal:
+
+Make the timeline explain every important self-learning transition.
+
+Tasks:
+
+- Emit diagnostic events for algorithm, mission, replay, adjustment, persistence, and digest-delivery transitions.
+- Add tests for event emission.
+
+Validation:
+
+```bash
+npm run lint:strict
+npm run typecheck:all
+npx vitest run src/services/diagnostics/__tests__/diagnostic-events.test.mts
+```
+
+### PR 5 - Capability Readiness Hydration
+
+Goal:
+
+Make readiness checkpoints use real runtime state.
+
+Tasks:
+
+- Add hydration service.
+- Feed readiness into export bundle and UI.
+- Add closed-loop learning readiness checks.
+
+Validation:
+
+```bash
+npm run lint:strict
+npm run typecheck:all
+npx vitest run src/services/ops/__tests__/closed-loop-batch.test.mts src/services/diagnostics/__tests__/system-health.test.mts
+```
+
+### PR 6 - Tunable Registry
+
+Goal:
+
+Make safe-adjustment proposals real, bounded, and reviewable.
+
+Tasks:
+
+- Add tunable registry.
+- Wire low-risk tunables into AlgorithmDiagnosticPanel.
+- Add proposal history shape.
+- Do not auto-apply.
+
+Validation:
+
+```bash
+npm run lint:strict
+npm run typecheck:all
+npx vitest run src/services/algorithms/__tests__/safe-adjustment.test.mts src/services/algorithms/__tests__/algorithm-health.test.mts
+```
+
+### PR 7 - Backtest Before Apply
+
+Goal:
+
+Block unsafe settings changes before they reach users.
+
+Tasks:
+
+- Add backtest comparison layer.
+- Compare baseline vs candidate replay results.
+- Add safety gates.
+- Attach backtest verdict to adjustment proposal.
+
+Validation:
+
+```bash
+npm run lint:strict
+npm run typecheck:all
+npx vitest run src/services/ops/__tests__/replay-harness.test.mts src/services/algorithms/__tests__/safe-adjustment.test.mts
+```
+
+### PR 8 - Additional Mission Bridges
+
+Goal:
+
+Expand closed-loop learning beyond weather.
+
+Tasks:
+
+- Add mission bridges for cyber exposure and compound risk first.
+- Then add infrastructure, shortage, market, travel, and conflict bridges.
+- Reuse weather bridge conventions.
+
+Validation:
+
+```bash
+npm run lint:strict
+npm run typecheck:all
+npm run test:api
+npm run test:sidecar
+```
+
+Add targeted tests for each new bridge.
+
+## Specific Bugs Or Risks To Watch
+
+### In-Memory Learning Illusion
+
+If ledgers are not persisted, the UI may look like it is learning during one session but forget everything after restart.
+
+### Ungraded Evaluation Pileup
+
+If evaluations are recorded but never graded, algorithm health stays unknown and safe adjustment never has evidence.
+
+### User Feedback As Truth
+
+User snooze/dismiss behavior should tune relevance/noise, not factual truth. A dismissed alert can still be true.
+
+### Digest Timestamp Pollution
+
+Do not write `user_notified` until the digest is actually delivered. PR `#183` fixed the routing-time version of this; preserve that invariant.
+
+### Unsafe Backtest Overfitting
+
+Do not accept a candidate setting that improves one replay fixture while regressing critical no-warning or after-event scenarios.
+
+### Private Data In Fixtures
+
+Do not commit generated local replay fixtures containing private saved places, exact coordinates, user notes, or contact details.
+
+## Full Verification Before Claiming Done
+
+Run:
+
+```bash
+npm run lint:strict
+npm run typecheck:all
+npm run secrets:scan
+npm run test:api
+npm run test:sidecar
+npm run build
+```
+
+Also run targeted tests for any touched service.
+
+## Claude Prompt
+
+```text
+You are working in /Users/bradleybond/Developer/crystalball.
+
+Goal: harden Crystal Ball's diagnostics, self-learning, and self-correction loop based on docs/CLAUDE_SYSTEM_DIAGNOSTICS_SELF_LEARNING_GAP_SCAN_2026-04-28.md.
+
+Read first:
+- AGENTS.md
+- docs/CLAUDE_SYSTEM_DIAGNOSTICS_SELF_LEARNING_GAP_SCAN_2026-04-28.md
+- docs/DIAGNOSTICS_OBSERVABILITY_ENHANCEMENT_PLAN.md
+- docs/CLAUDE_BACKTEST_SELF_IMPROVEMENT_HANDOFF_2026-04-28.md
+- docs/CLOSED_LOOP_INTELLIGENCE_OPERATIONS_PLAN.md
+
+Do not commit to main. Do not push to upstream/origin. Stage files by explicit path only.
+
+Start with PR 1: Closed-Loop Diagnostics Export.
+Implement this first because it makes every later failure debuggable:
+1. Extend src/services/diagnostics/export-bundle.ts with optional closed-loop sections:
+   - algorithmHealth
+   - recentAlgorithmEvaluations
+   - missionSnapshot
+   - timeToWarnSummary
+   - effectivenessReport
+   - nearMissReports
+   - replayReportSummary
+   - capabilityReadiness
+   - pendingAdjustmentProposals
+2. Add caps and truncation notes for each section.
+3. Redact sensitive details using the existing redaction helpers.
+4. Add tests in src/services/diagnostics/__tests__/export-bundle.test.mts for:
+   - JSON round trip
+   - redaction of mission/evaluation detail
+   - truncation metadata
+   - backward compatibility when closed-loop sections are omitted
+
+After PR 1, continue in this order:
+- durable algorithm and mission ledgers
+- outcome resolver linking mission results back to evaluation records
+- diagnostic event coverage for algorithm/mission/replay/adjustment transitions
+- capability readiness hydration from live runtime state
+- tunable registry for safe-adjustment proposals
+- backtest-before-apply safety gates
+- mission bridges beyond weather
+
+Safety rules:
+- no unreviewed auto-apply for safety-critical settings
+- no raw sensitive payloads in ledgers, exports, or fixtures
+- user dismiss/snooze tunes relevance, not factual truth
+- do not record digest user_notified until digest delivery actually happens
+- do not overwrite already graded algorithm evaluations
+- never allow a setting candidate that regresses no-warning or after-event critical cases
+
+Before claiming done, run:
+npm run lint:strict
+npm run typecheck:all
+npm run secrets:scan
+npm run test:api
+npm run test:sidecar
+npm run build
+
+Also run targeted tests for every touched module and report exact files changed, tests run, remaining risks, and which PR stage you completed.
+```

--- a/src/services/diagnostics/__tests__/failure-prediction.test.mts
+++ b/src/services/diagnostics/__tests__/failure-prediction.test.mts
@@ -1,0 +1,207 @@
+/**
+ * Coverage for `failure-prediction.ts` — verifies the deterministic
+ * per-capability risk classifier.
+ *
+ * Cases exercised:
+ *   - All-healthy inputs → all-low.
+ *   - Stale source on a safety-critical domain → elevated/high.
+ *   - Failing safety-critical algorithm → unsafe.
+ *   - Notification permission denied + safety domain → unsafe.
+ *   - Active-domain escalation moves elevated→high and high→unsafe.
+ *   - JSON-serializable.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { predictFailures, type PredictFailuresInput } from '../failure-prediction.ts';
+import type { CapabilityReadiness } from '@/services/ops/capability-readiness';
+import type { AlgorithmHealth } from '@/services/algorithms/algorithm-health';
+
+const NOW = 1_745_000_000_000;
+
+const weatherCapability: CapabilityReadiness = {
+  capabilityId: 'weather-warning',
+  label: 'Weather warning',
+  domain: 'weather_safety',
+  level: 'ready',
+  score: 1.0,
+  checkpoints: [],
+  summary: 'Weather warnings are operational.',
+};
+
+const cyberCapability: CapabilityReadiness = {
+  capabilityId: 'cyber-watch',
+  label: 'Cyber exposure',
+  domain: 'cyber_exposure',
+  level: 'ready',
+  score: 1.0,
+  checkpoints: [],
+  summary: 'Cyber feeds are operational.',
+};
+
+function baseInput(overrides: Partial<PredictFailuresInput> = {}): PredictFailuresInput {
+  return {
+    generatedAt: NOW,
+    capabilityReadiness: [weatherCapability, cyberCapability],
+    algorithmHealth: [],
+    providerSnapshots: [],
+    notificationTrace: { permissionGranted: true, recentDispatchCount: 0, recentDispatchErrors: 0 },
+    sourceFreshness: { byCapability: {} },
+    ...overrides,
+  };
+}
+
+test('all-healthy inputs produce all-low predictions', () => {
+  const report = predictFailures(baseInput());
+  assert.equal(report.worst, 'low');
+  for (const p of report.predictions) assert.equal(p.level, 'low');
+});
+
+test('stale weather source escalates beyond ceiling (30 min)', () => {
+  const report = predictFailures(baseInput({
+    sourceFreshness: {
+      byCapability: {
+        'weather-warning': { msSinceFresh: 90 * 60 * 1000, silentProviders: 0, degradedProviders: 0 },
+      },
+    },
+  }));
+  const weather = report.predictions.find((p) => p.capabilityId === 'weather-warning')!;
+  assert.notEqual(weather.level, 'low');
+  assert.ok(weather.reasons.some((r) => r.id === 'source_stale'));
+});
+
+test('safety-critical failing algorithm pushes capability to unsafe', () => {
+  const algo: AlgorithmHealth = {
+    algorithmId: 'weather-urgency',
+    label: 'Weather urgency',
+    domain: 'weather_urgency',
+    criticality: 'safety',
+    status: 'unsafe',
+    reason: 'Hit rate dropped below 60% over 50 samples',
+    explanation: ['Hit rate 58%'],
+  };
+  const report = predictFailures(baseInput({ algorithmHealth: [algo] }));
+  const weather = report.predictions.find((p) => p.capabilityId === 'weather-warning')!;
+  assert.equal(weather.level, 'unsafe', `weather: ${weather.level} reasons=${JSON.stringify(weather.reasons)}`);
+  assert.ok(weather.reasons.some((r) => r.id === 'algo_unsafe'));
+});
+
+test('notification permission denied + weather safety → unsafe', () => {
+  const report = predictFailures(baseInput({
+    notificationTrace: { permissionGranted: false, recentDispatchCount: 0, recentDispatchErrors: 0 },
+  }));
+  const weather = report.predictions.find((p) => p.capabilityId === 'weather-warning')!;
+  assert.equal(weather.level, 'unsafe');
+  assert.ok(weather.reasons.some((r) => r.id === 'notif_denied'));
+  assert.ok(weather.recommendations.some((r) => r.id === 'enable_notifications'));
+  // Cyber capability is also a safety domain; same signal applies.
+  const cyber = report.predictions.find((p) => p.capabilityId === 'cyber-watch')!;
+  assert.equal(cyber.level, 'unsafe');
+});
+
+test('active-domain escalation moves the level up one tier', () => {
+  // A stale safety-domain source (weight 0.5) lands at "high" without
+  // escalation; with the user actively depending on weather_safety
+  // it escalates to "unsafe".
+  const fresh = {
+    byCapability: {
+      'weather-warning': { msSinceFresh: 35 * 60 * 1000, silentProviders: 0, degradedProviders: 0 },
+    },
+  };
+  const without = predictFailures(baseInput({ sourceFreshness: fresh }));
+  const w1 = without.predictions.find((p) => p.capabilityId === 'weather-warning')!;
+  assert.equal(w1.level, 'high');
+
+  const withActive = predictFailures(baseInput({ sourceFreshness: fresh, activeDomains: ['weather_safety'] }));
+  const w2 = withActive.predictions.find((p) => p.capabilityId === 'weather-warning')!;
+  assert.equal(w2.level, 'unsafe', 'active domain escalates high → unsafe');
+});
+
+test('active-domain escalation: elevated → high (non-safety domain)', () => {
+  // Markets is non-safety, so a stale source uses the lower 0.3
+  // weight, landing at "elevated"; active-domain escalation lifts
+  // it to "high".
+  const marketCap: CapabilityReadiness = {
+    capabilityId: 'market-pulse',
+    label: 'Market pulse',
+    domain: 'market_portfolio_risk',
+    level: 'ready',
+    score: 1.0,
+    checkpoints: [],
+    summary: 'Markets feed operational.',
+  };
+  const fresh = {
+    byCapability: {
+      'market-pulse': { msSinceFresh: 30 * 60 * 1000, silentProviders: 0, degradedProviders: 0 },
+    },
+  };
+  const without = predictFailures(baseInput({ capabilityReadiness: [marketCap], sourceFreshness: fresh }));
+  const m1 = without.predictions.find((p) => p.capabilityId === 'market-pulse')!;
+  assert.equal(m1.level, 'elevated', `expected elevated, got ${m1.level} score=${m1.score}`);
+
+  const withActive = predictFailures(baseInput({
+    capabilityReadiness: [marketCap],
+    sourceFreshness: fresh,
+    activeDomains: ['market_portfolio_risk'],
+  }));
+  const m2 = withActive.predictions.find((p) => p.capabilityId === 'market-pulse')!;
+  assert.equal(m2.level, 'high', 'active domain escalates elevated → high');
+});
+
+test('not_ready capability surfaces remediation suggestions', () => {
+  const cap: CapabilityReadiness = {
+    capabilityId: 'cyber-watch',
+    label: 'Cyber exposure',
+    domain: 'cyber_exposure',
+    level: 'not_ready',
+    score: 0,
+    checkpoints: [{
+      id: 'cyber-key-set',
+      label: 'OTX key set',
+      satisfied: false,
+      reason: 'OTX_API_KEY not configured',
+      remediation: 'Add OTX API key in Settings → API Keys',
+    }],
+    summary: 'OTX_API_KEY missing.',
+  };
+  const report = predictFailures(baseInput({ capabilityReadiness: [cap] }));
+  const cyber = report.predictions.find((p) => p.capabilityId === 'cyber-watch')!;
+  assert.equal(cyber.recommendations.length, 1);
+  assert.equal(cyber.recommendations[0]!.needsUser, true);
+  assert.match(cyber.recommendations[0]!.text, /OTX/);
+});
+
+test('worst level reflects the worst single prediction', () => {
+  const report = predictFailures(baseInput({
+    notificationTrace: { permissionGranted: false, recentDispatchCount: 0, recentDispatchErrors: 0 },
+  }));
+  assert.equal(report.worst, 'unsafe');
+});
+
+test('empty input → low risk + sane summary', () => {
+  const report = predictFailures(baseInput({ capabilityReadiness: [] }));
+  assert.equal(report.predictions.length, 0);
+  assert.equal(report.worst, 'low');
+  assert.match(report.summary, /No capabilities/);
+});
+
+test('output is JSON-serializable', () => {
+  const report = predictFailures(baseInput({
+    notificationTrace: { permissionGranted: false, recentDispatchCount: 5, recentDispatchErrors: 4 },
+  }));
+  const json = JSON.stringify(report);
+  const round = JSON.parse(json);
+  assert.equal(JSON.stringify(round), json);
+});
+
+test('determinism: same inputs produce same outputs', () => {
+  const input = baseInput({
+    sourceFreshness: {
+      byCapability: { 'weather-warning': { msSinceFresh: 60 * 60 * 1000, silentProviders: 1, degradedProviders: 1 } },
+    },
+  });
+  const a = predictFailures(input);
+  const b = predictFailures(input);
+  assert.equal(JSON.stringify(a), JSON.stringify(b));
+});

--- a/src/services/diagnostics/failure-prediction.ts
+++ b/src/services/diagnostics/failure-prediction.ts
@@ -1,0 +1,399 @@
+/**
+ * Failure Prediction — per
+ * docs/CLAUDE_NEXT_LEVEL_SELF_LEARNING_ROADMAP_2026-04-28.md PR 1.
+ *
+ * Pure deterministic per-capability risk classifier. Reads the latest
+ * snapshots from existing diagnostic services (capability readiness,
+ * algorithm health, provider redundancy, notification trace summary,
+ * source freshness) and emits one PredictedRisk per capability with
+ * a level + reasons + recommended actions.
+ *
+ * Plan invariants:
+ *   - No ML, no random — all inputs → outputs are reproducible.
+ *   - No DOM, no fetch, no globals at import time.
+ *   - The function takes its inputs explicitly so tests can reproduce
+ *     edge cases without booting the live registries.
+ *   - Output is JSON-serializable for the diagnostics export bundle.
+ *   - "unsafe" is reserved for cases where a critical capability the
+ *     user already depends on is at risk of missing (e.g. weather
+ *     warning with denied notification permission). Lower-confidence
+ *     "this might break" predictions stay at "elevated" / "high".
+ */
+
+import type { CapabilityReadiness } from '@/services/ops/capability-readiness';
+import type { AlgorithmHealth, AlgorithmHealthStatus } from '@/services/algorithms/algorithm-health';
+import type { ProviderSnapshot } from '@/services/diagnostics/provider-redundancy';
+import type { MissionDomain } from '@/services/ops/mission-types';
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+export type PredictedRiskLevel = 'low' | 'elevated' | 'high' | 'unsafe';
+
+export interface PredictionReason {
+  /** Stable id ("source_stale", "notif_denied", "algo_failing"). */
+  id: string;
+  /** Free-text rationale, plan-readable. */
+  text: string;
+  /** Severity contribution. Higher = pushes toward unsafe. */
+  weight: number;
+}
+
+export interface RecommendedAction {
+  id: string;
+  text: string;
+  /** Whether this action requires user input (vs an automatic
+   *  app-side fix). User actions surface in the safety case prompt;
+   *  app actions queue for the repair-recommendation service. */
+  needsUser: boolean;
+}
+
+export interface PredictedRisk {
+  capabilityId: string;
+  domain: MissionDomain;
+  level: PredictedRiskLevel;
+  /** 0-1 raw risk score before label bucketing — useful for sorting. */
+  score: number;
+  reasons: readonly PredictionReason[];
+  /** Concrete remediation suggestions, sorted by importance. */
+  recommendations: readonly RecommendedAction[];
+}
+
+export interface PredictedRiskReport {
+  generatedAt: number;
+  predictions: readonly PredictedRisk[];
+  /** Highest level seen across all predictions. */
+  worst: PredictedRiskLevel;
+  /** Plain-English headline. */
+  summary: string;
+}
+
+// ── Inputs ──────────────────────────────────────────────────────────────
+
+/** Snapshot of recent notification dispatch trace. We summarize, not
+ *  store the raw events, so this fits the JSON-serializable invariant. */
+export interface NotificationTraceSummary {
+  /** True when the OS-level permission is currently granted. */
+  permissionGranted: boolean;
+  /** Recent dispatch attempts in the last hour. */
+  recentDispatchCount: number;
+  /** Recent dispatch errors in the same window. */
+  recentDispatchErrors: number;
+}
+
+/** Per-capability source freshness summary. */
+export interface SourceFreshnessSummary {
+  /** Maps capability id → freshness state. */
+  byCapability: Record<string, {
+    /** ms since the freshest source updated. Undefined = never seen. */
+    msSinceFresh?: number;
+    /** Number of upstream providers currently silent. */
+    silentProviders: number;
+    /** Number of upstream providers currently degraded. */
+    degradedProviders: number;
+  }>;
+}
+
+export interface PredictFailuresInput {
+  generatedAt?: number;
+  capabilityReadiness: readonly CapabilityReadiness[];
+  algorithmHealth: readonly AlgorithmHealth[];
+  providerSnapshots: readonly ProviderSnapshot[];
+  notificationTrace: NotificationTraceSummary;
+  sourceFreshness: SourceFreshnessSummary;
+  /** Optional set of mission domains the user is *currently* depending
+   *  on (active situation, mission ledger). Risk predictions for
+   *  capabilities serving these domains escalate one level (elevated
+   *  → high, high → unsafe). */
+  activeDomains?: readonly MissionDomain[];
+}
+
+// ── Implementation ──────────────────────────────────────────────────────
+
+const SAFETY_DOMAINS: ReadonlySet<MissionDomain> = new Set([
+  'weather_safety',
+  'cyber_exposure',
+  'local_infrastructure',
+]);
+
+/** Hard staleness ceiling per domain in ms. Past this, the data is
+ *  too old to be acted on and the capability flips toward unsafe. */
+const STALENESS_CEILING_MS: Record<MissionDomain, number> = {
+  weather_safety: 30 * 60 * 1000,
+  conflict_escalation: 60 * 60 * 1000,
+  cyber_exposure: 60 * 60 * 1000,
+  food_commodity_shortage: 12 * 60 * 60 * 1000,
+  energy_fuel_stress: 12 * 60 * 60 * 1000,
+  travel_disruption: 60 * 60 * 1000,
+  market_portfolio_risk: 5 * 60 * 1000,
+  local_infrastructure: 60 * 60 * 1000,
+};
+
+export function predictFailures(input: PredictFailuresInput): PredictedRiskReport {
+  const generatedAt = input.generatedAt ?? Date.now();
+  const activeDomains = new Set<MissionDomain>(input.activeDomains);
+  const algoByDomain = indexAlgorithmsByDomain(input.algorithmHealth);
+  const predictions: PredictedRisk[] = input.capabilityReadiness.map((cap) =>
+    predictForCapability(cap, {
+      algoByDomain,
+      providerSnapshots: input.providerSnapshots,
+      notificationTrace: input.notificationTrace,
+      sourceFreshness: input.sourceFreshness,
+      activeDomains,
+    }),
+  );
+
+  predictions.sort((a, b) => b.score - a.score);
+  const worst = predictions.reduce<PredictedRiskLevel>(
+    (acc, p) => worseLevel(acc, p.level),
+    'low',
+  );
+  return {
+    generatedAt,
+    predictions,
+    worst,
+    summary: buildSummary(predictions, worst),
+  };
+}
+
+interface PredictionContext {
+  algoByDomain: Map<string, readonly AlgorithmHealth[]>;
+  providerSnapshots: readonly ProviderSnapshot[];
+  notificationTrace: NotificationTraceSummary;
+  sourceFreshness: SourceFreshnessSummary;
+  activeDomains: ReadonlySet<MissionDomain>;
+}
+
+function readinessReason(cap: CapabilityReadiness): PredictionReason | undefined {
+  if (cap.level === 'not_ready') {
+    return { id: 'capability_not_ready', text: `${cap.label} is not ready: ${cap.summary}`, weight: 0.6 };
+  }
+  if (cap.level === 'partial') {
+    return { id: 'capability_partial', text: `${cap.label} is partially ready: ${cap.summary}`, weight: 0.3 };
+  }
+  return undefined;
+}
+
+function freshnessReasons(
+  cap: CapabilityReadiness,
+  ctx: PredictionContext,
+): PredictionReason[] {
+  const fresh = ctx.sourceFreshness.byCapability[cap.capabilityId];
+  if (!fresh) return [];
+  const out: PredictionReason[] = [];
+  const ceiling = STALENESS_CEILING_MS[cap.domain] ?? 60 * 60 * 1000;
+  if (fresh.msSinceFresh !== undefined && fresh.msSinceFresh > ceiling) {
+    out.push({
+      id: 'source_stale',
+      text: `Source for ${cap.label} hasn't updated in ${Math.round(fresh.msSinceFresh / 60_000)} min`,
+      weight: SAFETY_DOMAINS.has(cap.domain) ? 0.5 : 0.3,
+    });
+  }
+  if (fresh.silentProviders > 0) {
+    out.push({
+      id: 'silent_providers',
+      text: `${fresh.silentProviders} provider${fresh.silentProviders > 1 ? 's' : ''} silent for ${cap.label}`,
+      weight: 0.3,
+    });
+  }
+  if (fresh.degradedProviders >= 2) {
+    out.push({
+      id: 'degraded_providers',
+      text: `${fresh.degradedProviders} providers degraded for ${cap.label} — redundancy thin`,
+      weight: 0.25,
+    });
+  }
+  return out;
+}
+
+function algorithmReasons(
+  cap: CapabilityReadiness,
+  ctx: PredictionContext,
+): PredictionReason[] {
+  const algos = ctx.algoByDomain.get(cap.domain) ?? [];
+  const out: PredictionReason[] = [];
+  for (const algo of algos) {
+    const w = algorithmWeight(algo.status, algo.criticality);
+    if (w === 0) continue;
+    out.push({
+      id: `algo_${algo.status}`,
+      text: `${algo.label} (${algo.criticality}) is ${algo.status}: ${algo.reason}`,
+      weight: w,
+    });
+  }
+  return out;
+}
+
+function notificationReasons(
+  cap: CapabilityReadiness,
+  ctx: PredictionContext,
+): { reasons: PredictionReason[]; actions: RecommendedAction[] } {
+  const reasons: PredictionReason[] = [];
+  const actions: RecommendedAction[] = [];
+  if (SAFETY_DOMAINS.has(cap.domain) && !ctx.notificationTrace.permissionGranted) {
+    reasons.push({
+      id: 'notif_denied',
+      text: 'OS notification permission is denied — safety alerts cannot reach you',
+      weight: 0.7,
+    });
+    actions.push({
+      id: 'enable_notifications',
+      text: 'Enable notifications for Crystal Ball in System Settings → Notifications',
+      needsUser: true,
+    });
+  }
+  const dispatched = ctx.notificationTrace.recentDispatchCount;
+  if (dispatched > 0) {
+    const errorRate = ctx.notificationTrace.recentDispatchErrors / dispatched;
+    if (errorRate >= 0.5) {
+      reasons.push({
+        id: 'notif_error_rate',
+        text: `Notification dispatch error rate is ${Math.round(errorRate * 100)}% in the last hour`,
+        weight: 0.4,
+      });
+    }
+  }
+  return { reasons, actions };
+}
+
+function checkpointRecommendations(cap: CapabilityReadiness): RecommendedAction[] {
+  const out: RecommendedAction[] = [];
+  for (const cp of cap.checkpoints) {
+    if (cp.satisfied === false && cp.remediation) {
+      out.push({ id: cp.id, text: cp.remediation, needsUser: looksUserAction(cp.remediation) });
+    }
+  }
+  return out;
+}
+
+function predictForCapability(
+  cap: CapabilityReadiness,
+  ctx: PredictionContext,
+): PredictedRisk {
+  const reasons: PredictionReason[] = [];
+  const recommendations: RecommendedAction[] = [];
+
+  const r1 = readinessReason(cap);
+  if (r1) reasons.push(r1);
+  recommendations.push(...checkpointRecommendations(cap));
+
+  const notif = notificationReasons(cap, ctx);
+  reasons.push(
+    ...freshnessReasons(cap, ctx),
+    ...algorithmReasons(cap, ctx),
+    ...notif.reasons,
+  );
+  recommendations.push(...notif.actions);
+
+  const totalWeight = reasons.reduce((sum, r) => sum + r.weight, 0);
+  let level = bucketLevel(totalWeight);
+
+  // 6. Active-domain escalation.
+  if (ctx.activeDomains.has(cap.domain) && level !== 'low') {
+    level = escalate(level);
+  }
+
+  return {
+    capabilityId: cap.capabilityId,
+    domain: cap.domain,
+    level,
+    score: clamp01(totalWeight),
+    reasons,
+    recommendations: dedupeRecommendations(recommendations),
+  };
+}
+
+function indexAlgorithmsByDomain(
+  algorithms: readonly AlgorithmHealth[],
+): Map<string, readonly AlgorithmHealth[]> {
+  // The algorithm health domain is fine-grained ('weather_polygon',
+  // 'truth_score', etc.), and CapabilityReadiness uses MissionDomain
+  // ('weather_safety', etc.). Map known fine domains to their parent.
+  const PARENT_DOMAIN: Record<string, MissionDomain> = {
+    weather_polygon: 'weather_safety',
+    weather_urgency: 'weather_safety',
+    truth_score: 'cyber_exposure', // generic — re-bucket if we ever
+    evidence_graph: 'cyber_exposure',
+    situation_clustering: 'cyber_exposure',
+    baseline_deviation: 'cyber_exposure',
+    compound_risk: 'cyber_exposure',
+    forecast_calibration: 'market_portfolio_risk',
+    watchlist_relevance: 'cyber_exposure',
+    negative_evidence: 'cyber_exposure',
+    shortage_score: 'food_commodity_shortage',
+    reasoning_hypothesis: 'cyber_exposure',
+    other: 'local_infrastructure',
+  };
+  const out = new Map<string, AlgorithmHealth[]>();
+  for (const algo of algorithms) {
+    const parent = PARENT_DOMAIN[algo.domain];
+    if (!parent) continue;
+    const list = out.get(parent) ?? [];
+    list.push(algo);
+    out.set(parent, list);
+  }
+  return out;
+}
+
+const ALGO_STATUS_BASE: Record<AlgorithmHealthStatus, number> = {
+  healthy: 0,
+  unknown: 0,
+  degraded: 0.2,
+  failing: 0.4,
+  unsafe: 0.6,
+};
+
+const ALGO_CRITICALITY_MULT: Record<'safety' | 'high' | 'medium' | 'low', number> = {
+  safety: 1.5,
+  high: 1,
+  medium: 0.7,
+  low: 0.4,
+};
+
+function algorithmWeight(
+  status: AlgorithmHealthStatus,
+  criticality: 'safety' | 'high' | 'medium' | 'low',
+): number {
+  return ALGO_STATUS_BASE[status] * ALGO_CRITICALITY_MULT[criticality];
+}
+
+function bucketLevel(weight: number): PredictedRiskLevel {
+  if (weight >= 0.7) return 'unsafe';
+  if (weight >= 0.45) return 'high';
+  if (weight >= 0.2) return 'elevated';
+  return 'low';
+}
+
+function escalate(level: PredictedRiskLevel): PredictedRiskLevel {
+  if (level === 'elevated') return 'high';
+  if (level === 'high') return 'unsafe';
+  return level;
+}
+
+function worseLevel(a: PredictedRiskLevel, b: PredictedRiskLevel): PredictedRiskLevel {
+  const order: PredictedRiskLevel[] = ['low', 'elevated', 'high', 'unsafe'];
+  return order.indexOf(a) >= order.indexOf(b) ? a : b;
+}
+
+function clamp01(value: number): number {
+  if (Number.isNaN(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+function dedupeRecommendations(input: readonly RecommendedAction[]): RecommendedAction[] {
+  const seen = new Map<string, RecommendedAction>();
+  for (const r of input) if (!seen.has(r.id)) seen.set(r.id, r);
+  return [...seen.values()];
+}
+
+function looksUserAction(text: string): boolean {
+  const t = text.toLowerCase();
+  return /enable|grant|add|install|configure|sign in|set up|allow/.test(t);
+}
+
+function buildSummary(predictions: readonly PredictedRisk[], worst: PredictedRiskLevel): string {
+  if (predictions.length === 0) return 'No capabilities to evaluate.';
+  if (worst === 'low') return 'All capabilities are healthy.';
+  const top = predictions.slice(0, 3).filter((p) => p.level !== 'low');
+  const labels = top.map((p) => `${p.capabilityId} (${p.level})`).join(', ');
+  return `Worst predicted risk: ${worst}. Top concerns: ${labels}.`;
+}


### PR DESCRIPTION
## Summary

Per `docs/CLAUDE_NEXT_LEVEL_SELF_LEARNING_ROADMAP_2026-04-28.md` PR 1.

`predictFailures(input)` → `PredictedRiskReport`. Reads capability readiness, algorithm health, provider snapshots, notification trace summary, and source freshness; emits one `PredictedRisk` per capability with:
- `level`: `low` | `elevated` | `high` | `unsafe`
- `score`: 0..1 raw risk (sortable)
- `reasons`: weighted `PredictionReason[]`
- `recommendations`: concrete actions with `needsUser` flag

## Risk signals (deterministic — no ML)

1. **Capability readiness**: `not_ready` (0.6), `partial` (0.3)
2. **Source freshness**: stale beyond per-domain ceiling (0.5 safety / 0.3 non-safety), silent providers (0.3), thin redundancy (0.25)
3. **Algorithm health**: status × criticality table (unsafe×safety = 0.9, failing×high = 0.4, etc.)
4. **Notification path**: denied permission + safety domain = 0.7, dispatch error rate ≥ 50% = 0.4

**Active-domain escalation**: capabilities serving a domain the user is currently depending on (active situation, mission ledger) escalate one level — `elevated` → `high`, `high` → `unsafe`.

## Plan invariants honored
- JSON-serializable output for the diagnostics export bundle
- Pure deterministic — same inputs ⇒ same outputs
- No DOM, no fetch, no globals at import time
- Test-friendly explicit input shape

## Verification
- `npm run typecheck:all` clean
- `npm run lint:strict` (eslint clean for changed files)
- 11/11 failure-prediction tests pass — all-healthy, stale-source escalation, unsafe-algorithm propagation, notification-denial → unsafe, active-domain escalation in safety + non-safety domains, not_ready remediation surfacing, JSON round-trip, determinism

Cross-agent review: pending Codex review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
