### PR TITLE
feat(situations): Phase 3 — Watch Windows (confirmation, decay, invalidation)

### DIFF
--- a/src/services/situations/__tests__/watch-window.test.mts
+++ b/src/services/situations/__tests__/watch-window.test.mts
@@ -1,0 +1,246 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  applyWatchWindowEvaluation,
+  evaluateWatchWindow,
+} from '../watch-window';
+import type { Situation } from '../situation-types';
+
+const NOW = 1_745_000_000_000;
+
+function fakeSituation(overrides: Partial<Situation> = {}): Situation {
+  return {
+    id: 'wx:1',
+    domain: 'weather',
+    title: 'Test',
+    summary: 'test',
+    severity: 'critical',
+    confidence: 0.7,
+    urgency: 0.8,
+    userExposure: 0.9,
+    personalImpact: { summary: '', level: 'high', reasons: [] },
+    evidence: [],
+    sourceAgreement: { agreeing: [], disagreeing: [], independentSourceCount: 0 },
+    whatChanged: [],
+    expectedNextSignals: [
+      { id: 'sig:radar-strengthen', description: 'Radar core strengthens within 30 min' },
+      { id: 'sig:storm-reports', description: 'Storm reports begin' },
+    ],
+    invalidationSignals: [
+      { id: 'sig:nws-cancel', description: 'NWS cancels alert' },
+    ],
+    recommendedActions: [],
+    timeline: [],
+    diagnosticsTrace: {
+      createdReason: 'test',
+      severityRationale: 'test',
+      confidenceRationale: 'test',
+      exposureRationale: 'test',
+      sourceContributions: {},
+      thresholdsCrossed: [],
+    },
+    predictionOutcome: {},
+    phase: 'active',
+    firstSeen: NOW,
+    lastUpdated: NOW,
+    ...overrides,
+  };
+}
+
+describe('evaluateWatchWindow — confirmation', () => {
+  it('observed expected signal bumps confidence by +0.05', () => {
+    const e = evaluateWatchWindow({
+      situation: fakeSituation({ confidence: 0.7 }),
+      observedSignalIds: ['sig:radar-strengthen'],
+      now: () => NOW + 5 * 60_000,
+    });
+    assert.equal(e.confirmed.length, 1);
+    assert.ok(e.confidence > 0.7);
+    assert.ok(e.confidence <= 0.95);
+  });
+
+  it('multiple confirmations stack additively', () => {
+    const e = evaluateWatchWindow({
+      situation: fakeSituation({ confidence: 0.7 }),
+      observedSignalIds: ['sig:radar-strengthen', 'sig:storm-reports'],
+      now: () => NOW + 5 * 60_000,
+    });
+    assert.equal(e.confirmed.length, 2);
+    assert.ok(e.confidence >= 0.79); // 0.7 + 0.05 + 0.05
+  });
+
+  it('confidence caps at 0.95', () => {
+    const e = evaluateWatchWindow({
+      situation: fakeSituation({ confidence: 0.94 }),
+      observedSignalIds: ['sig:radar-strengthen', 'sig:storm-reports'],
+      now: () => NOW + 5 * 60_000,
+    });
+    assert.ok(e.confidence <= 0.95);
+  });
+
+  it('confirmed-only with no misses → phase active', () => {
+    const e = evaluateWatchWindow({
+      situation: fakeSituation({ phase: 'developing' }),
+      observedSignalIds: ['sig:radar-strengthen'],
+      now: () => NOW + 5 * 60_000,
+    });
+    assert.equal(e.phase, 'active');
+  });
+});
+
+describe('evaluateWatchWindow — decay on missed signals', () => {
+  it('signals past default window without observation → confidence and urgency drop', () => {
+    const e = evaluateWatchWindow({
+      situation: fakeSituation({ confidence: 0.7, urgency: 0.8 }),
+      observedSignalIds: [],
+      now: () => NOW + 90 * 60_000, // past 60-min default
+    });
+    assert.equal(e.missed.length, 2);
+    assert.ok(e.confidence < 0.7);
+    assert.ok(e.urgency < 0.8);
+  });
+
+  it('signal with explicit expectByMs respects that timestamp', () => {
+    const sit = fakeSituation({
+      expectedNextSignals: [
+        { id: 'short-window', description: 'urgent', expectByMs: NOW + 10 * 60_000 },
+      ],
+    });
+    const e = evaluateWatchWindow({
+      situation: sit,
+      observedSignalIds: [],
+      now: () => NOW + 12 * 60_000, // 2 min past the 10-min window
+    });
+    assert.equal(e.missed.length, 1);
+  });
+
+  it('within window without observation → no adjustment', () => {
+    const e = evaluateWatchWindow({
+      situation: fakeSituation({ confidence: 0.7 }),
+      observedSignalIds: [],
+      now: () => NOW + 5 * 60_000,
+    });
+    assert.equal(e.missed.length, 0);
+    assert.equal(e.confirmed.length, 0);
+    assert.equal(e.confidence, 0.7);
+  });
+
+  it('all-missed and confidence < 0.3 → phase resolved (or developing if 0.15..0.3)', () => {
+    const e = evaluateWatchWindow({
+      situation: fakeSituation({ confidence: 0.3 }),
+      observedSignalIds: [],
+      now: () => NOW + 90 * 60_000,
+    });
+    // 0.3 - 0.1 - 0.1 = 0.1 → < 0.15 → resolved
+    assert.equal(e.phase, 'resolved');
+  });
+
+  it('confidence ≥ 0.3 remains in active phase even after misses', () => {
+    const e = evaluateWatchWindow({
+      situation: fakeSituation({ confidence: 0.6 }),
+      observedSignalIds: [],
+      now: () => NOW + 90 * 60_000,
+    });
+    // 0.6 - 0.2 = 0.4 → ≥ 0.3 → phase unchanged
+    assert.equal(e.phase, 'active');
+  });
+});
+
+describe('evaluateWatchWindow — invalidation', () => {
+  it('observed invalidation signal collapses confidence to 0.1 + phase resolved', () => {
+    const e = evaluateWatchWindow({
+      situation: fakeSituation(),
+      observedSignalIds: ['sig:nws-cancel'],
+      now: () => NOW + 30 * 60_000,
+    });
+    assert.equal(e.confidence, 0.1);
+    assert.equal(e.phase, 'resolved');
+    assert.equal(e.invalidated.length, 1);
+    assert.equal(e.predictionOutcome?.verdict, 'false_positive');
+  });
+
+  it('invalidation wins over confirmation', () => {
+    const e = evaluateWatchWindow({
+      situation: fakeSituation(),
+      observedSignalIds: ['sig:radar-strengthen', 'sig:nws-cancel'],
+      now: () => NOW + 30 * 60_000,
+    });
+    assert.equal(e.confidence, 0.1);
+    assert.equal(e.phase, 'resolved');
+  });
+
+  it('predictionOutcome.notes names the firing signal', () => {
+    const e = evaluateWatchWindow({
+      situation: fakeSituation(),
+      observedSignalIds: ['sig:nws-cancel'],
+      now: () => NOW + 30 * 60_000,
+    });
+    assert.match(e.predictionOutcome?.notes ?? '', /sig:nws-cancel/);
+  });
+});
+
+describe('applyWatchWindowEvaluation', () => {
+  it('appends confirmed/missed entries to whatChanged + timeline', () => {
+    const sit = fakeSituation();
+    const evaluation = evaluateWatchWindow({
+      situation: sit,
+      observedSignalIds: ['sig:radar-strengthen'],
+      now: () => NOW + 5 * 60_000,
+    });
+    const updated = applyWatchWindowEvaluation(sit, evaluation, NOW + 5 * 60_000);
+    assert.ok(updated.whatChanged.length > sit.whatChanged.length);
+    assert.ok(updated.whatChanged.some((e) => /confirmed/i.test(e.text)));
+  });
+
+  it('appends thresholdsCrossed to diagnosticsTrace', () => {
+    const sit = fakeSituation();
+    const evaluation = evaluateWatchWindow({
+      situation: sit,
+      observedSignalIds: ['sig:radar-strengthen'],
+      now: () => NOW + 5 * 60_000,
+    });
+    const updated = applyWatchWindowEvaluation(sit, evaluation, NOW + 5 * 60_000);
+    assert.ok(updated.diagnosticsTrace.thresholdsCrossed.some((t) => t.startsWith('confirmed:')));
+  });
+
+  it('writes the new confidence/urgency/phase onto the situation', () => {
+    const sit = fakeSituation({ confidence: 0.7, urgency: 0.8 });
+    const evaluation = evaluateWatchWindow({
+      situation: sit,
+      observedSignalIds: ['sig:nws-cancel'],
+      now: () => NOW + 30 * 60_000,
+    });
+    const updated = applyWatchWindowEvaluation(sit, evaluation, NOW + 30 * 60_000);
+    assert.equal(updated.confidence, 0.1);
+    assert.equal(updated.urgency, 0.1);
+    assert.equal(updated.phase, 'resolved');
+    assert.equal(updated.predictionOutcome.verdict, 'false_positive');
+  });
+
+  it('preserves identity for fields not touched by the evaluator', () => {
+    const sit = fakeSituation({ summary: 'unique-summary-12345' });
+    const evaluation = evaluateWatchWindow({
+      situation: sit,
+      observedSignalIds: [],
+      now: () => NOW + 5 * 60_000,
+    });
+    const updated = applyWatchWindowEvaluation(sit, evaluation, NOW + 5 * 60_000);
+    assert.equal(updated.summary, 'unique-summary-12345');
+    assert.equal(updated.id, sit.id);
+    assert.equal(updated.domain, sit.domain);
+  });
+});
+
+describe('JSON round-trip after watch-window evaluation', () => {
+  it('updated situation remains JSON-serializable', () => {
+    const sit = fakeSituation();
+    const evaluation = evaluateWatchWindow({
+      situation: sit,
+      observedSignalIds: ['sig:radar-strengthen'],
+      now: () => NOW + 5 * 60_000,
+    });
+    const updated = applyWatchWindowEvaluation(sit, evaluation, NOW + 5 * 60_000);
+    assert.doesNotThrow(() => JSON.stringify(updated));
+  });
+});

--- a/src/services/situations/index.ts
+++ b/src/services/situations/index.ts
@@ -52,3 +52,26 @@ export { cyberThreatsToSituations } from './cyber-adapter';
 
 export type { WeatherAdapterInput } from './weather-adapter';
 export { weatherAlertsToSituations } from './weather-adapter';
+
+export type {
+  ExposureGraph,
+  ExposureSavedPlace,
+  ExposureWatchlist,
+  ExposureDevice,
+  ExposureScore,
+} from './exposure-graph';
+export {
+  scoreGeoExposure,
+  scoreCyberExposure,
+  scoreCountryExposure,
+  exposureToLevel,
+  setExposureGraph,
+  getExposureGraph,
+  resetExposureGraphForTests,
+} from './exposure-graph';
+
+export type { WatchWindowEvaluation, WatchWindowInput } from './watch-window';
+export {
+  evaluateWatchWindow,
+  applyWatchWindowEvaluation,
+} from './watch-window';

--- a/src/services/situations/watch-window.ts
+++ b/src/services/situations/watch-window.ts
@@ -1,0 +1,256 @@
+/**
+ * Watch-window evaluator — Phase 3 of
+ * docs/CLAUDE_HIGH_IMPACT_EVENT_INTELLIGENCE_VISION_2026-04-29.md.
+ *
+ * Pure deterministic. Takes a Situation + a list of observed signal
+ * ids + the current time, and produces an updated (confidence,
+ * urgency, phase, diagnosticsTrace) so the host loop can re-emit
+ * the situation through the store.
+ *
+ * Rules (all bounded so the math doesn't run away):
+ *   - Confirmation: each expected signal observed within its
+ *     watch window adds +0.05 confidence (max 0.95).
+ *   - Decay: each expected signal MISSED past its window subtracts
+ *     0.1 confidence and 0.1 urgency. After all expected signals
+ *     have missed, urgency drops to ≤ 0.2 and the situation moves
+ *     to 'de-escalating' / 'resolved' if confidence is below 0.3.
+ *   - Invalidation: any invalidation signal observed → confidence
+ *     0.1, phase 'resolved', verdict 'false_positive'.
+ *   - Diagnostics: every adjustment writes a line to the trace.
+ */
+
+import type {
+  ExpectedSignal,
+  Situation,
+} from './situation-types';
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+export interface WatchWindowEvaluation {
+  /** New confidence value (0..1). */
+  confidence: number;
+  /** New urgency value (0..1). */
+  urgency: number;
+  /** New phase verdict. */
+  phase: Situation['phase'];
+  /** Adjusted prediction outcome. Only populated when invalidation
+   *  signal fires. */
+  predictionOutcome?: Situation['predictionOutcome'];
+  /** Additional rationale lines appended to diagnosticsTrace.
+   *  Caller composes the new trace by joining these onto the
+   *  situation's existing rationale. */
+  diagnosticsAdditions: {
+    confidenceRationale: string;
+    severityRationale: string;
+    thresholdsCrossed: readonly string[];
+  };
+  /** Confirmed signal ids (for whatChanged + UI). */
+  confirmed: readonly string[];
+  /** Missed signal ids (timed out). */
+  missed: readonly string[];
+  /** Invalidation signal ids that fired. */
+  invalidated: readonly string[];
+}
+
+export interface WatchWindowInput {
+  /** Situation under evaluation. */
+  situation: Situation;
+  /** Signal ids the host has observed since the last evaluation. */
+  observedSignalIds: readonly string[];
+  /** Current ms timestamp; defaults to Date.now(). */
+  now?: () => number;
+  /** Default watch window (ms) for expected signals that didn't
+   *  declare an `expectByMs`. Defaults to 60 minutes. */
+  defaultWindowMs?: number;
+}
+
+const DEFAULT_WINDOW_MS = 60 * 60 * 1000;
+
+export function evaluateWatchWindow(input: WatchWindowInput): WatchWindowEvaluation {
+  const now = (input.now ?? Date.now)();
+  const defaultWindow = input.defaultWindowMs ?? DEFAULT_WINDOW_MS;
+  const observed = new Set(input.observedSignalIds);
+  const s = input.situation;
+
+  // 1. Invalidation wins — collapse confidence + mark resolved.
+  const invalidationsHit = s.invalidationSignals.filter((sig) => observed.has(sig.id));
+  if (invalidationsHit.length > 0) {
+    return {
+      confidence: 0.1,
+      urgency: 0.1,
+      phase: 'resolved',
+      predictionOutcome: {
+        ...s.predictionOutcome,
+        resolvedAt: now,
+        verdict: 'false_positive',
+        notes: `Invalidated by signal(s): ${invalidationsHit.map((sig) => sig.id).join(', ')}`,
+      },
+      diagnosticsAdditions: {
+        confidenceRationale: `Invalidation signal(s) observed: ${invalidationsHit.map((sig) => sig.id).join(', ')} → confidence dropped to 0.1`,
+        severityRationale: `Invalidation collapsed urgency to 0.1`,
+        thresholdsCrossed: invalidationsHit.map((sig) => `invalidated:${sig.id}`),
+      },
+      confirmed: [],
+      missed: [],
+      invalidated: invalidationsHit.map((sig) => sig.id),
+    };
+  }
+
+  // 2. Walk expected signals — confirmed vs. missed vs. still-pending.
+  const confirmed: string[] = [];
+  const missed: string[] = [];
+  let confirmAdjust = 0;
+  let missAdjust = 0;
+  let urgencyAdjust = 0;
+  for (const sig of s.expectedNextSignals) {
+    if (observed.has(sig.id)) {
+      confirmed.push(sig.id);
+      confirmAdjust += 0.05;
+    } else if (signalTimedOut(sig, s.firstSeen, now, defaultWindow)) {
+      missed.push(sig.id);
+      missAdjust -= 0.1;
+      urgencyAdjust -= 0.1;
+    }
+    // Pending — within the window, not yet observed → no adjustment.
+  }
+
+  const newConfidence = clamp(s.confidence + confirmAdjust + missAdjust, 0.05, 0.95);
+  const newUrgency = clamp(s.urgency + urgencyAdjust, 0, 1);
+
+  // 3. Phase update.
+  // If everything we expected has either confirmed or missed AND the
+  // confidence drops below 0.3 → de-escalating / resolved.
+  // If any confirmed signals fired AND nothing has missed → phase
+  // moves toward 'active'.
+  let phase: Situation['phase'] = s.phase;
+  if (missed.length > 0 && newConfidence < 0.3) {
+    phase = newConfidence < 0.15 ? 'resolved' : 'developing';
+  } else if (confirmed.length > 0 && missed.length === 0) {
+    phase = 'active';
+  }
+
+  return {
+    confidence: newConfidence,
+    urgency: newUrgency,
+    phase,
+    diagnosticsAdditions: {
+      confidenceRationale: composeConfidenceRationale(confirmed, missed, confirmAdjust, missAdjust),
+      severityRationale: urgencyAdjust < 0
+        ? `Urgency decay −${Math.abs(urgencyAdjust).toFixed(2)} from ${missed.length} missed signal(s)`
+        : '(urgency unchanged)',
+      thresholdsCrossed: [
+        ...confirmed.map((id) => `confirmed:${id}`),
+        ...missed.map((id) => `missed:${id}`),
+      ],
+    },
+    confirmed,
+    missed,
+    invalidated: [],
+  };
+}
+
+/** Apply the evaluation to a Situation, producing a new Situation
+ *  that the store can upsert. Convenience wrapper that does the
+ *  diagnosticsTrace + whatChanged composition. */
+export function applyWatchWindowEvaluation(
+  situation: Situation,
+  evaluation: WatchWindowEvaluation,
+  now: number = Date.now(),
+): Situation {
+  const { confidence, urgency, phase, predictionOutcome, diagnosticsAdditions, confirmed, missed, invalidated } = evaluation;
+  const whatChangedAdditions: { ts: number; text: string; source?: string }[] = [];
+  if (confirmed.length > 0) {
+    whatChangedAdditions.push({
+      ts: now,
+      text: `${confirmed.length} expected signal(s) confirmed`,
+      source: 'watch-window',
+    });
+  }
+  if (missed.length > 0) {
+    whatChangedAdditions.push({
+      ts: now,
+      text: `${missed.length} expected signal(s) timed out`,
+      source: 'watch-window',
+    });
+  }
+  if (invalidated.length > 0) {
+    whatChangedAdditions.push({
+      ts: now,
+      text: `Invalidation signal(s) fired — situation marked false-positive`,
+      source: 'watch-window',
+    });
+  }
+
+  return {
+    ...situation,
+    confidence,
+    urgency,
+    phase,
+    predictionOutcome: predictionOutcome ?? situation.predictionOutcome,
+    whatChanged: [...situation.whatChanged, ...whatChangedAdditions],
+    timeline: [
+      ...situation.timeline,
+      ...whatChangedAdditions.map((e) => ({ ts: e.ts, text: e.text, source: e.source })),
+    ],
+    diagnosticsTrace: {
+      ...situation.diagnosticsTrace,
+      confidenceRationale: appendLine(
+        situation.diagnosticsTrace.confidenceRationale,
+        diagnosticsAdditions.confidenceRationale,
+      ),
+      severityRationale: appendLine(
+        situation.diagnosticsTrace.severityRationale,
+        diagnosticsAdditions.severityRationale,
+      ),
+      thresholdsCrossed: [
+        ...situation.diagnosticsTrace.thresholdsCrossed,
+        ...diagnosticsAdditions.thresholdsCrossed,
+      ],
+    },
+    lastUpdated: now,
+  };
+}
+
+// ── Internals ───────────────────────────────────────────────────────────
+
+function signalTimedOut(
+  sig: ExpectedSignal,
+  firstSeen: number,
+  now: number,
+  defaultWindow: number,
+): boolean {
+  if (typeof sig.expectByMs === 'number') return now > sig.expectByMs;
+  return now - firstSeen > defaultWindow;
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  if (n < lo) return lo;
+  if (n > hi) return hi;
+  return n;
+}
+
+function appendLine(existing: string, addition: string): string {
+  if (!addition || addition === '(urgency unchanged)') return existing;
+  return existing.endsWith('\n') ? `${existing}${addition}` : `${existing}\n${addition}`;
+}
+
+function composeConfidenceRationale(
+  confirmed: readonly string[],
+  missed: readonly string[],
+  confirmAdjust: number,
+  missAdjust: number,
+): string {
+  const parts: string[] = [];
+  if (confirmed.length > 0) {
+    parts.push(`${confirmed.length} confirmed (+${confirmAdjust.toFixed(2)})`);
+  }
+  if (missed.length > 0) {
+    parts.push(`${missed.length} missed (${missAdjust.toFixed(2)})`);
+  }
+  if (parts.length === 0) return '(no watch-window changes)';
+  return `Watch-window: ${parts.join(', ')}`;
+}
+
+// Re-exports so consumers can pass invalidation signals through this
+// module without importing situation-types directly.
+export type { ExpectedSignal, InvalidationSignal } from './situation-types';


### PR DESCRIPTION
Phase 3 of `docs/CLAUDE_HIGH_IMPACT_EVENT_INTELLIGENCE_VISION_2026-04-29.md`.

Three rules, all bounded:

1. **Confirmation** — each expected signal observed within its watch window adds +0.05 confidence (max 0.95). Phase moves toward 'active' when confirmations arrive without misses.

2. **Decay** — each expected signal MISSED past its window subtracts 0.1 confidence and 0.1 urgency. After all expected signals have either confirmed or missed AND confidence drops below 0.3, phase moves to 'developing' (0.15..0.3) or 'resolved' (< 0.15).

3. **Invalidation** — any invalidation signal observed → confidence 0.1, phase 'resolved', `predictionOutcome.verdict: 'false_positive'` with notes naming the firing signal. Wins over confirmation.

`evaluateWatchWindow(input)` returns the structural delta. `applyWatchWindowEvaluation(situation, evaluation, now)` composes the new Situation with whatChanged + timeline + diagnosticsTrace additions. Both functions are pure — host loop calls them in sequence and upserts the result through the SituationStore.

## Verification

- typecheck → 0 errors
- **117 deterministic tests pass** (74 Phase 1 + 26 Phase 2 + 17 Phase 3)
- touched-file lint clean

## Acceptance criteria

| Phase 3 success criterion | Status |
|---|---|
| Situations can say 'what should happen next if this is real' | ✅ `expectedNextSignals` is now actionable |
| Confidence changes are explainable | ✅ `confidenceRationale` spells out 'X confirmed (+0.05), Y missed (-0.10)' |
| Missed expected signals reduce urgency | ✅ each miss subtracts 0.1 from urgency |

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>