### PR TITLE
Port World Monitor features to Crystal Ball: SatelliteIntel + webcam aggregator + sidecar hardening

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -699,14 +699,37 @@ async function buildRouteTable(root) {
 }
 
 const REQUEST_BODY_CACHE = Symbol('requestBodyCache');
+const REQUEST_BODY_OVERFLOW = Symbol('requestBodyOverflow');
+const MAX_REQUEST_BODY_BYTES = 16 * 1024 * 1024; // 16 MB
+
+class RequestBodyTooLargeError extends Error {
+  constructor(limit) {
+    super(`Request body exceeds ${limit} bytes`);
+    this.name = 'RequestBodyTooLargeError';
+    this.statusCode = 413;
+    this.limit = limit;
+  }
+}
 
 async function readBody(req) {
   if (Object.prototype.hasOwnProperty.call(req, REQUEST_BODY_CACHE)) {
- return req[REQUEST_BODY_CACHE];
+    return req[REQUEST_BODY_CACHE];
+  }
+  if (req[REQUEST_BODY_OVERFLOW]) {
+    throw new RequestBodyTooLargeError(MAX_REQUEST_BODY_BYTES);
   }
 
   const chunks = [];
-  for await (const chunk of req) chunks.push(chunk);
+  let total = 0;
+  for await (const chunk of req) {
+    total += chunk.length;
+    if (total > MAX_REQUEST_BODY_BYTES) {
+      req[REQUEST_BODY_OVERFLOW] = true;
+      try { req.destroy?.(); } catch { /* socket already gone */ }
+      throw new RequestBodyTooLargeError(MAX_REQUEST_BODY_BYTES);
+    }
+    chunks.push(chunk);
+  }
   const body = chunks.length ? Buffer.concat(chunks) : undefined;
   req[REQUEST_BODY_CACHE] = body;
   return body;
@@ -7278,23 +7301,33 @@ export async function createLocalApiServer(options = {}) {
  }
  } catch (error) {
  const durationMs = Date.now() - start;
+ const errorStatus = Number.isInteger(error?.statusCode) && error.statusCode >= 400 && error.statusCode < 600
+ ? error.statusCode
+ : 500;
+ if (errorStatus >= 500) {
  context.logger.error('[local-api] fatal', error);
  const host = (() => { try { return new URL(req.url || '/', `http://x`).host; } catch { return 'unknown'; } })();
  wmRecordHostFailure(host, error?.message || String(error));
+ }
 
  if (!skipRecord) {
  recordTraffic({
  timestamp: new Date().toISOString(),
  method: req.method,
  path: requestUrl.pathname + (requestUrl.search || ''),
- status: 500,
+ status: errorStatus,
  durationMs,
  error: error.message,
  });
  }
 
- res.writeHead(500, { 'content-type': 'application/json', ...makeCorsHeaders(req) });
- res.end(JSON.stringify({ error: 'Internal server error' }));
+ const errorBody = errorStatus === 413
+ ? { error: 'Payload too large', limit: error.limit ?? MAX_REQUEST_BODY_BYTES }
+ : errorStatus < 500
+ ? { error: error.message || 'Bad request' }
+ : { error: 'Internal server error' };
+ res.writeHead(errorStatus, { 'content-type': 'application/json', ...makeCorsHeaders(req) });
+ res.end(JSON.stringify(errorBody));
  }
   });
 

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -7039,6 +7039,131 @@ async function dispatch(requestUrl, req, routes, context) {
  }
   }
 
+  // -- Windy Webcams API v3 -- search by location or country
+  if (requestUrl.pathname === '/api/windy-webcams') {
+ const apiKey = process.env.WINDY_WEBCAMS_API_KEY;
+ if (!apiKey) return json({ webcams: [], error: 'WINDY_WEBCAMS_API_KEY not configured' }, 503);
+ const latRaw = requestUrl.searchParams.get('lat');
+ const lonRaw = requestUrl.searchParams.get('lon');
+ const lat = parseFloat(latRaw ?? 'NaN');
+ const lon = parseFloat(lonRaw ?? 'NaN');
+ const radius = Math.min(500, Math.max(1, parseFloat(requestUrl.searchParams.get('radius') ?? '50') || 50));
+ const country = requestUrl.searchParams.get('country');
+ const limit = Math.min(50, Math.max(1, parseInt(requestUrl.searchParams.get('limit') ?? '20', 10) || 20));
+ const hasCoords = Number.isFinite(lat) && Number.isFinite(lon);
+ if (!hasCoords && !country) {
+ return json({ webcams: [], error: 'Provide lat+lon or country' }, 400);
+ }
+ const cacheKey = `windy-webcams-${hasCoords ? `${lat}-${lon}-${radius}` : 'none'}-${country ?? 'none'}-${limit}`;
+ const cached = getCached(cacheKey, 30 * 60 * 1000);
+ if (cached) return json(cached);
+ try {
+ let url = 'https://api.windy.com/webcams/api/v3/webcams?include=images,location,player';
+ if (hasCoords) {
+ url += `&nearby=${lat},${lon},${radius}`;
+ }
+ if (country) {
+ url += `&countries=${encodeURIComponent(country)}`;
+ }
+ url += `&limit=${limit}`;
+ const resp = await fetchWithTimeout(url, {
+ headers: {
+ 'x-windy-api-key': apiKey,
+ 'User-Agent': 'CrystalBall/1.0',
+ },
+ }, 12_000);
+ if (!resp.ok) throw new Error(`Windy HTTP ${resp.status}`);
+ const data = await resp.json();
+ const webcams = (data?.webcams ?? []).map(w => ({
+ id: String(w.webcamId ?? w.id ?? ''),
+ title: w.title ?? '',
+ city: w.location?.city ?? '',
+ country: w.location?.country ?? '',
+ countryCode: w.location?.countryCode ?? '',
+ region: w.location?.region ?? '',
+ lat: w.location?.latitude ?? 0,
+ lon: w.location?.longitude ?? 0,
+ thumbnail: w.images?.current?.preview ?? w.images?.daylight?.preview ?? '',
+ playerUrl: w.player?.day?.embed ?? `https://webcams.windy.com/webcams/public/embed/player/${String(w.webcamId ?? w.id ?? '').replace(/[^a-zA-Z0-9_-]/g, '')}/day`,
+ status: w.status ?? 'active',
+ lastUpdated: w.lastUpdatedOn ?? '',
+ }));
+ const result = { webcams, updatedAt: Math.floor(Date.now() / 1000) };
+ setCached(cacheKey, result, 30 * 60 * 1000);
+ return json(result);
+ } catch (error) {
+ const stale = getCachedStale(cacheKey);
+ if (stale) return json({ ...stale, stale: true, error: error?.message ?? 'unknown' });
+ return json({ webcams: [], error: error?.message ?? 'unknown' }, 502);
+ }
+  }
+
+  // -- US DOT traffic cameras (public 511 feeds) — Caltrans + 511 NY
+  if (requestUrl.pathname === '/api/dot-traffic-cams') {
+ const state = requestUrl.searchParams.get('state') || 'all';
+ const cacheKey = `dot-cams-${state}`;
+ const cached = getCached(cacheKey, 5 * 60 * 1000);
+ if (cached) return json(cached);
+ try {
+ const feeds = [
+ { state: 'CA', url: 'https://cwwp2.dot.ca.gov/data/d7/cctv/cctvStatusD07.json', parser: 'caltrans' },
+ { state: 'NY', url: 'https://511ny.org/api/getTransportationConditions?key=public&format=json&eventCategory=cameras', parser: 'ny511' },
+ ];
+ const targetFeeds = state === 'all' ? feeds : feeds.filter(f => f.state === state.toUpperCase());
+ const results = await Promise.allSettled(targetFeeds.map(async (feed) => {
+ const resp = await fetchWithTimeout(feed.url, {
+ headers: { 'User-Agent': 'CrystalBall/1.0', Accept: 'application/json' },
+ }, 10_000);
+ if (!resp.ok) return [];
+ const data = await resp.json();
+ const cams = [];
+ if (feed.parser === 'caltrans') {
+ const items = Array.isArray(data) ? data : data?.data ?? [];
+ let idx = 0;
+ for (const c of items) {
+ if (!c.cctv?.imageUrl) continue;
+ cams.push({
+ id: `dot-ca-${c.cctv?.index ?? idx}`,
+ title: c.cctv?.location?.locationName ?? `CA Camera ${idx + 1}`,
+ state: 'CA',
+ lat: c.cctv?.location?.latitude ?? 0,
+ lon: c.cctv?.location?.longitude ?? 0,
+ imageUrl: c.cctv.imageUrl,
+ direction: c.cctv?.location?.direction ?? '',
+ });
+ idx++;
+ }
+ } else if (feed.parser === 'ny511') {
+ const items = Array.isArray(data) ? data : data?.cameras ?? data?.features ?? [];
+ let idx = 0;
+ for (const c of items) {
+ const props = c.properties ?? c;
+ if (!props.imageUrl && !props.url) continue;
+ cams.push({
+ id: `dot-ny-${props.id ?? idx}`,
+ title: props.name ?? props.description ?? `NY Camera ${idx + 1}`,
+ state: 'NY',
+ lat: props.latitude ?? c.geometry?.coordinates?.[1] ?? 0,
+ lon: props.longitude ?? c.geometry?.coordinates?.[0] ?? 0,
+ imageUrl: props.imageUrl ?? props.url ?? '',
+ direction: props.direction ?? '',
+ });
+ idx++;
+ }
+ }
+ return cams;
+ }));
+ const allCams = results.flatMap(r => r.status === 'fulfilled' ? r.value : []);
+ const result = { cameras: allCams, updatedAt: Math.floor(Date.now() / 1000) };
+ setCached(cacheKey, result, 5 * 60 * 1000);
+ return json(result);
+ } catch (error) {
+ const stale = getCachedStale(cacheKey);
+ if (stale) return json({ ...stale, stale: true, error: error?.message ?? 'unknown' });
+ return json({ cameras: [], error: error?.message ?? 'unknown' }, 502);
+ }
+  }
+
   if (context.cloudFallback && cloudPreferred.has(requestUrl.pathname)) {
  const cloudResponse = await tryCloudFallback(requestUrl, req, context);
  if (cloudResponse) return cloudResponse;

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -227,6 +227,7 @@ import { ShortageRadarPanel } from '@/components/ShortageRadarPanel';
 import { CascadeSimulatorPanel } from '@/components/CascadeSimulatorPanel';
 import { EmergencyBroadcastPanel } from '@/components/EmergencyBroadcastPanel';
 import { SatelliteChangePanel } from '@/components/SatelliteChangePanel';
+import { SatelliteIntelPanel } from '@/components/SatelliteIntelPanel';
 import { EconomicStressPanel } from '@/components/EconomicStressPanel';
 import { FederalRegisterPanel } from '@/components/FederalRegisterPanel';
 import { NuclearRiskPanel } from '@/components/NuclearRiskPanel';
@@ -1198,6 +1199,7 @@ export class PanelLayoutManager implements AppModule {
  this.ctx.panels['cascade-simulator'] = new CascadeSimulatorPanel();
  this.ctx.panels['emergency-broadcast'] = new EmergencyBroadcastPanel();
  this.ctx.panels['satellite-change'] = new SatelliteChangePanel();
+ this.ctx.panels['satellite-intel'] = new SatelliteIntelPanel();
 
  // Weather upgrade panels
  this.ctx.panels['extended-forecast'] = new ExtendedForecastPanel();

--- a/src/components/SatelliteIntelPanel.ts
+++ b/src/components/SatelliteIntelPanel.ts
@@ -1,0 +1,188 @@
+import { Panel } from './Panel';
+import { escapeHtml } from '@/utils/sanitize';
+import { satellitePropagator, type SatellitePosition } from '@/services/satellite-propagator';
+import { type SatelliteTLE, getClassificationLabel } from '@/services/satellite-catalog';
+import { getUpcomingPasses, getOverheadNow, computePasses, onPassesUpdated } from '@/services/satellite-passes';
+import { getSavedPlaces } from '@/services/saved-places';
+
+const BADGE_COLORS: Record<string, string> = {
+  notable: '#ef3232',
+  military: '#f97316',
+  constellation: '#60a5fa',
+  normal: '#9ca3af',
+};
+
+function formatTime(ms: number): string {
+  return new Date(ms).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function formatDuration(ms: number): string {
+  return String(Math.round(ms / 60_000));
+}
+
+export class SatelliteIntelPanel extends Panel {
+  private selectedSat: SatelliteTLE | null = null;
+  private selectedNoradId: number | null = null;
+  private unsubPositions: (() => void) | null = null;
+  private unsubPasses: (() => void) | null = null;
+  private latestPositions: SatellitePosition[] = [];
+  private lastRenderedLat = 0;
+  private lastRenderedLon = 0;
+  private lastRenderedAlt = 0;
+
+  private readonly onSatSelected = (e: Event) => {
+    const detail = (e as CustomEvent<{ satellite: SatelliteTLE; noradId: number }>).detail;
+    this.selectedSat = detail.satellite;
+    this.selectedNoradId = detail.noradId;
+    this.render();
+  };
+
+  constructor() {
+    super({
+      id: 'satellite-intel',
+      title: 'Satellite Intel',
+      showCount: true,
+      trackActivity: true,
+      infoTooltip: 'Live satellite tracking with pass predictions over your saved locations.',
+    });
+
+    window.addEventListener('satellite-selected', this.onSatSelected);
+
+    this.unsubPasses = onPassesUpdated(() => {
+      this.render();
+    });
+
+    this.unsubPositions = satellitePropagator.onPositions((positions) => {
+      this.latestPositions = positions;
+      if (this.selectedNoradId !== null) {
+        const pos = positions.find(p => p.noradId === this.selectedNoradId);
+        if (pos) {
+          const latChanged = Math.abs(pos.lat - this.lastRenderedLat) > 0.01;
+          const lonChanged = Math.abs(pos.lon - this.lastRenderedLon) > 0.01;
+          const altChanged = Math.abs(pos.altKm - this.lastRenderedAlt) > 1;
+          if (latChanged || lonChanged || altChanged) {
+            this.render();
+          }
+        }
+      }
+    });
+
+    this.render();
+    this.triggerComputePasses();
+  }
+
+  private triggerComputePasses(): void {
+    const places = getSavedPlaces().map(p => ({ id: p.id, name: p.name, lat: p.lat, lon: p.lon }));
+    void computePasses(places);
+  }
+
+  private classificationBadge(classification: string): string {
+    const color = BADGE_COLORS[classification] ?? BADGE_COLORS.normal;
+    const label = getClassificationLabel(classification as Parameters<typeof getClassificationLabel>[0]);
+    return `<span style="background:${color}22;color:${color};border:1px solid ${color}55;border-radius:3px;padding:1px 5px;font-size:10px;font-weight:700;letter-spacing:.05em">${escapeHtml(label)}</span>`;
+  }
+
+  private renderDetailCard(): string {
+    if (!this.selectedSat) {
+      return `<div class="panel-empty" style="padding:12px 0">Click a satellite on the map to view details</div>`;
+    }
+
+    const sat = this.selectedSat;
+    const pos = this.selectedNoradId === null
+      ? undefined
+      : this.latestPositions.find(p => p.noradId === this.selectedNoradId);
+
+    // TLE Line 2 columns 9-16 = inclination (degrees)
+    const inclination = Number.parseFloat(sat.line2.slice(8, 16).trim());
+    const incStr = Number.isNaN(inclination) ? '—' : `${inclination.toFixed(2)}°`;
+
+    const latStr = pos ? `${pos.lat.toFixed(3)}°` : '—';
+    const lonStr = pos ? `${pos.lon.toFixed(3)}°` : '—';
+    const altStr = pos ? `${pos.altKm.toFixed(0)} km` : '—';
+
+    if (pos) {
+      this.lastRenderedLat = pos.lat;
+      this.lastRenderedLon = pos.lon;
+      this.lastRenderedAlt = pos.altKm;
+    }
+
+    return `
+      <div style="background:rgba(255,255,255,0.04);border-radius:6px;padding:10px 12px;margin-bottom:8px">
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">
+          <span style="font-weight:700;font-size:13px">${escapeHtml(sat.name)}</span>
+          ${this.classificationBadge(sat.classification)}
+        </div>
+        <div style="display:grid;grid-template-columns:1fr 1fr 1fr 1fr;gap:6px;font-size:11px;opacity:0.8">
+          <div><div style="opacity:0.55;font-size:10px">NORAD ID</div>${escapeHtml(String(sat.noradId))}</div>
+          <div><div style="opacity:0.55;font-size:10px">INCL</div>${escapeHtml(incStr)}</div>
+          <div><div style="opacity:0.55;font-size:10px">LAT/LON</div>${escapeHtml(latStr)} / ${escapeHtml(lonStr)}</div>
+          <div><div style="opacity:0.55;font-size:10px">ALT</div>${escapeHtml(altStr)}</div>
+        </div>
+      </div>`;
+  }
+
+  private renderOverhead(): string {
+    const overhead = getOverheadNow();
+    if (overhead.length === 0) {
+      return `<div class="panel-empty" style="padding:8px 0;font-size:12px">No tracked satellites overhead</div>`;
+    }
+    const rows = overhead.map(p => `
+      <div style="display:flex;align-items:center;gap:8px;padding:4px 0;border-bottom:1px solid rgba(255,255,255,0.05);font-size:12px">
+        <div style="flex:1;font-weight:600">${escapeHtml(p.satelliteName)}</div>
+        <div style="opacity:0.7;font-size:11px">${escapeHtml(p.locationName)}</div>
+        <div style="opacity:0.7;font-size:11px;white-space:nowrap">${p.maxElevation.toFixed(0)}° el</div>
+      </div>`).join('');
+    return rows;
+  }
+
+  private renderPasses(): string {
+    const passes = getUpcomingPasses().slice(0, 20);
+    if (passes.length === 0) {
+      return `<div class="panel-empty" style="padding:8px 0;font-size:12px">No upcoming passes — add saved places to enable tracking</div>`;
+    }
+    const rows = passes.map(p => `
+      <tr>
+        <td style="font-weight:600;padding:4px 6px 4px 0;font-size:11px">${escapeHtml(p.satelliteName)}</td>
+        <td style="padding:4px 6px;font-size:11px;opacity:0.7">${escapeHtml(p.locationName)}</td>
+        <td style="padding:4px 6px;font-size:11px;white-space:nowrap">${escapeHtml(formatTime(p.riseTime))}</td>
+        <td style="padding:4px 6px;font-size:11px;text-align:right">${p.maxElevation.toFixed(0)}°</td>
+        <td style="padding:4px 6px 4px 0;font-size:11px;text-align:right">${escapeHtml(formatDuration(p.setTime - p.riseTime))} min</td>
+      </tr>`).join('');
+
+    return `
+      <table style="width:100%;border-collapse:collapse">
+        <thead>
+          <tr style="opacity:0.45;font-size:10px;text-transform:uppercase;letter-spacing:.05em">
+            <th style="text-align:left;padding:2px 6px 4px 0;font-weight:600">Satellite</th>
+            <th style="text-align:left;padding:2px 6px;font-weight:600">Location</th>
+            <th style="text-align:left;padding:2px 6px;font-weight:600">Rise</th>
+            <th style="text-align:right;padding:2px 6px;font-weight:600">Max El</th>
+            <th style="text-align:right;padding:2px 6px 4px 0;font-weight:600">Duration</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>`;
+  }
+
+  private render(): void {
+    const overhead = getOverheadNow();
+    this.setCount(overhead.length);
+
+    this.setContent(`
+      <div style="padding:4px 0">
+        <div style="font-size:10px;font-weight:700;letter-spacing:.08em;opacity:0.45;text-transform:uppercase;margin-bottom:6px">Selected Satellite</div>
+        ${this.renderDetailCard()}
+        <div style="font-size:10px;font-weight:700;letter-spacing:.08em;opacity:0.45;text-transform:uppercase;margin:10px 0 6px">Overhead Now</div>
+        ${this.renderOverhead()}
+        <div style="font-size:10px;font-weight:700;letter-spacing:.08em;opacity:0.45;text-transform:uppercase;margin:10px 0 6px">Upcoming Recon Passes</div>
+        ${this.renderPasses()}
+      </div>`);
+  }
+
+  override destroy(): void {
+    window.removeEventListener('satellite-selected', this.onSatSelected);
+    this.unsubPositions?.();
+    this.unsubPasses?.();
+    super.destroy();
+  }
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -136,6 +136,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'ripe-atlas': { name: 'RIPE Atlas', enabled: true, priority: 2 },
   'ipinfo-lookup': { name: 'IPInfo Lookup', enabled: true, priority: 2 },
   'aerospace-reentry': { name: 'Aerospace Reentry Tracker', enabled: true, priority: 2 },
+  'satellite-intel': { name: 'Satellite Intel', enabled: true, priority: 2 },
   'amtrak-alerts': { name: 'Amtrak Service Alerts', enabled: true, priority: 2 },
   'avalanche-hazard': { name: 'Avalanche Hazard', enabled: true, priority: 2 },
   'dsca-arms-transfers': { name: 'DSCA Arms Transfers', enabled: true, priority: 2 },
@@ -975,7 +976,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   },
   dataTracking: {
  labelKey: 'header.panelCatDataTracking',
- panelKeys: ['monitors', 'cyber-threats', 'threat-inbox', 'local-ids', 'comms-health', 'power-grid', 'ucdp-events', 'nuclear-risk', 'airstrikes', 'displacement', 'security-advisories', 'oref-sirens', 'space-weather', 'spaceflight-news', 'space-launches', 'population-exposure', 'internet-disruptions', 'air-traffic', 'threat-intel-hub', 'geo-intel', 'dark-web', 'anomaly-detection', 'financial-contagion', 'supply-chain-impact', 'nuclear-monitor', 'sigint-panel', 'dark-vessel', 'ics-ot-dashboard', 'ioc-manager', 'network-topology', 'stix-taxii', 'custom-geofence', 'sanctions-crossref', 'emergency-broadcast', 'satellite-change', 'phishstats-feed', 'urlscan-threats', 'bitcoin-abuse', 'cve-tracker', 'vulners-cve', 'pulsedive-intel', 'hibp-breaches', 'reddit-osint', 'ripe-ncc', 'ripe-atlas', 'ipinfo-lookup', 'aerospace-reentry'],
+ panelKeys: ['monitors', 'cyber-threats', 'threat-inbox', 'local-ids', 'comms-health', 'power-grid', 'ucdp-events', 'nuclear-risk', 'airstrikes', 'displacement', 'security-advisories', 'oref-sirens', 'space-weather', 'spaceflight-news', 'space-launches', 'population-exposure', 'internet-disruptions', 'air-traffic', 'threat-intel-hub', 'geo-intel', 'dark-web', 'anomaly-detection', 'financial-contagion', 'supply-chain-impact', 'nuclear-monitor', 'sigint-panel', 'dark-vessel', 'ics-ot-dashboard', 'ioc-manager', 'network-topology', 'stix-taxii', 'custom-geofence', 'sanctions-crossref', 'emergency-broadcast', 'satellite-change', 'phishstats-feed', 'urlscan-threats', 'bitcoin-abuse', 'cve-tracker', 'vulners-cve', 'pulsedive-intel', 'hibp-breaches', 'reddit-osint', 'ripe-ncc', 'ripe-atlas', 'ipinfo-lookup', 'aerospace-reentry', 'satellite-intel'],
  variants: ['full'],
   },
   hazards: {

--- a/src/services/data-freshness.ts
+++ b/src/services/data-freshness.ts
@@ -44,7 +44,8 @@ export type DataSourceId =
   | 's2_underground' // S2 Underground intelligence (GhostMaps)
   | 'faa_weather_cams' // FAA weather camera network
   | 'adsb' // ADS-B live aircraft tracking (OpenSky)
-  | 'adsb-military'; // Military ADS-B flight tracking
+  | 'adsb-military' // Military ADS-B flight tracking
+  | 'webcams'; // Aggregated webcam feeds (Windy + DOT + YouTube)
 
 export type FreshnessStatus = 'fresh' | 'stale' | 'very_stale' | 'no_data' | 'disabled' | 'error';
 
@@ -119,6 +120,7 @@ const SOURCE_METADATA: Record<DataSourceId, { name: string; requiredForRisk: boo
   faa_weather_cams: { name: 'FAA Weather Cameras', requiredForRisk: false, panelId: 'faa-weather-cams' },
   adsb: { name: 'ADS-B Aircraft', requiredForRisk: false, panelId: 'air-traffic' },
   'adsb-military': { name: 'Military ADS-B', requiredForRisk: false, panelId: 'geo-intel' },
+  webcams: { name: 'Webcam Aggregator', requiredForRisk: false, panelId: 'live-webcams' },
 };
 
 class DataFreshnessTracker {
@@ -398,6 +400,7 @@ const INTELLIGENCE_GAP_MESSAGES: Record<DataSourceId, string> = {
   faa_weather_cams: 'FAA weather camera data unavailable—camera feed not responding',
   adsb: 'Live aircraft positions unavailable—ADS-B tracking offline',
   'adsb-military': 'Military aircraft positions unavailable—military ADS-B tracking offline',
+  webcams: 'Webcam feeds unavailable—Windy/DOT/YouTube aggregation offline',
 };
 
 /**

--- a/src/services/satellite-catalog.ts
+++ b/src/services/satellite-catalog.ts
@@ -118,3 +118,18 @@ function annotateSatellite(name: string, noradId: number): SatelliteAnnotation |
   }
   return null;
 }
+
+/** True for satellites worth tracking passes for: ISS, recon birds, military. */
+export function isReconOrMilitary(classification: SatelliteClassification): boolean {
+  return classification === 'notable' || classification === 'military';
+}
+
+export function getClassificationLabel(classification: SatelliteClassification): string {
+  const labels: Record<SatelliteClassification, string> = {
+    notable: 'NOTABLE',
+    military: 'MILITARY',
+    constellation: 'CONSTELLATION',
+    normal: 'CIVIL',
+  };
+  return labels[classification];
+}

--- a/src/services/satellite-passes.ts
+++ b/src/services/satellite-passes.ts
@@ -1,0 +1,58 @@
+import { satellitePropagator, type SatellitePass } from './satellite-propagator';
+import { fetchSatelliteCatalog, isReconOrMilitary } from './satellite-catalog';
+
+let cachedPasses: SatellitePass[] = [];
+let lastComputed = 0;
+const RECOMPUTE_INTERVAL = 15 * 60 * 1000;
+const listeners = new Set<(passes: SatellitePass[]) => void>();
+let unsubPasses: (() => void) | null = null;
+
+export function getUpcomingPasses(): SatellitePass[] {
+  return cachedPasses
+    .filter(p => p.setTime > Date.now())
+    .sort((a, b) => a.riseTime - b.riseTime);
+}
+
+export function getOverheadNow(): SatellitePass[] {
+  const now = Date.now();
+  return cachedPasses.filter(p => p.riseTime <= now && p.setTime >= now);
+}
+
+export function onPassesUpdated(listener: (passes: SatellitePass[]) => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export async function computePasses(locations: { id: string; name: string; lat: number; lon: number }[]): Promise<void> {
+  if (Date.now() - lastComputed < RECOMPUTE_INTERVAL) return;
+  if (locations.length === 0) return;
+
+  const catalog = await fetchSatelliteCatalog();
+  // CB's `notable` classification covers ISS/Tiangong + recon birds + early warning,
+  // so isReconOrMilitary already includes the WM "station" set.
+  const notable = catalog.filter(s => isReconOrMilitary(s.classification));
+
+  satellitePropagator.requestPasses(notable, locations, 6);
+  lastComputed = Date.now();
+}
+
+export function teardown(): void {
+  unsubPasses?.();
+  unsubPasses = null;
+  cachedPasses = [];
+  lastComputed = 0;
+  listeners.clear();
+}
+
+function init(): void {
+  // Guard against HMR double-registration
+  unsubPasses?.();
+  unsubPasses = satellitePropagator.onPasses((passes) => {
+    cachedPasses = passes;
+    for (const listener of listeners) {
+      listener(passes);
+    }
+  });
+}
+
+init();

--- a/src/services/satellite-propagator.ts
+++ b/src/services/satellite-propagator.ts
@@ -20,13 +20,27 @@ export interface OrbitPath {
   points: [number, number, number][]; // [lon, lat, altKm]
 }
 
+export interface SatellitePass {
+  satelliteId: string;
+  satelliteName: string;
+  locationId: string;
+  locationName: string;
+  riseTime: number;
+  maxElevationTime: number;
+  setTime: number;
+  maxElevation: number;
+  duration: number;
+}
+
 type PositionListener = (positions: SatellitePosition[]) => void;
 type OrbitPathListener = (path: OrbitPath) => void;
+type PassListener = (passes: SatellitePass[]) => void;
 
 class SatellitePropagator {
   private worker: Worker | null = null;
   private positionListeners: PositionListener[] = [];
   private orbitPathListeners: OrbitPathListener[] = [];
+  private passListeners: PassListener[] = [];
   private latestPositions: SatellitePosition[] = [];
 
   start(catalog: SatelliteTLE[]): void {
@@ -38,7 +52,7 @@ class SatellitePropagator {
  );
 
  this.worker.addEventListener('message', (e: MessageEvent) => {
- const msg = e.data as { type: string; positions?: SatellitePosition[]; noradId?: number; points?: [number, number, number][] };
+ const msg = e.data as { type: string; positions?: SatellitePosition[]; noradId?: number; points?: [number, number, number][]; passes?: SatellitePass[] };
 
  if (msg.type === 'positions' && msg.positions) {
  this.latestPositions = msg.positions;
@@ -51,6 +65,12 @@ class SatellitePropagator {
  const path: OrbitPath = { noradId: msg.noradId, points: msg.points };
  for (const listener of this.orbitPathListeners) {
  listener(path);
+ }
+ }
+
+ if (msg.type === 'passes' && msg.passes) {
+ for (const listener of this.passListeners) {
+ listener(msg.passes);
  }
  }
  });
@@ -98,6 +118,27 @@ class SatellitePropagator {
  this.orbitPathListeners.push(listener);
  return () => {
  this.orbitPathListeners = this.orbitPathListeners.filter(l => l !== listener);
+ };
+  }
+
+  requestPasses(satellites: SatelliteTLE[], locations: { id: string; name: string; lat: number; lon: number; alt?: number }[], durationHours = 6): void {
+ this.worker?.postMessage({
+ type: 'computePasses',
+ satellites: satellites.map(s => ({
+ noradId: s.noradId,
+ name: s.name,
+ line1: s.line1,
+ line2: s.line2,
+ })),
+ locations,
+ durationHours,
+ });
+  }
+
+  onPasses(listener: PassListener): () => void {
+ this.passListeners.push(listener);
+ return () => {
+ this.passListeners = this.passListeners.filter(l => l !== listener);
  };
   }
 

--- a/src/services/situations/__tests__/cyber-storm-mode.test.mts
+++ b/src/services/situations/__tests__/cyber-storm-mode.test.mts
@@ -1,0 +1,133 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildCyberStormMode } from '../cyber-storm-mode';
+import type { Situation } from '../situation-types';
+
+const NOW = 1_745_000_000_000;
+
+function fakeCyberSituation(overrides: Partial<Situation> = {}): Situation {
+  return {
+    id: 'cyber:CVE-2026-1',
+    domain: 'cyber',
+    title: 'macOS WebKit RCE actively exploited',
+    summary: 's',
+    severity: 'critical',
+    confidence: 0.85,
+    urgency: 0.85,
+    userExposure: 0.9,
+    personalImpact: { summary: '', level: 'high', reasons: ['Affected vendor matches your OS'] },
+    evidence: [{ id: 'e1', source: 'CISA', claim: 'CVE-2026-1: Apple macOS RCE', observedAt: NOW, weight: 0.9 }],
+    sourceAgreement: { agreeing: ['CISA', 'Apple'], disagreeing: [], independentSourceCount: 2 },
+    whatChanged: [],
+    expectedNextSignals: [
+      { id: 'patch', description: 'Vendor patch or mitigation released' },
+      { id: 'kev', description: 'CISA advisory or KEV addition' },
+    ],
+    invalidationSignals: [],
+    recommendedActions: [],
+    timeline: [],
+    diagnosticsTrace: {
+      createdReason: 'test',
+      severityRationale: 'test',
+      confidenceRationale: 'test',
+      exposureRationale: 'test',
+      sourceContributions: { CISA: 0.5, Apple: 0.5 },
+      thresholdsCrossed: ['stage:kev_listed', 'severity:critical', 'user_vendor_match'],
+    },
+    predictionOutcome: {},
+    phase: 'active',
+    firstSeen: NOW,
+    lastUpdated: NOW,
+    ...overrides,
+  };
+}
+
+describe('buildCyberStormMode — activation threshold', () => {
+  it('activates for critical-severity cyber situation', () => {
+    const p = buildCyberStormMode(fakeCyberSituation());
+    assert.equal(p.active, true);
+  });
+
+  it('activates for severity=elevated when userExposure >= 0.85', () => {
+    const p = buildCyberStormMode(fakeCyberSituation({ severity: 'elevated', userExposure: 0.9 }));
+    assert.equal(p.active, true);
+  });
+
+  it('does NOT activate for severity=watch + low exposure', () => {
+    const p = buildCyberStormMode(fakeCyberSituation({ severity: 'watch', userExposure: 0.2 }));
+    assert.equal(p.active, false);
+  });
+
+  it('refuses to activate for non-cyber situations', () => {
+    const p = buildCyberStormMode(fakeCyberSituation({ domain: 'weather' }));
+    assert.equal(p.active, false);
+  });
+});
+
+describe('buildCyberStormMode — patch status mapping', () => {
+  it('kev_listed → patch available', () => {
+    const p = buildCyberStormMode(fakeCyberSituation({
+      diagnosticsTrace: { ...fakeCyberSituation().diagnosticsTrace, thresholdsCrossed: ['stage:kev_listed', 'severity:critical', 'user_vendor_match'] },
+    }));
+    assert.equal(p.patchStatus, 'available');
+  });
+
+  it('exploit_observed → no_patch_yet', () => {
+    const p = buildCyberStormMode(fakeCyberSituation({
+      diagnosticsTrace: { ...fakeCyberSituation().diagnosticsTrace, thresholdsCrossed: ['stage:exploit_observed', 'severity:critical', 'user_vendor_match'] },
+    }));
+    assert.equal(p.patchStatus, 'no_patch_yet');
+  });
+
+  it('ransomware_in_use → in_progress', () => {
+    const p = buildCyberStormMode(fakeCyberSituation({
+      diagnosticsTrace: { ...fakeCyberSituation().diagnosticsTrace, thresholdsCrossed: ['stage:ransomware_in_use', 'severity:critical', 'user_vendor_match'] },
+    }));
+    assert.equal(p.patchStatus, 'in_progress');
+  });
+});
+
+describe('buildCyberStormMode — phishing risk', () => {
+  it('critical_infra threat → high phishing risk', () => {
+    const p = buildCyberStormMode(fakeCyberSituation({
+      diagnosticsTrace: { ...fakeCyberSituation().diagnosticsTrace, thresholdsCrossed: ['stage:kev_listed', 'severity:critical', 'critical_infra'] },
+    }));
+    assert.equal(p.phishingScamRisk, 'high');
+  });
+
+  it('user_vendor_match alone → medium phishing risk', () => {
+    const p = buildCyberStormMode(fakeCyberSituation());
+    assert.equal(p.phishingScamRisk, 'medium');
+  });
+
+  it('no special threshold → low phishing risk', () => {
+    const p = buildCyberStormMode(fakeCyberSituation({
+      diagnosticsTrace: { ...fakeCyberSituation().diagnosticsTrace, thresholdsCrossed: ['stage:kev_listed', 'severity:critical'] },
+      userExposure: 0.95,
+    }));
+    assert.equal(p.phishingScamRisk, 'low');
+  });
+});
+
+describe('buildCyberStormMode — primaryAction', () => {
+  it('user-vendor-match patches their system', () => {
+    const p = buildCyberStormMode(fakeCyberSituation());
+    assert.match(p.primaryAction, /Patch/i);
+  });
+
+  it('no vendor match → monitor accounts + watch phishing', () => {
+    const p = buildCyberStormMode(fakeCyberSituation({
+      userExposure: 0.95,
+      diagnosticsTrace: { ...fakeCyberSituation().diagnosticsTrace, thresholdsCrossed: ['stage:kev_listed', 'severity:critical'] },
+    }));
+    assert.match(p.primaryAction, /Monitor|phishing/i);
+  });
+});
+
+describe('buildCyberStormMode — JSON round-trip', () => {
+  it('payload is JSON-serializable', () => {
+    const p = buildCyberStormMode(fakeCyberSituation());
+    assert.doesNotThrow(() => JSON.stringify(p));
+  });
+});

--- a/src/services/situations/__tests__/military-patterns.test.mts
+++ b/src/services/situations/__tests__/military-patterns.test.mts
@@ -1,0 +1,106 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  DEFAULT_MILITARY_PATTERNS,
+  matchAllMilitaryPatterns,
+  matchMilitaryPattern,
+} from '../military-patterns';
+
+describe('matchMilitaryPattern', () => {
+  it('returns null when no features defined', () => {
+    const r = matchMilitaryPattern({
+      pattern: { id: 'air_campaign_buildup', name: 'X', features: [], confirmingSignals: [], invalidatingSignals: [] },
+    });
+    assert.equal(r, null);
+  });
+
+  it('returns null when matchPercent below minMatch', () => {
+    const r = matchMilitaryPattern({
+      pattern: {
+        id: 'air_campaign_buildup',
+        name: 'Air',
+        features: [
+          { id: 'a', observed: false, weight: 1, label: 'a' },
+          { id: 'b', observed: false, weight: 1, label: 'b' },
+        ],
+        confirmingSignals: [],
+        invalidatingSignals: [],
+      },
+      minMatch: 0.3,
+    });
+    assert.equal(r, null);
+  });
+
+  it('matches when enough features observed', () => {
+    const r = matchMilitaryPattern({
+      pattern: {
+        id: 'air_campaign_buildup',
+        name: 'Air',
+        features: [
+          { id: 'a', observed: true, weight: 1, label: 'a' },
+          { id: 'b', observed: true, weight: 1, label: 'b' },
+          { id: 'c', observed: false, weight: 1, label: 'c' },
+        ],
+        confirmingSignals: ['a', 'b', 'c'],
+        invalidatingSignals: [],
+      },
+      minMatch: 0.5,
+    });
+    assert.ok(r);
+    assert.equal(r?.matchPercent, 0.67);
+    assert.ok((r?.confidence ?? 0) >= 0.67);
+  });
+
+  it('confidence caps at 0.95', () => {
+    const features = Array.from({ length: 10 }, (_, i) => ({
+      id: String(i), observed: true, weight: 1, label: String(i),
+    }));
+    const r = matchMilitaryPattern({
+      pattern: {
+        id: 'air_campaign_buildup',
+        name: 'Air',
+        features,
+        confirmingSignals: features.map((f) => f.id),
+        invalidatingSignals: [],
+      },
+    });
+    assert.ok((r?.confidence ?? 0) <= 0.95);
+  });
+});
+
+describe('matchAllMilitaryPatterns', () => {
+  it('returns matches sorted by confidence desc', () => {
+    const observations = {
+      'tanker-surge': true,
+      'awacs-presence': true,
+      'fighter-deployments': true,
+      'NOTAM-massive-airspace': false,
+      'carrier-group-positioned': true,
+    };
+    const matches = matchAllMilitaryPatterns(observations, DEFAULT_MILITARY_PATTERNS, 0.3);
+    assert.ok(matches.length >= 1);
+    // Sorted desc
+    for (let i = 1; i < matches.length; i++) {
+      assert.ok(matches[i - 1]!.confidence >= matches[i]!.confidence);
+    }
+  });
+
+  it('empty observations → empty result', () => {
+    const matches = matchAllMilitaryPatterns({});
+    assert.deepEqual(matches, []);
+  });
+
+  it('air_campaign_buildup recognized when 3 of 4 confirming signals fire', () => {
+    const observations = {
+      'tanker-surge': true,
+      'awacs-presence': true,
+      'fighter-deployments': true,
+      'NOTAM-massive-airspace': false,
+    };
+    const matches = matchAllMilitaryPatterns(observations);
+    const air = matches.find((m) => m.patternId === 'air_campaign_buildup');
+    assert.ok(air);
+    assert.equal(air?.matchPercent, 0.75);
+  });
+});

--- a/src/services/situations/__tests__/weather-nowcast.test.mts
+++ b/src/services/situations/__tests__/weather-nowcast.test.mts
@@ -1,0 +1,103 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { evaluateWeatherNowcast, type NowcastSignal } from '../weather-nowcast';
+
+const NOW = 1_745_000_000_000;
+
+function sig(kind: NowcastSignal['kind'], strength = 0.8, source = 'NWS'): NowcastSignal {
+  return { kind, observedAt: NOW, strength, source };
+}
+
+describe('evaluateWeatherNowcast — empty', () => {
+  it('zero signals → not escalating, slight urgency decay', () => {
+    const e = evaluateWeatherNowcast({ signals: [] });
+    assert.equal(e.escalate, false);
+    assert.equal(e.confirmed, false);
+    assert.ok(e.urgencyDelta < 0);
+  });
+});
+
+describe('evaluateWeatherNowcast — escalation', () => {
+  it('moderate weighted signals escalate but not confirm', () => {
+    const e = evaluateWeatherNowcast({
+      signals: [
+        sig('radar_core_strengthening', 1.0),
+        sig('lightning_density_rise', 1.0),
+        // 0.25 + 0.15 = 0.40 — still below escalateAt 0.5 default
+      ],
+    });
+    assert.equal(e.escalate, false);
+    assert.equal(e.confirmed, false);
+  });
+
+  it('strong multi-kind signals reach escalate', () => {
+    const e = evaluateWeatherNowcast({
+      signals: [
+        sig('radar_core_strengthening', 1.0),
+        sig('lightning_density_rise', 1.0),
+        sig('storm_reports', 1.0),
+        // 0.25 + 0.15 + 0.20 = 0.60
+      ],
+    });
+    assert.equal(e.escalate, true);
+    assert.ok(e.urgencyDelta > 0);
+  });
+
+  it('saturated signals reach confirm', () => {
+    const e = evaluateWeatherNowcast({
+      signals: [
+        sig('radar_core_strengthening', 1.0),
+        sig('lightning_density_rise', 1.0),
+        sig('storm_reports', 1.0),
+        sig('power_outage_reports', 1.0),
+        sig('airport_ground_stops', 1.0),
+        // 0.25+0.15+0.20+0.15+0.10 = 0.85
+      ],
+    });
+    assert.equal(e.confirmed, true);
+  });
+});
+
+describe('evaluateWeatherNowcast — byKind tally', () => {
+  it('counts each signal kind', () => {
+    const e = evaluateWeatherNowcast({
+      signals: [
+        sig('storm_reports'),
+        sig('storm_reports'),
+        sig('radar_core_strengthening'),
+      ],
+    });
+    assert.equal(e.byKind.storm_reports, 2);
+    assert.equal(e.byKind.radar_core_strengthening, 1);
+    assert.equal(e.byKind.lightning_density_rise, 0);
+  });
+});
+
+describe('evaluateWeatherNowcast — urgencyDelta bounds', () => {
+  it('urgencyDelta capped at +0.2 even with overwhelming signals', () => {
+    const signals = Array.from({ length: 50 }, () => sig('storm_reports', 1.0));
+    const e = evaluateWeatherNowcast({ signals });
+    assert.ok(e.urgencyDelta <= 0.2);
+  });
+});
+
+describe('evaluateWeatherNowcast — reason text', () => {
+  it('confirmed → reason mentions confirmed', () => {
+    const e = evaluateWeatherNowcast({
+      signals: [
+        sig('radar_core_strengthening', 1.0),
+        sig('lightning_density_rise', 1.0),
+        sig('storm_reports', 1.0),
+        sig('power_outage_reports', 1.0),
+        sig('airport_ground_stops', 1.0),
+      ],
+    });
+    assert.match(e.reason, /Confirmed/i);
+  });
+
+  it('not escalating → reason mentions threshold', () => {
+    const e = evaluateWeatherNowcast({ signals: [sig('storm_reports', 0.3)] });
+    assert.match(e.reason, /below|threshold/i);
+  });
+});

--- a/src/services/situations/cyber-storm-mode.ts
+++ b/src/services/situations/cyber-storm-mode.ts
@@ -1,0 +1,140 @@
+/* eslint-disable unicorn/no-nested-ternary, sonarjs/no-nested-conditional */
+/**
+ * Cyber Storm Mode payload — Phase 4 of
+ * docs/CLAUDE_HIGH_IMPACT_EVENT_INTELLIGENCE_VISION_2026-04-29.md.
+ *
+ * Pure deterministic. Takes a cyber Situation that has reached a
+ * threshold (severity ≥ critical OR userExposure ≥ 0.85) and produces
+ * a focused mode payload mirroring Personal Storm Mode. The host UI
+ * can render this as a full-screen takeover when active.
+ */
+
+import type { Situation } from './situation-types';
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+export interface CyberStormModePayload {
+  active: boolean;
+  /** Title for the mode banner. */
+  threatTitle: string;
+  /** Affected systems / vendors / sectors the user owns. */
+  affectedSystems: readonly string[];
+  /** Why the user is exposed (one line). */
+  userExposureReason: string;
+  /** When the user should act by (ms timestamp), or undefined for ASAP. */
+  actionDeadlineMs?: number;
+  /** Patch / mitigation status when known. */
+  patchStatus: 'available' | 'in_progress' | 'no_patch_yet' | 'unknown';
+  /** Phishing / scam risk that often follows major cyber events. */
+  phishingScamRisk: 'low' | 'medium' | 'high';
+  /** Signals to watch next (deduped from the situation). */
+  watchNext: readonly string[];
+  /** Source confirmation summary. */
+  sourceConfirmation: string;
+  /** Concrete user action. */
+  primaryAction: string;
+}
+
+export interface ActivationOptions {
+  /** Override the activation threshold; defaults to the doc-spec
+   *  (critical+ OR exposure ≥ 0.85). */
+  forceActive?: boolean;
+}
+
+/** Build a CyberStormMode payload from a Situation. Returns inactive
+ *  payload when the threshold isn't met (active=false, fields populated
+ *  for inspection but UI should hide). */
+export function buildCyberStormMode(
+  situation: Situation,
+  options: ActivationOptions = {},
+): CyberStormModePayload {
+  if (situation.domain !== 'cyber') {
+    return inactivePayload(situation, 'Not a cyber situation');
+  }
+
+  const meetsThreshold =
+    options.forceActive === true ||
+    situation.severity === 'critical' ||
+    situation.severity === 'emergency' ||
+    situation.userExposure >= 0.85;
+
+  if (!meetsThreshold) {
+    return inactivePayload(situation, 'Below storm-mode activation threshold');
+  }
+
+  const exposureReasons = situation.personalImpact.reasons.join('; ');
+  // Patch status — derive from threshold flags. Phase 4+ wires
+  // CISA / vendor advisory metadata directly into the situation,
+  // but for now we can reason from the diagnostics trace.
+  const thresholds = situation.diagnosticsTrace.thresholdsCrossed;
+  const isUserVendorMatch = thresholds.includes('user_vendor_match');
+  const isCriticalInfra = thresholds.includes('critical_infra');
+  const lastStage = thresholds.find((t) => t.startsWith('stage:'))?.split(':')[1] ?? '';
+
+  const patchStatus: CyberStormModePayload['patchStatus'] =
+    lastStage === 'kev_listed' || lastStage === 'sector_targeted'
+      ? 'available'
+      : lastStage === 'ransomware_in_use'
+      ? 'in_progress'
+      : lastStage === 'cve_published' || lastStage === 'exploit_observed'
+      ? 'no_patch_yet'
+      : 'unknown';
+
+  // Phishing risk rises during major events and when critical infra
+  // is hit (think: fake "CrowdStrike outage rescue" emails).
+  const phishingScamRisk: CyberStormModePayload['phishingScamRisk'] = isCriticalInfra
+    ? 'high'
+    : isUserVendorMatch
+    ? 'medium'
+    : 'low';
+
+  const primaryAction = isUserVendorMatch
+    ? `Patch your affected system(s) today.${patchStatus === 'no_patch_yet' ? ' (No vendor patch yet — apply mitigations.)' : ''}`
+    : `Monitor your accounts and watch for ${phishingScamRisk}-risk phishing campaigns.`;
+
+  return {
+    active: true,
+    threatTitle: situation.title,
+    affectedSystems: extractAffectedSystems(situation),
+    userExposureReason: exposureReasons || 'Critical-infrastructure threat that may affect services you depend on',
+    patchStatus,
+    phishingScamRisk,
+    watchNext: situation.expectedNextSignals.map((s) => s.description).slice(0, 4),
+    sourceConfirmation: composeSourceConfirmation(situation),
+    primaryAction,
+  };
+}
+
+// ── Internals ───────────────────────────────────────────────────────────
+
+function inactivePayload(situation: Situation, reason: string): CyberStormModePayload {
+  return {
+    active: false,
+    threatTitle: situation.title,
+    affectedSystems: [],
+    userExposureReason: reason,
+    patchStatus: 'unknown',
+    phishingScamRisk: 'low',
+    watchNext: [],
+    sourceConfirmation: composeSourceConfirmation(situation),
+    primaryAction: 'No action required.',
+  };
+}
+
+function extractAffectedSystems(situation: Situation): string[] {
+  // Try to pull from evidence claims (the cyber adapter writes
+  // 'CVE → vendor' style claims). Fall back to the title if empty.
+  const fromEvidence = situation.evidence
+    .map((e) => e.claim)
+    .filter((c) => /macOS|iOS|Windows|Linux|Android|Chrome|Safari|Firefox|kernel/i.test(c))
+    .slice(0, 3);
+  if (fromEvidence.length > 0) return fromEvidence;
+  return [situation.title];
+}
+
+function composeSourceConfirmation(situation: Situation): string {
+  const { agreeing, disagreeing, independentSourceCount } = situation.sourceAgreement;
+  if (agreeing.length === 0) return 'No corroborating sources yet';
+  const dis = disagreeing.length > 0 ? ` (${disagreeing.length} disputing)` : '';
+  return `${independentSourceCount} independent source(s): ${agreeing.slice(0, 3).join(', ')}${dis}`;
+}

--- a/src/services/situations/index.ts
+++ b/src/services/situations/index.ts
@@ -53,6 +53,7 @@ export { cyberThreatsToSituations } from './cyber-adapter';
 export type { WeatherAdapterInput } from './weather-adapter';
 export { weatherAlertsToSituations } from './weather-adapter';
 
+// ── Phase 2: Personal Exposure Graph ─────────────────────────────────────
 export type {
   ExposureGraph,
   ExposureSavedPlace,
@@ -70,11 +71,36 @@ export {
   resetExposureGraphForTests,
 } from './exposure-graph';
 
+// ── Phase 3: Watch Windows ───────────────────────────────────────────────
 export type { WatchWindowEvaluation, WatchWindowInput } from './watch-window';
 export {
   evaluateWatchWindow,
   applyWatchWindowEvaluation,
 } from './watch-window';
+
+// ── Phase 4: Domain Superpowers ──────────────────────────────────────────
+export type {
+  MilitaryPatternId,
+  MilitaryPatternFeature,
+  MilitaryPatternMatch,
+  MilitaryPatternDefinition,
+} from './military-patterns';
+export {
+  matchMilitaryPattern,
+  matchAllMilitaryPatterns,
+  DEFAULT_MILITARY_PATTERNS,
+} from './military-patterns';
+
+export type { CyberStormModePayload } from './cyber-storm-mode';
+export { buildCyberStormMode } from './cyber-storm-mode';
+
+export type {
+  NowcastSignal,
+  NowcastSignalKind,
+  NowcastEvaluation,
+  NowcastInput,
+} from './weather-nowcast';
+export { evaluateWeatherNowcast } from './weather-nowcast';
 
 // ── Phase 5: Compound Threat Engine ──────────────────────────────────────
 export type {

--- a/src/services/situations/military-patterns.ts
+++ b/src/services/situations/military-patterns.ts
@@ -1,0 +1,170 @@
+/**
+ * Military historical pattern matcher — Phase 4 of
+ * docs/CLAUDE_HIGH_IMPACT_EVENT_INTELLIGENCE_VISION_2026-04-29.md.
+ *
+ * Compares current movement signatures against known patterns
+ * (air-campaign buildup, naval strike posture, rapid deployment,
+ * blockade setup, evacuation precursor, recon surge, multi-front
+ * posturing). Each match returns a percentage + evidence + the
+ * confirming/invalidating signals.
+ *
+ * Pure deterministic. No fetch, no DOM. Adapter consumes the host's
+ * existing situation-engine outputs and emits structured pattern
+ * matches.
+ */
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+export type MilitaryPatternId =
+  | 'air_campaign_buildup'
+  | 'naval_strike_posture'
+  | 'rapid_deployment'
+  | 'blockade_setup'
+  | 'evacuation_precursor'
+  | 'recon_surge'
+  | 'multi_front_posturing';
+
+export interface MilitaryPatternFeature {
+  id: string;
+  /** Whether this feature was observed in the current movement
+   *  signature. */
+  observed: boolean;
+  /** Per-feature weight 0..1. Heavier features dominate the match
+   *  percentage. */
+  weight: number;
+  /** Display label for the diagnostics trace. */
+  label: string;
+}
+
+export interface MilitaryPatternMatch {
+  patternId: MilitaryPatternId;
+  patternName: string;
+  /** 0..1 fraction of weighted features observed. */
+  matchPercent: number;
+  /** Confidence reflects (a) how many features observed and
+   *  (b) how strong the observed features are. Bounded to 0.95. */
+  confidence: number;
+  /** Features that contributed to the match. */
+  observedFeatures: readonly MilitaryPatternFeature[];
+  /** Features that would confirm the pattern if observed next. */
+  confirmingSignals: readonly string[];
+  /** Features that would invalidate the pattern if observed. */
+  invalidatingSignals: readonly string[];
+}
+
+/** Per-pattern definition: features to look for, what would confirm,
+ *  what would invalidate. */
+export interface MilitaryPatternDefinition {
+  id: MilitaryPatternId;
+  name: string;
+  features: readonly MilitaryPatternFeature[];
+  confirmingSignals: readonly string[];
+  invalidatingSignals: readonly string[];
+}
+
+/** Default pattern catalog — a starting point that the host can
+ *  override per theater later. */
+export const DEFAULT_MILITARY_PATTERNS: readonly Omit<MilitaryPatternDefinition, 'features'>[] = [
+  {
+    id: 'air_campaign_buildup',
+    name: 'Air campaign buildup',
+    confirmingSignals: ['tanker-surge', 'awacs-presence', 'fighter-deployments', 'NOTAM-massive-airspace'],
+    invalidatingSignals: ['withdrawal-announcement', 'tanker-stand-down'],
+  },
+  {
+    id: 'naval_strike_posture',
+    name: 'Naval strike posture',
+    confirmingSignals: ['carrier-group-positioned', 'submarine-deployment', 'AIS-dark-vessels-spike'],
+    invalidatingSignals: ['carrier-departure', 'naval-exercise-conclusion'],
+  },
+  {
+    id: 'rapid_deployment',
+    name: 'Rapid deployment',
+    confirmingSignals: ['c-17-surge', 'fuel-truck-spike', 'embassy-airlift'],
+    invalidatingSignals: ['movement-cancelled', 'troops-recalled'],
+  },
+  {
+    id: 'blockade_setup',
+    name: 'Blockade setup',
+    confirmingSignals: ['naval-perimeter', 'shipping-rerouting', 'port-closure'],
+    invalidatingSignals: ['blockade-lifted', 'ships-cleared'],
+  },
+  {
+    id: 'evacuation_precursor',
+    name: 'Evacuation precursor',
+    confirmingSignals: ['embassy-charter-flights', 'state-dept-advisory', 'commercial-flight-cancellations'],
+    invalidatingSignals: ['advisory-downgraded', 'flights-resumed'],
+  },
+  {
+    id: 'recon_surge',
+    name: 'Recon surge',
+    confirmingSignals: ['recon-aircraft-spike', 'satellite-tasking', 'NOTAM-ISR-orbits'],
+    invalidatingSignals: ['recon-stand-down'],
+  },
+  {
+    id: 'multi_front_posturing',
+    name: 'Multi-front posturing',
+    confirmingSignals: ['simultaneous-theater-elevations', 'cross-theater-tanker-bridge'],
+    invalidatingSignals: ['theater-de-escalation'],
+  },
+];
+
+export interface MatchInput {
+  /** Pattern to evaluate. */
+  pattern: MilitaryPatternDefinition;
+  /** Confidence floor — patterns below this are not surfaced. */
+  minMatch?: number;
+}
+
+export function matchMilitaryPattern(input: MatchInput): MilitaryPatternMatch | null {
+  const minMatch = input.minMatch ?? 0.3;
+  const totalWeight = input.pattern.features.reduce((s, f) => s + f.weight, 0);
+  if (totalWeight === 0) return null;
+  const observedWeight = input.pattern.features
+    .filter((f) => f.observed)
+    .reduce((s, f) => s + f.weight, 0);
+  const matchPercent = observedWeight / totalWeight;
+  if (matchPercent < minMatch) return null;
+  // Confidence is the match percent, scaled by how many features
+  // we have signals on (more features = stronger evidence). Capped 0.95.
+  const observedCount = input.pattern.features.filter((f) => f.observed).length;
+  const breadthBonus = Math.min(0.2, observedCount * 0.05);
+  const confidence = Math.min(0.95, matchPercent + breadthBonus);
+
+  return {
+    patternId: input.pattern.id,
+    patternName: input.pattern.name,
+    matchPercent: Number(matchPercent.toFixed(2)),
+    confidence: Number(confidence.toFixed(2)),
+    observedFeatures: input.pattern.features.filter((f) => f.observed),
+    confirmingSignals: input.pattern.confirmingSignals,
+    invalidatingSignals: input.pattern.invalidatingSignals,
+  };
+}
+
+/** Match all default patterns against a feature observation map.
+ *  The map is keyed by feature id; missing keys are treated as
+ *  unobserved (false). */
+export function matchAllMilitaryPatterns(
+  observations: Readonly<Record<string, boolean>>,
+  patterns: readonly Omit<MilitaryPatternDefinition, 'features'>[] = DEFAULT_MILITARY_PATTERNS,
+  minMatch = 0.3,
+): MilitaryPatternMatch[] {
+  return patterns
+    .map((p) => {
+      const features: MilitaryPatternFeature[] = [
+        ...p.confirmingSignals.map((id) => ({
+          id,
+          observed: observations[id] ?? false,
+          weight: 1,
+          label: id.replace(/-/g, ' '),
+        })),
+      ];
+      return matchMilitaryPattern({
+        pattern: { ...p, features },
+        minMatch,
+      });
+    })
+    .filter((m): m is MilitaryPatternMatch => m !== null)
+    .sort((a, b) => b.confidence - a.confidence);
+}

--- a/src/services/situations/weather-nowcast.ts
+++ b/src/services/situations/weather-nowcast.ts
@@ -1,0 +1,125 @@
+/**
+ * Weather nowcast confirmation loop — Phase 4 of
+ * docs/CLAUDE_HIGH_IMPACT_EVENT_INTELLIGENCE_VISION_2026-04-29.md.
+ *
+ * Pure deterministic. Tracks expected nowcast signals (radar core
+ * strengthening, lightning density rise, storm reports, power
+ * outages, airport ground stops, stream gauge rise) and:
+ *   - Confirms the situation when those signals arrive in time
+ *   - Decays urgency when they don't
+ *
+ * This is a domain-specific complement to the generic watch-window
+ * evaluator: it adds a richer confirmation taxonomy + escalation
+ * logic specific to severe weather.
+ */
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+export type NowcastSignalKind =
+  | 'radar_core_strengthening'
+  | 'lightning_density_rise'
+  | 'storm_reports'
+  | 'power_outage_reports'
+  | 'airport_ground_stops'
+  | 'stream_gauge_rise'
+  | 'polygon_expansion';
+
+export interface NowcastSignal {
+  kind: NowcastSignalKind;
+  observedAt: number;
+  /** 0..1 strength of the observation (radar reflectivity, outage
+   *  count fraction, etc.). */
+  strength: number;
+  /** Free-text source label. */
+  source: string;
+}
+
+export interface NowcastEvaluation {
+  /** Whether enough confirmation signals have appeared to escalate
+   *  the underlying situation. */
+  escalate: boolean;
+  /** Whether enough confirmations have arrived to declare the
+   *  situation 'confirmed' (UI can stop showing "watch" wording). */
+  confirmed: boolean;
+  /** Plain-English reason. */
+  reason: string;
+  /** Confirmation count by kind. */
+  byKind: Readonly<Record<NowcastSignalKind, number>>;
+  /** Total weighted confirmation score 0..1. */
+  weightedScore: number;
+  /** Recommended urgency adjustment for the host to apply on top
+   *  of the existing situation urgency. Bounded -0.2..+0.2. */
+  urgencyDelta: number;
+}
+
+export interface NowcastInput {
+  /** Signals observed since the situation was first emitted. */
+  signals: readonly NowcastSignal[];
+  /** Optional escalation threshold (default 0.5). */
+  escalateAt?: number;
+  /** Optional confirmation threshold (default 0.7). */
+  confirmAt?: number;
+}
+
+const KIND_WEIGHT: Record<NowcastSignalKind, number> = {
+  radar_core_strengthening: 0.25,
+  lightning_density_rise: 0.15,
+  storm_reports: 0.2,
+  power_outage_reports: 0.15,
+  airport_ground_stops: 0.1,
+  stream_gauge_rise: 0.1,
+  polygon_expansion: 0.05,
+};
+
+export function evaluateWeatherNowcast(input: NowcastInput): NowcastEvaluation {
+  const escalateAt = input.escalateAt ?? 0.5;
+  const confirmAt = input.confirmAt ?? 0.7;
+
+  const byKind: Record<NowcastSignalKind, number> = {
+    radar_core_strengthening: 0,
+    lightning_density_rise: 0,
+    storm_reports: 0,
+    power_outage_reports: 0,
+    airport_ground_stops: 0,
+    stream_gauge_rise: 0,
+    polygon_expansion: 0,
+  };
+  let weightedScore = 0;
+  for (const sig of input.signals) {
+    byKind[sig.kind] = (byKind[sig.kind] ?? 0) + 1;
+    // Weight by kind × strength; cap at 1 so a single very-strong
+    // signal can't dominate over diversity.
+    weightedScore += Math.min(1, sig.strength) * KIND_WEIGHT[sig.kind];
+  }
+  weightedScore = Math.min(1, weightedScore);
+
+  const escalate = weightedScore >= escalateAt;
+  const confirmed = weightedScore >= confirmAt;
+  // Linear ramp: 0.5 → +0.05, 0.9 → +0.2. Below escalateAt, mild
+  // negative for "things are quieting down" so urgency drifts back
+  // when no signals arrive.
+  let urgencyDelta = 0;
+  if (weightedScore >= escalateAt) {
+    urgencyDelta = Math.min(0.2, 0.05 + (weightedScore - escalateAt) * 0.4);
+  } else if (input.signals.length === 0) {
+    urgencyDelta = -0.05;
+  }
+
+  let reason: string;
+  if (confirmed) {
+    reason = `Confirmed by ${input.signals.length} nowcast signal(s) (weighted ${weightedScore.toFixed(2)} ≥ confirm ${confirmAt})`;
+  } else if (escalate) {
+    reason = `Escalating: ${input.signals.length} signal(s), weighted ${weightedScore.toFixed(2)} ≥ escalate ${escalateAt}`;
+  } else {
+    reason = `Below escalation threshold (${weightedScore.toFixed(2)} < ${escalateAt})`;
+  }
+
+  return {
+    escalate,
+    confirmed,
+    reason,
+    byKind,
+    weightedScore,
+    urgencyDelta,
+  };
+}

--- a/src/services/webcam-sources.ts
+++ b/src/services/webcam-sources.ts
@@ -1,0 +1,253 @@
+import { getApiBaseUrl } from '@/services/runtime';
+import { dataFreshness } from '@/services/data-freshness';
+
+export type WebcamSource = 'windy' | 'youtube' | 'dot' | 'custom';
+export type WebcamRegion = 'iran' | 'middle-east' | 'europe' | 'asia' | 'americas';
+export type EmbedType = 'iframe' | 'image';
+
+export interface WebcamFeed {
+  id: string;
+  source: WebcamSource;
+  title: string;
+  city: string;
+  country: string;
+  region: WebcamRegion;
+  lat: number;
+  lon: number;
+  thumbnailUrl?: string;
+  embedUrl: string;
+  embedType: EmbedType;
+  refreshIntervalMs?: number;
+  isLive: boolean;
+  lastVerified: number;
+  sourceId: string;
+}
+
+const YOUTUBE_CURATED = [
+  { id: 'iran-tehran', city: 'Tehran', country: 'Iran', region: 'iran' as WebcamRegion, channelHandle: '@IranHDCams', fallbackVideoId: '-zGuR1qVKrU' },
+  { id: 'iran-telaviv', city: 'Tel Aviv', country: 'Israel', region: 'iran' as WebcamRegion, channelHandle: '@IsraelLiveCam', fallbackVideoId: 'gmtlJ_m2r5A' },
+  { id: 'iran-jerusalem', city: 'Jerusalem', country: 'Israel', region: 'iran' as WebcamRegion, channelHandle: '@JerusalemLive', fallbackVideoId: 'JHwwZRH2wz8' },
+  { id: 'iran-multicam', city: 'Middle East', country: 'Multi', region: 'iran' as WebcamRegion, channelHandle: '@MiddleEastCams', fallbackVideoId: '4E-iFtUM2kk' },
+  { id: 'jerusalem', city: 'Jerusalem', country: 'Israel', region: 'middle-east' as WebcamRegion, channelHandle: '@TheWesternWall', fallbackVideoId: 'UyduhBUpO7Q' },
+  { id: 'tehran', city: 'Tehran', country: 'Iran', region: 'middle-east' as WebcamRegion, channelHandle: '@IranHDCams', fallbackVideoId: '-zGuR1qVKrU' },
+  { id: 'tel-aviv', city: 'Tel Aviv', country: 'Israel', region: 'middle-east' as WebcamRegion, channelHandle: '@IsraelLiveCam', fallbackVideoId: 'gmtlJ_m2r5A' },
+  { id: 'mecca', city: 'Mecca', country: 'Saudi Arabia', region: 'middle-east' as WebcamRegion, channelHandle: '@MakkahLive', fallbackVideoId: 'DEcpmPUbkDQ' },
+  { id: 'kyiv', city: 'Kyiv', country: 'Ukraine', region: 'europe' as WebcamRegion, channelHandle: '@DWNews', fallbackVideoId: '-Q7FuPINDjA' },
+  { id: 'odessa', city: 'Odessa', country: 'Ukraine', region: 'europe' as WebcamRegion, channelHandle: '@UkraineLiveCam', fallbackVideoId: 'e2gC37ILQmk' },
+  { id: 'paris', city: 'Paris', country: 'France', region: 'europe' as WebcamRegion, channelHandle: '@PalaisIena', fallbackVideoId: 'OzYp4NRZlwQ' },
+  { id: 'st-petersburg', city: 'St. Petersburg', country: 'Russia', region: 'europe' as WebcamRegion, channelHandle: '@SPBLiveCam', fallbackVideoId: 'CjtIYbmVfck' },
+  { id: 'london', city: 'London', country: 'UK', region: 'europe' as WebcamRegion, channelHandle: '@EarthCam', fallbackVideoId: 'Lxqcg1qt0XU' },
+  { id: 'washington', city: 'Washington DC', country: 'USA', region: 'americas' as WebcamRegion, channelHandle: '@AxisCommunications', fallbackVideoId: '1wV9lLe14aU' },
+  { id: 'new-york', city: 'New York', country: 'USA', region: 'americas' as WebcamRegion, channelHandle: '@EarthCam', fallbackVideoId: '4qyZLflp-sI' },
+  { id: 'los-angeles', city: 'Los Angeles', country: 'USA', region: 'americas' as WebcamRegion, channelHandle: '@VeniceVHotel', fallbackVideoId: 'EO_1LWqsCNE' },
+  { id: 'miami', city: 'Miami', country: 'USA', region: 'americas' as WebcamRegion, channelHandle: '@FloridaLiveCams', fallbackVideoId: '5YCajRjvWCg' },
+  { id: 'taipei', city: 'Taipei', country: 'Taiwan', region: 'asia' as WebcamRegion, channelHandle: '@JackyWuTaipei', fallbackVideoId: 'z_fY1pj1VBw' },
+  { id: 'shanghai', city: 'Shanghai', country: 'China', region: 'asia' as WebcamRegion, channelHandle: '@SkylineWebcams', fallbackVideoId: '76EwqI5XZIc' },
+  { id: 'tokyo', city: 'Tokyo', country: 'Japan', region: 'asia' as WebcamRegion, channelHandle: '@TokyoLiveCam4K', fallbackVideoId: '4pu9sF5Qssw' },
+  { id: 'seoul', city: 'Seoul', country: 'South Korea', region: 'asia' as WebcamRegion, channelHandle: '@UNvillage_live', fallbackVideoId: '-JhoMGoAfFc' },
+  { id: 'sydney', city: 'Sydney', country: 'Australia', region: 'asia' as WebcamRegion, channelHandle: '@WebcamSydney', fallbackVideoId: '7pcL-0Wo77U' },
+];
+
+const WINDY_COUNTRY_TO_REGION: Record<string, WebcamRegion> = {
+  IR: 'iran',
+  IL: 'middle-east',
+  SA: 'middle-east',
+  JO: 'middle-east',
+  LB: 'middle-east',
+  UA: 'europe',
+  RU: 'europe',
+  FR: 'europe',
+  GB: 'europe',
+  DE: 'europe',
+  PL: 'europe',
+  US: 'americas',
+  CA: 'americas',
+  MX: 'americas',
+  BR: 'americas',
+  CN: 'asia',
+  JP: 'asia',
+  KR: 'asia',
+  TW: 'asia',
+  AU: 'asia',
+  IN: 'asia',
+};
+
+const CUSTOM_WEBCAMS_KEY = 'crystalball-custom-webcams';
+
+const cache = new Map<string, { feeds: WebcamFeed[]; expiresAt: number }>();
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+const REGION_TO_COUNTRIES: Record<WebcamRegion, string[]> = {
+  iran: ['IR'],
+  'middle-east': ['IL', 'SA', 'JO', 'LB', 'IQ', 'SY', 'YE', 'AE', 'QA', 'BH', 'KW', 'OM'],
+  europe: ['UA', 'RU', 'FR', 'GB', 'DE', 'PL', 'IT', 'ES', 'NL', 'BE', 'CZ', 'RO', 'SE', 'NO'],
+  americas: ['US', 'CA', 'MX', 'BR', 'AR', 'CL', 'CO'],
+  asia: ['CN', 'JP', 'KR', 'TW', 'AU', 'IN', 'TH', 'VN', 'PH', 'SG'],
+};
+
+export async function fetchWindyWebcams(region?: WebcamRegion): Promise<WebcamFeed[]> {
+  try {
+    const base = getApiBaseUrl();
+    const countries = region ? REGION_TO_COUNTRIES[region] : undefined;
+    if (region && (!countries || countries.length === 0)) return [];
+    const countryParam = countries ? `&country=${countries.join(',')}` : '&country=US';
+    const res = await fetch(`${base}/api/windy-webcams?limit=20${countryParam}`);
+    if (!res.ok) return [];
+    const data = await res.json() as { webcams?: { id: string; title: string; playerUrl: string; city: string; country: string; countryCode: string; lat: number; lon: number; thumbnail?: string }[] };
+    const webcams = data.webcams ?? [];
+    const feeds: WebcamFeed[] = [];
+    for (const cam of webcams) {
+      const cc = cam.countryCode ?? '';
+      const camRegion = WINDY_COUNTRY_TO_REGION[cc] ?? 'europe';
+      if (region && camRegion !== region) continue;
+      feeds.push({
+        id: `windy-${cam.id}`,
+        source: 'windy',
+        title: cam.title ?? '',
+        city: cam.city ?? '',
+        country: cam.country ?? '',
+        region: camRegion,
+        lat: cam.lat ?? 0,
+        lon: cam.lon ?? 0,
+        thumbnailUrl: cam.thumbnail,
+        embedUrl: cam.playerUrl ?? '',
+        embedType: 'iframe',
+        isLive: true,
+        lastVerified: Date.now(),
+        sourceId: String(cam.id),
+      });
+    }
+    return feeds;
+  } catch {
+    return [];
+  }
+}
+
+export function youtubeToFeeds(region?: WebcamRegion): WebcamFeed[] {
+  const base = getApiBaseUrl();
+  return YOUTUBE_CURATED
+    .filter(f => !region || f.region === region)
+    .map(f => ({
+      id: `youtube-${f.id}`,
+      source: 'youtube' as WebcamSource,
+      title: `${f.city} Live`,
+      city: f.city,
+      country: f.country,
+      region: f.region,
+      lat: 0,
+      lon: 0,
+      embedUrl: `${base}/api/youtube-embed?videoId=${f.fallbackVideoId}`,
+      embedType: 'iframe' as EmbedType,
+      isLive: true,
+      lastVerified: Date.now(),
+      sourceId: f.fallbackVideoId,
+    }));
+}
+
+export async function fetchDotCams(region?: WebcamRegion): Promise<WebcamFeed[]> {
+  if (region && region !== 'americas') return [];
+  try {
+    const res = await fetch(`${getApiBaseUrl()}/api/dot-traffic-cams`);
+    if (!res.ok) return [];
+    const data = await res.json() as { cameras?: { id: string; title: string; state: string; lat: number; lon: number; imageUrl: string; direction: string }[] };
+    const cams = data.cameras ?? [];
+    return cams.map(cam => ({
+      id: `dot-${cam.id}`,
+      source: 'dot' as WebcamSource,
+      title: cam.title ?? '',
+      city: cam.title ?? '',
+      country: 'USA',
+      region: 'americas' as WebcamRegion,
+      lat: cam.lat ?? 0,
+      lon: cam.lon ?? 0,
+      embedUrl: cam.imageUrl,
+      embedType: 'image' as EmbedType,
+      refreshIntervalMs: 30_000,
+      isLive: true,
+      lastVerified: Date.now(),
+      sourceId: String(cam.id),
+    }));
+  } catch {
+    return [];
+  }
+}
+
+export function getCustomWebcams(): WebcamFeed[] {
+  try {
+    const stored = localStorage.getItem(CUSTOM_WEBCAMS_KEY);
+    if (!stored) return [];
+    const parsed: unknown = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return [];
+    return (parsed as WebcamFeed[]).filter(f => f && typeof f.id === 'string' && typeof f.embedUrl === 'string');
+  } catch {
+    return [];
+  }
+}
+
+export function addCustomWebcam(url: string, title: string, city: string, country: string, region: WebcamRegion): void {
+  const existing = getCustomWebcams();
+  const feed: WebcamFeed = {
+    id: `custom-${Date.now()}`,
+    source: 'custom',
+    title,
+    city,
+    country,
+    region,
+    lat: 0,
+    lon: 0,
+    embedUrl: url,
+    embedType: 'iframe',
+    isLive: false,
+    lastVerified: Date.now(),
+    sourceId: url,
+  };
+  localStorage.setItem(CUSTOM_WEBCAMS_KEY, JSON.stringify([...existing, feed]));
+}
+
+export function removeCustomWebcam(id: string): void {
+  const existing = getCustomWebcams();
+  localStorage.setItem(CUSTOM_WEBCAMS_KEY, JSON.stringify(existing.filter(f => f.id !== id)));
+}
+
+export async function getWebcamFeeds(region?: WebcamRegion, limit = 24): Promise<WebcamFeed[]> {
+  const cacheKey = region ?? '__all__';
+  const cached = cache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.feeds.slice(0, limit);
+  }
+
+  const [windyResult, dotResult] = await Promise.allSettled([
+    fetchWindyWebcams(region),
+    fetchDotCams(region),
+  ]);
+
+  const windy = windyResult.status === 'fulfilled' ? windyResult.value : [];
+  const youtube = youtubeToFeeds(region);
+  const dot = dotResult.status === 'fulfilled' ? dotResult.value : [];
+  const custom = getCustomWebcams().filter(f => !region || f.region === region);
+
+  const seen = new Set<string>();
+  const merged: WebcamFeed[] = [];
+
+  for (const feed of [...windy, ...youtube, ...dot, ...custom]) {
+    const key = `${feed.city.toLowerCase()}-${feed.country.toLowerCase()}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      merged.push(feed);
+    }
+  }
+
+  const result = merged.slice(0, limit);
+
+  cache.set(cacheKey, { feeds: merged, expiresAt: Date.now() + CACHE_TTL_MS });
+
+  if (result.length > 0) {
+    dataFreshness.recordUpdate('webcams', result.length);
+  }
+
+  return result;
+}
+
+export function clearWebcamCache(): void {
+  cache.clear();
+}

--- a/src/workers/satellite-propagator.worker.ts
+++ b/src/workers/satellite-propagator.worker.ts
@@ -10,6 +10,8 @@ import {
   propagate,
   gstime,
   eciToGeodetic,
+  eciToEcf,
+  ecfToLookAngles,
 } from 'satellite.js';
 
 interface TLEInput {
@@ -34,10 +36,19 @@ interface OrbitPathRequest {
   durationMinutes: number;
 }
 
+interface PassLocation {
+  id: string;
+  name: string;
+  lat: number;
+  lon: number;
+  alt?: number;
+}
+
 type WorkerMessage =
   | { type: 'loadTLEs'; tles: TLEInput[] }
   | { type: 'requestOrbitPath'; request: OrbitPathRequest }
-  | { type: 'stop' };
+  | { type: 'stop' }
+  | { type: 'computePasses'; satellites: TLEInput[]; locations: PassLocation[]; durationHours: number };
 
 let tles: TLEInput[] = [];
 let intervalId: ReturnType<typeof setInterval> | null = null;
@@ -101,6 +112,120 @@ function computeOrbitPath(req: OrbitPathRequest): void {
   self.postMessage({ type: 'orbitPath', noradId: req.noradId, points });
 }
 
+interface PassRecord {
+  satelliteId: string;
+  satelliteName: string;
+  locationId: string;
+  locationName: string;
+  riseTime: number;
+  maxElevationTime: number;
+  setTime: number;
+  maxElevation: number;
+  duration: number;
+}
+
+interface PassState {
+  inPass: boolean;
+  riseTime: number;
+  maxEl: number;
+  maxElTime: number;
+}
+
+function getElevationDeg(satrec: ReturnType<typeof twoline2satrec>, t: Date, gmst: number, observerGd: { longitude: number; latitude: number; height: number }): number | null {
+  const posVel = propagate(satrec, t);
+  if (!posVel.position || typeof posVel.position === 'boolean') return null;
+  const ecf = eciToEcf(posVel.position, gmst);
+  const lookAngles = ecfToLookAngles(observerGd, ecf);
+  return lookAngles.elevation * (180 / Math.PI);
+}
+
+function applyPassStep(state: PassState, elDeg: number, tMs: number, minElevation: number, sat: TLEInput, loc: PassLocation, passes: PassRecord[]): void {
+  if (elDeg >= minElevation && !state.inPass) {
+    state.inPass = true;
+    state.riseTime = tMs;
+    state.maxEl = elDeg;
+    state.maxElTime = tMs;
+  } else if (elDeg >= minElevation) {
+    if (elDeg > state.maxEl) {
+      state.maxEl = elDeg;
+      state.maxElTime = tMs;
+    }
+  } else if (state.inPass) {
+    state.inPass = false;
+    passes.push({
+      satelliteId: String(sat.noradId),
+      satelliteName: sat.name,
+      locationId: loc.id,
+      locationName: loc.name,
+      riseTime: state.riseTime,
+      maxElevationTime: state.maxElTime,
+      setTime: tMs,
+      maxElevation: Math.round(state.maxEl * 10) / 10,
+      duration: Math.round((tMs - state.riseTime) / 1000),
+    });
+  }
+}
+
+function computePassesForSatLoc(satrec: ReturnType<typeof twoline2satrec>, sat: TLEInput, loc: PassLocation, totalSteps: number, stepMs: number, minElevation: number, passes: PassRecord[], startMs: number): void {
+  const observerGd = {
+    longitude: loc.lon * (Math.PI / 180),
+    latitude: loc.lat * (Math.PI / 180),
+    height: (loc.alt ?? 0) / 1000,
+  };
+  const state: PassState = { inPass: false, riseTime: 0, maxEl: 0, maxElTime: 0 };
+
+  for (let step = 0; step <= totalSteps; step++) {
+    const t = new Date(startMs + step * stepMs);
+    const gmst = gstime(t);
+    const elDeg = getElevationDeg(satrec, t, gmst, observerGd);
+    if (elDeg === null) continue;
+    applyPassStep(state, elDeg, t.getTime(), minElevation, sat, loc, passes);
+  }
+
+  // Flush an open pass at the window boundary so we don't drop a partial pass
+  if (state.inPass) {
+    const endMs = startMs + totalSteps * stepMs;
+    passes.push({
+      satelliteId: String(sat.noradId),
+      satelliteName: sat.name,
+      locationId: loc.id,
+      locationName: loc.name,
+      riseTime: state.riseTime,
+      maxElevationTime: state.maxElTime,
+      setTime: endMs,
+      maxElevation: Math.round(state.maxEl * 10) / 10,
+      duration: Math.round((endMs - state.riseTime) / 1000),
+    });
+  }
+}
+
+async function computePasses(
+  satellites: TLEInput[],
+  locations: PassLocation[],
+  durationHours: number,
+): Promise<void> {
+  const passes: PassRecord[] = [];
+  const stepMs = 30_000;
+  const totalSteps = Math.floor((durationHours * 3_600_000) / stepMs);
+  const minElevation = 10;
+  const startMs = Date.now();
+
+  for (const [i, satellite] of satellites.entries()) {
+    const sat = satellite!;
+    try {
+      const satrec = twoline2satrec(sat.line1, sat.line2);
+      for (const loc of locations) {
+        computePassesForSatLoc(satrec, sat, loc, totalSteps, stepMs, minElevation, passes, startMs);
+      }
+    } catch {
+      // Skip satellites with bad TLEs
+    }
+    // Yield every 10 satellites so the 1Hz position update interval keeps firing
+    if (i % 10 === 9) await new Promise<void>(r => setTimeout(r, 0));
+  }
+  self.postMessage({ type: 'passes', passes });
+}
+
 self.addEventListener('message', (e: MessageEvent<WorkerMessage>) => {
   // Workers receive messages only from their owning page; origin is always empty string.
   if (e.origin !== '' && e.origin !== self.location.origin) return;
@@ -116,6 +241,10 @@ self.addEventListener('message', (e: MessageEvent<WorkerMessage>) => {
 
   if (msg.type === 'requestOrbitPath') {
  computeOrbitPath(msg.request);
+  }
+
+  if (msg.type === 'computePasses') {
+ void computePasses(msg.satellites, msg.locations, msg.durationHours);
   }
 
   if (msg.type === 'stop') {


### PR DESCRIPTION
Ports the remaining World Monitor features that aren't covered by the parallel God's Eye 4D and algorithm-services sessions.

## What this brings over

### 1. SatelliteIntelPanel
A saved-place-aware companion to the existing satellite layers. Three sections:
- **Selected Satellite** — detail card (NORAD ID, inclination, lat/lon, altitude) for whichever sat the user clicked on the globe
- **Overhead Now** — live list of tracked satellites currently visible from a saved place
- **Upcoming Recon Passes** — next 20 passes sorted by rise time

CB classifies recon birds + space stations under a single \`notable\` bucket (vs WM's separate \`recon | station\`), so the badge color map collapses to four classes. The decay-warning badge from WM is omitted here because CB's \`DebrisReentry\` shape doesn't carry NORAD IDs yet — easy follow-up once that parser learns to capture \`NORAD_CAT_ID\`.

### 2. Pass-prediction infrastructure
The panel needed propagator/worker/catalog hooks that didn't exist in CB:
- Worker: \`computePasses\` message + elevation/lookAngles math, yields every 10 sats so the 1Hz position stream keeps firing
- Propagator: \`SatellitePass\` type, \`requestPasses()\`, \`onPasses()\`
- Catalog: \`isReconOrMilitary()\` + \`getClassificationLabel()\` helpers
- Service: \`satellite-passes.ts\` with 15-minute recompute + HMR-safe init

### 3. Webcam aggregator service
\`webcam-sources.ts\` aggregates Windy + Caltrans/511-NY + curated YouTube + custom user feeds, dedupes by city/country, falls through gracefully when individual sources are down. Uses \`crystalball-custom-webcams\` localStorage key (rebranded from WM). Adds \`webcams\` to the \`DataSourceId\` enum so freshness tracking covers it.

### 4. Sidecar routes
- \`/api/windy-webcams\` — proxies the Windy v3 API (requires \`WINDY_WEBCAMS_API_KEY\`, returns 503 without it)
- \`/api/dot-traffic-cams\` — public 511 feeds for Caltrans + 511 NY, no key required

### 5. Sidecar hardening
- 16 MB cap on \`readBody\` — destroys the request socket and surfaces \`RequestBodyTooLargeError\` instead of buffering unbounded bytes
- Top-level dispatch handler is now \`statusCode\`-aware: errors with a numeric \`statusCode\` in [400, 600) return that status (so 413 surfaces as 413 instead of being masked as 500)
- All 99 sidecar tests still pass

## What I deliberately skipped

- **\`unified-inbox\` panel** — turned out to be a legacy duplicate alias for \`unified-alert-inbox\` in WM (both registered, both pointing at \`UnifiedAlertInboxPanel\`). CB already has the cleaner single registration.
- **\`world-monitor-chat\` → \`crystal-ball-chat\` port** — CB's \`crystal-ball-chat.ts\` is already further along than WM's version (history persistence, \`runIntel\` provider, alert-activity-log integration).
- **MapLayer additions** — none. CB's MapLayers is a strict superset of WM's (CB has \`strikePackages\`, \`streetTiles\`, \`navigationRoute\` that WM doesn't, and there are no WM-only layers).
- **The other ~15 missing sidecar routes** (\`abuseipdb-reports\`, \`epa-radnet-proxy\`, \`hifld-infrastructure\`, \`ollama-stream\`, \`adsb-military\`, etc.) — out of scope without explicit direction. Ported only the two routes the new webcam-sources service consumes plus the explicitly-named \`bgpview-asn\` (already integrated into CB's \`/api/asn-info\`).

## Notes for review

- One commit in the diff (\`Phase 4 — Domain Superpowers\`) was already on this worktree branch before I started — it's the user's own pre-existing work, not something I added.
- \`WINDY_WEBCAMS_API_KEY\` isn't registered in the supported-secrets allowlist in \`main.rs\` / \`runtime-config.ts\`. Users without the key get 503; those who set it via env var get the full feature. Adding it to the keychain UI is a separate ergonomic improvement.
- Verified the SatelliteIntelPanel renders correctly in the dev server: title, tooltip, three sections, and proper empty states.
- \`npm run typecheck\` clean. \`npm run test:sidecar\` 99/99 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)