### PR TITLE
fix(faa-cams): stop disaster-mode startup from clearing map cameras

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -383,9 +383,14 @@ export class DataLoaderManager implements AppModule {
  if (detail) unifiedAlertStore.ingest([normalizeResourceAlert(detail)]);
  });
 
- // Disaster-proximate FAA cameras — formerly gated on disaster mode entry,
- // now loaded unconditionally once at startup so the user always has the
- // most-active camera set. Re-runs are unnecessary (mode triggers removed).
+ // Disaster-proximate FAA cameras — informs the panel's disaster
+ // mode badge so cameras near severe weather are highlighted, but
+ // does NOT touch the map's camera layer. The full
+ // `loadFAACameras()` task already populates the map with every
+ // scored camera; overwriting it here used to clear the map down
+ // to the disaster subset (or to [] when no severe disasters were
+ // active), which is why FAA cams disappeared from the map at
+ // startup.
  void (async () => {
  try {
  const [raw, nwsResult, gdacsResult] = await Promise.all([
@@ -394,7 +399,7 @@ export class DataLoaderManager implements AppModule {
  withOfflineCache('gdacs-events', () => fetchGDACSEvents(), 1 * 60 * 60 * 1000),
  ]);
  const proximate = getDisasterProximateCameras(raw, nwsResult.data, gdacsResult.data);
- this.ctx.map?.setFAACameras(proximate);
+ // Panel-side disaster badge only — map keeps the full set.
  (this.ctx.panels['faa-weather-cams'] as FAAWeatherCamsPanel | undefined)?.setDisasterMode(true, proximate);
  } catch { /* non-critical */ }
  })();

--- a/src/components/FAAWeatherCamsPanel.ts
+++ b/src/components/FAAWeatherCamsPanel.ts
@@ -253,12 +253,23 @@ export class FAAWeatherCamsPanel extends Panel {
   }
 
   public setDisasterMode(active: boolean, disasterCameras?: ScoredFAACamera[]): void {
- if (active && disasterCameras) {
- this.cameras = disasterCameras;
+ // Disaster-mode flips the alert-only filter on/off. It does NOT
+ // overwrite this.cameras with just the disaster subset — that
+ // used to leave the panel showing nothing when no severe weather
+ // / GDACS events were active. The panel always loads the full
+ // camera list and uses `alertOnly` to filter at render time.
+ if (active && disasterCameras && disasterCameras.length > 0) {
+ // Merge: keep the existing full list + ensure the disaster
+ // subset is included with up-to-date alert proximity scores.
+ const byId = new Map(this.cameras.map((c) => [c.id, c]));
+ for (const cam of disasterCameras) byId.set(cam.id, cam);
+ this.cameras = [...byId.values()];
  this.alertOnly = true;
- } else if (!active) {
+ } else {
+ // Either disaster mode is off, or active without any proximate
+ // cameras — show the full list. Lazy-load if we don't have it yet.
  this.alertOnly = false;
- void this.load();
+ if (this.cameras.length === 0) void this.load();
  }
  this.render();
   }


### PR DESCRIPTION
**User report:** *I'm missing FAA cams on the map in the latest build.*

Two regressions caused FAA cams to disappear from both the map and the panel after startup.

## Bug 1 — startup IIFE overwrites the map's full camera set with an empty list

`data-loader.ts` had a startup IIFE that computed *disaster-proximate* cameras (within 200 mi of an Extreme/Severe NWS alert or an Orange/Red GDACS event) and called `this.ctx.map?.setFAACameras(proximate)`.

When no severe disasters are active near any camera, `proximate` is `[]`. The IIFE runs AFTER the broader `loadFAACameras()` task that populates the full set, so it overwrites every scored camera with the (often empty) subset. **Result: the map's camera layer goes blank.**

**Fix:** keep the disaster-proximate computation but stop touching the map. The full `loadFAACameras()` task already populates the map with every scored camera. The proximate list is only used to inform the panel's `setDisasterMode()` badge.

## Bug 2 — panel's `setDisasterMode(true, [])` empties the panel

When called with `active=true + disasterCameras=[]`, the panel's `setDisasterMode` replaced `this.cameras` with the empty subset, then engaged the `alertOnly` filter. **Result:** *'No cameras near active alerts.'* even though 3,303 cameras are available.

**Fix:** merge the disaster subset into the existing camera list (preserves the full list while updating alert proximity for the matched cameras). Only engage the `alertOnly` filter when there are actual proximate cameras.

## Verification
- typecheck → 0 errors
- panel smoke → exit 0, 234 tests pass, 0 silent / 0 errored / 0 asyncErrors
- touched-file lint clean

Cross-agent review: Claude self-review on 2026-04-29; outcome: pass

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>