### PR TITLE
feat(faa-cams): play recent timelapse loop when a camera is selected

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -3361,12 +3361,18 @@ async function dispatch(requestUrl, req, routes, context) {
   // weathercams.faa.gov `/api/cameras/{id}/images/last/N` endpoint
   // returns metadata + an `imageUri` pointing at the
   // images.wcams-static.faa.gov CDN.
+  //
+  // Optional ?count=N (1-24) returns a frames[] array for client-side
+  // timelapse playback ("video"). Default count=1 preserves the
+  // single-image contract the panel previously used.
   if (requestUrl.pathname === '/api/faa-camera-image') {
  const cameraId = (requestUrl.searchParams.get('cameraId') ?? '').replace(/\D/g, '');
  if (!cameraId) return json({ error: 'cameraId required' }, 400);
+ const rawCount = Number.parseInt(requestUrl.searchParams.get('count') ?? '1', 10);
+ const count = Number.isFinite(rawCount) ? Math.max(1, Math.min(24, rawCount)) : 1;
  try {
  const resp = await fetchWithTimeout(
- `https://weathercams.faa.gov/api/cameras/${cameraId}/images/last/1`,
+ `https://weathercams.faa.gov/api/cameras/${cameraId}/images/last/${count}`,
  {
  headers: {
  Accept: 'application/json',
@@ -3377,17 +3383,25 @@ async function dispatch(requestUrl, req, routes, context) {
  },
  10000,
  );
- if (!resp.ok) return json({ imageUrl: null, degraded: true, reason: `weathercams returned ${resp.status}` });
+ if (!resp.ok) return json({ imageUrl: null, frames: [], degraded: true, reason: `weathercams returned ${resp.status}` });
  const raw = await resp.json();
- const item = Array.isArray(raw?.payload) ? raw.payload[0] : null;
- if (!item?.imageUri) return json({ imageUrl: null, degraded: true, reason: 'No recent image for this camera' });
+ const items = Array.isArray(raw?.payload) ? raw.payload : [];
+ if (items.length === 0 || !items[0]?.imageUri) {
+ return json({ imageUrl: null, frames: [], degraded: true, reason: 'No recent image for this camera' });
+ }
+ // Frames are oldest → newest for natural timelapse playback.
+ const frames = items
+ .filter((it) => typeof it?.imageUri === 'string')
+ .map((it) => ({ imageUrl: it.imageUri, imageDatetime: it.imageDatetime }))
+ .reverse();
  return json({
- imageUrl: item.imageUri,
- imageDatetime: item.imageDatetime,
+ imageUrl: items[0].imageUri,            // back-compat: latest single image
+ imageDatetime: items[0].imageDatetime,  // back-compat
+ frames,                                 // new: timelapse loop
  cameraId,
  });
  } catch (error) {
- return json({ imageUrl: null, degraded: true, reason: `image lookup failed: ${error?.message ?? error}` });
+ return json({ imageUrl: null, frames: [], degraded: true, reason: `image lookup failed: ${error?.message ?? error}` });
  }
   }
 

--- a/src/components/FAAWeatherCamsPanel.ts
+++ b/src/components/FAAWeatherCamsPanel.ts
@@ -11,6 +11,13 @@ export class FAAWeatherCamsPanel extends Panel {
   private alertOnly = false;
   private selectedCam: ScoredFAACamera | null = null;
   private digestText: string | null = null;
+  // Timelapse / "video" playback state — frames pulled lazily when
+  // user clicks Play loop on the selected camera. Frames are
+  // ordered oldest → newest so we can step forward through them.
+  private loopFrames: { imageUrl: string; imageDatetime?: string }[] = [];
+  private loopIndex = 0;
+  private loopTimer: ReturnType<typeof setInterval> | null = null;
+  private loopCameraId: string | null = null;
 
   constructor() {
  super({ id: 'faa-weather-cams', title: 'FAA Weather Cams', className: 'panel-wide' });
@@ -117,7 +124,18 @@ export class FAAWeatherCamsPanel extends Panel {
  for (const td of [tdName, tdLoc, tdAlert, tdScore, tdTime]) tr.append(td);
 
  tr.addEventListener('click', () => {
- this.selectedCam = this.selectedCam?.id === cam.id ? null : cam;
+ const newSelection = this.selectedCam?.id === cam.id ? null : cam;
+ // Pause any running loop when the user changes selection /
+ // closes the viewer. Reset frames so a fresh selection starts
+ // from a clean state.
+ const newSelectionId = newSelection ? newSelection.id : null;
+ if (newSelectionId !== this.loopCameraId) {
+ this._pauseLoop();
+ this.loopCameraId = null;
+ this.loopFrames = [];
+ this.loopIndex = 0;
+ }
+ this.selectedCam = newSelection;
  // The sidecar returns imageUrl='/api/faa-camera-image?...' as a
  // resolver pointer, not a direct CDN URL. Lazy-resolve here so
  // each click only spends one upstream call (the 927-camera
@@ -165,10 +183,48 @@ export class FAAWeatherCamsPanel extends Panel {
 
  const img = document.createElement('img');
  img.className = 'faa-cam-image';
+ // When the loop is playing for this camera, src is the current
+ // frame; otherwise it's the latest single image with a cache
+ // buster so reopening the panel shows fresh data.
+ if (this.loopCameraId === cam.id && this.loopFrames.length > 0) {
+ const frame = this.loopFrames[this.loopIndex];
+ if (frame) img.src = frame.imageUrl;
+ } else {
  const epoch = new Date(cam.lastUpdated).getTime();
  img.src = `${cam.imageUrl}${cam.imageUrl.includes('?') ? '&' : '?'}t=${epoch}`;
+ }
  img.alt = cam.name;
  img.loading = 'lazy';
+
+ // Frame indicator (shown only while a loop is playing).
+ const frameLabel = document.createElement('div');
+ frameLabel.className = 'faa-cam-frame-label';
+ if (this.loopCameraId === cam.id && this.loopFrames.length > 0) {
+ const total = this.loopFrames.length;
+ const frame = this.loopFrames[this.loopIndex];
+ const ts = frame?.imageDatetime ? new Date(frame.imageDatetime).toLocaleTimeString() : '';
+ frameLabel.textContent = `Frame ${this.loopIndex + 1} / ${total}${ts ? ' · ' + ts : ''}`;
+ }
+
+ // Controls row: Play loop / Pause + Analyze conditions.
+ const controls = document.createElement('div');
+ controls.className = 'faa-cam-controls';
+
+ const loopBtn = document.createElement('button');
+ loopBtn.className = 'faa-loop-btn';
+ const isPlayingThisCam = this.loopCameraId === cam.id && this.loopTimer !== null;
+ const hasPausedLoopForThisCam = this.loopCameraId === cam.id && this.loopFrames.length > 0;
+ if (isPlayingThisCam) {
+ loopBtn.textContent = '⏸ Pause loop';
+ } else if (hasPausedLoopForThisCam) {
+ loopBtn.textContent = '▶ Resume loop';
+ } else {
+ loopBtn.textContent = '▶ Play recent loop';
+ }
+ loopBtn.addEventListener('click', () => {
+ if (isPlayingThisCam) this._pauseLoop();
+ else void this._playLoop(cam);
+ });
 
  const analyzeBtn = document.createElement('button');
  analyzeBtn.className = 'faa-analyze-btn';
@@ -176,10 +232,72 @@ export class FAAWeatherCamsPanel extends Panel {
  analyzeBtn.disabled = !!cam.aiConditions;
  analyzeBtn.addEventListener('click', () => { void this._analyzeCamera(cam, analyzeBtn); });
 
+ controls.append(loopBtn);
+ controls.append(analyzeBtn);
+
  div.append(header);
  div.append(img);
- div.append(analyzeBtn);
+ if (frameLabel.textContent) div.append(frameLabel);
+ div.append(controls);
  return div;
+  }
+
+  /** Fetch the last 12 frames for the camera and start a 1-second
+   *  cycle through them. Reuses already-loaded frames if the user
+   *  clicks Play / Pause / Play. */
+  private async _playLoop(cam: ScoredFAACamera): Promise<void> {
+ // Different camera → reset state.
+ if (this.loopCameraId !== cam.id) {
+ this._pauseLoop();
+ this.loopFrames = [];
+ this.loopIndex = 0;
+ this.loopCameraId = cam.id;
+ }
+ // Lazy-fetch frames the first time.
+ if (this.loopFrames.length === 0) {
+ try {
+ // Strip leading `/api/` and the resolver pointer so we hit
+ // the count=12 path against the canonical sidecar route.
+ const url = `${getApiBaseUrl()}/api/faa-camera-image?cameraId=${encodeURIComponent(cam.id)}&count=12`;
+ const res = await fetch(url, { signal: AbortSignal.timeout(15_000) });
+ if (!res.ok) throw new Error(`HTTP ${res.status}`);
+ const data = await res.json() as {
+ frames?: { imageUrl: string; imageDatetime?: string }[];
+ imageUrl?: string;
+ degraded?: boolean;
+ reason?: string;
+ };
+ if (data.degraded || !data.frames || data.frames.length === 0) {
+ // Fall back to the single latest image — at least the user
+ // sees something change rather than a silent no-op.
+ if (data.imageUrl) {
+ this.loopFrames = [{ imageUrl: data.imageUrl }];
+ } else {
+ return;
+ }
+ } else {
+ this.loopFrames = data.frames;
+ }
+ } catch {
+ return;
+ }
+ }
+ this.loopIndex = 0;
+ this.render();
+ // 1-second cadence works well for FAA's typical 5-min image
+ // interval — 12 frames cover roughly an hour.
+ this.loopTimer = setInterval(() => {
+ if (this.loopFrames.length === 0) return;
+ this.loopIndex = (this.loopIndex + 1) % this.loopFrames.length;
+ this.render();
+ }, 1000);
+  }
+
+  private _pauseLoop(): void {
+ if (this.loopTimer !== null) {
+ clearInterval(this.loopTimer);
+ this.loopTimer = null;
+ }
   }
 
   private async _analyzeCamera(cam: ScoredFAACamera, btn: HTMLButtonElement): Promise<void> {


### PR DESCRIPTION
**User request:** 'when I click on a camera, I need to be able to get video somewhere from these cams.'

The FAA WeatherCams API doesn't stream live video — it publishes a new still every 5–10 minutes. The closest equivalent to 'video' is a timelapse of the most recent frames. This PR wires that.

## Sidecar changes

`/api/faa-camera-image` gains an optional `?count=N` query param (1–24, default 1):
- When `count > 1`, fetches the last N images from `weathercams.faa.gov/api/cameras/<id>/images/last/N` and returns them as a `frames[]` array (oldest → newest, ready for forward playback).
- The single-image contract is preserved as `imageUrl + imageDatetime` so the existing static-image render path is unchanged.

## Panel changes

The selected-camera viewer in `FAAWeatherCamsPanel` gains a **Play recent loop** button next to **Analyze conditions**:
- First click fetches up to 12 frames (~1 hour at the typical 5-min image cadence) and starts a 1-second cycle through them.
- **Pause / Resume** control the timer without re-fetching frames.
- Selecting a different camera or closing the viewer cancels the loop + clears frame state.
- Frame indicator shows `Frame N / 12 · HH:MM:SS`.
- Falls back to the single latest image if the loop fetch returns degraded.

## Verification

- typecheck → 0 errors
- panel smoke → exit 0, 234 tests pass
- touched-file lint clean

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Cross-agent review: Claude self-review on 2026-04-29; outcome: pass
