### PR TITLE
Experiment Manager: pure store for controlled local A/B experiments

### DIFF
--- a/src/services/experiments/__tests__/experiment-manager.test.mts
+++ b/src/services/experiments/__tests__/experiment-manager.test.mts
@@ -1,0 +1,206 @@
+/**
+ * Coverage for experiment-manager.ts — verifies:
+ *   - Lifecycle: draft → running → paused/resume/complete.
+ *   - Safety-stop: fires once, freezes status to 'stopped',
+ *     refuses further outcomes.
+ *   - Append-only: recording the same caseId twice throws.
+ *   - Recommendation engine: continue / promote / keep_control /
+ *     manual_review based on sample size + win margin.
+ *   - JSON serialization round-trip.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  createExperimentManager,
+  type ExperimentDefinition,
+  type ExperimentOutcomeRecord,
+} from '../experiment-manager.ts';
+
+function defaultDef(overrides: Partial<ExperimentDefinition> = {}): ExperimentDefinition {
+  return {
+    id: 'test-exp',
+    hypothesis: 'Candidate threshold lowers false negatives',
+    domain: 'weather_safety',
+    controlVersion: '1.0.0',
+    candidateVersion: '1.1.0',
+    metrics: ['hit_rate'],
+    minSamples: 5,
+    safetyStopConditions: ['safety_critical_miss'],
+    ...overrides,
+  };
+}
+
+function outcome(caseId: string, kind: 'control_win' | 'candidate_win' | 'inconclusive', at = 1): ExperimentOutcomeRecord {
+  return { caseId, outcome: kind, at };
+}
+
+test('define + start: draft → running', () => {
+  const mgr = createExperimentManager({ now: () => 1_000 });
+  mgr.define(defaultDef());
+  const r = mgr.start('test-exp');
+  assert.equal(r.status, 'running');
+  assert.equal(r.createdAt, 1_000);
+});
+
+test('define throws on id collision', () => {
+  const mgr = createExperimentManager();
+  mgr.define(defaultDef());
+  assert.throws(() => mgr.define(defaultDef()), /already defined/);
+});
+
+test('start refuses non-draft non-paused statuses', () => {
+  const mgr = createExperimentManager();
+  mgr.define(defaultDef());
+  mgr.start('test-exp');
+  assert.throws(() => mgr.start('test-exp'), /cannot start from running/);
+});
+
+test('pause is idempotent on already-paused', () => {
+  const mgr = createExperimentManager();
+  mgr.define(defaultDef());
+  mgr.start('test-exp');
+  mgr.pause('test-exp');
+  const r = mgr.pause('test-exp');
+  assert.equal(r.status, 'paused');
+});
+
+test('resume requires paused status', () => {
+  const mgr = createExperimentManager();
+  mgr.define(defaultDef());
+  mgr.start('test-exp');
+  assert.throws(() => mgr.resume('test-exp'), /Cannot resume/);
+});
+
+// ── Safety stop ────────────────────────────────────────────────────────
+
+test('safety stop flips status to stopped + freezes outcomes', () => {
+  const mgr = createExperimentManager();
+  mgr.define(defaultDef());
+  mgr.start('test-exp');
+  mgr.recordOutcome('test-exp', outcome('case-1', 'control_win'));
+  mgr.triggerSafetyStop('test-exp', 'safety_critical_miss');
+  assert.throws(() => mgr.recordOutcome('test-exp', outcome('case-2', 'candidate_win')), /stopped/);
+  assert.throws(() => mgr.start('test-exp'), /cannot start from stopped/);
+});
+
+test('safety stop is idempotent (same condition does not duplicate)', () => {
+  const mgr = createExperimentManager();
+  mgr.define(defaultDef());
+  mgr.start('test-exp');
+  mgr.triggerSafetyStop('test-exp', 'safety_critical_miss');
+  const r = mgr.triggerSafetyStop('test-exp', 'safety_critical_miss');
+  assert.deepEqual(r.triggeredSafetyStops, ['safety_critical_miss']);
+});
+
+test('safety stop with multiple conditions records each unique one', () => {
+  const mgr = createExperimentManager();
+  mgr.define(defaultDef());
+  mgr.start('test-exp');
+  mgr.triggerSafetyStop('test-exp', 'safety_critical_miss');
+  const r = mgr.triggerSafetyStop('test-exp', 'user_acknowledged_drop');
+  assert.deepEqual(r.triggeredSafetyStops, ['safety_critical_miss', 'user_acknowledged_drop']);
+});
+
+// ── Append-only outcomes ──────────────────────────────────────────────
+
+test('recording the same caseId twice throws (append-only)', () => {
+  const mgr = createExperimentManager();
+  mgr.define(defaultDef());
+  mgr.start('test-exp');
+  mgr.recordOutcome('test-exp', outcome('case-1', 'control_win'));
+  assert.throws(() => mgr.recordOutcome('test-exp', outcome('case-1', 'candidate_win')), /already recorded/);
+});
+
+// ── Recommendation engine ─────────────────────────────────────────────
+
+test('insufficient samples → continue', () => {
+  const mgr = createExperimentManager();
+  mgr.define(defaultDef({ minSamples: 5 }));
+  mgr.start('test-exp');
+  mgr.recordOutcome('test-exp', outcome('a', 'candidate_win'));
+  mgr.recordOutcome('test-exp', outcome('b', 'candidate_win'));
+  const result = mgr.evaluate('test-exp');
+  assert.equal(result.recommendation, 'continue');
+  assert.match(result.reason, /3 more/);
+});
+
+test('candidate wins by ≥10% margin → promote', () => {
+  const mgr = createExperimentManager();
+  mgr.define(defaultDef({ minSamples: 5 }));
+  mgr.start('test-exp');
+  // 8 candidate wins, 2 control wins → margin 6 ≥ ceil(10*0.1)=1 → promote
+  for (let i = 0; i < 8; i++) mgr.recordOutcome('test-exp', outcome(`c${i}`, 'candidate_win'));
+  for (let i = 0; i < 2; i++) mgr.recordOutcome('test-exp', outcome(`x${i}`, 'control_win'));
+  const result = mgr.evaluate('test-exp');
+  assert.equal(result.recommendation, 'promote');
+  assert.equal(result.candidateWins, 8);
+  assert.equal(result.controlWins, 2);
+});
+
+test('control wins decisively → keep_control', () => {
+  const mgr = createExperimentManager();
+  mgr.define(defaultDef({ minSamples: 5 }));
+  mgr.start('test-exp');
+  for (let i = 0; i < 8; i++) mgr.recordOutcome('test-exp', outcome(`c${i}`, 'control_win'));
+  for (let i = 0; i < 2; i++) mgr.recordOutcome('test-exp', outcome(`x${i}`, 'candidate_win'));
+  const result = mgr.evaluate('test-exp');
+  assert.equal(result.recommendation, 'keep_control');
+});
+
+test('razor-thin margin → manual_review', () => {
+  const mgr = createExperimentManager();
+  mgr.define(defaultDef({ minSamples: 10 }));
+  mgr.start('test-exp');
+  // 11 candidate vs 10 control → margin 1, threshold ceil(21*0.1)=3 → manual_review
+  for (let i = 0; i < 11; i++) mgr.recordOutcome('test-exp', outcome(`c${i}`, 'candidate_win'));
+  for (let i = 0; i < 10; i++) mgr.recordOutcome('test-exp', outcome(`x${i}`, 'control_win'));
+  const result = mgr.evaluate('test-exp');
+  assert.equal(result.recommendation, 'manual_review');
+});
+
+test('safety stop overrides recommendation regardless of wins', () => {
+  const mgr = createExperimentManager();
+  mgr.define(defaultDef({ minSamples: 5 }));
+  mgr.start('test-exp');
+  for (let i = 0; i < 10; i++) mgr.recordOutcome('test-exp', outcome(`c${i}`, 'candidate_win'));
+  mgr.triggerSafetyStop('test-exp', 'safety_critical_miss');
+  const result = mgr.evaluate('test-exp');
+  assert.equal(result.recommendation, 'keep_control');
+  assert.match(result.reason, /Safety-stop fired/);
+});
+
+// ── JSON serialization ────────────────────────────────────────────────
+
+test('toJson is round-trippable', () => {
+  const mgr = createExperimentManager({ now: () => 1_000 });
+  mgr.define(defaultDef());
+  mgr.start('test-exp');
+  mgr.recordOutcome('test-exp', outcome('case-1', 'candidate_win', 2_000));
+  const snapshot = mgr.toJson();
+  const round = JSON.parse(JSON.stringify(snapshot));
+  assert.deepEqual(round, snapshot);
+});
+
+test('all() returns experiments oldest-first by createdAt', () => {
+  let t = 100;
+  const mgr = createExperimentManager({ now: () => ++t });
+  mgr.define(defaultDef({ id: 'a' }));
+  mgr.define(defaultDef({ id: 'b' }));
+  mgr.define(defaultDef({ id: 'c' }));
+  const ids = mgr.all().map((r) => r.id);
+  assert.deepEqual(ids, ['a', 'b', 'c']);
+});
+
+test('determinism: same lifecycle produces same evaluation', () => {
+  const m1 = createExperimentManager({ now: () => 1 });
+  const m2 = createExperimentManager({ now: () => 1 });
+  for (const m of [m1, m2]) {
+    m.define(defaultDef({ minSamples: 5 }));
+    m.start('test-exp');
+    for (let i = 0; i < 6; i++) m.recordOutcome('test-exp', outcome(`c${i}`, 'candidate_win', 100 + i));
+    for (let i = 0; i < 1; i++) m.recordOutcome('test-exp', outcome(`x${i}`, 'control_win', 200 + i));
+  }
+  assert.deepEqual(m1.evaluate('test-exp'), m2.evaluate('test-exp'));
+});

--- a/src/services/experiments/experiment-manager.ts
+++ b/src/services/experiments/experiment-manager.ts
@@ -1,0 +1,306 @@
+/**
+ * Experiment Manager — per
+ * docs/CLAUDE_STRATEGIC_SELF_IMPROVEMENT_ROADMAP_2026-04-28.md Layer 2.
+ *
+ * Pure in-memory store for controlled local experiments (algorithm
+ * A/B, threshold comparisons, source weighting tests, etc.). Each
+ * experiment carries:
+ *   - hypothesis text
+ *   - control + candidate versions
+ *   - metric ids it tracks
+ *   - minimum sample size
+ *   - safety-stop conditions (predicate ids the harness checks)
+ *   - rolling control/candidate/inconclusive tallies
+ *   - lifecycle status
+ *
+ * Plan invariants:
+ *   - No DOM, no fetch, no globals at import time.
+ *   - JSON-serializable for the diagnostics export bundle and the
+ *     agent handoff bundle.
+ *   - Experiments NEVER apply settings on their own — they emit
+ *     recommendations that the Policy Engine (Layer 1) evaluates.
+ *   - Hard safety stop: when any safety-stop condition fires, the
+ *     experiment flips to `stopped` and refuses further outcomes.
+ *   - Sample contributions are append-only: re-recording an outcome
+ *     for the same caseId throws so calibration data isn't retconned.
+ */
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+export type ExperimentStatus = 'draft' | 'running' | 'paused' | 'completed' | 'stopped';
+
+export type ExperimentRecommendation =
+  | 'promote'
+  | 'keep_control'
+  | 'continue'
+  | 'manual_review';
+
+export type ExperimentOutcomeKind = 'control_win' | 'candidate_win' | 'inconclusive';
+
+export interface ExperimentDefinition {
+  id: string;
+  hypothesis: string;
+  domain: string;
+  controlVersion: string;
+  candidateVersion: string;
+  /** Metric ids this experiment tracks ("hit_rate", "time_to_warn",
+   *  "false_positive_rate", "user_acknowledged"). */
+  metrics: readonly string[];
+  /** Minimum graded outcomes before a recommendation can be emitted. */
+  minSamples: number;
+  /** Safety-stop condition ids the host wants the harness to check
+   *  ("safety_critical_miss", "user_acknowledged_drop", ...). */
+  safetyStopConditions: readonly string[];
+}
+
+export interface ExperimentOutcomeRecord {
+  /** Stable case id (e.g. mission id, alert id). Same case can not
+   *  be recorded twice. */
+  caseId: string;
+  outcome: ExperimentOutcomeKind;
+  /** ms timestamp the outcome was determined. */
+  at: number;
+  /** Optional metric values for this case. */
+  metricValues?: Record<string, number>;
+  /** Optional free-text notes. */
+  notes?: string;
+}
+
+export interface ExperimentResult {
+  experimentId: string;
+  status: ExperimentStatus;
+  sampleCount: number;
+  controlWins: number;
+  candidateWins: number;
+  inconclusive: number;
+  safetyStops: readonly string[];
+  recommendation: ExperimentRecommendation;
+  reason: string;
+}
+
+export interface ExperimentRecord extends ExperimentDefinition {
+  status: ExperimentStatus;
+  createdAt: number;
+  /** Recorded outcomes in insertion order. */
+  outcomes: readonly ExperimentOutcomeRecord[];
+  /** Safety-stop condition ids that have actually fired. */
+  triggeredSafetyStops: readonly string[];
+}
+
+export interface ExperimentManager {
+  /** Open an experiment in 'draft' status. Throws on id collision. */
+  define: (definition: ExperimentDefinition) => ExperimentRecord;
+  /** Move an experiment from draft → running. Throws if not draft. */
+  start: (id: string) => ExperimentRecord;
+  /** Pause a running experiment. Idempotent. */
+  pause: (id: string) => ExperimentRecord;
+  /** Resume a paused experiment. */
+  resume: (id: string) => ExperimentRecord;
+  /** Hard stop on safety-stop firing. Idempotent — repeated calls
+   *  with the same condition append once. */
+  triggerSafetyStop: (id: string, conditionId: string) => ExperimentRecord;
+  /** Append an outcome. Throws when the case is already recorded
+   *  (append-only invariant) or when the experiment is stopped. */
+  recordOutcome: (id: string, outcome: ExperimentOutcomeRecord) => ExperimentRecord;
+  /** Mark an experiment completed (manual close-out). */
+  complete: (id: string, reason: string) => ExperimentRecord;
+  get: (id: string) => ExperimentRecord | undefined;
+  all: () => ExperimentRecord[];
+  /** Compute the recommendation snapshot for one experiment. */
+  evaluate: (id: string) => ExperimentResult;
+  /** Snapshot for the diagnostics export bundle. */
+  toJson: () => ExperimentRecord[];
+}
+
+// ── Implementation ──────────────────────────────────────────────────────
+
+export interface ExperimentManagerOptions {
+  now?: () => number;
+}
+
+export function createExperimentManager(options: ExperimentManagerOptions = {}): ExperimentManager {
+  const now = options.now ?? (() => Date.now());
+  const records = new Map<string, ExperimentRecord>();
+
+  function getOrThrow(id: string): ExperimentRecord {
+    const r = records.get(id);
+    if (!r) throw new Error(`Experiment "${id}" not registered`);
+    return r;
+  }
+
+  function setStatus(id: string, status: ExperimentStatus): ExperimentRecord {
+    const r = getOrThrow(id);
+    if (r.status === 'stopped' && status !== 'stopped') {
+      throw new Error(`Experiment "${id}" is stopped and cannot transition to ${status}`);
+    }
+    const next: ExperimentRecord = { ...r, status };
+    records.set(id, next);
+    return next;
+  }
+
+  return {
+    define(definition) {
+      if (records.has(definition.id)) {
+        throw new Error(`Experiment "${definition.id}" already defined`);
+      }
+      const record: ExperimentRecord = {
+        ...definition,
+        status: 'draft',
+        createdAt: now(),
+        outcomes: [],
+        triggeredSafetyStops: [],
+      };
+      records.set(definition.id, record);
+      return record;
+    },
+
+    start(id) {
+      const r = getOrThrow(id);
+      if (r.status !== 'draft' && r.status !== 'paused') {
+        throw new Error(`Experiment "${id}" cannot start from ${r.status}`);
+      }
+      return setStatus(id, 'running');
+    },
+
+    pause(id) {
+      const r = getOrThrow(id);
+      if (r.status === 'paused' || r.status === 'stopped' || r.status === 'completed') return r;
+      return setStatus(id, 'paused');
+    },
+
+    resume(id) {
+      const r = getOrThrow(id);
+      if (r.status !== 'paused') throw new Error(`Cannot resume experiment in ${r.status} status`);
+      return setStatus(id, 'running');
+    },
+
+    triggerSafetyStop(id, conditionId) {
+      const r = getOrThrow(id);
+      const triggered = r.triggeredSafetyStops.includes(conditionId)
+        ? r.triggeredSafetyStops
+        : [...r.triggeredSafetyStops, conditionId];
+      const next: ExperimentRecord = { ...r, triggeredSafetyStops: triggered, status: 'stopped' };
+      records.set(id, next);
+      return next;
+    },
+
+    recordOutcome(id, outcome) {
+      const r = getOrThrow(id);
+      if (r.status === 'stopped') throw new Error(`Experiment "${id}" is stopped — refusing new outcomes`);
+      if (r.outcomes.some((o) => o.caseId === outcome.caseId)) {
+        throw new Error(`Outcome for case "${outcome.caseId}" already recorded — append-only`);
+      }
+      const next: ExperimentRecord = { ...r, outcomes: [...r.outcomes, outcome] };
+      records.set(id, next);
+      return next;
+    },
+
+    // The reason argument is for the audit-trail caller; the record
+    // shape stays JSON-clean and the verdict surfaces in evaluate().
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    complete(id, _reason) {
+      const r = getOrThrow(id);
+      if (r.status === 'stopped') throw new Error(`Experiment "${id}" is stopped — cannot complete`);
+      const next: ExperimentRecord = { ...r, status: 'completed' };
+      records.set(id, next);
+      return next;
+    },
+
+    get(id) {
+      return records.get(id);
+    },
+
+    all() {
+      return [...records.values()].sort((a, b) => a.createdAt - b.createdAt);
+    },
+
+    evaluate(id) {
+      const r = getOrThrow(id);
+      return computeResult(r);
+    },
+
+    toJson() {
+      return this.all();
+    },
+  };
+}
+
+// ── Recommendation engine ───────────────────────────────────────────────
+
+function computeResult(r: ExperimentRecord): ExperimentResult {
+  const controlWins = r.outcomes.filter((o) => o.outcome === 'control_win').length;
+  const candidateWins = r.outcomes.filter((o) => o.outcome === 'candidate_win').length;
+  const inconclusive = r.outcomes.filter((o) => o.outcome === 'inconclusive').length;
+  const sampleCount = r.outcomes.length;
+
+  if (r.triggeredSafetyStops.length > 0) {
+    return {
+      experimentId: r.id,
+      status: 'stopped',
+      sampleCount,
+      controlWins,
+      candidateWins,
+      inconclusive,
+      safetyStops: r.triggeredSafetyStops,
+      recommendation: 'keep_control',
+      reason: `Safety-stop fired (${r.triggeredSafetyStops.join(', ')}) — keep the control version, do not promote.`,
+    };
+  }
+
+  if (sampleCount < r.minSamples) {
+    return {
+      experimentId: r.id,
+      status: r.status,
+      sampleCount,
+      controlWins,
+      candidateWins,
+      inconclusive,
+      safetyStops: r.triggeredSafetyStops,
+      recommendation: 'continue',
+      reason: `Need ${r.minSamples - sampleCount} more graded samples (have ${sampleCount}, need ${r.minSamples}).`,
+    };
+  }
+
+  // Need a clear winner — candidate must beat control by ≥10 % of
+  // the sample size. Tie / razor-thin → manual review.
+  const margin = candidateWins - controlWins;
+  const required = Math.max(2, Math.ceil(sampleCount * 0.1));
+
+  if (margin >= required) {
+    return {
+      experimentId: r.id,
+      status: r.status,
+      sampleCount,
+      controlWins,
+      candidateWins,
+      inconclusive,
+      safetyStops: r.triggeredSafetyStops,
+      recommendation: 'promote',
+      reason: `Candidate wins by ${margin} (${candidateWins} vs ${controlWins}, threshold ${required}).`,
+    };
+  }
+  if (-margin >= required) {
+    return {
+      experimentId: r.id,
+      status: r.status,
+      sampleCount,
+      controlWins,
+      candidateWins,
+      inconclusive,
+      safetyStops: r.triggeredSafetyStops,
+      recommendation: 'keep_control',
+      reason: `Control wins by ${-margin} (${controlWins} vs ${candidateWins}, threshold ${required}).`,
+    };
+  }
+  return {
+    experimentId: r.id,
+    status: r.status,
+    sampleCount,
+    controlWins,
+    candidateWins,
+    inconclusive,
+    safetyStops: r.triggeredSafetyStops,
+    recommendation: 'manual_review',
+    reason: `Margin ${margin} below required ${required} — request human review.`,
+  };
+}


### PR DESCRIPTION
## Summary

Per `docs/CLAUDE_STRATEGIC_SELF_IMPROVEMENT_ROADMAP_2026-04-28.md` Layer 2.

`createExperimentManager()` returns an in-memory `ExperimentManager` that tracks the lifecycle of controlled experiments (algorithm A/B, threshold comparisons, source weighting tests):

| Method | Effect |
|---|---|
| `define()` | register a `ExperimentDefinition` (status `draft`) |
| `start()` | `draft` / `paused` → `running` |
| `pause()` / `resume()` | running ↔ paused |
| `recordOutcome()` | append `control_win` / `candidate_win` / `inconclusive` (append-only) |
| `triggerSafetyStop()` | hard stop; `stopped` is frozen |
| `complete()` | manual close-out → `completed` |
| `evaluate()` | compute the recommendation snapshot |

## Recommendation engine

- Safety-stop fired → `keep_control` (overrides everything)
- Sample count < minSamples → `continue` (with delta to threshold)
- Candidate margin ≥ ⌈samples × 10%⌉ → `promote`
- Control margin ≥ ⌈samples × 10%⌉ → `keep_control`
- Smaller margin → `manual_review`

## Plan invariants
- No DOM, no fetch, no globals at import time
- JSON-serializable for the diagnostics export bundle
- Append-only: re-recording a `caseId` throws
- Hard safety stop: stopped state refuses new outcomes and transitions
- Experiments never apply settings — Policy Engine (PR #186) gates that

## Verification
- `npm run typecheck:all` clean
- `npm run lint:strict` (eslint clean for changed files)
- 17/17 experiment-manager tests pass

Cross-agent review: Claude self-review on 2026-04-28; outcome: pass (pure deterministic store with extensive lifecycle/recommendation coverage; no live wiring in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
