### PR TITLE
feat(situations): Phase 2 — Personal Exposure Graph wired into all 3 adapters

### DIFF
--- a/src/services/situations/__tests__/exposure-graph.test.mts
+++ b/src/services/situations/__tests__/exposure-graph.test.mts
@@ -1,0 +1,176 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  exposureToLevel,
+  getExposureGraph,
+  resetExposureGraphForTests,
+  scoreCountryExposure,
+  scoreCyberExposure,
+  scoreGeoExposure,
+  setExposureGraph,
+  type ExposureGraph,
+} from '../exposure-graph';
+
+const HOME = { id: 'home', name: 'La Porte', lat: 41.6, lon: -86.7, tags: ['home'], primary: true };
+const WORK = { id: 'work', name: 'Chicago', lat: 41.88, lon: -87.63, tags: ['work'], primary: false };
+
+beforeEach(() => {
+  resetExposureGraphForTests();
+});
+
+describe('setExposureGraph + getExposureGraph', () => {
+  it('round-trips a full graph', () => {
+    const graph: ExposureGraph = {
+      savedPlaces: [HOME],
+      watchlist: { countries: ['USA'], sectors: ['finance'], tickers: ['AAPL'], vendors: ['Apple'], cves: [] },
+      device: { osLabels: ['macOS'], versions: ['macOS 14'] },
+    };
+    setExposureGraph(graph);
+    assert.deepEqual(getExposureGraph(), graph);
+  });
+
+  it('default is an empty graph', () => {
+    const graph = getExposureGraph();
+    assert.equal(graph.savedPlaces.length, 0);
+    assert.equal(graph.watchlist.countries.length, 0);
+  });
+});
+
+describe('scoreGeoExposure', () => {
+  it('returns baseline 0.1 when centroid is missing', () => {
+    const r = scoreGeoExposure(undefined, { savedPlaces: [HOME], watchlist: { countries: [], sectors: [], tickers: [], vendors: [], cves: [] }, device: { osLabels: [], versions: [] } });
+    assert.equal(r.score, 0.1);
+  });
+
+  it('within 25 km of primary place → severe (>= 0.95)', () => {
+    const r = scoreGeoExposure(
+      { lat: 41.61, lon: -86.72 }, // ~1 km from home
+      { savedPlaces: [HOME], watchlist: { countries: [], sectors: [], tickers: [], vendors: [], cves: [] }, device: { osLabels: [], versions: [] } },
+    );
+    assert.ok(r.score >= 0.95, `expected ≥0.95, got ${r.score}`);
+    assert.ok(r.reasons.length > 0);
+  });
+
+  it('within 80 km → high (~0.6)', () => {
+    const r = scoreGeoExposure(
+      { lat: 42.0, lon: -86.6 }, // ~50 km from home
+      { savedPlaces: [HOME], watchlist: { countries: [], sectors: [], tickers: [], vendors: [], cves: [] }, device: { osLabels: [], versions: [] } },
+    );
+    assert.ok(r.score >= 0.6 && r.score < 0.9);
+  });
+
+  it('beyond 200 km → baseline 0.1', () => {
+    const r = scoreGeoExposure(
+      { lat: 35.0, lon: -90.0 }, // ~700 km from home
+      { savedPlaces: [HOME], watchlist: { countries: [], sectors: [], tickers: [], vendors: [], cves: [] }, device: { osLabels: [], versions: [] } },
+    );
+    assert.equal(r.score, 0.1);
+  });
+
+  it('current location wins over saved place by +0.05 bump', () => {
+    const r = scoreGeoExposure(
+      { lat: 41.6, lon: -86.7 },
+      {
+        savedPlaces: [HOME],
+        watchlist: { countries: [], sectors: [], tickers: [], vendors: [], cves: [] },
+        device: { osLabels: [], versions: [] },
+        currentLocation: { lat: 41.61, lon: -86.71 },
+      },
+    );
+    assert.ok(r.reasons[0]?.toLowerCase().includes('current location'));
+  });
+
+  it('records a contributions map keyed by source', () => {
+    const r = scoreGeoExposure(
+      { lat: 41.61, lon: -86.72 },
+      { savedPlaces: [HOME], watchlist: { countries: [], sectors: [], tickers: [], vendors: [], cves: [] }, device: { osLabels: [], versions: [] } },
+    );
+    assert.ok('place:home' in r.contributions);
+  });
+});
+
+describe('scoreCyberExposure', () => {
+  const baseGraph: ExposureGraph = {
+    savedPlaces: [],
+    watchlist: { countries: [], sectors: ['finance'], tickers: [], vendors: ['Apple'], cves: ['CVE-2026-WATCHED'] },
+    device: { osLabels: ['macOS'], versions: ['macOS 14'] },
+  };
+
+  it('vendor match → score 0.85', () => {
+    const r = scoreCyberExposure({ affectedVendors: ['Apple macOS'], affectedSectors: [] }, baseGraph);
+    assert.ok(r.score >= 0.85);
+    assert.ok(r.reasons.some((rs) => /vendor/i.test(rs)));
+  });
+
+  it('sector match alone → score 0.6', () => {
+    const r = scoreCyberExposure({ affectedVendors: [], affectedSectors: ['finance'] }, baseGraph);
+    assert.equal(r.score, 0.6);
+  });
+
+  it('CVE on watchlist → score 1.0', () => {
+    const r = scoreCyberExposure(
+      { affectedVendors: [], affectedSectors: [], cveId: 'CVE-2026-WATCHED' },
+      baseGraph,
+    );
+    assert.equal(r.score, 1);
+    assert.ok(r.reasons.some((rs) => /CVE-2026-WATCHED/.test(rs)));
+  });
+
+  it('no matches → baseline 0.1', () => {
+    const r = scoreCyberExposure({ affectedVendors: ['Microsoft'], affectedSectors: [] }, baseGraph);
+    assert.equal(r.score, 0.1);
+  });
+
+  it('case-insensitive vendor match', () => {
+    const r = scoreCyberExposure(
+      { affectedVendors: ['APPLE iOS'], affectedSectors: [] },
+      { ...baseGraph, watchlist: { ...baseGraph.watchlist, vendors: ['apple'] } },
+    );
+    assert.ok(r.score >= 0.85);
+  });
+});
+
+describe('scoreCountryExposure', () => {
+  const graph: ExposureGraph = {
+    savedPlaces: [],
+    watchlist: { countries: ['USA', 'TWN'], sectors: [], tickers: [], vendors: [], cves: [] },
+    device: { osLabels: [], versions: [] },
+  };
+
+  it('matched country → score 0.6 (single match)', () => {
+    const r = scoreCountryExposure(['TWN'], graph);
+    assert.equal(r.score, 0.6);
+    assert.ok(r.reasons.some((rs) => /TWN/.test(rs)));
+  });
+
+  it('multiple matches → higher score (capped 0.85)', () => {
+    const r = scoreCountryExposure(['USA', 'TWN'], graph);
+    assert.equal(r.score, 0.7);
+  });
+
+  it('no overlap → baseline 0.1', () => {
+    const r = scoreCountryExposure(['CHN'], graph);
+    assert.equal(r.score, 0.1);
+  });
+
+  it('empty input → baseline 0.1', () => {
+    const r = scoreCountryExposure([], graph);
+    assert.equal(r.score, 0.1);
+  });
+
+  it('case-insensitive country match', () => {
+    const r = scoreCountryExposure(['twn'], graph);
+    assert.equal(r.score, 0.6);
+  });
+});
+
+describe('exposureToLevel', () => {
+  it('maps the score ladder correctly', () => {
+    assert.equal(exposureToLevel(0.95), 'severe');
+    assert.equal(exposureToLevel(0.75), 'high');
+    assert.equal(exposureToLevel(0.45), 'medium');
+    assert.equal(exposureToLevel(0.25), 'low');
+    assert.equal(exposureToLevel(0.1), 'none');
+  });
+});

--- a/src/services/situations/__tests__/exposure-integration.test.mts
+++ b/src/services/situations/__tests__/exposure-integration.test.mts
@@ -1,0 +1,215 @@
+/**
+ * Phase 2 acceptance — Personal Exposure Graph end-to-end.
+ *
+ * Vision doc Phase 2 success criteria:
+ *   - Every situation has a user exposure score
+ *   - User-exposed events rank above distant global noise
+ *   - Alerts explain the exposure reason
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  cyberThreatsToSituations,
+  militaryPosturesToSituations,
+  weatherAlertsToSituations,
+  type ExposureGraph,
+} from '../index';
+import { createSituationStore } from '../situation-store';
+
+const NOW = 1_745_000_000_000;
+
+const FULL_GRAPH: ExposureGraph = {
+  savedPlaces: [
+    { id: 'home', name: 'La Porte', lat: 41.6, lon: -86.7, tags: ['home'], primary: true },
+  ],
+  watchlist: {
+    countries: ['USA', 'TWN'],
+    sectors: ['finance'],
+    tickers: ['AAPL'],
+    vendors: ['Apple'],
+    cves: [],
+  },
+  device: { osLabels: ['macOS'], versions: ['macOS 14'] },
+};
+
+describe('Phase 2 acceptance: every situation gets exposure from the graph', () => {
+  it('weather alert near saved place → high userExposure', () => {
+    const [s] = weatherAlertsToSituations({
+      alerts: [{
+        id: 'wx-1',
+        event: 'Tornado Warning',
+        severity: 'Extreme',
+        headline: 'h',
+        description: 'd',
+        areaDesc: 'La Porte',
+        onset: new Date(NOW + 5 * 60_000),
+        expires: new Date(NOW + 30 * 60_000),
+        coordinates: [],
+        centroid: [-86.7, 41.6],
+      }],
+      exposureGraph: FULL_GRAPH,
+      now: () => NOW,
+    });
+    assert.ok((s?.userExposure ?? 0) >= 0.95);
+    assert.ok(s?.personalImpact.reasons[0]?.includes('La Porte'));
+  });
+
+  it('cyber threat matching user OS → high userExposure', () => {
+    const [s] = cyberThreatsToSituations({
+      threats: [{
+        threatId: 'CVE-2026-1',
+        title: 'macOS WebKit RCE',
+        stagesReached: ['cve_published', 'exploit_observed'],
+        affectedSectors: [],
+        affectedVendors: ['Apple macOS'],
+        evidence: [],
+        agreeingSources: ['CISA'],
+        disagreeingSources: [],
+      }],
+      exposureGraph: FULL_GRAPH,
+      now: () => NOW,
+    });
+    assert.ok((s?.userExposure ?? 0) >= 0.85);
+    assert.ok(s?.personalImpact.reasons.some((r) => /vendor/i.test(r)));
+  });
+
+  it('military theater in watched country → meaningful userExposure', () => {
+    const [s] = militaryPosturesToSituations({
+      postures: [{
+        theaterId: 'taiwan-strait',
+        theaterName: 'Taiwan Strait',
+        posture: 'strike_ready',
+        postureScore: 0.8,
+        countries: ['TWN'],
+        evidence: [],
+        agreeingSources: ['OpenSky', 'NOTAMs'],
+        disagreeingSources: [],
+      }],
+      exposureGraph: FULL_GRAPH,
+      now: () => NOW,
+    });
+    assert.ok((s?.userExposure ?? 0) >= 0.6);
+    assert.ok(s?.personalImpact.reasons.some((r) => /TWN/.test(r)));
+  });
+});
+
+describe('Phase 2 acceptance: user-exposed events outrank distant ones in ranking', () => {
+  it('weather affecting saved place > distant cyber + distant military', () => {
+    const store = createSituationStore({ now: () => NOW });
+
+    // Distant cyber: no user OS match
+    const distantCyber = cyberThreatsToSituations({
+      threats: [{
+        threatId: 'CVE-2026-DIST',
+        title: 'Linux kernel bug',
+        stagesReached: ['cve_published', 'exploit_observed', 'kev_listed'],
+        affectedSectors: [],
+        affectedVendors: ['Linux kernel'],
+        evidence: [],
+        agreeingSources: ['CISA'],
+        disagreeingSources: [],
+      }],
+      exposureGraph: FULL_GRAPH,
+      now: () => NOW,
+    });
+
+    // Distant military: not in watchlist countries
+    const distantMil = militaryPosturesToSituations({
+      postures: [{
+        theaterId: 'arctic',
+        theaterName: 'Arctic',
+        posture: 'elevated',
+        postureScore: 0.4,
+        countries: ['NOR'],
+        evidence: [],
+        agreeingSources: ['NATO'],
+        disagreeingSources: [],
+      }],
+      exposureGraph: FULL_GRAPH,
+      now: () => NOW,
+    });
+
+    // Local weather: tornado warning over saved place
+    const localWx = weatherAlertsToSituations({
+      alerts: [{
+        id: 'wx-local',
+        event: 'Tornado Warning',
+        severity: 'Severe',
+        headline: 'h',
+        description: 'd',
+        areaDesc: 'La Porte',
+        onset: new Date(NOW + 10 * 60_000),
+        expires: new Date(NOW + 60 * 60_000),
+        coordinates: [],
+        centroid: [-86.7, 41.6],
+      }],
+      exposureGraph: FULL_GRAPH,
+      now: () => NOW,
+    });
+
+    [...distantCyber, ...distantMil, ...localWx].forEach((s) => store.upsert(s));
+    const top = store.ranked(1);
+    assert.equal(top[0]?.domain, 'weather', 'local weather should outrank distant cyber/military');
+  });
+});
+
+describe('Phase 2 acceptance: alerts explain the exposure reason', () => {
+  it('weather: reason names the saved place + distance', () => {
+    const [s] = weatherAlertsToSituations({
+      alerts: [{
+        id: 'wx-x',
+        event: 'Severe Thunderstorm Warning',
+        severity: 'Severe',
+        headline: 'h',
+        description: 'd',
+        areaDesc: 'La Porte',
+        onset: new Date(NOW + 30 * 60_000),
+        expires: new Date(NOW + 90 * 60_000),
+        coordinates: [],
+        centroid: [-86.7, 41.6],
+      }],
+      exposureGraph: FULL_GRAPH,
+      now: () => NOW,
+    });
+    assert.ok(s?.personalImpact.reasons[0]?.includes('La Porte'));
+    assert.match(s?.personalImpact.reasons[0] ?? '', /\d+(\.\d+)?\s*km/);
+  });
+
+  it('cyber: reason names the matched vendor', () => {
+    const [s] = cyberThreatsToSituations({
+      threats: [{
+        threatId: 'CVE-2026-X',
+        title: 'macOS bug',
+        stagesReached: ['cve_published', 'exploit_observed'],
+        affectedSectors: [],
+        affectedVendors: ['Apple macOS'],
+        evidence: [],
+        agreeingSources: ['CISA'],
+        disagreeingSources: [],
+      }],
+      exposureGraph: FULL_GRAPH,
+      now: () => NOW,
+    });
+    assert.ok(s?.personalImpact.reasons.some((r) => /Apple|vendor/i.test(r)));
+  });
+
+  it('military: reason names the matched country', () => {
+    const [s] = militaryPosturesToSituations({
+      postures: [{
+        theaterId: 'taiwan-strait',
+        theaterName: 'Taiwan Strait',
+        posture: 'strike_ready',
+        postureScore: 0.8,
+        countries: ['TWN'],
+        evidence: [],
+        agreeingSources: ['OpenSky'],
+        disagreeingSources: [],
+      }],
+      exposureGraph: FULL_GRAPH,
+      now: () => NOW,
+    });
+    assert.ok(s?.personalImpact.reasons.some((r) => /TWN/.test(r)));
+  });
+});

--- a/src/services/situations/cyber-adapter.ts
+++ b/src/services/situations/cyber-adapter.ts
@@ -15,6 +15,7 @@ import {
   type Situation,
   type SituationSeverity,
 } from './situation-types';
+import { scoreCyberExposure, type ExposureGraph } from './exposure-graph';
 
 // ── Public API ──────────────────────────────────────────────────────────
 
@@ -77,13 +78,33 @@ export interface CyberAdapterUserContext {
 
 export interface CyberAdapterInput {
   threats: readonly CyberThreatInput[];
+  /** Phase 2: full exposure graph. When present, drives userExposure
+   *  via scoreCyberExposure(). */
+  exposureGraph?: ExposureGraph;
+  /** Phase 1 fallback for callers that haven't migrated. */
   user?: CyberAdapterUserContext;
   now?: () => number;
 }
 
 export function cyberThreatsToSituations(input: CyberAdapterInput): Situation[] {
   const now = input.now ?? Date.now;
-  return (input.threats ?? []).map((t) => threatToSituation(t, input.user ?? {}, now()));
+  // Synthesize a graph from the legacy `user` input when no explicit
+  // graph is supplied — preserves Phase 1 behavior.
+  const graph: ExposureGraph = input.exposureGraph ?? {
+    savedPlaces: [],
+    watchlist: {
+      countries: [],
+      sectors: input.user?.watchedSectors ?? [],
+      tickers: [],
+      vendors: input.user?.userVendors ?? [],
+      cves: [],
+    },
+    device: {
+      osLabels: input.user?.userVendors ?? [],
+      versions: [],
+    },
+  };
+  return (input.threats ?? []).map((t) => threatToSituation(t, graph, now()));
 }
 
 // ── Internals ───────────────────────────────────────────────────────────
@@ -110,7 +131,7 @@ const CRITICAL_INFRA_SECTORS: ReadonlySet<CyberSector> = new Set([
 
 function threatToSituation(
   t: CyberThreatInput,
-  user: CyberAdapterUserContext,
+  graph: ExposureGraph,
   ts: number,
 ): Situation {
   // Take the highest stage reached as the primary score driver.
@@ -121,23 +142,24 @@ function threatToSituation(
   const hitsCriticalInfra = t.affectedSectors.some((s) => CRITICAL_INFRA_SECTORS.has(s));
   if (hitsCriticalInfra) score = Math.min(1, score + 0.1);
 
-  // User exposure: vendor or sector match → bump exposure (and score).
-  const userVendors = (user.userVendors ?? []).map((v) => v.toLowerCase());
-  const userVendorMatch = t.affectedVendors.some((v) =>
-    userVendors.some((u) => v.toLowerCase().includes(u)),
+  // Phase 2: scoreCyberExposure walks the exposure graph (device OS,
+  // vendor watchlist, sector watchlist, explicit CVE flags) and
+  // returns a (score, reasons, contributions) breakdown.
+  const exposure = scoreCyberExposure(
+    {
+      affectedVendors: t.affectedVendors,
+      affectedSectors: t.affectedSectors,
+      cveId: t.threatId,
+    },
+    graph,
   );
-  const userSectorMatch = (user.watchedSectors ?? []).some((s) => t.affectedSectors.includes(s));
-  let userExposure = 0.1;
-  const exposureReasons: string[] = [];
-  if (userVendorMatch) {
-    userExposure = Math.max(userExposure, 0.85);
-    exposureReasons.push(`Affected vendor matches user OS / software`);
-    score = Math.min(1, score + 0.1);
-  }
-  if (userSectorMatch) {
-    userExposure = Math.max(userExposure, 0.6);
-    exposureReasons.push(`Affected sector is on user watchlist`);
-  }
+  const userExposure = exposure.score;
+  const exposureReasons = [...exposure.reasons];
+  const userVendorMatch = exposure.contributions['vendor-match'] !== undefined;
+  const userSectorMatch = exposure.contributions['sector-match'] !== undefined;
+  // Vendor match also bumps the severity score (a CVE you actually
+  // run is more impactful than a CVE you don't).
+  if (userVendorMatch) score = Math.min(1, score + 0.1);
 
   const severity: SituationSeverity = severityFromScore(score);
 

--- a/src/services/situations/exposure-graph.ts
+++ b/src/services/situations/exposure-graph.ts
@@ -1,0 +1,284 @@
+/* eslint-disable sonarjs/cognitive-complexity */
+/**
+ * Personal Exposure Graph — Phase 2 of
+ * docs/CLAUDE_HIGH_IMPACT_EVENT_INTELLIGENCE_VISION_2026-04-29.md.
+ *
+ * Aggregates the user's "world" — saved places, watchlisted countries
+ * / companies / sectors, current device OS — into a single read-only
+ * structure that adapters score situations against.
+ *
+ * Pure deterministic. No DOM, no fetch. Adapters call
+ * `scoreExposure()` to get a (score, reasons) breakdown, replacing
+ * Phase 1's adapter-internal radial-distance heuristics.
+ *
+ * The graph is fed by the host loop via `setExposureGraph(...)` —
+ * this module is type+score logic only, no global state at import
+ * time except a singleton accessor for app code to read.
+ */
+
+import type { CyberSector } from './cyber-adapter';
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+export interface ExposureSavedPlace {
+  id: string;
+  name: string;
+  lat: number;
+  lon: number;
+  /** Tags from the saved-places module — 'home', 'work', 'family',
+   *  etc. Used for prioritization (home > work > travel). */
+  tags: readonly string[];
+  /** Whether this is the user's primary place. */
+  primary: boolean;
+}
+
+export interface ExposureWatchlist {
+  /** ISO 3166-1 alpha-3 codes. */
+  countries: readonly string[];
+  /** Free-form sector tags ('finance', 'power_grid', 'consumer_software', ...). */
+  sectors: readonly string[];
+  /** Stock tickers. */
+  tickers: readonly string[];
+  /** Vendor names — 'Apple', 'Microsoft', etc. — for cyber matching. */
+  vendors: readonly string[];
+  /** CVE ids the user has explicitly flagged. */
+  cves: readonly string[];
+}
+
+export interface ExposureDevice {
+  /** OS labels the user runs — 'macOS', 'iOS', 'Windows', 'Linux'. */
+  osLabels: readonly string[];
+  /** Major-version hints for cyber matching ('macOS 14', 'iOS 17'). */
+  versions: readonly string[];
+}
+
+export interface ExposureGraph {
+  savedPlaces: readonly ExposureSavedPlace[];
+  watchlist: ExposureWatchlist;
+  device: ExposureDevice;
+  /** Optional current location for "near me" exposure. */
+  currentLocation?: { lat: number; lon: number };
+}
+
+/** Score with reasons breakdown — consumed by adapters. */
+export interface ExposureScore {
+  /** 0..1 raw exposure score. */
+  score: number;
+  /** Plain-English reasons exposure is non-zero, sorted by weight. */
+  reasons: readonly string[];
+  /** Per-rule score contributions for the diagnostics trace. */
+  contributions: Readonly<Record<string, number>>;
+}
+
+// ── Singleton wiring ────────────────────────────────────────────────────
+
+const EMPTY_GRAPH: ExposureGraph = {
+  savedPlaces: [],
+  watchlist: { countries: [], sectors: [], tickers: [], vendors: [], cves: [] },
+  device: { osLabels: [], versions: [] },
+};
+
+let currentGraph: ExposureGraph = EMPTY_GRAPH;
+
+/** Host loop calls this to install the user's exposure data. The
+ *  graph is replaced wholesale — no merging — so callers should
+ *  always pass the complete current state. */
+export function setExposureGraph(graph: ExposureGraph): void {
+  currentGraph = graph;
+}
+
+/** Read the current graph. Adapters call this when score functions
+ *  weren't given an explicit graph parameter. */
+export function getExposureGraph(): ExposureGraph {
+  return currentGraph;
+}
+
+/** Reset to empty. Tests + storybook only. */
+export function resetExposureGraphForTests(): void {
+  currentGraph = EMPTY_GRAPH;
+}
+
+// ── Geo exposure scoring ────────────────────────────────────────────────
+
+/** Compute exposure for a geographic event — weather alert, military
+ *  theater, regional cyber outage. Caller passes the event's centroid
+ *  (or current location); the helper finds the closest saved place /
+ *  current-location and grades exposure on a haversine-distance ladder.
+ *
+ *  Bands (km radius from the event centroid):
+ *    < 25 km  → severe (0.95)
+ *    < 80 km  → high   (0.6)
+ *    < 200 km → medium (0.25)
+ *    further  → low    (0.1)
+ *  Home/primary saved place adds +0.05 to the band score (capped at 1).
+ *  Currentlocation match wins over saved-place match by 0.05.
+ */
+export function scoreGeoExposure(
+  centroid: { lat: number; lon: number } | undefined,
+  graph: ExposureGraph = currentGraph,
+): ExposureScore {
+  if (!centroid) {
+    return {
+      score: 0.1,
+      reasons: [],
+      contributions: { 'no-centroid': 0.1 },
+    };
+  }
+
+  const reasons: string[] = [];
+  const contributions: Record<string, number> = {};
+  let score = 0.1;
+
+  // Saved places — find the closest match, prefer home/primary.
+  for (const place of graph.savedPlaces) {
+    const km = haversineKm(centroid.lat, centroid.lon, place.lat, place.lon);
+    const band = bandFromKm(km);
+    if (band === 0) continue;
+    const isPrimary = place.primary || place.tags.includes('home');
+    const placeScore = Math.min(1, band + (isPrimary ? 0.05 : 0));
+    if (placeScore > score) {
+      score = placeScore;
+      const km100 = Math.round(km * 10) / 10;
+      const tagLabel = place.tags[0] ? ` (${place.tags[0]})` : '';
+      reasons.unshift(`${place.name}${tagLabel} ${km100} km from event`);
+      contributions[`place:${place.id}`] = placeScore;
+    } else if (band >= 0.6) {
+      // Still record secondary nearby places as additional reasons.
+      const km100 = Math.round(km * 10) / 10;
+      reasons.push(`${place.name} ${km100} km from event`);
+    }
+  }
+
+  // Current location — the user is literally there. Wins ties with
+  // saved places (>=) since "I'm at this exact spot" is more
+  // actionable than "this is one of my saved places."
+  if (graph.currentLocation) {
+    const km = haversineKm(centroid.lat, centroid.lon, graph.currentLocation.lat, graph.currentLocation.lon);
+    const band = bandFromKm(km);
+    if (band > 0) {
+      const liveScore = Math.min(1, band + 0.05);
+      if (liveScore >= score) {
+        score = liveScore;
+        const km100 = Math.round(km * 10) / 10;
+        reasons.unshift(`Current location ${km100} km from event`);
+        contributions['current-location'] = liveScore;
+      }
+    }
+  }
+
+  return {
+    score,
+    reasons: reasons.slice(0, 5),
+    contributions,
+  };
+}
+
+// ── Cyber exposure scoring ──────────────────────────────────────────────
+
+export interface CyberExposureInput {
+  affectedVendors: readonly string[];
+  affectedSectors: readonly CyberSector[];
+  cveId?: string;
+}
+
+/** Compute exposure for a cyber threat — match affected vendors
+ *  against the user's device OS, affected sectors against the
+ *  watchlist, and CVE id against any explicitly-flagged CVEs. */
+export function scoreCyberExposure(
+  input: CyberExposureInput,
+  graph: ExposureGraph = currentGraph,
+): ExposureScore {
+  const reasons: string[] = [];
+  const contributions: Record<string, number> = {};
+  let score = 0.1;
+
+  // Vendor / OS match — strongest signal.
+  const userOs = graph.device.osLabels.map((s) => s.toLowerCase());
+  const userVendors = graph.watchlist.vendors.map((s) => s.toLowerCase());
+  const matchedVendor = input.affectedVendors.find((v) => {
+    const lower = v.toLowerCase();
+    return userOs.some((o) => lower.includes(o)) || userVendors.some((u) => lower.includes(u));
+  });
+  if (matchedVendor) {
+    score = Math.max(score, 0.85);
+    reasons.unshift(`Affected vendor ${matchedVendor} matches your OS / watched vendors`);
+    contributions['vendor-match'] = 0.85;
+  }
+
+  // Sector match — medium signal.
+  const watchedSectors = new Set(graph.watchlist.sectors);
+  const matchedSector = input.affectedSectors.find((s) => watchedSectors.has(s));
+  if (matchedSector) {
+    score = Math.max(score, 0.6);
+    reasons.push(`Affected sector ${matchedSector} is on your watchlist`);
+    contributions['sector-match'] = 0.6;
+  }
+
+  // CVE id match — explicit flag → severe.
+  if (input.cveId && graph.watchlist.cves.includes(input.cveId)) {
+    score = 1;
+    reasons.unshift(`CVE ${input.cveId} is on your watchlist`);
+    contributions['cve-match'] = 1;
+  }
+
+  return {
+    score,
+    reasons,
+    contributions,
+  };
+}
+
+// ── Country exposure scoring ────────────────────────────────────────────
+
+/** Compute exposure for a country-tagged event (military theater,
+ *  diplomatic incident, etc.). */
+export function scoreCountryExposure(
+  countries: readonly string[],
+  graph: ExposureGraph = currentGraph,
+): ExposureScore {
+  if (countries.length === 0) {
+    return { score: 0.1, reasons: [], contributions: {} };
+  }
+  const watched = new Set(graph.watchlist.countries.map((c) => c.toUpperCase()));
+  const matched = countries.filter((c) => watched.has(c.toUpperCase()));
+  if (matched.length === 0) {
+    return { score: 0.1, reasons: [], contributions: { 'no-country-match': 0.1 } };
+  }
+  // Multiple matches → higher exposure.
+  const score = Math.min(0.85, 0.5 + 0.1 * matched.length);
+  return {
+    score,
+    reasons: matched.map((c) => `${c} is on your country watchlist`),
+    contributions: { 'country-match': score },
+  };
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function bandFromKm(km: number): number {
+  if (km < 25) return 0.95;
+  if (km < 80) return 0.6;
+  if (km < 200) return 0.25;
+  return 0;
+}
+
+function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLon = ((lon2 - lon1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+/** Convenience: convert raw exposure score to the personalImpact level. */
+export function exposureToLevel(score: number): 'none' | 'low' | 'medium' | 'high' | 'severe' {
+  if (score >= 0.85) return 'severe';
+  if (score >= 0.6) return 'high';
+  if (score >= 0.35) return 'medium';
+  if (score >= 0.15) return 'low';
+  return 'none';
+}

--- a/src/services/situations/military-adapter.ts
+++ b/src/services/situations/military-adapter.ts
@@ -16,6 +16,11 @@ import {
   type Situation,
   type SituationSeverity,
 } from './situation-types';
+import {
+  scoreCountryExposure,
+  scoreGeoExposure,
+  type ExposureGraph,
+} from './exposure-graph';
 
 // ── Public API ──────────────────────────────────────────────────────────
 
@@ -37,6 +42,13 @@ export interface TheaterPostureInput {
   postureScore: number;
   /** 0..1 prior score, so whatChanged can show direction. */
   priorScore?: number;
+  /** Optional theater coordinates so the geo exposure scorer can
+   *  match against saved places + current location. */
+  centroid?: { lat: number; lon: number };
+  /** Optional ISO 3166-1 alpha-3 country codes the theater spans
+   *  (e.g. ['CHN','TWN'] for the Taiwan Strait). Drives country-watchlist
+   *  exposure matching. */
+  countries?: readonly string[];
   /** Source-attributed evidence rows from the host's threat-convergence
    *  / escalation-forecast / military-flights pipelines. */
   evidence: readonly {
@@ -57,19 +69,28 @@ export interface TheaterPostureInput {
 
 export interface MilitaryAdapterInput {
   postures: readonly TheaterPostureInput[];
-  /** Optional saved-place coordinates — reserved for Phase 2 user
-   *  exposure (e.g. travel risk near a specific theater). Phase 1
-   *  uses presence-only as a small exposure bump. */
+  /** Phase 2: full exposure graph. When present, drives userExposure
+   *  via scoreGeoExposure() (saved-place proximity to theater centroid)
+   *  + scoreCountryExposure() (country watchlist match). */
+  exposureGraph?: ExposureGraph;
+  /** Phase 1 fallback for callers that haven't migrated. */
   savedPlaces?: readonly { id: string; name: string; lat: number; lon: number }[];
   now?: () => number;
 }
 
 export function militaryPosturesToSituations(input: MilitaryAdapterInput): Situation[] {
   const now = input.now ?? Date.now;
+  const graph: ExposureGraph = input.exposureGraph ?? {
+    savedPlaces: (input.savedPlaces ?? []).map((p) => ({
+      id: p.id, name: p.name, lat: p.lat, lon: p.lon, tags: [], primary: false,
+    })),
+    watchlist: { countries: [], sectors: [], tickers: [], vendors: [], cves: [] },
+    device: { osLabels: [], versions: [] },
+  };
   return (input.postures ?? [])
     // Filter out 'normal' postures — they don't make the high-impact list.
     .filter((p) => p.posture !== 'normal')
-    .map((p) => postureToSituation(p, input.savedPlaces ?? [], now()));
+    .map((p) => postureToSituation(p, graph, now()));
 }
 
 // ── Internals ───────────────────────────────────────────────────────────
@@ -84,7 +105,7 @@ const POSTURE_SCORE_FLOOR: Record<TheaterPosture, number> = {
 
 function postureToSituation(
   p: TheaterPostureInput,
-  savedPlaces: readonly { id: string; name: string; lat: number; lon: number }[],
+  graph: ExposureGraph,
   ts: number,
 ): Situation {
   // The score floor enforces that 'strike_ready' lands at least
@@ -109,10 +130,14 @@ function postureToSituation(
   const independentSources = new Set(p.agreeingSources).size;
   const confidence = Math.min(0.95, 0.5 + 0.1 * independentSources);
 
-  // Phase 1 user exposure: presence of saved places gives a small
-  // bump (the user has *something* to lose). Phase 2 will reason
-  // about specific exposure (travel route, watchlisted ticker, etc.).
-  const userExposure = savedPlaces.length > 0 ? 0.25 : 0.1;
+  // Phase 2: combine geo (saved place near theater) + country
+  // (theater country on user watchlist). Take the max so a watched
+  // country alone produces meaningful exposure even when the user
+  // has no nearby saved places.
+  const geoExposure = scoreGeoExposure(p.centroid, graph);
+  const countryExposure = scoreCountryExposure(p.countries ?? [], graph);
+  const userExposure = Math.max(geoExposure.score, countryExposure.score);
+  const exposureReasons = [...geoExposure.reasons, ...countryExposure.reasons];
 
   const direction = typeof p.priorScore === 'number'
     ? (p.postureScore - p.priorScore > 0.05 ? 'rising' : p.postureScore - p.priorScore < -0.05 ? 'falling' : 'steady')
@@ -157,13 +182,17 @@ function postureToSituation(
     urgency,
     userExposure,
     personalImpact: {
-      summary: severity === 'critical' || severity === 'emergency'
+      summary: exposureReasons.length > 0
+        ? exposureReasons[0] ?? 'Watchlist exposure'
+        : severity === 'critical' || severity === 'emergency'
         ? 'May affect travel, fuel prices, and shipping if escalation continues.'
         : 'Indirect exposure: market and commodity volatility possible.',
-      level: severity === 'emergency' ? 'high' : severity === 'critical' ? 'medium' : 'low',
-      reasons: severity === 'critical' || severity === 'emergency'
-        ? ['Theater posture meets strike-readiness threshold']
-        : [],
+      level: userExposure >= 0.85 ? 'severe' : userExposure >= 0.6 ? 'high' : userExposure >= 0.35 ? 'medium' : 'low',
+      reasons: exposureReasons.length > 0
+        ? exposureReasons
+        : (severity === 'critical' || severity === 'emergency'
+          ? ['Theater posture meets strike-readiness threshold']
+          : []),
     },
     evidence: p.evidence,
     sourceAgreement: {
@@ -195,9 +224,9 @@ function postureToSituation(
       createdReason: `Theater ${p.theaterId} posture is '${p.posture}' (score ${p.postureScore.toFixed(2)})`,
       severityRationale: `Posture floor ${floor.toFixed(2)} + raw score ${p.postureScore.toFixed(2)} → max ${score.toFixed(2)} → tier '${severity}'`,
       confidenceRationale: `${independentSources} independent agreeing source(s) → confidence ${confidence.toFixed(2)}`,
-      exposureRationale: savedPlaces.length > 0
-        ? 'Saved-place presence gives a small exposure bump (Phase 2 will refine)'
-        : 'No saved places — minimal user exposure',
+      exposureRationale: exposureReasons.length > 0
+        ? `Personal exposure graph: ${exposureReasons.join('; ')}`
+        : 'No saved-place proximity or country watchlist match — minimal user exposure',
       sourceContributions: Object.fromEntries(
         p.agreeingSources.map((s) => [s, 1 / Math.max(1, p.agreeingSources.length)]),
       ),

--- a/src/services/situations/weather-adapter.ts
+++ b/src/services/situations/weather-adapter.ts
@@ -20,13 +20,24 @@ import {
   type Situation,
   type SituationSeverity,
 } from './situation-types';
+import {
+  exposureToLevel,
+  scoreGeoExposure,
+  type ExposureGraph,
+} from './exposure-graph';
 
 // ── Public API ──────────────────────────────────────────────────────────
 
 export interface WeatherAdapterInput {
   alerts: readonly WeatherAlert[];
-  /** Optional saved-place coordinates for Phase 2 user-exposure
-   *  scoring. Phase 1 uses this only when present to bump exposure. */
+  /**
+   * Phase 2: Personal Exposure Graph drives userExposure.
+   * Pass the user's full graph (saved places, current location).
+   * Phase 1's standalone savedPlaces input remains for back-compat
+   * — when both are present, the graph wins.
+   */
+  exposureGraph?: ExposureGraph;
+  /** Phase 1 fallback for callers that haven't migrated to the graph. */
   savedPlaces?: readonly { id: string; name: string; lat: number; lon: number }[];
   /** Optional clock for tests. */
   now?: () => number;
@@ -37,7 +48,21 @@ export interface WeatherAdapterInput {
 export function weatherAlertsToSituations(input: WeatherAdapterInput): Situation[] {
   const now = input.now ?? Date.now;
   const alerts = input.alerts ?? [];
-  return alerts.map((alert) => alertToSituation(alert, input.savedPlaces ?? [], now()));
+  // If an exposure graph is supplied, use it. Otherwise synthesize a
+  // minimal one from the legacy savedPlaces input.
+  const graph: ExposureGraph = input.exposureGraph ?? {
+    savedPlaces: (input.savedPlaces ?? []).map((p) => ({
+      id: p.id,
+      name: p.name,
+      lat: p.lat,
+      lon: p.lon,
+      tags: [],
+      primary: false,
+    })),
+    watchlist: { countries: [], sectors: [], tickers: [], vendors: [], cves: [] },
+    device: { osLabels: [], versions: [] },
+  };
+  return alerts.map((alert) => alertToSituation(alert, graph, now()));
 }
 
 // ── Internals ───────────────────────────────────────────────────────────
@@ -52,7 +77,7 @@ const NWS_TO_SCORE: Record<WeatherAlert['severity'], number> = {
 
 function alertToSituation(
   alert: WeatherAlert,
-  savedPlaces: readonly { id: string; name: string; lat: number; lon: number }[],
+  graph: ExposureGraph,
   ts: number,
 ): Situation {
   const score = NWS_TO_SCORE[alert.severity] ?? 0.2;
@@ -64,9 +89,16 @@ function alertToSituation(
   // Linear ramp: 0 min → 1.0 urgency, 60+ min → 0.3 urgency.
   const urgency = clamp01(1 - minutesToOnset / 90);
 
-  // Phase 1 user-exposure: simple distance check vs saved places.
-  // Phase 2 will use polygon-match + watchlist + travel routes.
-  const { exposure, exposureReasons } = computeWeatherExposure(alert, savedPlaces);
+  // Phase 2: scoreGeoExposure walks the full ExposureGraph (saved
+  // places + current location) and returns a (score, reasons,
+  // contributions) breakdown. Phase 3 will swap radial distance for
+  // polygon-match using the existing weather/nws-polygon-match
+  // service.
+  const exposureScore = alert.centroid
+    ? scoreGeoExposure({ lat: alert.centroid[1], lon: alert.centroid[0] }, graph)
+    : { score: 0.1, reasons: [], contributions: { 'no-centroid': 0.1 } };
+  const exposure = exposureScore.score;
+  const exposureReasons = exposureScore.reasons;
 
   const evidence = [
     {
@@ -129,7 +161,7 @@ function alertToSituation(
     userExposure: exposure,
     personalImpact: {
       summary: exposureReasons.length > 0
-        ? `Affects ${savedPlaces.length > 0 ? 'a saved place' : 'your area'}`
+        ? `Affects ${exposureReasons[0]?.includes('Current location') ? 'your current location' : 'a saved place'}`
         : 'No direct exposure detected',
       level: exposureToLevel(exposure),
       reasons: exposureReasons,
@@ -154,8 +186,8 @@ function alertToSituation(
       severityRationale: `NWS severity '${alert.severity}' → score ${score.toFixed(2)} → tier '${severity}'`,
       confidenceRationale: 'NWS is the authoritative source for US weather alerts (baseline 0.9).',
       exposureRationale: exposureReasons.length > 0
-        ? `Saved place(s) within proximity radius: ${exposureReasons.join('; ')}`
-        : 'No saved places within proximity radius — exposure scored from severity only.',
+        ? `Personal exposure graph: ${exposureReasons.join('; ')}`
+        : 'No saved places or current location within proximity radius — exposure scored as baseline (0.1).',
       sourceContributions: { NWS: 1.0 },
       thresholdsCrossed: [`severity:${severity}`, `urgency:${urgency.toFixed(2)}`],
     },
@@ -166,54 +198,8 @@ function alertToSituation(
   };
 }
 
-/** Phase 1 user-exposure: cheap radial proximity. Phase 2 will use
- *  the existing polygon-match service. */
-function computeWeatherExposure(
-  alert: WeatherAlert,
-  savedPlaces: readonly { id: string; name: string; lat: number; lon: number }[],
-): { exposure: number; exposureReasons: string[] } {
-  if (savedPlaces.length === 0 || !alert.centroid) {
-    return { exposure: 0.1, exposureReasons: [] };
-  }
-  const reasons: string[] = [];
-  let maxExposure = 0.1;
-  for (const place of savedPlaces) {
-    const km = haversineKm(alert.centroid[1], alert.centroid[0], place.lat, place.lon);
-    if (km < 25) {
-      maxExposure = Math.max(maxExposure, 0.95);
-      reasons.push(`${place.name} within 25 km of alert centroid`);
-    } else if (km < 80) {
-      maxExposure = Math.max(maxExposure, 0.6);
-      reasons.push(`${place.name} within 80 km of alert centroid`);
-    } else if (km < 200) {
-      maxExposure = Math.max(maxExposure, 0.25);
-    }
-  }
-  return { exposure: maxExposure, exposureReasons: reasons };
-}
-
-function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
-  const R = 6371;
-  const dLat = ((lat2 - lat1) * Math.PI) / 180;
-  const dLon = ((lon2 - lon1) * Math.PI) / 180;
-  const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos((lat1 * Math.PI) / 180) *
-      Math.cos((lat2 * Math.PI) / 180) *
-      Math.sin(dLon / 2) ** 2;
-  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-}
-
 function clamp01(n: number): number {
   if (n < 0) return 0;
   if (n > 1) return 1;
   return n;
-}
-
-function exposureToLevel(exposure: number): 'none' | 'low' | 'medium' | 'high' | 'severe' {
-  if (exposure >= 0.85) return 'severe';
-  if (exposure >= 0.6) return 'high';
-  if (exposure >= 0.35) return 'medium';
-  if (exposure >= 0.15) return 'low';
-  return 'none';
 }


### PR DESCRIPTION
Phase 2 of `docs/CLAUDE_HIGH_IMPACT_EVENT_INTELLIGENCE_VISION_2026-04-29.md`.

Adds the shared exposure graph and refactors all three Phase 1 adapters to use it. Replaces per-adapter ad-hoc heuristics with one consistent scoring surface.

## What's new

`exposure-graph.ts` exposes:
- `ExposureGraph` — savedPlaces + watchlist (countries/sectors/tickers/vendors/cves) + device (osLabels/versions) + optional currentLocation
- `scoreGeoExposure(centroid, graph)` — haversine ladder; currentLocation wins ties
- `scoreCyberExposure({vendors, sectors, cveId}, graph)` — vendor 0.85, sector 0.6, explicit CVE on watchlist 1.0
- `scoreCountryExposure(countries, graph)` — single match 0.6, multi-match up to 0.85
- `exposureToLevel(score)` — 5-tier mapping
- `setExposureGraph / getExposureGraph` singleton accessors

Adapter changes:
- **weather-adapter**: drops per-adapter haversine + tier code; calls `scoreGeoExposure`. exposureRationale now reads *'Personal exposure graph: <reasons>'*
- **cyber-adapter**: drops per-adapter vendor/sector matching; calls `scoreCyberExposure`. Adds CVE-watchlist match path
- **military-adapter**: previously bumped exposure on presence-of-saved-places. Now combines geo (saved place near theater centroid) + country (theater country in watchlist), takes the max so a watched country alone produces meaningful exposure

## Verification

- typecheck → 0 errors
- **100 deterministic tests pass** across 8 test files (74 existing Phase 1 + 26 new)
- panel smoke unchanged (no UI changes)

## Acceptance criteria

| | Status |
|---|---|
| Every situation has a user exposure score | ✅ adapters populate from the graph |
| User-exposed events rank above distant global noise | ✅ proven by exposure-integration.test.mts |
| Alerts explain the exposure reason | ✅ personalImpact.reasons + diagnosticsTrace.exposureRationale both name the match |

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>