### PR TITLE
feat(map): weather radar toggles + NWS polygon outlines + radar on by default

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -327,6 +327,32 @@ function getOverlayColors() {
 let _cachedTheme: string | null = null;
 let COLORS = getOverlayColors();
 
+/** Severity → color triplet for weather alerts. Three variants:
+ *  - 'icon'   : opaque punchy color for the centroid pin
+ *  - 'stroke' : same hue as icon, full alpha for polygon outline
+ *  - 'fill'   : same hue at low alpha so polygon fill doesn't
+ *               obscure underlying basemap labels.
+ *  Used by both the icon layer and the polygon layer so the visual
+ *  treatment stays consistent across the two rendering paths. */
+function weatherSeverityColor(
+  severity: 'Extreme' | 'Severe' | 'Moderate' | 'Minor' | 'Unknown',
+  variant: 'icon' | 'stroke' | 'fill',
+): [number, number, number, number] {
+  // Base RGB by severity tier
+  let rgb: [number, number, number];
+  if (severity === 'Extreme') rgb = [255, 0, 0];
+  else if (severity === 'Severe') rgb = [255, 100, 0];
+  else if (severity === 'Moderate') rgb = [255, 170, 0];
+  else rgb = [100, 150, 255];
+
+  let alpha: number;
+  if (variant === 'fill') alpha = 60;          // ~24%
+  else if (variant === 'stroke') alpha = 220;  // ~86%
+  else alpha = severity === 'Extreme' ? 200 : severity === 'Severe' ? 180 : severity === 'Moderate' ? 160 : 180;
+
+  return [rgb[0], rgb[1], rgb[2], alpha];
+}
+
 // SVG icons as data URLs for different marker shapes
 // ── Canvas-drawn icon atlas (SVG data URIs fail in WKWebView WebGL) ──
 // All icons are drawn onto a single 32-tall sprite sheet using Canvas 2D API.
@@ -1387,8 +1413,12 @@ export class DeckGLMap {
  layers.push(this.createGhostLayer('iran-events-layer', this.iranEvents, d => [d.longitude, d.latitude], { radiusMinPixels: 12 }));
  }
 
- // Weather alerts layer
+ // Weather alerts layer — polygon shape (so user can see what
+ // area is covered) + centroid icon (so the alert is visible
+ // even when zoomed out and the polygon collapses to a pixel).
  if (mapLayers.weather && filteredWeatherAlerts.length > 0) {
+ const polyLayer = this.createWeatherPolygonLayer(filteredWeatherAlerts);
+ if (polyLayer) layers.push(polyLayer);
  layers.push(this.createWeatherLayer(filteredWeatherAlerts));
  }
 
@@ -2232,13 +2262,37 @@ export class DeckGLMap {
  getSize: 24,
  sizeMinPixels: 14,
  sizeMaxPixels: 28,
- getColor: (d) => {
- if (d.severity === 'Extreme') return [255, 0, 0, 200] as [number, number, number, number];
- if (d.severity === 'Severe') return [255, 100, 0, 180] as [number, number, number, number];
- if (d.severity === 'Moderate') return [255, 170, 0, 160] as [number, number, number, number];
- return COLORS.weather;
- },
+ getColor: (d) => weatherSeverityColor(d.severity, 'icon'),
  pickable: true,
+ });
+  }
+
+  /** Polygon outline + fill for each NWS alert. Until now we only
+   *  drew a centroid pin, so the user couldn't see what area was
+   *  covered by the alert. Filters alerts that lack polygon
+   *  coordinates (some alerts ship as pure geometry-less area
+   *  descriptions). */
+  private createWeatherPolygonLayer(alerts: WeatherAlert[]): PolygonLayer | null {
+ const polygonAlerts = alerts.filter((a) => a.coordinates?.length >= 3);
+ if (polygonAlerts.length === 0) return null;
+
+ return new PolygonLayer<WeatherAlert>({
+ id: 'weather-polygons-layer',
+ data: polygonAlerts,
+ getPolygon: (d) => d.coordinates,
+ getFillColor: (d) => weatherSeverityColor(d.severity, 'fill'),
+ getLineColor: (d) => weatherSeverityColor(d.severity, 'stroke'),
+ lineWidthUnits: 'pixels',
+ getLineWidth: 1.5,
+ stroked: true,
+ filled: true,
+ pickable: true,
+ // Update triggers so palette color changes propagate without
+ // a full layer rebuild.
+ updateTriggers: {
+ getFillColor: polygonAlerts.length,
+ getLineColor: polygonAlerts.length,
+ },
  });
   }
 
@@ -4147,6 +4201,13 @@ export class DeckGLMap {
  { key: 'pipelines', label: t('components.deckgl.layers.pipelines'), icon: '&#128738;' },
  { key: 'outages', label: t('components.deckgl.layers.internetOutages'), icon: '&#128225;' },
  { key: 'weather', label: t('components.deckgl.layers.weatherAlerts'), icon: '&#9928;' },
+ { key: 'weatherRadar', label: 'Weather Radar', icon: '&#127783;' },
+ { key: 'weatherSatellite', label: 'Satellite', icon: '&#128752;' },
+ { key: 'lightning', label: 'Lightning', icon: '&#9889;' },
+ { key: 'owmTemperature', label: 'Temperature (OWM)', icon: '&#127777;' },
+ { key: 'owmPrecipitation', label: 'Precipitation (OWM)', icon: '&#9748;' },
+ { key: 'owmClouds', label: 'Clouds (OWM)', icon: '&#9729;' },
+ { key: 'owmWind', label: 'Wind (OWM)', icon: '&#127788;' },
  { key: 'economic', label: t('components.deckgl.layers.economicCenters'), icon: '&#128176;' },
  { key: 'waterways', label: t('components.deckgl.layers.strategicWaterways'), icon: '&#9875;' },
  { key: 'natural', label: t('components.deckgl.layers.naturalEvents'), icon: '&#127755;' },
@@ -4184,6 +4245,13 @@ export class DeckGLMap {
  { key: 'displacement', label: t('components.deckgl.layers.displacementFlows'), icon: '&#128101;' },
  { key: 'climate', label: t('components.deckgl.layers.climateAnomalies'), icon: '&#127787;' },
  { key: 'weather', label: t('components.deckgl.layers.weatherAlerts'), icon: '&#9928;' },
+ { key: 'weatherRadar', label: 'Weather Radar', icon: '&#127783;' },
+ { key: 'weatherSatellite', label: 'Satellite', icon: '&#128752;' },
+ { key: 'lightning', label: 'Lightning', icon: '&#9889;' },
+ { key: 'owmTemperature', label: 'Temperature (OWM)', icon: '&#127777;' },
+ { key: 'owmPrecipitation', label: 'Precipitation (OWM)', icon: '&#9748;' },
+ { key: 'owmClouds', label: 'Clouds (OWM)', icon: '&#9729;' },
+ { key: 'owmWind', label: 'Wind (OWM)', icon: '&#127788;' },
  { key: 'outages', label: t('components.deckgl.layers.internetOutages'), icon: '&#128225;' },
  { key: 'cyberThreats', label: t('components.deckgl.layers.cyberThreats'), icon: '&#128737;' },
  { key: 'natural', label: t('components.deckgl.layers.naturalEvents'), icon: '&#127755;' },

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -263,8 +263,9 @@ const FULL_MAP_LAYERS: MapLayers = {
   convergenceRings: true,
   threatHeatmap: false,
   sigintConvergence: true,
-  // Weather overlay layers
-  weatherRadar: false,
+  // Weather overlay layers — radar on by default so users see
+  // precipitation tiles out of the box without hunting for the toggle.
+  weatherRadar: true,
   weatherSatellite: false,
   lightning: false,
   owmTemperature: false,


### PR DESCRIPTION
Closes the weather-visibility gap that hid radar/satellite/lightning behind a missing UI toggle and made NWS alerts invisible outside their pin centroid.

## Three changes

### 1. Layer-toggle dropdown gains 7 weather raster entries

`syncWeatherRasterLayers()` already rendered radar/satellite/lightning/OWM tiles, but the dropdown UI only showed *'Weather Alerts'* (NWS centroid pins). The boolean keys existed in `MapLayers` and persisted to localStorage, but stayed `false` forever unless flipped via DevTools.

Added to **FULL** and **FINANCE** variant layer menus:
- 🌧 **Weather Radar** — RainViewer (free, global)
- 🛰 **Satellite** — NOAA GOES geocolor (free)
- ⚡ **Lightning** — Blitzortung
- 🌡 **Temperature (OWM)** — needs OWM key
- ☔ **Precipitation (OWM)** — needs OWM key
- ☁ **Clouds (OWM)** — needs OWM key
- 🌬 **Wind (OWM)** — needs OWM key

### 2. NWS alert polygon outlines (was: centroid pins only)

Until now the map only drew a cloud-icon pin at the centroid of each NWS alert polygon, so the user couldn't see what area was covered. Added `createWeatherPolygonLayer()` that draws each polygon with a 24% fill + sharp outline. Severity-based palette via shared `weatherSeverityColor()` helper:

| Severity | Color |
|---|---|
| Extreme | red `255,0,0` |
| Severe | orange `255,100,0` |
| Moderate | amber `255,170,0` |
| Minor | blue `100,150,255` |

Centroid icons still render on top so alerts stay visible at low zoom levels where the polygon collapses to a pixel.

### 3. `weatherRadar: true` by default in FULL desktop variant

Net effect: a clean install in the full desktop variant shows RainViewer radar tiles immediately — no hunting for the toggle. Mobile + tech + finance + happy variants stay off (mobile to preserve bandwidth, others because radar isn't on-mission).

## Verification

- `typecheck` → 0 errors
- `test:panels:smoke` → exit 0, 234 tests pass, 0 silent / 0 errored / 0 asyncErrors
- Touched-file lint clean

## Note on FAA Weather Cams + broader degraded-shape issue

User flagged that FAA Weather Cams aren't visible either, and asked to investigate panels with no data. Confirmed:

- FAA cams **data is loading** (sidecar `/api/faa-cameras` returns 3,303 cameras). Map dots are 4–8 pixels and easy to miss especially on satellite basemap. Layer toggle exists in dropdown.
- Real runtime failures from `desktop.log`: Military Flights (OpenSky 503), GDELT Tensions (sidecar reports "Local handler unavailable in this build"), Disease Outbreaks (`{reliefweb: null, who: null}`), Extended Forecast, Tide Predictions, ADS-B background. The sidecar degrades gracefully but several panels don't recognize the degraded shape — same pattern as the PR199 bug-smash on a different set of panels.

Both are out of scope for this weather-visibility PR; following up separately.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>