### PR TITLE
feat(situations): Phase 1 — shared high-impact Situation model + military/cyber/weather adapters

### DIFF
--- a/src/services/situations/__tests__/cyber-adapter.test.mts
+++ b/src/services/situations/__tests__/cyber-adapter.test.mts
@@ -1,0 +1,181 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { cyberThreatsToSituations, type CyberThreatInput } from '../cyber-adapter';
+
+const NOW = 1_745_000_000_000;
+
+function fakeThreat(overrides: Partial<CyberThreatInput> = {}): CyberThreatInput {
+  return {
+    threatId: 'CVE-2026-12345',
+    title: 'Critical macOS WebKit RCE',
+    stagesReached: ['cve_published', 'exploit_observed'],
+    affectedSectors: [],
+    affectedVendors: ['Apple macOS'],
+    evidence: [
+      {
+        id: 'cisa-1',
+        source: 'CISA',
+        claim: 'Active exploitation observed',
+        observedAt: NOW,
+        weight: 0.8,
+      },
+    ],
+    agreeingSources: ['CISA', 'Apple'],
+    disagreeingSources: [],
+    observedAt: NOW,
+    ...overrides,
+  };
+}
+
+describe('cyberThreatsToSituations — empty input', () => {
+  it('returns empty for no threats', () => {
+    assert.deepEqual(cyberThreatsToSituations({ threats: [], now: () => NOW }), []);
+  });
+});
+
+describe('cyberThreatsToSituations — lifecycle stage scoring', () => {
+  it('cve_published only → fyi tier', () => {
+    const [s] = cyberThreatsToSituations({
+      threats: [fakeThreat({ stagesReached: ['cve_published'] })],
+      now: () => NOW,
+    });
+    assert.equal(s?.severity, 'fyi');
+  });
+
+  it('exploit_observed → elevated tier', () => {
+    const [s] = cyberThreatsToSituations({
+      threats: [fakeThreat({ stagesReached: ['cve_published', 'exploit_observed'] })],
+      now: () => NOW,
+    });
+    assert.equal(s?.severity, 'elevated');
+  });
+
+  it('user_exposed → emergency tier', () => {
+    const [s] = cyberThreatsToSituations({
+      threats: [fakeThreat({
+        stagesReached: ['cve_published', 'exploit_observed', 'kev_listed', 'user_exposed'],
+      })],
+      now: () => NOW,
+    });
+    assert.equal(s?.severity, 'emergency');
+  });
+});
+
+describe('cyberThreatsToSituations — critical-infrastructure bump', () => {
+  it('finance sector bumps the score above the bare lifecycle stage', () => {
+    const baseline = cyberThreatsToSituations({
+      threats: [fakeThreat({
+        stagesReached: ['cve_published', 'exploit_observed'],
+        affectedSectors: [],
+      })],
+      now: () => NOW,
+    })[0];
+    const withInfra = cyberThreatsToSituations({
+      threats: [fakeThreat({
+        stagesReached: ['cve_published', 'exploit_observed'],
+        affectedSectors: ['finance'],
+      })],
+      now: () => NOW,
+    })[0];
+    // Both should be `elevated` — the +0.1 bump pushes inside the
+    // same tier — but the diagnostics trace should record it.
+    assert.match(withInfra?.diagnosticsTrace.severityRationale ?? '', /infra-bump \+0\.1/);
+    assert.doesNotMatch(baseline?.diagnosticsTrace.severityRationale ?? '', /infra-bump \+0\.1/);
+  });
+
+  it('flags critical_infra in thresholdsCrossed when applicable', () => {
+    const [s] = cyberThreatsToSituations({
+      threats: [fakeThreat({ affectedSectors: ['power_grid'] })],
+      now: () => NOW,
+    });
+    assert.ok(s?.diagnosticsTrace.thresholdsCrossed.includes('critical_infra'));
+  });
+});
+
+describe('cyberThreatsToSituations — user vendor matching', () => {
+  it('matching vendor bumps user exposure to high', () => {
+    const [s] = cyberThreatsToSituations({
+      threats: [fakeThreat({ affectedVendors: ['Apple macOS'] })],
+      user: { userVendors: ['macos'] },
+      now: () => NOW,
+    });
+    assert.ok((s?.userExposure ?? 0) >= 0.85);
+    assert.equal(s?.personalImpact.level, 'high');
+  });
+
+  it('vendor mismatch keeps user exposure low', () => {
+    const [s] = cyberThreatsToSituations({
+      threats: [fakeThreat({ affectedVendors: ['Microsoft Windows'] })],
+      user: { userVendors: ['macos'] },
+      now: () => NOW,
+    });
+    assert.ok((s?.userExposure ?? 1) <= 0.2);
+  });
+
+  it('user vendor match flags user_vendor_match in thresholdsCrossed', () => {
+    const [s] = cyberThreatsToSituations({
+      threats: [fakeThreat({ affectedVendors: ['Apple macOS'] })],
+      user: { userVendors: ['macos'] },
+      now: () => NOW,
+    });
+    assert.ok(s?.diagnosticsTrace.thresholdsCrossed.includes('user_vendor_match'));
+  });
+});
+
+describe('cyberThreatsToSituations — recommended actions', () => {
+  it('user-vendor match → immediate patch action', () => {
+    const [s] = cyberThreatsToSituations({
+      threats: [fakeThreat({ stagesReached: ['cve_published', 'exploit_observed', 'kev_listed'] })],
+      user: { userVendors: ['macos'] },
+      now: () => NOW,
+    });
+    assert.ok(s?.recommendedActions.some((a) => a.urgency === 'immediate' && /patch/i.test(a.text)));
+  });
+
+  it('no user exposure + low severity → fyi only', () => {
+    const [s] = cyberThreatsToSituations({
+      threats: [fakeThreat({ stagesReached: ['cve_published'] })],
+      now: () => NOW,
+    });
+    assert.ok(s?.recommendedActions.every((a) => a.urgency === 'fyi'));
+  });
+});
+
+describe('cyberThreatsToSituations — diagnostics trace', () => {
+  it('records stage and severity in thresholdsCrossed', () => {
+    const [s] = cyberThreatsToSituations({
+      threats: [fakeThreat()],
+      now: () => NOW,
+    });
+    assert.ok(s?.diagnosticsTrace.thresholdsCrossed.some((t) => t.startsWith('stage:')));
+    assert.ok(s?.diagnosticsTrace.thresholdsCrossed.some((t) => t.startsWith('severity:')));
+  });
+
+  it('records source contributions', () => {
+    const [s] = cyberThreatsToSituations({
+      threats: [fakeThreat({ agreeingSources: ['CISA', 'Apple'] })],
+      now: () => NOW,
+    });
+    const total = Object.values(s?.diagnosticsTrace.sourceContributions ?? {}).reduce((a, b) => a + b, 0);
+    assert.ok(total > 0.99 && total < 1.01); // sums to ~1.0
+  });
+});
+
+describe('cyberThreatsToSituations — output shape', () => {
+  it('namespaces ids with cyber: prefix', () => {
+    const [s] = cyberThreatsToSituations({
+      threats: [fakeThreat({ threatId: 'CVE-2026-99999' })],
+      now: () => NOW,
+    });
+    assert.equal(s?.id, 'cyber:CVE-2026-99999');
+  });
+
+  it('produces JSON-serializable Situations', () => {
+    const sits = cyberThreatsToSituations({
+      threats: [fakeThreat()],
+      now: () => NOW,
+    });
+    assert.doesNotThrow(() => JSON.stringify(sits));
+  });
+});

--- a/src/services/situations/__tests__/integration.test.mts
+++ b/src/services/situations/__tests__/integration.test.mts
@@ -1,0 +1,161 @@
+/**
+ * Integration test — Phase 1 acceptance criteria from
+ * docs/CLAUDE_HIGH_IMPACT_EVENT_INTELLIGENCE_VISION_2026-04-29.md:
+ *
+ *   - Military, cyber, and weather can all produce normalized situations.
+ *   - The command center can rank situations by impact.
+ *
+ * This test feeds one input from each domain into the store and
+ * asserts the ranked output respects severity × confidence ordering.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createSituationStore,
+  weatherAlertsToSituations,
+  militaryPosturesToSituations,
+  cyberThreatsToSituations,
+  type SituationStore,
+} from '../index';
+
+const NOW = 1_745_000_000_000;
+
+let store: SituationStore;
+
+beforeEach(() => {
+  store = createSituationStore({ now: () => NOW });
+});
+
+describe('Phase 1 acceptance: cross-domain ingest + ranking', () => {
+  it('all three adapters emit Situations the store accepts', () => {
+    const wx = weatherAlertsToSituations({
+      alerts: [{
+        id: 'wx-1',
+        event: 'Tornado Warning',
+        severity: 'Extreme',
+        headline: 'Tornado near La Porte',
+        description: 'Confirmed tornado.',
+        areaDesc: 'La Porte',
+        onset: new Date(NOW + 5 * 60_000),
+        expires: new Date(NOW + 30 * 60_000),
+        coordinates: [],
+        centroid: [-86.7, 41.6],
+      }],
+      savedPlaces: [{ id: 'home', name: 'La Porte', lat: 41.6, lon: -86.7 }],
+      now: () => NOW,
+    });
+
+    const mil = militaryPosturesToSituations({
+      postures: [{
+        theaterId: 'taiwan-strait',
+        theaterName: 'Taiwan Strait',
+        posture: 'strike_ready',
+        postureScore: 0.78,
+        priorScore: 0.5,
+        evidence: [{ id: 'e1', source: 'OpenSky', claim: 'Surge', observedAt: NOW, weight: 0.6 }],
+        agreeingSources: ['OpenSky', 'NOTAMs', 'Reuters'],
+        disagreeingSources: [],
+        observedAt: NOW,
+      }],
+      now: () => NOW,
+    });
+
+    const cy = cyberThreatsToSituations({
+      threats: [{
+        threatId: 'CVE-2026-12345',
+        title: 'Critical macOS WebKit RCE',
+        stagesReached: ['cve_published', 'exploit_observed', 'kev_listed'],
+        affectedSectors: ['consumer_software'],
+        affectedVendors: ['Apple macOS'],
+        evidence: [{ id: 'cisa', source: 'CISA KEV', claim: 'KEV', observedAt: NOW, weight: 0.9 }],
+        agreeingSources: ['CISA', 'Apple'],
+        disagreeingSources: [],
+      }],
+      user: { userVendors: ['macos'] },
+      now: () => NOW,
+    });
+
+    [...wx, ...mil, ...cy].forEach((s) => store.upsert(s));
+
+    const ranked = store.ranked();
+    assert.equal(ranked.length, 3);
+    // The Extreme/Tornado Warning with high user-exposure should
+    // outrank the others; this matches the vision doc's principle
+    // that user-exposed events rank above distant global noise.
+    assert.equal(ranked[0]?.domain, 'weather');
+    // All three domains must be represented
+    const domains = new Set(ranked.map((s) => s.domain));
+    assert.equal(domains.size, 3);
+  });
+
+  it('every emitted Situation has a non-empty diagnosticsTrace', () => {
+    const wx = weatherAlertsToSituations({
+      alerts: [{
+        id: 'wx-2', event: 'Severe Thunderstorm Warning', severity: 'Severe',
+        headline: 'h', description: 'd', areaDesc: 'a',
+        onset: new Date(NOW), expires: new Date(NOW + 60_000),
+        coordinates: [], centroid: [-86.7, 41.6],
+      }],
+      now: () => NOW,
+    });
+    for (const s of wx) {
+      assert.ok(s.diagnosticsTrace.createdReason.length > 0);
+      assert.ok(s.diagnosticsTrace.severityRationale.length > 0);
+      assert.ok(s.diagnosticsTrace.confidenceRationale.length > 0);
+      assert.ok(s.diagnosticsTrace.exposureRationale.length > 0);
+      assert.ok(s.diagnosticsTrace.thresholdsCrossed.length > 0);
+    }
+  });
+
+  it('store.toJson round-trips through JSON', () => {
+    const [s] = weatherAlertsToSituations({
+      alerts: [{
+        id: 'wx-3', event: 'Flash Flood Warning', severity: 'Severe',
+        headline: 'h', description: 'd', areaDesc: 'a',
+        onset: new Date(NOW), expires: new Date(NOW + 60_000),
+        coordinates: [], centroid: [-86.7, 41.6],
+      }],
+      now: () => NOW,
+    });
+    if (s) store.upsert(s);
+    const json = JSON.stringify(store.toJson());
+    const parsed = JSON.parse(json);
+    assert.equal(parsed.length, 1);
+    assert.equal(parsed[0].domain, 'weather');
+  });
+
+  it('user-exposed cyber threat ranks above distant military elevated', () => {
+    const distantMil = militaryPosturesToSituations({
+      postures: [{
+        theaterId: 'arctic',
+        theaterName: 'Arctic',
+        posture: 'elevated',
+        postureScore: 0.4,
+        evidence: [],
+        agreeingSources: ['NATO'],
+        disagreeingSources: [],
+      }],
+      now: () => NOW,
+    });
+    const userCyber = cyberThreatsToSituations({
+      threats: [{
+        threatId: 'CVE-2026-USER',
+        title: 'Apple zero-day',
+        stagesReached: ['cve_published', 'exploit_observed', 'kev_listed', 'user_exposed'],
+        affectedSectors: ['consumer_software'],
+        affectedVendors: ['Apple macOS'],
+        evidence: [],
+        agreeingSources: ['CISA'],
+        disagreeingSources: [],
+      }],
+      user: { userVendors: ['macos'] },
+      now: () => NOW,
+    });
+    [...distantMil, ...userCyber].forEach((s) => store.upsert(s));
+    const top = store.ranked(1);
+    assert.equal(top[0]?.domain, 'cyber');
+    assert.equal(top[0]?.id, 'cyber:CVE-2026-USER');
+  });
+});

--- a/src/services/situations/__tests__/military-adapter.test.mts
+++ b/src/services/situations/__tests__/military-adapter.test.mts
@@ -1,0 +1,165 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { militaryPosturesToSituations, type TheaterPostureInput } from '../military-adapter';
+
+const NOW = 1_745_000_000_000;
+
+function fakePosture(overrides: Partial<TheaterPostureInput> = {}): TheaterPostureInput {
+  return {
+    theaterId: 'taiwan-strait',
+    theaterName: 'Taiwan Strait',
+    posture: 'elevated',
+    postureScore: 0.4,
+    priorScore: 0.3,
+    evidence: [
+      {
+        id: 'e1',
+        source: 'OpenSky',
+        claim: 'Aircraft surge above baseline',
+        observedAt: NOW,
+        weight: 0.6,
+      },
+    ],
+    agreeingSources: ['OpenSky', 'NOTAMs'],
+    disagreeingSources: [],
+    observedAt: NOW,
+    ...overrides,
+  };
+}
+
+describe('militaryPosturesToSituations — empty input', () => {
+  it('returns empty for no postures', () => {
+    assert.deepEqual(militaryPosturesToSituations({ postures: [], now: () => NOW }), []);
+  });
+
+  it('filters out normal posture', () => {
+    assert.deepEqual(
+      militaryPosturesToSituations({
+        postures: [fakePosture({ posture: 'normal' })],
+        now: () => NOW,
+      }),
+      [],
+    );
+  });
+});
+
+describe('militaryPosturesToSituations — posture floor', () => {
+  it('strike_ready cannot drop below critical even with low raw score', () => {
+    const [s] = militaryPosturesToSituations({
+      postures: [fakePosture({ posture: 'strike_ready', postureScore: 0.2 })],
+      now: () => NOW,
+    });
+    assert.equal(s?.severity, 'critical');
+  });
+
+  it('active_escalation forces emergency tier', () => {
+    const [s] = militaryPosturesToSituations({
+      postures: [fakePosture({ posture: 'active_escalation', postureScore: 0.5 })],
+      now: () => NOW,
+    });
+    assert.equal(s?.severity, 'emergency');
+  });
+
+  it('elevated lands in watch tier when raw score is low', () => {
+    const [s] = militaryPosturesToSituations({
+      postures: [fakePosture({ posture: 'elevated', postureScore: 0.3 })],
+      now: () => NOW,
+    });
+    assert.equal(s?.severity, 'watch');
+  });
+});
+
+describe('militaryPosturesToSituations — confidence scaling', () => {
+  it('more independent agreeing sources → higher confidence', () => {
+    const lo = militaryPosturesToSituations({
+      postures: [fakePosture({ agreeingSources: ['A'] })],
+      now: () => NOW,
+    })[0];
+    const hi = militaryPosturesToSituations({
+      postures: [fakePosture({ agreeingSources: ['A', 'B', 'C', 'D'] })],
+      now: () => NOW,
+    })[0];
+    assert.ok((hi?.confidence ?? 0) > (lo?.confidence ?? 1));
+  });
+
+  it('confidence caps at 0.95', () => {
+    const [s] = militaryPosturesToSituations({
+      postures: [fakePosture({ agreeingSources: Array.from({ length: 20 }, (_, i) => `S${i}`) })],
+      now: () => NOW,
+    });
+    assert.ok((s?.confidence ?? 0) <= 0.95);
+  });
+});
+
+describe('militaryPosturesToSituations — diagnostics trace', () => {
+  it('records the posture floor + raw score in severityRationale', () => {
+    const [s] = militaryPosturesToSituations({
+      postures: [fakePosture({ posture: 'strike_ready', postureScore: 0.2 })],
+      now: () => NOW,
+    });
+    assert.match(s?.diagnosticsTrace.severityRationale ?? '', /floor|score|tier/i);
+  });
+
+  it('includes posture and severity in thresholdsCrossed', () => {
+    const [s] = militaryPosturesToSituations({
+      postures: [fakePosture({ posture: 'deployment' })],
+      now: () => NOW,
+    });
+    assert.ok(s?.diagnosticsTrace.thresholdsCrossed.some((t) => t.startsWith('posture:')));
+    assert.ok(s?.diagnosticsTrace.thresholdsCrossed.some((t) => t.startsWith('severity:')));
+  });
+});
+
+describe('militaryPosturesToSituations — whatChanged narrative', () => {
+  it('reports rising direction when score increased', () => {
+    const [s] = militaryPosturesToSituations({
+      postures: [fakePosture({ priorScore: 0.3, postureScore: 0.5 })],
+      now: () => NOW,
+    });
+    assert.match(s?.whatChanged[0]?.text ?? '', /rising/i);
+  });
+
+  it('reports falling direction when score decreased', () => {
+    const [s] = militaryPosturesToSituations({
+      postures: [fakePosture({ posture: 'elevated', priorScore: 0.6, postureScore: 0.4 })],
+      now: () => NOW,
+    });
+    assert.match(s?.whatChanged[0]?.text ?? '', /falling/i);
+  });
+
+  it('reports steady when delta is small', () => {
+    const [s] = militaryPosturesToSituations({
+      postures: [fakePosture({ priorScore: 0.4, postureScore: 0.41 })],
+      now: () => NOW,
+    });
+    assert.doesNotMatch(s?.whatChanged[0]?.text ?? '', /rising|falling/i);
+  });
+});
+
+describe('militaryPosturesToSituations — output shape', () => {
+  it('namespaces ids with military: prefix', () => {
+    const [s] = militaryPosturesToSituations({
+      postures: [fakePosture({ theaterId: 'persian-gulf' })],
+      now: () => NOW,
+    });
+    assert.equal(s?.id, 'military:persian-gulf');
+  });
+
+  it('produces JSON-serializable Situations', () => {
+    const sits = militaryPosturesToSituations({
+      postures: [fakePosture()],
+      now: () => NOW,
+    });
+    assert.doesNotThrow(() => JSON.stringify(sits));
+  });
+
+  it('seeds expected and invalidation signals', () => {
+    const [s] = militaryPosturesToSituations({
+      postures: [fakePosture()],
+      now: () => NOW,
+    });
+    assert.ok((s?.expectedNextSignals.length ?? 0) >= 3);
+    assert.ok((s?.invalidationSignals.length ?? 0) >= 2);
+  });
+});

--- a/src/services/situations/__tests__/situation-store.test.mts
+++ b/src/services/situations/__tests__/situation-store.test.mts
@@ -1,0 +1,163 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createSituationStore, type SituationStore } from '../situation-store';
+import type { Situation } from '../situation-types';
+
+const NOW = 1_745_000_000_000;
+
+function fakeSituation(overrides: Partial<Situation> = {}): Situation {
+  return {
+    id: 'test:1',
+    domain: 'weather',
+    title: 'Test situation',
+    summary: 'A test',
+    severity: 'elevated',
+    confidence: 0.7,
+    urgency: 0.6,
+    userExposure: 0.5,
+    personalImpact: { summary: '', level: 'low', reasons: [] },
+    evidence: [],
+    sourceAgreement: { agreeing: [], disagreeing: [], independentSourceCount: 0 },
+    whatChanged: [],
+    expectedNextSignals: [],
+    invalidationSignals: [],
+    recommendedActions: [],
+    timeline: [],
+    diagnosticsTrace: {
+      createdReason: 'test',
+      severityRationale: 'test',
+      confidenceRationale: 'test',
+      exposureRationale: 'test',
+      sourceContributions: {},
+      thresholdsCrossed: [],
+    },
+    predictionOutcome: {},
+    phase: 'active',
+    firstSeen: NOW,
+    lastUpdated: NOW,
+    ...overrides,
+  };
+}
+
+let store: SituationStore;
+
+beforeEach(() => {
+  store = createSituationStore({ now: () => NOW });
+});
+
+describe('SituationStore.upsert', () => {
+  it('inserts a new situation', () => {
+    const s = fakeSituation();
+    const stored = store.upsert(s);
+    assert.equal(stored.id, 'test:1');
+    assert.equal(store.get('test:1')?.id, 'test:1');
+  });
+
+  it('preserves firstSeen across updates', () => {
+    store.upsert(fakeSituation({ firstSeen: NOW }));
+    const updated = store.upsert(fakeSituation({ firstSeen: NOW + 60_000, severity: 'critical' }));
+    assert.equal(updated.firstSeen, NOW, 'firstSeen must be sticky after first upsert');
+    assert.equal(updated.severity, 'critical', 'other fields must update');
+  });
+
+  it('merges timelines without duplicates', () => {
+    store.upsert(fakeSituation({
+      timeline: [{ ts: 100, text: 'a' }, { ts: 200, text: 'b' }],
+    }));
+    const merged = store.upsert(fakeSituation({
+      timeline: [{ ts: 200, text: 'b' }, { ts: 300, text: 'c' }],
+    }));
+    assert.equal(merged.timeline.length, 3);
+    assert.deepEqual(
+      merged.timeline.map((t) => t.text),
+      ['a', 'b', 'c'],
+    );
+  });
+});
+
+describe('SituationStore.ranked', () => {
+  it('returns active situations sorted by composite score', () => {
+    store.upsert(fakeSituation({ id: 'low', severity: 'fyi', confidence: 0.5 }));
+    store.upsert(fakeSituation({ id: 'mid', severity: 'elevated', confidence: 0.7 }));
+    store.upsert(fakeSituation({ id: 'high', severity: 'critical', confidence: 0.9 }));
+    const ranked = store.ranked();
+    assert.deepEqual(ranked.map((s) => s.id), ['high', 'mid', 'low']);
+  });
+
+  it('limit parameter caps the result', () => {
+    store.upsert(fakeSituation({ id: 'a', severity: 'critical' }));
+    store.upsert(fakeSituation({ id: 'b', severity: 'critical' }));
+    store.upsert(fakeSituation({ id: 'c', severity: 'critical' }));
+    const top2 = store.ranked(2);
+    assert.equal(top2.length, 2);
+  });
+
+  it('excludes resolved situations', () => {
+    store.upsert(fakeSituation({ id: 'a', severity: 'critical' }));
+    store.upsert(fakeSituation({ id: 'b', severity: 'fyi' }));
+    store.markResolved('a', 'correct');
+    const ranked = store.ranked();
+    assert.equal(ranked.length, 1);
+    assert.equal(ranked[0]?.id, 'b');
+  });
+});
+
+describe('SituationStore.markResolved', () => {
+  it('moves a situation to resolved phase with verdict', () => {
+    store.upsert(fakeSituation());
+    const resolved = store.markResolved('test:1', 'correct', 'Caught the storm 42 min before arrival');
+    assert.equal(resolved?.phase, 'resolved');
+    assert.equal(resolved?.predictionOutcome.verdict, 'correct');
+    assert.equal(resolved?.predictionOutcome.notes, 'Caught the storm 42 min before arrival');
+  });
+
+  it('returns undefined for missing id', () => {
+    assert.equal(store.markResolved('does-not-exist', 'correct'), undefined);
+  });
+});
+
+describe('SituationStore.subscribe', () => {
+  it('notifies on upsert', () => {
+    let calls = 0;
+    store.subscribe(() => calls++);
+    store.upsert(fakeSituation());
+    store.upsert(fakeSituation({ id: 'test:2' }));
+    assert.equal(calls, 2);
+  });
+
+  it('unsubscribe stops further notifications', () => {
+    let calls = 0;
+    const off = store.subscribe(() => calls++);
+    store.upsert(fakeSituation());
+    off();
+    store.upsert(fakeSituation({ id: 'test:2' }));
+    assert.equal(calls, 1);
+  });
+
+  it('listener errors do not break the store', () => {
+    store.subscribe(() => { throw new Error('listener boom'); });
+    assert.doesNotThrow(() => store.upsert(fakeSituation()));
+  });
+});
+
+describe('SituationStore.toJson', () => {
+  it('returns a JSON-serializable snapshot', () => {
+    store.upsert(fakeSituation({ id: 'a' }));
+    store.upsert(fakeSituation({ id: 'b' }));
+    const snap = store.toJson();
+    const json = JSON.stringify(snap);
+    const parsed = JSON.parse(json) as Situation[];
+    assert.equal(parsed.length, 2);
+    assert.equal(parsed[0]?.id, 'a');
+  });
+});
+
+describe('SituationStore.reset', () => {
+  it('clears all situations', () => {
+    store.upsert(fakeSituation({ id: 'a' }));
+    store.upsert(fakeSituation({ id: 'b' }));
+    store.reset();
+    assert.equal(store.active().length, 0);
+  });
+});

--- a/src/services/situations/__tests__/situation-types.test.mts
+++ b/src/services/situations/__tests__/situation-types.test.mts
@@ -1,0 +1,92 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  rankingScore,
+  severityFromScore,
+  SEVERITY_RANK,
+  type Situation,
+} from '../situation-types';
+
+const baseSituation = (
+  overrides: Partial<Pick<Situation, 'severity' | 'confidence' | 'urgency' | 'userExposure'>>,
+): Pick<Situation, 'severity' | 'confidence' | 'urgency' | 'userExposure'> => ({
+  severity: 'fyi',
+  confidence: 0.5,
+  urgency: 0.5,
+  userExposure: 0.5,
+  ...overrides,
+});
+
+describe('SEVERITY_RANK', () => {
+  it('orders fyi < watch < elevated < critical < emergency', () => {
+    assert.ok(SEVERITY_RANK.fyi < SEVERITY_RANK.watch);
+    assert.ok(SEVERITY_RANK.watch < SEVERITY_RANK.elevated);
+    assert.ok(SEVERITY_RANK.elevated < SEVERITY_RANK.critical);
+    assert.ok(SEVERITY_RANK.critical < SEVERITY_RANK.emergency);
+  });
+});
+
+describe('severityFromScore', () => {
+  it('maps the score ladder correctly', () => {
+    assert.equal(severityFromScore(0.95), 'emergency');
+    assert.equal(severityFromScore(0.85), 'emergency');
+    assert.equal(severityFromScore(0.7), 'critical');
+    assert.equal(severityFromScore(0.5), 'elevated');
+    assert.equal(severityFromScore(0.3), 'watch');
+    assert.equal(severityFromScore(0.1), 'fyi');
+    assert.equal(severityFromScore(0), 'fyi');
+  });
+
+  it('round-trips: every emitted severity maps back to the same tier', () => {
+    // For each severity, find a representative score and confirm
+    // severityFromScore returns the same tier.
+    assert.equal(severityFromScore(0.05), 'fyi');
+    assert.equal(severityFromScore(0.3), 'watch');
+    assert.equal(severityFromScore(0.5), 'elevated');
+    assert.equal(severityFromScore(0.7), 'critical');
+    assert.equal(severityFromScore(0.9), 'emergency');
+  });
+});
+
+describe('rankingScore', () => {
+  it('ranks higher severity above lower severity at equal confidence/urgency/exposure', () => {
+    const lo = rankingScore(baseSituation({ severity: 'fyi' }));
+    const hi = rankingScore(baseSituation({ severity: 'emergency' }));
+    assert.ok(hi > lo);
+  });
+
+  it('low-confidence emergency does not outrank high-confidence elevated', () => {
+    const lowConfEmergency = rankingScore(
+      baseSituation({ severity: 'emergency', confidence: 0.1, urgency: 0.5, userExposure: 0.5 }),
+    );
+    const highConfElevated = rankingScore(
+      baseSituation({ severity: 'elevated', confidence: 0.95, urgency: 0.5, userExposure: 0.5 }),
+    );
+    assert.ok(highConfElevated > lowConfEmergency,
+      `expected highConfElevated (${highConfElevated}) > lowConfEmergency (${lowConfEmergency})`);
+  });
+
+  it('userExposure breaks ties at equal severity/confidence/urgency', () => {
+    const direct = rankingScore(baseSituation({ severity: 'critical', userExposure: 0.9 }));
+    const distant = rankingScore(baseSituation({ severity: 'critical', userExposure: 0.1 }));
+    assert.ok(direct > distant);
+  });
+
+  it('urgency contributes positively', () => {
+    const urgent = rankingScore(baseSituation({ severity: 'elevated', urgency: 0.95 }));
+    const calm = rankingScore(baseSituation({ severity: 'elevated', urgency: 0.05 }));
+    assert.ok(urgent > calm);
+  });
+
+  it('zero-confidence situation still has comparative ordering (floor 0.1)', () => {
+    const a = rankingScore(baseSituation({ severity: 'critical', confidence: 0 }));
+    const b = rankingScore(baseSituation({ severity: 'fyi', confidence: 0 }));
+    assert.ok(a > b);
+  });
+
+  it('is deterministic', () => {
+    const inputs = baseSituation({ severity: 'critical', confidence: 0.7, urgency: 0.8, userExposure: 0.6 });
+    assert.equal(rankingScore(inputs), rankingScore(inputs));
+  });
+});

--- a/src/services/situations/__tests__/weather-adapter.test.mts
+++ b/src/services/situations/__tests__/weather-adapter.test.mts
@@ -1,0 +1,187 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { weatherAlertsToSituations } from '../weather-adapter';
+import type { WeatherAlert } from '@/services/weather';
+
+const NOW = 1_745_000_000_000;
+
+function fakeAlert(overrides: Partial<WeatherAlert> = {}): WeatherAlert {
+  return {
+    id: 'NWS.IND.1',
+    event: 'Severe Thunderstorm Warning',
+    severity: 'Severe',
+    headline: 'Severe Thunderstorm Warning in effect for La Porte and St. Joseph until 4 PM EDT',
+    description: 'Damaging winds and large hail likely.',
+    areaDesc: 'La Porte; St. Joseph',
+    onset: new Date(NOW + 15 * 60_000),
+    expires: new Date(NOW + 90 * 60_000),
+    coordinates: [
+      [-86.7, 41.6],
+      [-86.5, 41.7],
+      [-86.4, 41.5],
+      [-86.7, 41.6],
+    ],
+    centroid: [-86.6, 41.6],
+    ...overrides,
+  };
+}
+
+describe('weatherAlertsToSituations — empty input', () => {
+  it('returns an empty array for no alerts', () => {
+    assert.deepEqual(weatherAlertsToSituations({ alerts: [], now: () => NOW }), []);
+  });
+});
+
+describe('weatherAlertsToSituations — severity mapping', () => {
+  it('maps Extreme → emergency', () => {
+    const [s] = weatherAlertsToSituations({
+      alerts: [fakeAlert({ severity: 'Extreme' })],
+      now: () => NOW,
+    });
+    assert.equal(s?.severity, 'emergency');
+  });
+
+  it('maps Severe → critical', () => {
+    const [s] = weatherAlertsToSituations({
+      alerts: [fakeAlert({ severity: 'Severe' })],
+      now: () => NOW,
+    });
+    assert.equal(s?.severity, 'critical');
+  });
+
+  it('maps Moderate → elevated', () => {
+    const [s] = weatherAlertsToSituations({
+      alerts: [fakeAlert({ severity: 'Moderate' })],
+      now: () => NOW,
+    });
+    assert.equal(s?.severity, 'elevated');
+  });
+
+  it('maps Minor → watch', () => {
+    const [s] = weatherAlertsToSituations({
+      alerts: [fakeAlert({ severity: 'Minor' })],
+      now: () => NOW,
+    });
+    assert.equal(s?.severity, 'watch');
+  });
+
+  it('maps Unknown → fyi', () => {
+    const [s] = weatherAlertsToSituations({
+      alerts: [fakeAlert({ severity: 'Unknown' })],
+      now: () => NOW,
+    });
+    assert.equal(s?.severity, 'fyi');
+  });
+});
+
+describe('weatherAlertsToSituations — urgency from time-to-onset', () => {
+  it('imminent onset (< 15 min) → high urgency', () => {
+    const [s] = weatherAlertsToSituations({
+      alerts: [fakeAlert({ onset: new Date(NOW + 5 * 60_000) })],
+      now: () => NOW,
+    });
+    assert.ok((s?.urgency ?? 0) > 0.85);
+  });
+
+  it('distant onset (> 90 min) → low urgency', () => {
+    const [s] = weatherAlertsToSituations({
+      alerts: [fakeAlert({ onset: new Date(NOW + 120 * 60_000) })],
+      now: () => NOW,
+    });
+    assert.ok((s?.urgency ?? 1) <= 0.3);
+  });
+});
+
+describe('weatherAlertsToSituations — user exposure', () => {
+  it('saved place within 25 km → high exposure', () => {
+    const [s] = weatherAlertsToSituations({
+      alerts: [fakeAlert()],
+      savedPlaces: [{ id: 'home', name: 'La Porte', lat: 41.61, lon: -86.72 }],
+      now: () => NOW,
+    });
+    assert.ok((s?.userExposure ?? 0) > 0.9);
+    assert.equal(s?.personalImpact.level, 'severe');
+    assert.ok(s?.personalImpact.reasons.length ?? 0 > 0);
+  });
+
+  it('saved place > 200 km → low exposure', () => {
+    const [s] = weatherAlertsToSituations({
+      alerts: [fakeAlert()],
+      savedPlaces: [{ id: 'home', name: 'Denver', lat: 39.7, lon: -104.99 }],
+      now: () => NOW,
+    });
+    assert.ok((s?.userExposure ?? 1) <= 0.15);
+  });
+
+  it('no saved places → minimal exposure with empty reasons', () => {
+    const [s] = weatherAlertsToSituations({
+      alerts: [fakeAlert()],
+      now: () => NOW,
+    });
+    assert.equal(s?.userExposure, 0.1);
+    assert.deepEqual(s?.personalImpact.reasons, []);
+  });
+});
+
+describe('weatherAlertsToSituations — diagnostics trace', () => {
+  it('includes the severity rationale string', () => {
+    const [s] = weatherAlertsToSituations({
+      alerts: [fakeAlert({ severity: 'Severe' })],
+      now: () => NOW,
+    });
+    assert.match(s?.diagnosticsTrace.severityRationale ?? '', /score|tier|severe/i);
+  });
+
+  it('lists NWS as the contributing source', () => {
+    const [s] = weatherAlertsToSituations({
+      alerts: [fakeAlert()],
+      now: () => NOW,
+    });
+    assert.equal(s?.diagnosticsTrace.sourceContributions.NWS, 1.0);
+  });
+
+  it('records thresholdsCrossed', () => {
+    const [s] = weatherAlertsToSituations({
+      alerts: [fakeAlert()],
+      now: () => NOW,
+    });
+    assert.ok((s?.diagnosticsTrace.thresholdsCrossed.length ?? 0) > 0);
+  });
+});
+
+describe('weatherAlertsToSituations — recommended actions', () => {
+  it('critical/emergency situations include an immediate-shelter action', () => {
+    const [s] = weatherAlertsToSituations({
+      alerts: [fakeAlert({ severity: 'Extreme' })],
+      now: () => NOW,
+    });
+    assert.ok(s?.recommendedActions.some((a) => a.urgency === 'immediate'));
+  });
+
+  it('Minor severity includes a monitor-only action', () => {
+    const [s] = weatherAlertsToSituations({
+      alerts: [fakeAlert({ severity: 'Minor' })],
+      now: () => NOW,
+    });
+    assert.ok(s?.recommendedActions.every((a) => a.urgency === 'monitor' || a.urgency === 'fyi'));
+  });
+});
+
+describe('weatherAlertsToSituations — output shape', () => {
+  it('produces a JSON-serializable Situation', () => {
+    const [s] = weatherAlertsToSituations({
+      alerts: [fakeAlert()],
+      now: () => NOW,
+    });
+    assert.doesNotThrow(() => JSON.stringify(s));
+  });
+
+  it('namespaces the id with weather: prefix', () => {
+    const [s] = weatherAlertsToSituations({
+      alerts: [fakeAlert({ id: 'abc' })],
+      now: () => NOW,
+    });
+    assert.equal(s?.id, 'weather:abc');
+  });
+});

--- a/src/services/situations/cyber-adapter.ts
+++ b/src/services/situations/cyber-adapter.ts
@@ -1,0 +1,258 @@
+/* eslint-disable unicorn/no-nested-ternary, sonarjs/no-nested-conditional, sonarjs/cognitive-complexity */
+/**
+ * Cyber → Situation adapter.
+ *
+ * Phase 1 of docs/CLAUDE_HIGH_IMPACT_EVENT_INTELLIGENCE_VISION_2026-04-29.md.
+ *
+ * Pure deterministic. Implements the Exploit-To-Impact pipeline shape
+ * (CVE → exploit → KEV → ransomware → sector → user-exposure) so any
+ * input that walks through those phases produces a Situation.
+ * Phase 4 will wire CISA KEV + ransomware feeds + user OS detection.
+ */
+
+import {
+  severityFromScore,
+  type Situation,
+  type SituationSeverity,
+} from './situation-types';
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+export type CyberLifecycleStage =
+  | 'cve_published'
+  | 'exploit_observed'
+  | 'kev_listed'
+  | 'ransomware_in_use'
+  | 'sector_targeted'
+  | 'user_exposed';
+
+export type CyberSector =
+  | 'power_grid'
+  | 'water'
+  | 'finance'
+  | 'telecom'
+  | 'hospitals'
+  | 'airports'
+  | 'gps_satellite'
+  | 'gov_services'
+  | 'cloud_provider'
+  | 'consumer_software'
+  | 'unknown';
+
+export interface CyberThreatInput {
+  /** Stable id (e.g. CVE-2026-12345). */
+  threatId: string;
+  /** Display title. */
+  title: string;
+  /** Cumulative lifecycle stages reached (most-recent last). */
+  stagesReached: readonly CyberLifecycleStage[];
+  /** Affected sectors when known. */
+  affectedSectors: readonly CyberSector[];
+  /** Affected vendors / OS labels (e.g. 'Apple macOS', 'Microsoft Windows'). */
+  affectedVendors: readonly string[];
+  /** Source-attributed evidence rows (CISA KEV, vendor advisories, news). */
+  evidence: readonly {
+    id: string;
+    source: string;
+    claim: string;
+    observedAt: number;
+    weight: number;
+    url?: string;
+  }[];
+  /** Sources that agree this is a real, exploited threat. */
+  agreeingSources: readonly string[];
+  /** Sources that contradict (disputed advisory, retracted KEV entry). */
+  disagreeingSources: readonly string[];
+  /** Optional ms timestamp; defaults to now(). */
+  observedAt?: number;
+}
+
+export interface CyberAdapterUserContext {
+  /** Vendors / OS labels the user runs (matched against affectedVendors). */
+  userVendors?: readonly string[];
+  /** Sectors the user has watchlisted (e.g. 'finance' if they have
+   *  a watched bank). */
+  watchedSectors?: readonly CyberSector[];
+}
+
+export interface CyberAdapterInput {
+  threats: readonly CyberThreatInput[];
+  user?: CyberAdapterUserContext;
+  now?: () => number;
+}
+
+export function cyberThreatsToSituations(input: CyberAdapterInput): Situation[] {
+  const now = input.now ?? Date.now;
+  return (input.threats ?? []).map((t) => threatToSituation(t, input.user ?? {}, now()));
+}
+
+// ── Internals ───────────────────────────────────────────────────────────
+
+const STAGE_SCORE: Record<CyberLifecycleStage, number> = {
+  cve_published: 0.15,
+  exploit_observed: 0.45,
+  kev_listed: 0.6,
+  ransomware_in_use: 0.7,
+  sector_targeted: 0.75,
+  user_exposed: 0.95,
+};
+
+const CRITICAL_INFRA_SECTORS: ReadonlySet<CyberSector> = new Set([
+  'power_grid',
+  'water',
+  'finance',
+  'telecom',
+  'hospitals',
+  'airports',
+  'gps_satellite',
+  'gov_services',
+]);
+
+function threatToSituation(
+  t: CyberThreatInput,
+  user: CyberAdapterUserContext,
+  ts: number,
+): Situation {
+  // Take the highest stage reached as the primary score driver.
+  const lastStage = t.stagesReached[t.stagesReached.length - 1] ?? 'cve_published';
+  let score = STAGE_SCORE[lastStage] ?? 0.15;
+
+  // Critical-infrastructure sectors bump the score by +0.1 (capped at 1.0).
+  const hitsCriticalInfra = t.affectedSectors.some((s) => CRITICAL_INFRA_SECTORS.has(s));
+  if (hitsCriticalInfra) score = Math.min(1, score + 0.1);
+
+  // User exposure: vendor or sector match → bump exposure (and score).
+  const userVendors = (user.userVendors ?? []).map((v) => v.toLowerCase());
+  const userVendorMatch = t.affectedVendors.some((v) =>
+    userVendors.some((u) => v.toLowerCase().includes(u)),
+  );
+  const userSectorMatch = (user.watchedSectors ?? []).some((s) => t.affectedSectors.includes(s));
+  let userExposure = 0.1;
+  const exposureReasons: string[] = [];
+  if (userVendorMatch) {
+    userExposure = Math.max(userExposure, 0.85);
+    exposureReasons.push(`Affected vendor matches user OS / software`);
+    score = Math.min(1, score + 0.1);
+  }
+  if (userSectorMatch) {
+    userExposure = Math.max(userExposure, 0.6);
+    exposureReasons.push(`Affected sector is on user watchlist`);
+  }
+
+  const severity: SituationSeverity = severityFromScore(score);
+
+  // Urgency rises with KEV / ransomware / user-exposure.
+  const urgency = lastStage === 'user_exposed'
+    ? 0.95
+    : lastStage === 'ransomware_in_use' || lastStage === 'sector_targeted'
+    ? 0.8
+    : lastStage === 'kev_listed'
+    ? 0.6
+    : lastStage === 'exploit_observed'
+    ? 0.4
+    : 0.2;
+
+  const independentSources = new Set(t.agreeingSources).size;
+  const confidence = Math.min(0.95, 0.55 + 0.1 * independentSources);
+
+  const recommendedActions: Situation['recommendedActions'] = userVendorMatch
+    ? [
+        {
+          id: `${t.threatId}:patch`,
+          text: `Patch ${t.affectedVendors.join(' / ')} today; this CVE is actively exploited.`,
+          urgency: 'immediate',
+        },
+        {
+          id: `${t.threatId}:monitor`,
+          text: 'Watch your accounts and devices for suspicious activity.',
+          urgency: 'soon',
+        },
+      ]
+    : severity === 'critical' || severity === 'emergency'
+    ? [
+        {
+          id: `${t.threatId}:watch`,
+          text: `Critical sector under threat — monitor for service disruption.`,
+          urgency: 'soon',
+        },
+      ]
+    : [
+        {
+          id: `${t.threatId}:fyi`,
+          text: 'Tracking for escalation; no user action required yet.',
+          urgency: 'fyi',
+        },
+      ];
+
+  return {
+    id: `cyber:${t.threatId}`,
+    domain: 'cyber',
+    title: t.title,
+    summary: `${prettyStage(lastStage)} — ${t.affectedVendors.join(', ') || t.affectedSectors.join(', ') || 'multiple targets'}.`,
+    severity,
+    confidence,
+    urgency,
+    userExposure,
+    personalImpact: {
+      summary: userVendorMatch
+        ? `Your ${t.affectedVendors.join(' / ')} system is affected.`
+        : userSectorMatch
+        ? `A sector you watch is targeted.`
+        : 'No direct exposure detected.',
+      level: userVendorMatch ? 'high' : userSectorMatch ? 'medium' : 'low',
+      reasons: exposureReasons,
+    },
+    evidence: t.evidence,
+    sourceAgreement: {
+      agreeing: t.agreeingSources,
+      disagreeing: t.disagreeingSources,
+      independentSourceCount: independentSources,
+    },
+    whatChanged: [
+      { ts, text: `Lifecycle stage: ${prettyStage(lastStage)}`, source: t.evidence[0]?.source ?? 'cyber-feed' },
+    ],
+    expectedNextSignals: [
+      { id: `${t.threatId}:patch-released`, description: 'Vendor patch / mitigation released' },
+      { id: `${t.threatId}:cisa-advisory`, description: 'CISA advisory or KEV addition' },
+      { id: `${t.threatId}:ransomware-association`, description: 'Ransomware group associated with the CVE' },
+    ],
+    invalidationSignals: [
+      { id: `${t.threatId}:retracted`, description: 'Advisory retracted or downgraded' },
+      { id: `${t.threatId}:no-exploitation`, description: '30-day window without observed exploitation' },
+    ],
+    recommendedActions,
+    timeline: t.stagesReached.map((stage, i) => ({
+      ts: t.evidence[i]?.observedAt ?? ts,
+      text: prettyStage(stage),
+      source: t.evidence[i]?.source ?? 'cyber-feed',
+    })),
+    diagnosticsTrace: {
+      createdReason: `Cyber threat ${t.threatId} reached stage '${lastStage}'`,
+      severityRationale: `Stage '${lastStage}' base ${STAGE_SCORE[lastStage]}, infra-bump ${
+        hitsCriticalInfra ? '+0.1' : '+0'
+      }, user-bump ${userVendorMatch ? '+0.1' : '+0'} → score ${score.toFixed(2)} → tier '${severity}'`,
+      confidenceRationale: `${independentSources} independent source(s) → confidence ${confidence.toFixed(2)}`,
+      exposureRationale: exposureReasons.length > 0
+        ? exposureReasons.join('; ')
+        : 'No vendor or sector match against user context',
+      sourceContributions: Object.fromEntries(
+        t.agreeingSources.map((s) => [s, 1 / Math.max(1, t.agreeingSources.length)]),
+      ),
+      thresholdsCrossed: [
+        `stage:${lastStage}`,
+        `severity:${severity}`,
+        ...(hitsCriticalInfra ? ['critical_infra'] : []),
+        ...(userVendorMatch ? ['user_vendor_match'] : []),
+        ...(userSectorMatch ? ['user_sector_match'] : []),
+      ],
+    },
+    predictionOutcome: {},
+    phase: lastStage === 'user_exposed' ? 'active' : lastStage === 'cve_published' ? 'emerging' : 'developing',
+    firstSeen: t.observedAt ?? ts,
+    lastUpdated: ts,
+  };
+}
+
+function prettyStage(s: CyberLifecycleStage): string {
+  return s.replace(/_/g, ' ');
+}

--- a/src/services/situations/index.ts
+++ b/src/services/situations/index.ts
@@ -1,0 +1,54 @@
+/**
+ * High-Impact Situation Intelligence — Phase 1 entry point.
+ *
+ * Re-exports the public surface so consumers can `import {...}` from
+ * `@/services/situations` without reaching into individual files.
+ */
+
+export type {
+  Situation,
+  SituationDomain,
+  SituationSeverity,
+  SituationPhase,
+  SituationEvidence,
+  SourceAgreement,
+  ExpectedSignal,
+  InvalidationSignal,
+  RecommendedAction,
+  TimelineEvent,
+  PersonalImpact,
+  DiagnosticsTrace,
+  PredictionOutcome,
+} from './situation-types';
+
+export {
+  rankingScore,
+  severityFromScore,
+  SEVERITY_RANK,
+} from './situation-types';
+
+export type { SituationStore, SituationListener } from './situation-store';
+export {
+  createSituationStore,
+  getSituationStore,
+  resetSituationStoreForTests,
+} from './situation-store';
+
+export type {
+  TheaterPosture,
+  TheaterPostureInput,
+  MilitaryAdapterInput,
+} from './military-adapter';
+export { militaryPosturesToSituations } from './military-adapter';
+
+export type {
+  CyberLifecycleStage,
+  CyberSector,
+  CyberThreatInput,
+  CyberAdapterUserContext,
+  CyberAdapterInput,
+} from './cyber-adapter';
+export { cyberThreatsToSituations } from './cyber-adapter';
+
+export type { WeatherAdapterInput } from './weather-adapter';
+export { weatherAlertsToSituations } from './weather-adapter';

--- a/src/services/situations/military-adapter.ts
+++ b/src/services/situations/military-adapter.ts
@@ -1,0 +1,215 @@
+/* eslint-disable unicorn/no-nested-ternary, sonarjs/no-nested-conditional, unicorn/no-zero-fractions, sonarjs/cognitive-complexity */
+/**
+ * Military → Situation adapter.
+ *
+ * Phase 1 of docs/CLAUDE_HIGH_IMPACT_EVENT_INTELLIGENCE_VISION_2026-04-29.md.
+ *
+ * Pure deterministic. The vision describes a Theater Escalation Watch
+ * across 9 named theaters. Phase 1 ships the normalizer so any input
+ * carrying {theater, posture, score, sources} can become a Situation.
+ * Phase 4 will fuse OpenSky / tankers / NOTAMs / OSINT into the
+ * `posture` value and add the Strike Readiness classifier.
+ */
+
+import {
+  severityFromScore,
+  type Situation,
+  type SituationSeverity,
+} from './situation-types';
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+export type TheaterPosture =
+  | 'normal'
+  | 'elevated'
+  | 'deployment'
+  | 'strike_ready'
+  | 'active_escalation';
+
+export interface TheaterPostureInput {
+  /** Stable id for the theater (e.g. 'taiwan-strait', 'persian-gulf'). */
+  theaterId: string;
+  /** Display name. */
+  theaterName: string;
+  /** Current posture verdict from the host's existing escalation engine. */
+  posture: TheaterPosture;
+  /** 0..1 score from the upstream escalation forecaster. */
+  postureScore: number;
+  /** 0..1 prior score, so whatChanged can show direction. */
+  priorScore?: number;
+  /** Source-attributed evidence rows from the host's threat-convergence
+   *  / escalation-forecast / military-flights pipelines. */
+  evidence: readonly {
+    id: string;
+    source: string;
+    claim: string;
+    observedAt: number;
+    weight: number;
+    url?: string;
+  }[];
+  /** Sources that agree with the posture verdict. */
+  agreeingSources: readonly string[];
+  /** Sources that contradict the posture verdict. */
+  disagreeingSources: readonly string[];
+  /** Optional ms timestamp; defaults to now(). */
+  observedAt?: number;
+}
+
+export interface MilitaryAdapterInput {
+  postures: readonly TheaterPostureInput[];
+  /** Optional saved-place coordinates — reserved for Phase 2 user
+   *  exposure (e.g. travel risk near a specific theater). Phase 1
+   *  uses presence-only as a small exposure bump. */
+  savedPlaces?: readonly { id: string; name: string; lat: number; lon: number }[];
+  now?: () => number;
+}
+
+export function militaryPosturesToSituations(input: MilitaryAdapterInput): Situation[] {
+  const now = input.now ?? Date.now;
+  return (input.postures ?? [])
+    // Filter out 'normal' postures — they don't make the high-impact list.
+    .filter((p) => p.posture !== 'normal')
+    .map((p) => postureToSituation(p, input.savedPlaces ?? [], now()));
+}
+
+// ── Internals ───────────────────────────────────────────────────────────
+
+const POSTURE_SCORE_FLOOR: Record<TheaterPosture, number> = {
+  normal: 0.0,
+  elevated: 0.35,
+  deployment: 0.5,
+  strike_ready: 0.75,
+  active_escalation: 0.9,
+};
+
+function postureToSituation(
+  p: TheaterPostureInput,
+  savedPlaces: readonly { id: string; name: string; lat: number; lon: number }[],
+  ts: number,
+): Situation {
+  // The score floor enforces that 'strike_ready' lands at least
+  // 'critical' even if the upstream forecaster's raw score is low —
+  // the posture verdict is operator-supplied and must dominate.
+  const floor = POSTURE_SCORE_FLOOR[p.posture] ?? 0.3;
+  const score = Math.max(p.postureScore, floor);
+  const severity: SituationSeverity = severityFromScore(score);
+
+  // Urgency is highest for active_escalation, lower for static
+  // deployment posture.
+  const urgency = p.posture === 'active_escalation'
+    ? 0.95
+    : p.posture === 'strike_ready'
+    ? 0.8
+    : p.posture === 'deployment'
+    ? 0.5
+    : 0.3;
+
+  // Confidence: more agreeing sources → higher confidence.
+  // Base 0.5 + 0.1 per independent source, capped at 0.95.
+  const independentSources = new Set(p.agreeingSources).size;
+  const confidence = Math.min(0.95, 0.5 + 0.1 * independentSources);
+
+  // Phase 1 user exposure: presence of saved places gives a small
+  // bump (the user has *something* to lose). Phase 2 will reason
+  // about specific exposure (travel route, watchlisted ticker, etc.).
+  const userExposure = savedPlaces.length > 0 ? 0.25 : 0.1;
+
+  const direction = typeof p.priorScore === 'number'
+    ? (p.postureScore - p.priorScore > 0.05 ? 'rising' : p.postureScore - p.priorScore < -0.05 ? 'falling' : 'steady')
+    : 'unknown';
+
+  const recommendedActions = (severity === 'critical' || severity === 'emergency')
+    ? [
+        {
+          id: `${p.theaterId}:monitor`,
+          text: `Monitor ${p.theaterName} closely — posture is ${prettyPosture(p.posture)}.`,
+          urgency: 'immediate' as const,
+        },
+        {
+          id: `${p.theaterId}:travel-review`,
+          text: `Review any planned travel near ${p.theaterName}; check State Dept advisories.`,
+          urgency: 'soon' as const,
+        },
+      ]
+    : severity === 'elevated'
+    ? [
+        {
+          id: `${p.theaterId}:watch`,
+          text: `Watch ${p.theaterName} for escalation indicators (NOTAMs, naval movements).`,
+          urgency: 'monitor' as const,
+        },
+      ]
+    : [
+        {
+          id: `${p.theaterId}:fyi`,
+          text: `${p.theaterName} posture noted; no action required.`,
+          urgency: 'fyi' as const,
+        },
+      ];
+
+  return {
+    id: `military:${p.theaterId}`,
+    domain: 'military',
+    title: `${p.theaterName} — ${prettyPosture(p.posture)}`,
+    summary: `Posture ${prettyPosture(p.posture)} (score ${p.postureScore.toFixed(2)}, ${direction}).`,
+    severity,
+    confidence,
+    urgency,
+    userExposure,
+    personalImpact: {
+      summary: severity === 'critical' || severity === 'emergency'
+        ? 'May affect travel, fuel prices, and shipping if escalation continues.'
+        : 'Indirect exposure: market and commodity volatility possible.',
+      level: severity === 'emergency' ? 'high' : severity === 'critical' ? 'medium' : 'low',
+      reasons: severity === 'critical' || severity === 'emergency'
+        ? ['Theater posture meets strike-readiness threshold']
+        : [],
+    },
+    evidence: p.evidence,
+    sourceAgreement: {
+      agreeing: p.agreeingSources,
+      disagreeing: p.disagreeingSources,
+      independentSourceCount: independentSources,
+    },
+    whatChanged: typeof p.priorScore === 'number' && Math.abs(p.postureScore - p.priorScore) > 0.05
+      ? [{
+          ts,
+          text: `Posture score ${direction}: ${p.priorScore.toFixed(2)} → ${p.postureScore.toFixed(2)}`,
+          source: 'escalation-forecast',
+        }]
+      : [{ ts, text: `${p.theaterName} posture observed at ${prettyPosture(p.posture)}`, source: 'escalation-forecast' }],
+    expectedNextSignals: [
+      { id: `${p.theaterId}:flight-surge`, description: 'Military aircraft surge above baseline (OpenSky / Wingbits)' },
+      { id: `${p.theaterId}:notam`, description: 'New NOTAM closures near theater' },
+      { id: `${p.theaterId}:naval`, description: 'Naval concentration above baseline (AIS dark gaps)' },
+    ],
+    invalidationSignals: [
+      { id: `${p.theaterId}:withdrawal`, description: 'Withdrawal / re-positioning announced by official sources' },
+      { id: `${p.theaterId}:de-escalation`, description: 'Multiple corroborating de-escalation reports' },
+    ],
+    recommendedActions,
+    timeline: [
+      { ts, text: `Posture: ${prettyPosture(p.posture)} (score ${p.postureScore.toFixed(2)})`, source: 'escalation-forecast' },
+    ],
+    diagnosticsTrace: {
+      createdReason: `Theater ${p.theaterId} posture is '${p.posture}' (score ${p.postureScore.toFixed(2)})`,
+      severityRationale: `Posture floor ${floor.toFixed(2)} + raw score ${p.postureScore.toFixed(2)} → max ${score.toFixed(2)} → tier '${severity}'`,
+      confidenceRationale: `${independentSources} independent agreeing source(s) → confidence ${confidence.toFixed(2)}`,
+      exposureRationale: savedPlaces.length > 0
+        ? 'Saved-place presence gives a small exposure bump (Phase 2 will refine)'
+        : 'No saved places — minimal user exposure',
+      sourceContributions: Object.fromEntries(
+        p.agreeingSources.map((s) => [s, 1 / Math.max(1, p.agreeingSources.length)]),
+      ),
+      thresholdsCrossed: [`posture:${p.posture}`, `severity:${severity}`],
+    },
+    predictionOutcome: {},
+    phase: p.posture === 'active_escalation' ? 'active' : 'developing',
+    firstSeen: p.observedAt ?? ts,
+    lastUpdated: ts,
+  };
+}
+
+function prettyPosture(p: TheaterPosture): string {
+  return p.replace(/_/g, ' ');
+}

--- a/src/services/situations/situation-store.ts
+++ b/src/services/situations/situation-store.ts
@@ -1,0 +1,180 @@
+/**
+ * Situation store — singleton + pure registry for high-impact
+ * situations across military, cyber, weather, and compound domains.
+ *
+ * Phase 1 of docs/CLAUDE_HIGH_IMPACT_EVENT_INTELLIGENCE_VISION_2026-04-29.md.
+ *
+ * Design:
+ *   - Adapters call `upsertSituation(s)` to add or update a situation
+ *     identified by `s.id`. The store keeps `firstSeen` stable across
+ *     updates and refreshes `lastUpdated`.
+ *   - `getRankedSituations(n)` returns the top N sorted by composite
+ *     ranking (severity × confidence + urgency + userExposure).
+ *   - `getActiveSituations()` returns everything not in `resolved`.
+ *   - `markResolved(id, verdict, notes)` ends a situation and writes
+ *     the after-action verdict — used by Phase 6.
+ *   - All operations are sync; listeners run on demand.
+ *
+ * No DOM, no fetch, no globals at import time.
+ */
+
+import { rankingScore, type Situation, type PredictionOutcome } from './situation-types';
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+export interface SituationStore {
+  /** Insert or update a situation. Preserves firstSeen and merges the
+   *  timeline + whatChanged across calls. Returns the stored copy. */
+  upsert: (situation: Situation) => Situation;
+  /** Read one. */
+  get: (id: string) => Situation | undefined;
+  /** Active situations (not resolved). */
+  active: () => Situation[];
+  /** Top N sorted by composite ranking. */
+  ranked: (limit?: number) => Situation[];
+  /** Mark a situation resolved with a verdict. */
+  markResolved: (id: string, verdict: PredictionOutcome['verdict'], notes?: string) => Situation | undefined;
+  /** Remove all situations. Tests + storybook only. */
+  reset: () => void;
+  /** Subscribe to change events. Returns an unsubscribe handle. */
+  subscribe: (listener: SituationListener) => () => void;
+  /** Snapshot for the diagnostics export bundle / agent handoff. */
+  toJson: () => readonly Situation[];
+}
+
+export type SituationListener = (situations: readonly Situation[]) => void;
+
+// ── Implementation ──────────────────────────────────────────────────────
+
+interface CreateOptions {
+  now?: () => number;
+}
+
+export function createSituationStore(options: CreateOptions = {}): SituationStore {
+  const now = options.now ?? (() => Date.now());
+  const items = new Map<string, Situation>();
+  const listeners = new Set<SituationListener>();
+
+  function snapshot(): readonly Situation[] {
+    return [...items.values()];
+  }
+
+  function notify(): void {
+    if (listeners.size === 0) return;
+    const snap = snapshot();
+    for (const fn of listeners) {
+      try {
+        fn(snap);
+      } catch {
+        // Listeners must not break the store.
+      }
+    }
+  }
+
+  return {
+    upsert(situation) {
+      const existing = items.get(situation.id);
+      const merged: Situation = existing
+        ? {
+            ...situation,
+            firstSeen: existing.firstSeen,
+            lastUpdated: now(),
+            // Append-only timeline: keep prior entries that aren't in
+            // the incoming list (matched by ts + text).
+            timeline: mergeTimeline(existing.timeline, situation.timeline),
+          }
+        : {
+            ...situation,
+            firstSeen: situation.firstSeen || now(),
+            lastUpdated: situation.lastUpdated || now(),
+          };
+      items.set(merged.id, merged);
+      notify();
+      return merged;
+    },
+
+    get(id) {
+      return items.get(id);
+    },
+
+    active() {
+      return [...items.values()].filter((s) => s.phase !== 'resolved');
+    },
+
+    ranked(limit) {
+      const out = [...items.values()]
+        .filter((s) => s.phase !== 'resolved')
+        .sort((a, b) => {
+          const diff = rankingScore(b) - rankingScore(a);
+          if (Math.abs(diff) > 1e-9) return diff;
+          // Stable tiebreaker: most recent first, then id ascending.
+          if (b.lastUpdated !== a.lastUpdated) return b.lastUpdated - a.lastUpdated;
+          return a.id.localeCompare(b.id);
+        });
+      return typeof limit === 'number' ? out.slice(0, limit) : out;
+    },
+
+    markResolved(id, verdict, notes) {
+      const existing = items.get(id);
+      if (!existing) return undefined;
+      const resolved: Situation = {
+        ...existing,
+        phase: 'resolved',
+        lastUpdated: now(),
+        predictionOutcome: {
+          ...existing.predictionOutcome,
+          resolvedAt: now(),
+          verdict,
+          notes,
+        },
+      };
+      items.set(id, resolved);
+      notify();
+      return resolved;
+    },
+
+    reset() {
+      items.clear();
+      notify();
+    },
+
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+
+    toJson() {
+      return snapshot();
+    },
+  };
+}
+
+function mergeTimeline(
+  existing: readonly { ts: number; text: string; source?: string }[],
+  incoming: readonly { ts: number; text: string; source?: string }[],
+): readonly { ts: number; text: string; source?: string }[] {
+  const seen = new Set<string>();
+  const out: { ts: number; text: string; source?: string }[] = [];
+  for (const e of [...existing, ...incoming]) {
+    const key = `${e.ts}|${e.text}|${e.source ?? ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(e);
+  }
+  out.sort((a, b) => a.ts - b.ts);
+  return out;
+}
+
+// ── Singleton accessor ──────────────────────────────────────────────────
+
+let singleton: SituationStore | undefined;
+
+export function getSituationStore(): SituationStore {
+  singleton ??= createSituationStore();
+  return singleton;
+}
+
+/** Reset the singleton. Tests + storybook only. */
+export function resetSituationStoreForTests(): void {
+  singleton = undefined;
+}

--- a/src/services/situations/situation-types.ts
+++ b/src/services/situations/situation-types.ts
@@ -1,0 +1,249 @@
+/**
+ * High-Impact Situation Model — per
+ * docs/CLAUDE_HIGH_IMPACT_EVENT_INTELLIGENCE_VISION_2026-04-29.md Phase 1.
+ *
+ * Shared cross-domain model for "the few things that could matter."
+ * Distinct from the legacy `src/services/situation-types.ts` which
+ * powers the older situation-engine + scenario projector. The legacy
+ * engine continues to run; this model is a higher-level normalizer
+ * that ties military, cyber, weather, and compound events into one
+ * shape every consumer (Command Center, notifications, after-action
+ * review, diagnostics export) can read.
+ *
+ * Plan invariants:
+ *   - Pure deterministic types. No DOM, no fetch.
+ *   - JSON-serializable so situations can flow through the diagnostics
+ *     export bundle and the agent handoff packet.
+ *   - Every field that drives a UI / notification decision has an
+ *     explicit numeric or enum value (no implicit "if the string
+ *     looks scary").
+ *   - Every situation carries a DiagnosticsTrace explaining why it
+ *     was created at this severity / confidence / urgency.
+ */
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+/** Cross-domain category. `compound` is reserved for situations that
+ *  span multiple domains and merge into one story. */
+export type SituationDomain = 'military' | 'cyber' | 'weather' | 'compound';
+
+/** Severity tier from FYI to Emergency. Drives notification ladder
+ *  and command-center prominence (see vision doc § Notification Ladder).
+ *  - fyi:       background / inbox only
+ *  - watch:     digest-level; calm wording
+ *  - elevated:  banner + command-center prominence
+ *  - critical:  native notification + persistent in-app status
+ *  - emergency: persistent critical alert; quiet-hours bypass available
+ */
+export type SituationSeverity =
+  | 'fyi'
+  | 'watch'
+  | 'elevated'
+  | 'critical'
+  | 'emergency';
+
+/** Phase signalling continuity over time — a situation moves through
+ *  these as new evidence arrives. Phase 1 emits 'emerging' /
+ *  'developing' / 'active' from adapters; Phase 3 will add decay logic. */
+export type SituationPhase = 'emerging' | 'developing' | 'active' | 'resolved';
+
+// ── Personal exposure ──────────────────────────────────────────────────
+
+/** User-facing impact translation. Phase 1 ships shape-only; Phase 2
+ *  fills in real per-user reasoning from the Personal Exposure Graph. */
+export interface PersonalImpact {
+  /** One-line "how this affects you." Calm wording — avoid panic. */
+  summary: string;
+  /** Coarse user-facing impact band. */
+  level: 'none' | 'low' | 'medium' | 'high' | 'severe';
+  /** Concrete reasons exposure is non-zero (saved place inside polygon,
+   *  watchlisted ticker exposed to commodity shock, etc.). */
+  reasons: readonly string[];
+}
+
+// ── Evidence + provenance ──────────────────────────────────────────────
+
+/** A single source-attributed evidence row. Intentionally close to
+ *  the existing EvidencePack shape but flatter so adapters can build
+ *  it without depending on the legacy module. */
+export interface SituationEvidence {
+  /** Stable id for the source document or signal. */
+  id: string;
+  /** Short label for the source — e.g. "NWS", "CISA KEV", "OpenSky". */
+  source: string;
+  /** Plain-English claim or observation. */
+  claim: string;
+  /** ms timestamp the evidence was observed. */
+  observedAt: number;
+  /** Optional URL to the underlying record. */
+  url?: string;
+  /** Per-evidence weight in the truth/severity computation, 0..1. */
+  weight: number;
+}
+
+/** Source-agreement summary across the evidence list. The vision doc
+ *  asks for an explicit agreement-vs-disagreement breakdown so the UI
+ *  can show "X agree, Y contradict" without inferring it from text. */
+export interface SourceAgreement {
+  /** Source labels (e.g. "NWS", "OpenSky") that corroborate the claim. */
+  agreeing: readonly string[];
+  /** Source labels that contradict the claim, if any. */
+  disagreeing: readonly string[];
+  /** Independent-source count (deduped by source label). */
+  independentSourceCount: number;
+}
+
+// ── Watch windows ──────────────────────────────────────────────────────
+
+/** Signals the system expects to see if this situation is real. Drives
+ *  Phase 3 confidence-decay logic (when expected signals fail to
+ *  appear in the watch window, urgency drops). */
+export interface ExpectedSignal {
+  id: string;
+  description: string;
+  /** ms by which this signal should appear if the situation is real. */
+  expectByMs?: number;
+}
+
+/** Signals that, if observed, would invalidate the situation (e.g.
+ *  "NWS retracts the warning", "CISA removes from KEV"). */
+export interface InvalidationSignal {
+  id: string;
+  description: string;
+}
+
+// ── Recommended actions + timeline ─────────────────────────────────────
+
+/** Calm, concrete user action. Phase 1 produces shape-correct entries;
+ *  Phase 4 adds full Action Brief integration. */
+export interface RecommendedAction {
+  id: string;
+  /** Short imperative — e.g. "Avoid low-water crossings for 2 hours." */
+  text: string;
+  /** Cue for UI grouping. */
+  urgency: 'immediate' | 'soon' | 'monitor' | 'fyi';
+}
+
+/** Time-ordered narrative entry — a single "what changed" line. */
+export interface TimelineEvent {
+  ts: number;
+  text: string;
+  /** Optional source label so the UI can show provenance. */
+  source?: string;
+}
+
+// ── Diagnostics + outcome tracking ─────────────────────────────────────
+
+/** Why this situation has the severity / confidence / urgency it does.
+ *  Required on every emitted situation (see vision doc § Testing And
+ *  Diagnostics Requirements). */
+export interface DiagnosticsTrace {
+  /** Why the situation was created. */
+  createdReason: string;
+  /** Free-text breakdown of severity decision (rule names, contributing
+   *  thresholds). */
+  severityRationale: string;
+  /** Why confidence is at this level. */
+  confidenceRationale: string;
+  /** Why user exposure is at this level. */
+  exposureRationale: string;
+  /** Source contributions, e.g. "NWS=0.6, OpenSky=0.3". */
+  sourceContributions: Record<string, number>;
+  /** Threshold cuts that fired (rule ids). */
+  thresholdsCrossed: readonly string[];
+}
+
+/** Filled in only after the situation resolves; supports the
+ *  after-action review / self-learning loop (Phase 6). */
+export interface PredictionOutcome {
+  resolvedAt?: number;
+  /** Was the alert correct, late, early, false-positive, or missed? */
+  verdict?: 'correct' | 'late' | 'early' | 'false_positive' | 'missed' | 'unknown';
+  /** Free-text after-action notes. */
+  notes?: string;
+}
+
+// ── The Situation ─────────────────────────────────────────────────────
+
+/** What changed since the user's last look. Empty array on first emit. */
+export type WhatChangedEntry = TimelineEvent;
+
+/** The shared cross-domain situation model. */
+export interface Situation {
+  id: string;
+  domain: SituationDomain;
+  title: string;
+  summary: string;
+  severity: SituationSeverity;
+  /** 0..1 confidence the situation is real. */
+  confidence: number;
+  /** 0..1 urgency — how time-sensitive is action? */
+  urgency: number;
+  /** 0..1 user exposure — how directly does this affect the user? */
+  userExposure: number;
+  /** Per-user impact translation. */
+  personalImpact: PersonalImpact;
+  /** Source-attributed evidence backing the situation. */
+  evidence: readonly SituationEvidence[];
+  /** Source agreement / disagreement summary. */
+  sourceAgreement: SourceAgreement;
+  /** Time-ordered "what changed" narrative since last emit. */
+  whatChanged: readonly WhatChangedEntry[];
+  /** Signals to watch for that would confirm the situation. */
+  expectedNextSignals: readonly ExpectedSignal[];
+  /** Signals that would invalidate the situation. */
+  invalidationSignals: readonly InvalidationSignal[];
+  /** User actions, sorted by urgency. */
+  recommendedActions: readonly RecommendedAction[];
+  /** Full timeline (most recent last). */
+  timeline: readonly TimelineEvent[];
+  /** Why this situation has these scores. */
+  diagnosticsTrace: DiagnosticsTrace;
+  /** Phase 6 outcome data. Empty until the situation resolves. */
+  predictionOutcome: PredictionOutcome;
+  /** Lifecycle phase. */
+  phase: SituationPhase;
+  /** ms timestamp of first emission. */
+  firstSeen: number;
+  /** ms timestamp of last update. */
+  lastUpdated: number;
+}
+
+// ── Severity / phase helpers ──────────────────────────────────────────
+
+/** Numeric severity rank for sorting (higher = more severe). */
+export const SEVERITY_RANK: Record<SituationSeverity, number> = {
+  fyi: 0,
+  watch: 1,
+  elevated: 2,
+  critical: 3,
+  emergency: 4,
+};
+
+/** Compose the four signals into a single 0..1 ranking score that
+ *  the Command Center uses to pick the top N situations. Higher is
+ *  more important. */
+export function rankingScore(s: Pick<Situation, 'severity' | 'confidence' | 'urgency' | 'userExposure'>): number {
+  // Severity is the dominant axis (4× weight). Confidence multiplies
+  // the whole thing — a low-confidence emergency must not outrank a
+  // high-confidence elevated. Urgency and userExposure are additive
+  // bumps for tie-breaking.
+  const severityNorm = SEVERITY_RANK[s.severity] / 4; // 0..1
+  const base = severityNorm * 4 + s.urgency + s.userExposure;
+  return base * Math.max(s.confidence, 0.1); // floor on confidence so a
+                                              // 0-confidence situation
+                                              // still has comparative
+                                              // ordering
+}
+
+/** Convenience: derive severity tier from a 0..1 composite score
+ *  using a stable ladder. Adapters can produce raw scores and let
+ *  this helper do the bucketing so the ladder stays consistent
+ *  across military / cyber / weather. */
+export function severityFromScore(score: number): SituationSeverity {
+  if (score >= 0.85) return 'emergency';
+  if (score >= 0.65) return 'critical';
+  if (score >= 0.45) return 'elevated';
+  if (score >= 0.25) return 'watch';
+  return 'fyi';
+}

--- a/src/services/situations/weather-adapter.ts
+++ b/src/services/situations/weather-adapter.ts
@@ -1,0 +1,219 @@
+/* eslint-disable unicorn/no-nested-ternary, sonarjs/no-nested-conditional, unicorn/no-zero-fractions */
+/**
+ * Weather → Situation adapter.
+ *
+ * Phase 1 of docs/CLAUDE_HIGH_IMPACT_EVENT_INTELLIGENCE_VISION_2026-04-29.md.
+ *
+ * Pure deterministic. Takes the existing NWS WeatherAlert shape and
+ * produces normalized Situation records. Adapter is intentionally
+ * narrow:
+ *   - One alert → one Situation (compound merging is Phase 5)
+ *   - User-exposure scoring is shape-only in Phase 1 (Phase 2 wires
+ *     real saved-place / route data via the Personal Exposure Graph)
+ *   - Watch-window + invalidation signals are seeded with sensible
+ *     defaults so the model can demonstrate decay logic in Phase 3
+ */
+
+import type { WeatherAlert } from '@/services/weather';
+import {
+  severityFromScore,
+  type Situation,
+  type SituationSeverity,
+} from './situation-types';
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+export interface WeatherAdapterInput {
+  alerts: readonly WeatherAlert[];
+  /** Optional saved-place coordinates for Phase 2 user-exposure
+   *  scoring. Phase 1 uses this only when present to bump exposure. */
+  savedPlaces?: readonly { id: string; name: string; lat: number; lon: number }[];
+  /** Optional clock for tests. */
+  now?: () => number;
+}
+
+/** Map every alert to a Situation. Returns an empty array if alerts
+ *  is empty. */
+export function weatherAlertsToSituations(input: WeatherAdapterInput): Situation[] {
+  const now = input.now ?? Date.now;
+  const alerts = input.alerts ?? [];
+  return alerts.map((alert) => alertToSituation(alert, input.savedPlaces ?? [], now()));
+}
+
+// ── Internals ───────────────────────────────────────────────────────────
+
+const NWS_TO_SCORE: Record<WeatherAlert['severity'], number> = {
+  Extreme: 0.9,
+  Severe: 0.7,
+  Moderate: 0.5,
+  Minor: 0.3,
+  Unknown: 0.2,
+};
+
+function alertToSituation(
+  alert: WeatherAlert,
+  savedPlaces: readonly { id: string; name: string; lat: number; lon: number }[],
+  ts: number,
+): Situation {
+  const score = NWS_TO_SCORE[alert.severity] ?? 0.2;
+  const severity: SituationSeverity = severityFromScore(score);
+  // Watch-window: NWS alerts include onset + expires. Time-to-onset
+  // drives urgency — closer onset → higher urgency.
+  const onsetMs = alert.onset?.getTime?.() ?? ts;
+  const minutesToOnset = Math.max(0, (onsetMs - ts) / 60_000);
+  // Linear ramp: 0 min → 1.0 urgency, 60+ min → 0.3 urgency.
+  const urgency = clamp01(1 - minutesToOnset / 90);
+
+  // Phase 1 user-exposure: simple distance check vs saved places.
+  // Phase 2 will use polygon-match + watchlist + travel routes.
+  const { exposure, exposureReasons } = computeWeatherExposure(alert, savedPlaces);
+
+  const evidence = [
+    {
+      id: alert.id,
+      source: 'NWS',
+      claim: `${alert.event}: ${alert.headline}`.slice(0, 200),
+      observedAt: alert.onset?.getTime?.() ?? ts,
+      weight: 1.0,
+    },
+  ];
+
+  const expectedNextSignals = [
+    { id: `${alert.id}:radar-strengthen`, description: 'Radar core strengthens within 30 min' },
+    { id: `${alert.id}:lightning-density`, description: 'Lightning density increase near affected area' },
+    { id: `${alert.id}:storm-reports`, description: 'Spotter / storm reports begin arriving' },
+  ];
+
+  const invalidationSignals = [
+    { id: `${alert.id}:nws-cancellation`, description: 'NWS cancels or expires the alert' },
+    { id: `${alert.id}:radar-decay`, description: 'Radar signature decays for 20+ minutes' },
+  ];
+
+  const recommendedActions = severity === 'critical' || severity === 'emergency'
+    ? [
+        {
+          id: `${alert.id}:shelter`,
+          text: `Take shelter — ${alert.event} threatens ${alert.areaDesc.split(';')[0]?.trim() ?? 'your area'}.`,
+          urgency: 'immediate' as const,
+        },
+        {
+          id: `${alert.id}:monitor`,
+          text: 'Monitor NWS updates and local emergency notifications.',
+          urgency: 'immediate' as const,
+        },
+      ]
+    : severity === 'elevated'
+    ? [
+        {
+          id: `${alert.id}:prepare`,
+          text: `Prepare for ${alert.event}; review evacuation route if applicable.`,
+          urgency: 'soon' as const,
+        },
+      ]
+    : [
+        {
+          id: `${alert.id}:monitor`,
+          text: 'Monitor for escalation; no action required yet.',
+          urgency: 'monitor' as const,
+        },
+      ];
+
+  return {
+    id: `weather:${alert.id}`,
+    domain: 'weather',
+    title: `${alert.event} — ${alert.areaDesc.split(';')[0]?.trim() ?? 'area'}`,
+    summary: alert.headline.slice(0, 240),
+    severity,
+    confidence: 0.9, // NWS is authoritative; high baseline
+    urgency,
+    userExposure: exposure,
+    personalImpact: {
+      summary: exposureReasons.length > 0
+        ? `Affects ${savedPlaces.length > 0 ? 'a saved place' : 'your area'}`
+        : 'No direct exposure detected',
+      level: exposureToLevel(exposure),
+      reasons: exposureReasons,
+    },
+    evidence,
+    sourceAgreement: {
+      agreeing: ['NWS'],
+      disagreeing: [],
+      independentSourceCount: 1,
+    },
+    whatChanged: [
+      { ts, text: `New ${alert.severity.toLowerCase()} alert from NWS`, source: 'NWS' },
+    ],
+    expectedNextSignals,
+    invalidationSignals,
+    recommendedActions,
+    timeline: [
+      { ts: alert.onset?.getTime?.() ?? ts, text: `Onset: ${alert.event}`, source: 'NWS' },
+    ],
+    diagnosticsTrace: {
+      createdReason: `NWS alert ${alert.id} (${alert.severity}) reached the high-impact threshold`,
+      severityRationale: `NWS severity '${alert.severity}' → score ${score.toFixed(2)} → tier '${severity}'`,
+      confidenceRationale: 'NWS is the authoritative source for US weather alerts (baseline 0.9).',
+      exposureRationale: exposureReasons.length > 0
+        ? `Saved place(s) within proximity radius: ${exposureReasons.join('; ')}`
+        : 'No saved places within proximity radius — exposure scored from severity only.',
+      sourceContributions: { NWS: 1.0 },
+      thresholdsCrossed: [`severity:${severity}`, `urgency:${urgency.toFixed(2)}`],
+    },
+    predictionOutcome: {},
+    phase: 'active',
+    firstSeen: ts,
+    lastUpdated: ts,
+  };
+}
+
+/** Phase 1 user-exposure: cheap radial proximity. Phase 2 will use
+ *  the existing polygon-match service. */
+function computeWeatherExposure(
+  alert: WeatherAlert,
+  savedPlaces: readonly { id: string; name: string; lat: number; lon: number }[],
+): { exposure: number; exposureReasons: string[] } {
+  if (savedPlaces.length === 0 || !alert.centroid) {
+    return { exposure: 0.1, exposureReasons: [] };
+  }
+  const reasons: string[] = [];
+  let maxExposure = 0.1;
+  for (const place of savedPlaces) {
+    const km = haversineKm(alert.centroid[1], alert.centroid[0], place.lat, place.lon);
+    if (km < 25) {
+      maxExposure = Math.max(maxExposure, 0.95);
+      reasons.push(`${place.name} within 25 km of alert centroid`);
+    } else if (km < 80) {
+      maxExposure = Math.max(maxExposure, 0.6);
+      reasons.push(`${place.name} within 80 km of alert centroid`);
+    } else if (km < 200) {
+      maxExposure = Math.max(maxExposure, 0.25);
+    }
+  }
+  return { exposure: maxExposure, exposureReasons: reasons };
+}
+
+function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLon = ((lon2 - lon1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function clamp01(n: number): number {
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}
+
+function exposureToLevel(exposure: number): 'none' | 'low' | 'medium' | 'high' | 'severe' {
+  if (exposure >= 0.85) return 'severe';
+  if (exposure >= 0.6) return 'high';
+  if (exposure >= 0.35) return 'medium';
+  if (exposure >= 0.15) return 'low';
+  return 'none';
+}


### PR DESCRIPTION
Phase 1 of the High-Impact Event Intelligence Vision per `docs/CLAUDE_HIGH_IMPACT_EVENT_INTELLIGENCE_VISION_2026-04-29.md`.

Foundation only — no UI changes, no behavioral change to existing panels. Adds the shared cross-domain Situation model + adapters from military, cyber, and weather signals, with ranking by severity × confidence × urgency × user exposure and diagnostics explaining why each situation was created.

## What Phase 1 ships

### 1. Shared Situation model (`situation-types.ts`)

| Field | Phase 1 contract |
|---|---|
| `domain` | `military` / `cyber` / `weather` / `compound` |
| `severity` | 5-tier ladder: `fyi` → `watch` → `elevated` → `critical` → `emergency` |
| `confidence` | 0..1 — how sure are we this is real |
| `urgency` | 0..1 — how time-sensitive is action |
| `userExposure` | 0..1 — how directly does this affect the user (Phase 2 wires real exposure graph) |
| `personalImpact` | calm 1-line "how this affects you" + level + reasons |
| `evidence[]` | source-attributed rows |
| `sourceAgreement` | explicit `{agreeing, disagreeing, independentSourceCount}` |
| `whatChanged[]` | append-only narrative since last look |
| `expectedNextSignals[]` | Phase 3 confidence-decay hook |
| `invalidationSignals[]` | Phase 3 hook |
| `recommendedActions[]` | calm imperative phrases sorted by urgency |
| `timeline[]` | full time-ordered history |
| `diagnosticsTrace` | **required** — `createdReason`, `severityRationale`, `confidenceRationale`, `exposureRationale`, `sourceContributions`, `thresholdsCrossed` |
| `predictionOutcome` | filled by Phase 6 after-action review |

`rankingScore(s)` composes the 4 numeric signals into one comparable value. Severity is the dominant axis (4× weight). Confidence multiplies the whole thing — a low-confidence emergency cannot outrank a high-confidence elevated. Urgency + userExposure are additive bumps for tiebreaking.

`severityFromScore(0..1)` shares one tier ladder across all adapters.

### 2. SituationStore (`situation-store.ts`)

`upsert / get / active / ranked / markResolved / subscribe / toJson / reset`. Timeline merging is append-only and dedupes by `(ts, text, source)`. `firstSeen` is sticky across upserts. Listeners run sync; listener errors don't break the store.

### 3. Three adapters

**Weather** — `NWS WeatherAlert[] → Situation[]`. Maps NWS severity tiers, derives urgency from time-to-onset (linear 90-min ramp), scores user exposure from saved-place haversine distance to alert centroid. Phase 1 uses cheap radial distance; Phase 2 will swap in the existing polygon-match service.

**Military** — `TheaterPostureInput[] → Situation[]`. Posture floors enforce that `strike_ready` never drops below `critical` (operator verdict dominates raw score) and `active_escalation` forces `emergency`. Confidence rises with independent agreeing source count, capped at 0.95. `whatChanged` narrative reports rising/falling/steady direction.

**Cyber** — `CyberThreatInput[] → Situation[]`. Implements the CVE → exploit_observed → kev_listed → ransomware → sector_targeted → user_exposed lifecycle. Critical-infrastructure sector match adds +0.1 score bump. User vendor/sector match bumps `userExposure` (and score), drives the immediate-patch action.

## Verification

- `typecheck:all` → 0 errors
- `secrets:scan` → 2079 files clean
- **74 deterministic tests** across 6 test files:
  - `situation-types.test.mts` — 10 tests (severity rank, score-to-tier, ranking score behavior)
  - `situation-store.test.mts` — 12 tests (upsert/merge, ranked, resolved, subscribe, JSON round-trip, reset)
  - `weather-adapter.test.mts` — 16 tests (severity mapping, urgency curve, exposure tiers, diagnostics rationale, action shape)
  - `military-adapter.test.mts` — 15 tests (floor enforcement, confidence scaling, whatChanged narrative, threshold logging)
  - `cyber-adapter.test.mts` — 15 tests (lifecycle stages, infra bump, vendor matching, threshold flags, action shape)
  - `integration.test.mts` — 4 tests (cross-domain ingest, diagnostics required, JSON round-trip, user-exposed-cyber outranks distant-military-elevated)
- `test:panels:smoke` → exit 0, 234 tests pass, 0 silent / 0 errored / 0 asyncErrors

## Acceptance criteria from the vision doc

| Phase 1 success criterion | Status |
|---|---|
| Military, cyber, and weather can all produce normalized situations | ✅ |
| Existing panels keep working | ✅ panel smoke unchanged |
| The command center can rank situations by impact | ✅ `store.ranked()` |

## What's NOT in this PR

Service-first per the vision doc's implementation principles ("Build service-first, UI second"):
- No UI surface yet — Command Center wiring is Phase 2 alongside the Personal Exposure Graph
- No live data ingestion wiring — adapters are called by future host loops; the legacy SituationEngine continues to run unchanged
- No notification routing — Phase 4
- No compound merge — Phase 5
- No after-action review hooks — Phase 6

Each future phase adds capabilities without changing the model shape.

## Out-of-band

Branch `claude/panel-quality-B` carries pending PR B work-in-progress (panel data contracts + fixture expansion + XSS coverage). It's saved on the branch and can be picked up later.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>