### PR TITLE
feat(gods-vision): port God's Eye 4D system from World Monitor

### DIFF
--- a/src/components/GlobeDataManager.ts
+++ b/src/components/GlobeDataManager.ts
@@ -257,6 +257,59 @@ interface GlobeLayer {
   loaded: boolean;
 }
 
+/** Common shape of `entity.properties.getValue(julian)` for timestamp lookup. */
+interface TimestampedProperties { timestamp?: Date | string | number }
+
+/** Per-entity position+timestamp tuple for trail rendering. */
+export interface EntityPositionSample {
+  id: string;
+  lat: number;
+  lon: number;
+  timeMs: number;
+}
+
+/** Per-entity sample with severity + description for pillars / degradation. */
+export interface EntityTimestampedSample extends EntityPositionSample {
+  severity: number;
+  description: string;
+}
+
+/** A single time-range block for one swimlane lane. */
+export interface EventBlock {
+  id: string;
+  layerName: string;
+  category: 'conflicts' | 'disasters' | 'military' | 'seismic' | 'cyber' | 'weather';
+  startMs: number;
+  endMs: number;
+  severity: number;
+  name: string;
+  lat?: number;
+  lon?: number;
+  isForecast: boolean;
+}
+
+/** Layer-name to severity multiplier for pillars + event blocks. */
+const LAYER_BASE_SEVERITY: Record<string, number> = {
+  airstrikes: 10,
+  conflicts: 8,
+  gdacs: 7,
+  cyber: 6,
+  cyclones: 6,
+  earthquakes: 5,
+  gpsJamming: 5,
+  fires: 4,
+};
+
+/** Swimlane category → contributing layer names. */
+const SWIMLANE_CATEGORY_MAP: Record<EventBlock['category'], string[]> = {
+  conflicts: ['conflicts', 'airstrikes'],
+  disasters: ['gdacs', 'cyclones'],
+  military: ['flights', 'vessels', 'darkVessels'],
+  seismic: ['earthquakes', 'volcanoes'],
+  cyber: ['cyber', 'gpsJamming'],
+  weather: ['fires'],
+};
+
 // Layers that get auto-clustered at low zoom, keyed by layer name → category color.
 const CLUSTER_LAYERS: Record<string, Color> = {
   earthquakes: Color.fromCssColorString('#ff8c00'),
@@ -1822,6 +1875,110 @@ ${pkg.composition.map(u => u.type + ' x' + String(u.count)).join(', ')}`,
 
   getBuildingTier(): string {
  return this.buildingManager?.providerName ?? 'Not loaded';
+  }
+
+  /**
+   * Returns position+timestamp pairs for visible entities in the named layer.
+   * Used by GlobeTrails to build comet tails.
+   */
+  getEntityPositionHistory(layerName: string): EntityPositionSample[] {
+ const layer = this.layers.get(layerName);
+ if (!layer?.source.show) return [];
+ const results: EntityPositionSample[] = [];
+ const now = JulianDate.fromDate(new Date());
+ for (const entity of layer.source.entities.values) {
+ if (!entity.show) continue;
+ const pos = entity.position?.getValue(now);
+ if (!pos) continue;
+ const carto = Cartographic.fromCartesian(pos);
+ let timeMs = Date.now();
+ try {
+ const bag = entity.properties?.getValue(now) as TimestampedProperties | undefined;
+ const ts = bag?.timestamp;
+ if (ts) timeMs = ts instanceof Date ? ts.getTime() : Number(ts);
+ } catch { /* no timestamp — fall back to now */ }
+ results.push({
+ id: String(entity.id),
+ lat: CesiumMath.toDegrees(carto.latitude),
+ lon: CesiumMath.toDegrees(carto.longitude),
+ timeMs,
+ });
+ }
+ return results;
+  }
+
+  /**
+   * Returns entities with severity metadata for pillar and degradation rendering.
+   */
+  getLayerEntitiesWithTimestamps(layerName: string): EntityTimestampedSample[] {
+ const layer = this.layers.get(layerName);
+ if (!layer?.source.show) return [];
+ const baseSeverity = LAYER_BASE_SEVERITY[layerName] ?? 1;
+ const now = JulianDate.fromDate(new Date());
+ const results: EntityTimestampedSample[] = [];
+ for (const entity of layer.source.entities.values) {
+ if (!entity.show) continue;
+ const pos = entity.position?.getValue(now);
+ if (!pos) continue;
+ const carto = Cartographic.fromCartesian(pos);
+ let timeMs = Date.now();
+ try {
+ const bag = entity.properties?.getValue(now) as TimestampedProperties | undefined;
+ const ts = bag?.timestamp;
+ if (ts) timeMs = ts instanceof Date ? ts.getTime() : Number(ts);
+ } catch { /* no timestamp */ }
+ const desc = entity.description?.getValue(now) as unknown;
+ results.push({
+ id: String(entity.id),
+ lat: CesiumMath.toDegrees(carto.latitude),
+ lon: CesiumMath.toDegrees(carto.longitude),
+ timeMs,
+ severity: baseSeverity,
+ description: typeof desc === 'string' ? desc : (entity.name ?? layerName),
+ });
+ }
+ return results;
+  }
+
+  /**
+   * Returns event blocks grouped by swimlane category for timeline rendering.
+   */
+  // eslint-disable-next-line sonarjs/cognitive-complexity -- nested by design: category × layer × entity. Restructuring into helpers split the timestamp/severity/coord assembly across functions and made the data flow harder to follow than the linear loop.
+  getEventBlocks(): EventBlock[] {
+ const nowMs = Date.now();
+ const blocks: EventBlock[] = [];
+ const now = JulianDate.fromDate(new Date());
+ for (const [category, layerNames] of Object.entries(SWIMLANE_CATEGORY_MAP) as [EventBlock['category'], string[]][]) {
+ for (const layerName of layerNames) {
+ const layer = this.layers.get(layerName);
+ if (!layer) continue;
+ for (const entity of layer.source.entities.values) {
+ const pos = entity.position?.getValue(now);
+ if (!pos) continue;
+ const carto = Cartographic.fromCartesian(pos);
+ let timeMs = nowMs;
+ try {
+ const bag = entity.properties?.getValue(now) as TimestampedProperties | undefined;
+ const ts = bag?.timestamp;
+ if (ts) timeMs = ts instanceof Date ? ts.getTime() : Number(ts);
+ } catch { /* use now */ }
+ const desc = entity.description?.getValue(now) as unknown;
+ blocks.push({
+ id: String(entity.id),
+ layerName,
+ category,
+ startMs: timeMs,
+ endMs: timeMs + 3_600_000,
+ severity: LAYER_BASE_SEVERITY[layerName] ?? 1,
+ name: typeof desc === 'string' ? desc : (entity.name ?? layerName),
+ lat: CesiumMath.toDegrees(carto.latitude),
+ lon: CesiumMath.toDegrees(carto.longitude),
+ isForecast: timeMs > nowMs,
+ });
+ }
+ }
+ }
+ return blocks;
   }
 
 }

--- a/src/components/GlobeHUD.ts
+++ b/src/components/GlobeHUD.ts
@@ -17,6 +17,14 @@ export interface HUDState {
   disasters?: number;
   nearestHotspot?: { name: string; distanceKm: number } | null;
   tickerItems?: string[];
+  fourDActive?: boolean;
+  fourDPlaybackMode?: 'documentary' | 'director' | 'heartbeat';
+}
+
+function fourDBadgeLabel(mode: 'documentary' | 'director' | 'heartbeat' | undefined): string {
+  if (mode === 'director') return '4D · DIRECTOR';
+  if (mode === 'heartbeat') return '4D · HEARTBEAT';
+  return '4D';
 }
 
 function sunAltitudeDeg(lat: number, lon: number, date: Date): number {
@@ -93,6 +101,7 @@ export class GlobeHUD {
   private audioEnabled = false;
   private clusteringEnabled = true;
   private clockId: number | null = null;
+  private fourDBadgeEl: HTMLElement | null = null;
 
   // Cached DOM refs
   private threatEl: HTMLElement | null = null;
@@ -144,6 +153,11 @@ export class GlobeHUD {
  card.append(this.clockEl);
  const threatLabel = this.el('div', 'ge-hud-micro-label', 'THREAT ASSESSMENT');
  card.append(threatLabel);
+ this.fourDBadgeEl = document.createElement('div');
+ this.fourDBadgeEl.className = 'ge-hud-4d-badge';
+ this.fourDBadgeEl.textContent = '4D';
+ this.fourDBadgeEl.style.display = 'none';
+ card.append(this.fourDBadgeEl);
  this.threatEl = this.el('div', 'ge-hud-threat-value ge-threat-nominal', 'NOMINAL');
  card.append(this.threatEl);
  this.threatDetailEl = this.el('div', 'ge-hud-threat-detail', '');
@@ -602,6 +616,13 @@ export class GlobeHUD {
  const items = state.tickerItems.length ? state.tickerItems : ['Awaiting feeds…'];
  this.tickerTrackEl.textContent = items.join(' • ') + ' • ' + items.join(' • ');
  }
+ if (state.fourDActive !== undefined && this.fourDBadgeEl) {
+ this.fourDBadgeEl.style.display = state.fourDActive ? 'inline-flex' : 'none';
+ if (state.fourDActive) {
+ this.fourDBadgeEl.textContent = fourDBadgeLabel(state.fourDPlaybackMode);
+ }
+ }
+ if (state.fourDPlaybackMode !== undefined && this.fourDBadgeEl?.style.display !== 'none' && this.fourDBadgeEl) this.fourDBadgeEl.textContent = fourDBadgeLabel(state.fourDPlaybackMode);
   }
 
   private updateCameraContext(): void {
@@ -809,5 +830,6 @@ export class GlobeHUD {
  this.element.remove();
  this.onLayerToggle = null;
  this.onExit = null;
+ this.fourDBadgeEl = null;
   }
 }

--- a/src/components/GlobeTimeMachine.ts
+++ b/src/components/GlobeTimeMachine.ts
@@ -24,6 +24,7 @@ export class GlobeTimeMachine {
   private rafId: number | null = null;
   private lastFrame = 0;
   private debounceId: number | null = null;
+  private timeChangeListeners: ((ms: number) => void)[] = [];
 
   constructor(viewer: Viewer, dataManager: GlobeDataManager, container: HTMLElement) {
  this.viewer = viewer;
@@ -103,6 +104,7 @@ export class GlobeTimeMachine {
  this.liveIndicator = null;
  this.playBtn = null;
  this.speedPills = [];
+ this.timeChangeListeners = [];
  // Ensure layers return to unfiltered state
  this.dataManager.applyTimeFilter(null);
   }
@@ -128,6 +130,38 @@ export class GlobeTimeMachine {
  if (this.slider) this.slider.value = String(clamped);
  this.scheduleFilter();
  this.updateUi();
+ this.notifyTimeChange();
+  }
+
+  /**
+   * Public read-only accessors for 4D mode consumers (Globe4DManager, swimlane).
+   * Avoid mutating these directly — go through {@link setTime}, {@link setSpeed}, {@link play}/{@link pause}.
+   */
+  getCurrentMs(): number { return this.currentMs; }
+  getSpeed(): number { return this.speed; }
+  isPlaying(): boolean { return this.playing; }
+  isLive(): boolean { return this.live; }
+
+  /**
+   * Register a callback fired whenever the current time changes (scrub, play tick, snap-to-now).
+   * Returns an unsubscribe function. Listeners are invoked synchronously after internal state
+   * is updated; keep them cheap or debounce inside the listener.
+   */
+  onTimeChange(listener: (ms: number) => void): () => void {
+ this.timeChangeListeners.push(listener);
+ return () => {
+ this.timeChangeListeners = this.timeChangeListeners.filter(l => l !== listener);
+ };
+  }
+
+  private notifyTimeChange(): void {
+ for (const listener of this.timeChangeListeners) {
+ try { listener(this.currentMs); }
+ catch (error) {
+ // eslint-disable-next-line no-console
+ console.error('[GlobeTimeMachine] time-change listener threw', error);
+ }
+ }
   }
 
   play(): void {
@@ -180,6 +214,7 @@ export class GlobeTimeMachine {
  this.viewer.clock.currentTime = JulianDate.fromDate(new Date(this.currentMs));
  this.dataManager.applyTimeFilter(null);
  this.updateUi();
+ this.notifyTimeChange();
   }
 
   private scheduleFilter(): void {

--- a/src/components/GodsVisionView.ts
+++ b/src/components/GodsVisionView.ts
@@ -10,6 +10,7 @@ import { GlobeDataManager } from '@/components/GlobeDataManager';
 import { GlobeHUD } from '@/components/GlobeHUD';
 import { GlobeTimeMachine } from '@/components/GlobeTimeMachine';
 import { AutoFollowEngine } from '@/components/gods-vision/AutoFollowEngine';
+import { Globe4DManager } from '@/components/gods-vision/Globe4DManager';
 import { GlobePulse } from '@/components/gods-vision/GlobePulse';
 import { GlobeArcs } from '@/components/gods-vision/GlobeArcs';
 import { GlobeHeatmap } from '@/components/gods-vision/GlobeHeatmap';
@@ -69,6 +70,7 @@ export class GodsVisionView {
   private hud: GlobeHUD | null = null;
   private timeMachine: GlobeTimeMachine | null = null;
   private autoFollow: AutoFollowEngine | null = null;
+  private fourD: Globe4DManager | null = null;
   private reactorBeacons: GlobeReactorBeacons | null = null;
   private globePulse: GlobePulse | null = null;
   private globeArcs: GlobeArcs | null = null;
@@ -252,6 +254,22 @@ export class GodsVisionView {
  this.hud.setOnHeatmapToggle((enabled) => this.globeHeatmap?.setEnabled(enabled));
  this.hud.setOnNavigationToggle(() => void this.toggleNavigation());
 
+ // 4D mode orchestrator (T toggles; D/I/H pick playback mode; Tab/[/]/Esc cycle UI).
+ this.fourD = new Globe4DManager({
+ hud: this.hud,
+ timeMachine: this.timeMachine,
+ dataManager: this.dataManager,
+ autoFollow: this.autoFollow,
+ viewer: this.globe?.cesiumViewer ?? null,
+ overlayContainer: this.container,
+ });
+ this.fourD.onChange((state) => {
+ this.hud?.updateState({
+ fourDActive: state.active,
+ fourDPlaybackMode: state.playbackMode,
+ });
+ });
+
  // Navigation HUD + Panel
  this.navHud = new NavigationHUD(this.container);
  this.navHud.mount();
@@ -357,6 +375,9 @@ export class GodsVisionView {
 
  this.timeMachine?.destroy();
  this.timeMachine = null;
+
+ this.fourD?.destroy();
+ this.fourD = null;
 
  this.reactorBeacons?.destroy();
  this.reactorBeacons = null;
@@ -571,6 +592,13 @@ export class GodsVisionView {
 
  // ── Normal mode keys ──────────────────────────────
 
+ // Esc clears any active Tier 2 overlay before the existing Esc-exits handler runs.
+ if (ke.key === 'Escape' && this.fourD?.hasActiveTier2()) {
+ this.fourD.clearTier2();
+ ke.stopPropagation();
+ return;
+ }
+
  // ESC exits God's Eye
  if (ke.key === 'Escape') {
  this.exit();
@@ -600,6 +628,23 @@ export class GodsVisionView {
  if (ke.key === 'n' || ke.key === 'N') {
  void this.toggleNavigation();
  return;
+ }
+
+ // T toggles 4D mode. Avoid stealing Cmd+T (open new tab in browsers).
+ if (ke.key === 't' || ke.key === 'T') {
+ if (ke.metaKey || ke.ctrlKey || ke.altKey) return;
+ this.fourD?.toggle();
+ return;
+ }
+
+ // 4D-only shortcuts: D/I/H playback, Tab collapse, [/] zoom.
+ if (this.fourD?.isActive() && !ke.metaKey && !ke.ctrlKey && !ke.altKey) {
+ if (ke.key === 'd' || ke.key === 'D') { this.fourD.setPlaybackMode('documentary'); return; }
+ if (ke.key === 'i' || ke.key === 'I') { this.fourD.setPlaybackMode('director'); return; }
+ if (ke.key === 'h' || ke.key === 'H') { this.fourD.setPlaybackMode('heartbeat'); return; }
+ if (ke.key === 'Tab') { ke.preventDefault(); this.fourD.toggleSwimlaneCollapse(); return; }
+ if (ke.key === '[') { this.fourD.swimlaneZoomIn(); return; }
+ if (ke.key === ']') { this.fourD.swimlaneZoomOut(); return; }
  }
 
  // Bookmark save: Cmd+1-5

--- a/src/components/gods-vision/AutoFollowEngine.ts
+++ b/src/components/gods-vision/AutoFollowEngine.ts
@@ -15,6 +15,7 @@
 import {
   Cartesian3,
   Cartographic,
+  JulianDate,
   Math as CesiumMath,
   type Viewer,
   type Entity,
@@ -79,7 +80,7 @@ function entityToLatLon(entity: Entity): { lat: number; lon: number } | null {
   const pos = entity.position;
   if (!pos) return null;
   try {
- const cart = pos.getValue(new Date() as unknown as import('cesium').JulianDate);
+ const cart = pos.getValue(JulianDate.fromDate(new Date()));
  if (!cart) return null;
  const carto = Cartographic.fromCartesian(cart);
  return {
@@ -89,6 +90,53 @@ function entityToLatLon(entity: Entity): { lat: number; lon: number } | null {
   } catch {
  return null;
   }
+}
+
+/** Inner edge of the temporal-weight band: |Δt| ≤ 30 min → 2× boost. */
+const TEMPORAL_BOOST_INNER_MS = 30 * 60 * 1000;
+/** Outer edge of the temporal-weight band: |Δt| ≥ 6 h → 0.5× damp. */
+const TEMPORAL_BOOST_OUTER_MS = 6 * 60 * 60 * 1000;
+const TEMPORAL_BOOST_MAX = 2;
+const TEMPORAL_BOOST_MIN = 0.5;
+
+/**
+ * Multiplicative weight applied to an entity's score based on the proximity
+ * of its timestamp to the current playback time. Designed for AI Director
+ * mode 4D playback so the camera tracks events that were happening *then*,
+ * not just events that are happening *now*.
+ *
+ * - |Δt| ≤ 30 min → 2.0 × score
+ * - |Δt| ≥  6 h   → 0.5 × score
+ * - between → log-linear interpolation
+ */
+export function temporalWeight(tsMs: number | null, playbackMs: number | null): number {
+  if (tsMs === null || playbackMs === null) return 1;
+  const dt = Math.abs(tsMs - playbackMs);
+  if (dt <= TEMPORAL_BOOST_INNER_MS) return TEMPORAL_BOOST_MAX;
+  if (dt >= TEMPORAL_BOOST_OUTER_MS) return TEMPORAL_BOOST_MIN;
+  const inner = Math.log(TEMPORAL_BOOST_INNER_MS);
+  const outer = Math.log(TEMPORAL_BOOST_OUTER_MS);
+  const here = Math.log(dt);
+  const fraction = (here - inner) / (outer - inner);
+  return TEMPORAL_BOOST_MAX + (TEMPORAL_BOOST_MIN - TEMPORAL_BOOST_MAX) * fraction;
+}
+
+/**
+ * Extract entity timestamp (last-updated) in ms epoch from PropertyBag.
+ * Returns null if no timestamp is set.
+ */
+function entityTimestampMs(entity: Entity, julian: JulianDate): number | null {
+  try {
+ const bag = entity.properties?.getValue(julian) as { timestamp?: Date | string | number } | undefined;
+ const ts = bag?.timestamp;
+ if (ts instanceof Date) return ts.getTime();
+ if (typeof ts === 'number' && Number.isFinite(ts)) return ts;
+ if (typeof ts === 'string') {
+ const parsed = Date.parse(ts);
+ return Number.isFinite(parsed) ? parsed : null;
+ }
+  } catch { /* none */ }
+  return null;
 }
 
 export class AutoFollowEngine {
@@ -101,6 +149,8 @@ export class AutoFollowEngine {
   private opts: Required<AutoFollowOptions>;
   private onTargetChange: ((target: FollowTarget | null, index: number, total: number) => void) | null = null;
   private dataSources: () => Map<string, CustomDataSource>;
+  /** Active 4D playback time, or null when scoring against wall-clock NOW. */
+  private playbackMs: number | null = null;
 
   constructor(
  viewer: Viewer,
@@ -172,6 +222,20 @@ export class AutoFollowEngine {
  this.advanceToNext();
   }
 
+  /**
+   * Refresh targets relative to a specific playback time. Used by 4D
+   * AI Director mode so the camera follows what was important at the
+   * point in time being played back, not just wall-clock NOW.
+   */
+  refreshAtTime(playbackMs: number): void {
+ this.playbackMs = Number.isFinite(playbackMs) ? playbackMs : null;
+ this.refreshTargets();
+ this.playbackMs = null;
+ if (this.targets.length > 0 && this._active) {
+ this.flyToCurrentTarget();
+ }
+  }
+
   private refreshTargets(): void {
  const scored: FollowTarget[] = [];
  const sources = this.dataSources();
@@ -187,20 +251,24 @@ export class AutoFollowEngine {
  const entities = source.entities.values;
  // Sample up to 10 entities per layer to keep target list manageable
  const step = Math.max(1, Math.floor(entities.length / 10));
+ const julian = JulianDate.fromDate(new Date());
  for (let i = 0; i < entities.length; i += step) {
  const entity = entities[i]!;
  const loc = entityToLatLon(entity);
  if (!loc) continue;
 
+ const tsMs = entityTimestampMs(entity, julian);
+ const baseScore = weight + simpleHash(entity.id) * 0.5;
+
  scored.push({
  id: entity.id,
  layer: layerName,
- name: (entity.description?.getValue(new Date() as unknown as import('cesium').JulianDate) as string)
+ name: (entity.description?.getValue(julian) as string)
  ?? entity.name
  ?? layerName,
  lat: loc.lat,
  lon: loc.lon,
- score: weight + simpleHash(entity.id) * 0.5, // Deterministic jitter to vary cycle order
+ score: baseScore * temporalWeight(tsMs, this.playbackMs),
  });
  }
  }

--- a/src/components/gods-vision/Globe4DManager.ts
+++ b/src/components/gods-vision/Globe4DManager.ts
@@ -1,0 +1,313 @@
+/**
+ * Globe4DManager — orchestrator for God's Eye 4D mode.
+ *
+ * Wires swimlane + playback + trails + pillars + degradation + predictions +
+ * branching behind a single enable() / disable() lifecycle. Hosts plug into
+ * the broadcast via {@link onChange} for HUD updates.
+ */
+
+import type { GlobeDataManager } from '@/components/GlobeDataManager';
+import type { GlobeTimeMachine } from '@/components/GlobeTimeMachine';
+import type { GlobeHUD } from '@/components/GlobeHUD';
+import type { AutoFollowEngine } from '@/components/gods-vision/AutoFollowEngine';
+import type { Viewer } from 'cesium';
+import { GlobeSwimlane } from '@/components/gods-vision/GlobeSwimlane';
+import { GlobePlayback } from '@/components/gods-vision/GlobePlayback';
+import type { PlaybackMode } from '@/components/gods-vision/GlobePlayback';
+import { GlobeTrails } from '@/components/gods-vision/GlobeTrails';
+import { GlobePillars } from '@/components/gods-vision/GlobePillars';
+import { GlobeDegradation } from '@/components/gods-vision/GlobeDegradation';
+import { GlobePredictions } from '@/components/gods-vision/GlobePredictions';
+import { GlobeBranching } from '@/components/gods-vision/GlobeBranching';
+import type {
+  AftershockForecast,
+  BranchingForecast,
+  ForecastCone,
+} from '@/services/forecast-engine';
+
+export type { PlaybackMode } from '@/components/gods-vision/GlobePlayback';
+
+export interface Globe4DState {
+  /** True when the user has toggled 4D mode on (e.g. via the `T` key). */
+  active: boolean;
+  /** Currently selected playback mode. Defaults to documentary. */
+  playbackMode: PlaybackMode;
+  /** Active trail count — populated when GlobeTrails lands. */
+  trailCount: number;
+  /** Forecast-entity count — populated when GlobeDegradation lands. */
+  forecastCount: number;
+}
+
+export interface Globe4DManagerDeps {
+  hud?: GlobeHUD | null;
+  timeMachine?: GlobeTimeMachine | null;
+  dataManager?: GlobeDataManager | null;
+  autoFollow?: AutoFollowEngine | null;
+  /** Cesium viewer needed for trails + pillars (Cesium-rendered overlays). */
+  viewer?: Viewer | null;
+  /** DOM node the swimlane mounts into. Usually the God's Eye container. */
+  overlayContainer?: HTMLElement | null;
+}
+
+const HUD_REFRESH_MS = 1000;
+
+const SWIMLANE_REFRESH_MS = 1500;
+
+export class Globe4DManager {
+  private state: Globe4DState = {
+    active: false,
+    playbackMode: 'documentary',
+    trailCount: 0,
+    forecastCount: 0,
+  };
+  private listeners: ((state: Readonly<Globe4DState>) => void)[] = [];
+  private deps: Globe4DManagerDeps;
+  private unsubTimeChange: (() => void) | null = null;
+  private swimlane: GlobeSwimlane | null = null;
+  private swimlaneRefreshId: ReturnType<typeof setInterval> | null = null;
+  private playback: GlobePlayback | null = null;
+  private trails: GlobeTrails | null = null;
+  private pillars: GlobePillars | null = null;
+  private degradation: GlobeDegradation | null = null;
+  private predictions: GlobePredictions | null = null;
+  private branching: GlobeBranching | null = null;
+  private hudRefreshId: ReturnType<typeof setInterval> | null = null;
+
+  constructor(deps: Globe4DManagerDeps) {
+    this.deps = deps;
+  }
+
+  /** Idempotent enable. Wires sub-components when they exist. */
+  enable(): void {
+    if (this.state.active) return;
+    this.state = { ...this.state, active: true };
+    document.body.classList.add('gods-eye-4d-active');
+
+    this.mountSwimlane();
+    this.mountPlayback();
+    this.mountVisualOverlays();
+    this.startHudCounterRefresh();
+
+    // Drive swimlane NOW line + degradation pipeline from time-machine state.
+    this.unsubTimeChange = this.deps.timeMachine?.onTimeChange((ms) => {
+      this.swimlane?.updateNow(ms);
+      this.degradation?.applyDegradation(ms);
+    }) ?? null;
+
+    this.broadcast();
+  }
+
+  /** Idempotent disable. Tears down any active sub-component. */
+  disable(): void {
+    if (!this.state.active) return;
+    this.state = { ...this.state, active: false };
+    document.body.classList.remove('gods-eye-4d-active');
+
+    if (this.unsubTimeChange) {
+      this.unsubTimeChange();
+      this.unsubTimeChange = null;
+    }
+
+    this.stopHudCounterRefresh();
+    this.unmountVisualOverlays();
+    this.unmountPlayback();
+    this.unmountSwimlane();
+
+    this.broadcast();
+  }
+
+  toggle(): void {
+    if (this.state.active) this.disable();
+    else this.enable();
+  }
+
+  isActive(): boolean { return this.state.active; }
+
+  setPlaybackMode(mode: PlaybackMode): void {
+    if (this.state.playbackMode === mode) return;
+    this.state = { ...this.state, playbackMode: mode };
+    this.playback?.setMode(mode);
+    this.broadcast();
+  }
+
+  /** Play/pause the active playback engine. No-op if 4D is off. */
+  togglePlayback(): void {
+    this.playback?.toggle();
+  }
+
+  /** Collapse / expand the swimlane. No-op if 4D is off. */
+  toggleSwimlaneCollapse(): void {
+    this.swimlane?.toggleCollapse();
+  }
+
+  /** Step swimlane zoom one preset finer (1h ← 6h ← 24h ← 7d ← 30d). */
+  swimlaneZoomIn(): void { this.swimlane?.zoomIn(); }
+
+  /** Step swimlane zoom one preset coarser. */
+  swimlaneZoomOut(): void { this.swimlane?.zoomOut(); }
+
+  getState(): Readonly<Globe4DState> { return this.state; }
+
+  /**
+   * Subscribe to 4D state changes. Returns an unsubscribe function.
+   * Listeners are invoked synchronously after state is updated.
+   */
+  onChange(listener: (state: Readonly<Globe4DState>) => void): () => void {
+    this.listeners.push(listener);
+    return () => {
+      this.listeners = this.listeners.filter(l => l !== listener);
+    };
+  }
+
+  destroy(): void {
+    this.disable();
+    this.listeners = [];
+  }
+
+  private mountSwimlane(): void {
+    const container = this.deps.overlayContainer;
+    const dataManager = this.deps.dataManager;
+    if (!container || !dataManager) return; // running headless or pre-mount
+
+    this.swimlane = new GlobeSwimlane(container);
+    this.swimlane.setOnTimeChange((ms) => { this.deps.timeMachine?.setTime(ms); });
+    this.swimlane.setOnEventClick((block) => {
+      // Future PR (Tier 2 deep analysis) will fly camera to block.lat/lon
+      // and open prediction overlays. For now, just scrub time to the event.
+      this.deps.timeMachine?.setTime(block.startMs);
+    });
+    this.swimlane.setOnLaneToggle((category) => {
+      // Lane labels toggle the contributing data layers. The mapping lives
+      // in GlobeDataManager (SWIMLANE_CATEGORY_MAP) but isn't currently
+      // exported; for the swimlane MVP we leave this as a no-op hook so
+      // future PRs can wire layer visibility via a public method.
+      // eslint-disable-next-line no-console
+      console.debug('[Globe4DManager] lane toggle (no-op pending layer-visibility hook):', category);
+    });
+    this.swimlane.mount();
+    this.refreshSwimlaneBlocks();
+    this.swimlaneRefreshId = setInterval(() => this.refreshSwimlaneBlocks(), SWIMLANE_REFRESH_MS);
+  }
+
+  private unmountSwimlane(): void {
+    if (this.swimlaneRefreshId != null) {
+      clearInterval(this.swimlaneRefreshId);
+      this.swimlaneRefreshId = null;
+    }
+    this.swimlane?.destroy();
+    this.swimlane = null;
+  }
+
+  private refreshSwimlaneBlocks(): void {
+    if (!this.deps.dataManager) return;
+    try {
+      const blocks = this.deps.dataManager.getEventBlocks();
+      this.swimlane?.updateBlocks(blocks);
+      this.playback?.updateEventBlocks(blocks);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('[Globe4DManager] getEventBlocks failed', error);
+    }
+  }
+
+  private mountPlayback(): void {
+    const timeMachine = this.deps.timeMachine;
+    if (!timeMachine) return;
+    this.playback = new GlobePlayback(timeMachine, this.deps.autoFollow ?? null);
+    this.playback.setMode(this.state.playbackMode);
+    this.playback.setOnModeChange((mode) => {
+      if (this.state.playbackMode !== mode) {
+        this.state = { ...this.state, playbackMode: mode };
+        this.broadcast();
+      }
+    });
+  }
+
+  private unmountPlayback(): void {
+    this.playback?.destroy();
+    this.playback = null;
+  }
+
+  private mountVisualOverlays(): void {
+    const viewer = this.deps.viewer;
+    const dataManager = this.deps.dataManager;
+    if (!viewer || !dataManager) return;
+    this.trails = new GlobeTrails(viewer, dataManager);
+    this.trails.mount();
+    this.pillars = new GlobePillars(viewer, dataManager);
+    this.pillars.mount();
+    this.degradation = new GlobeDegradation(viewer, dataManager);
+    // Apply once on enable so any forecast entities visible at NOW are
+    // immediately degraded; subsequent updates ride the time-change hook.
+    const initialMs = this.deps.timeMachine?.getCurrentMs() ?? Date.now();
+    this.degradation.applyDegradation(initialMs);
+    this.predictions = new GlobePredictions(viewer);
+    this.predictions.mount();
+    this.branching = new GlobeBranching(viewer);
+    this.branching.mount();
+  }
+
+  private unmountVisualOverlays(): void {
+    this.trails?.destroy();
+    this.trails = null;
+    this.pillars?.destroy();
+    this.pillars = null;
+    this.degradation?.destroy();
+    this.degradation = null;
+    this.predictions?.destroy();
+    this.predictions = null;
+    this.branching?.destroy();
+    this.branching = null;
+  }
+
+  /** Imperative Tier 2 overlay API. Wired into entity click/hover by
+   * GodsEyeView in a follow-up; today the API surface is here so callers
+   * can invoke it with a known-good shape. */
+  showPredictionCone(cone: ForecastCone): void { this.predictions?.showCone(cone); }
+  showAftershockForecast(forecast: AftershockForecast): void {
+    this.predictions?.showAftershock(forecast);
+  }
+  showBranchingForecast(forecast: BranchingForecast): void {
+    this.branching?.showBranches(forecast);
+  }
+  clearTier2(): void {
+    this.predictions?.clear();
+    this.branching?.clear();
+  }
+  hasActiveTier2(): boolean {
+    return (this.predictions?.hasActive() ?? false) || (this.branching?.hasActive() ?? false);
+  }
+
+  private startHudCounterRefresh(): void {
+    if (!this.deps.hud) return;
+    this.tickHudCounters();
+    this.hudRefreshId = setInterval(() => this.tickHudCounters(), HUD_REFRESH_MS);
+  }
+
+  private tickHudCounters(): void {
+    const trailCount = this.trails?.activeTrailCount ?? 0;
+    const forecastCount = this.degradation?.forecastEntityCount ?? this.pillars?.activePillarCount ?? 0;
+    if (this.state.trailCount !== trailCount || this.state.forecastCount !== forecastCount) {
+      this.state = { ...this.state, trailCount, forecastCount };
+      this.broadcast();
+    }
+  }
+
+  private stopHudCounterRefresh(): void {
+    if (this.hudRefreshId) {
+      clearInterval(this.hudRefreshId);
+      this.hudRefreshId = null;
+    }
+    this.state = { ...this.state, trailCount: 0, forecastCount: 0 };
+  }
+
+  private broadcast(): void {
+    for (const listener of this.listeners) {
+      try { listener(this.state); }
+      catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('[Globe4DManager] listener threw', error);
+      }
+    }
+  }
+}

--- a/src/components/gods-vision/GlobeBranching.ts
+++ b/src/components/gods-vision/GlobeBranching.ts
@@ -1,0 +1,90 @@
+/**
+ * GlobeBranching — Tier 2 scenario-fork visualization.
+ *
+ * Renders 3 forecast branches as polylines diverging from an entity, with:
+ *   • Polyline thickness encoding probability (max 5px at p=1.0)
+ *   • Polyline alpha encoding probability (min 0.15)
+ *   • Color encoding outcome (green deescalation, yellow stalemate,
+ *     red escalation)
+ *
+ * Used together with GlobePredictions for click-only Tier 2 deep analysis.
+ *
+ * Plan: docs/superpowers/plans/2026-04-13-gods-eye-4d.md (Task 11)
+ */
+
+import {
+  Cartesian3,
+  Color,
+  CustomDataSource,
+  Entity,
+  PolylineGraphics,
+  type Viewer,
+} from 'cesium';
+import type { BranchingForecast, ScenarioBranch } from '@/services/forecast-engine';
+
+const OUTCOME_COLORS: Record<ScenarioBranch['outcome'], Color> = {
+  deescalation: Color.fromCssColorString('#00ffaa'),
+  stalemate:    Color.fromCssColorString('#ffc800'),
+  escalation:   Color.fromCssColorString('#ff3333'),
+};
+
+const MAX_BRANCH_WIDTH_PX = 5;
+const MIN_BRANCH_ALPHA = 0.15;
+
+export class GlobeBranching {
+  private viewer: Viewer;
+  private source: CustomDataSource;
+  private activeEntities: Entity[] = [];
+  private onBranchHoverCb: ((branch: ScenarioBranch | null) => void) | null = null;
+
+  constructor(viewer: Viewer) {
+    this.viewer = viewer;
+    this.source = new CustomDataSource('4d-branching');
+  }
+
+  mount(): void {
+    this.viewer.dataSources.add(this.source).catch((error: unknown) => {
+      // eslint-disable-next-line no-console
+      console.error('[GlobeBranching] dataSources.add failed', error);
+    });
+  }
+
+  destroy(): void {
+    this.clear();
+    this.viewer.dataSources.remove(this.source, true);
+  }
+
+  setOnBranchHover(cb: (branch: ScenarioBranch | null) => void): void {
+    this.onBranchHoverCb = cb;
+  }
+
+  hasActive(): boolean { return this.activeEntities.length > 0; }
+
+  clear(): void {
+    for (const e of this.activeEntities) this.source.entities.remove(e);
+    this.activeEntities = [];
+    this.onBranchHoverCb?.(null);
+  }
+
+  showBranches(forecast: BranchingForecast): void {
+    this.clear();
+
+    for (const branch of forecast.branches) {
+      if (branch.path.length < 2) continue;
+      const positions = branch.path.map(p => Cartesian3.fromDegrees(p.lon, p.lat));
+      const color = OUTCOME_COLORS[branch.outcome];
+      const width = Math.max(1, branch.probability * MAX_BRANCH_WIDTH_PX);
+      const alpha = Math.max(MIN_BRANCH_ALPHA, branch.probability);
+
+      this.activeEntities.push(this.source.entities.add(new Entity({
+        polyline: new PolylineGraphics({
+          positions,
+          width,
+          material: color.withAlpha(alpha),
+          clampToGround: true,
+        }),
+        description: `${branch.label} (${Math.round(branch.probability * 100)}%): ${branch.conditions}`,
+      })));
+    }
+  }
+}

--- a/src/components/gods-vision/GlobeDegradation.ts
+++ b/src/components/gods-vision/GlobeDegradation.ts
@@ -1,0 +1,245 @@
+/**
+ * GlobeDegradation — reality-degradation rendering pipeline.
+ *
+ * Computes per-entity confidence based on how far ahead of NOW the entity's
+ * timestamp sits, then applies opacity / dash / blur / jitter rules:
+ *   • confidence = 1                     → crisp past event
+ *   • 0.5 ≤ confidence < 1               → near future, full color, slight fade
+ *   • 0.3 ≤ confidence < 0.5             → dashed paths, faded labels
+ *   • confidence < 0.3                   → blurred, ghostly
+ *   • confidence < 0.2                   → jitter the billboard offset by ±jitter px
+ *
+ * Decay is exponential: confidence(t) = exp(-t / τ_layer), with τ tuned per
+ * layer (fast-moving GDACS/fires decay quicker than 30-day earthquake horizon).
+ *
+ * ConstantProperty instances are reused per-entity via setValue() to avoid
+ * garbage churn on each TimeMachine tick.
+ */
+
+import {
+  Cartesian2,
+  Color,
+  ColorMaterialProperty,
+  ConstantProperty,
+  JulianDate,
+  PolylineDashMaterialProperty,
+  type Entity,
+  type Viewer,
+} from 'cesium';
+import type { GlobeDataManager } from '@/components/GlobeDataManager';
+import {
+  computeDegradationState,
+  computeJitterOffset as computeJitterPureOffset,
+  LAYER_DECAY_TAU_MS,
+  LABEL_THRESHOLD,
+  type DegradationState,
+} from '@/components/gods-vision/degradation-math';
+
+/* eslint-disable @typescript-eslint/no-unused-vars -- viewer kept on the
+ * constructor for future Cesium-primitive trail/path degradation; today's
+ * implementation only mutates per-entity properties from the data sources. */
+
+export type { DegradationState } from '@/components/gods-vision/degradation-math';
+
+interface EntityPropertyCache {
+  billboardColor?: ConstantProperty;
+  billboardScale?: ConstantProperty;
+  billboardPixelOffset?: ConstantProperty;
+  pointColor?: ConstantProperty;
+  pointPixelSize?: ConstantProperty;
+  labelShow?: ConstantProperty;
+  polylineDashMaterial?: PolylineDashMaterialProperty;
+  polylineSolidMaterial?: ColorMaterialProperty;
+  polylineMaterialColor?: ConstantProperty;
+  polylineWasDashed?: boolean;
+  jitterSeed?: number;
+}
+
+export class GlobeDegradation {
+  private dataManager: GlobeDataManager;
+  private cache = new Map<string, DegradationState>();
+  private propCache = new Map<string, EntityPropertyCache>();
+  private destroyed = false;
+
+  constructor(_viewer: Viewer, dataManager: GlobeDataManager) {
+    this.dataManager = dataManager;
+  }
+
+  /**
+   * Recompute degradation for every visible forecast-able entity relative to
+   * `currentMs` (typically TimeMachine.getCurrentMs()). The caller is expected
+   * to debounce this — the existing 250 ms TimeMachine debounce is a fine fit.
+   */
+  applyDegradation(currentMs: number): void {
+    if (this.destroyed) return;
+    this.cache.clear();
+    const sources = this.dataManager.getDataSources();
+
+    for (const [layerName, tau] of Object.entries(LAYER_DECAY_TAU_MS)) {
+      const entities = this.dataManager.getLayerEntitiesWithTimestamps(layerName);
+      const source = sources.get(layerName);
+      if (!source) continue;
+
+      for (const e of entities) {
+        const timeFromNow = e.timeMs - currentMs;
+        const state = timeFromNow <= 0
+          ? { confidence: 1, opacity: 1, isDashed: false, blur: 0, jitter: 0 }
+          : GlobeDegradation.computeState(timeFromNow, tau);
+        this.cache.set(e.id, state);
+
+        const cesium = source.entities.getById(e.id);
+        if (cesium) this.applyToEntity(e.id, cesium, state);
+      }
+    }
+  }
+
+  getState(entityId: string): DegradationState | undefined {
+    return this.cache.get(entityId);
+  }
+
+  /** Number of entities currently rendered with degraded confidence (< 1). */
+  get forecastEntityCount(): number {
+    let count = 0;
+    for (const state of this.cache.values()) {
+      if (state.confidence < 1) count++;
+    }
+    return count;
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    this.cache.clear();
+    this.propCache.clear();
+  }
+
+  static computeState(timeFromNowMs: number, tauMs: number): DegradationState {
+    return computeDegradationState(timeFromNowMs, tauMs);
+  }
+
+  /**
+   * Apply degradation to a single entity's primitives. Reuses cached
+   * ConstantProperty / PolylineDashMaterialProperty instances via setValue()
+   * so we don't churn the GC on every TimeMachine tick.
+   */
+  private applyToEntity(id: string, entity: Entity, state: DegradationState): void {
+    let cache = this.propCache.get(id);
+    if (!cache) {
+      cache = {};
+      this.propCache.set(id, cache);
+    }
+
+    const julian = JulianDate.fromDate(new Date());
+    const blurScale = 1 - Math.min(0.6, state.blur * 0.3);
+    const blurPixelMul = 1 - Math.min(0.5, state.blur * 0.25);
+    const [jitterX, jitterY] = computeJitterOffset(id, cache, state.jitter);
+
+    if (entity.billboard) {
+      applyBillboard(entity.billboard, state, cache, julian, blurScale, jitterX, jitterY);
+    }
+    if (entity.point) {
+      applyPoint(entity.point, state, cache, julian, blurPixelMul);
+    }
+    if (entity.label) {
+      applyLabel(entity.label, state, cache);
+    }
+    if (entity.polyline) {
+      applyPolyline(entity.polyline, state, cache, julian);
+    }
+  }
+}
+
+function setOrCreate<T>(
+  cache: EntityPropertyCache,
+  key: keyof EntityPropertyCache,
+  value: T,
+): ConstantProperty {
+  const existing = cache[key] as ConstantProperty | undefined;
+  if (existing) {
+    existing.setValue(value);
+    return existing;
+  }
+  const created = new ConstantProperty(value);
+  (cache as Record<string, unknown>)[key as string] = created;
+  return created;
+}
+
+function applyBillboard(
+  billboard: NonNullable<Entity['billboard']>,
+  state: DegradationState,
+  cache: EntityPropertyCache,
+  julian: JulianDate,
+  blurScale: number,
+  jitterX: number,
+  jitterY: number,
+): void {
+  const current = billboard.color?.getValue(julian) as Color | undefined;
+  if (current) {
+    billboard.color = setOrCreate(cache, 'billboardColor', current.withAlpha(state.opacity));
+  }
+  billboard.scale = setOrCreate(cache, 'billboardScale', blurScale);
+  billboard.pixelOffset = setOrCreate(cache, 'billboardPixelOffset', new Cartesian2(jitterX, jitterY));
+}
+
+function applyPoint(
+  point: NonNullable<Entity['point']>,
+  state: DegradationState,
+  cache: EntityPropertyCache,
+  julian: JulianDate,
+  blurPixelMul: number,
+): void {
+  const current = point.color?.getValue(julian) as Color | undefined;
+  if (current) {
+    point.color = setOrCreate(cache, 'pointColor', current.withAlpha(state.opacity));
+  }
+  const currentSize = point.pixelSize?.getValue(julian) as number | undefined;
+  if (typeof currentSize === 'number' && currentSize > 0) {
+    point.pixelSize = setOrCreate(cache, 'pointPixelSize', currentSize * blurPixelMul);
+  }
+}
+
+function applyLabel(
+  label: NonNullable<Entity['label']>,
+  state: DegradationState,
+  cache: EntityPropertyCache,
+): void {
+  label.show = setOrCreate(cache, 'labelShow', state.confidence > LABEL_THRESHOLD);
+}
+
+function applyPolyline(
+  polyline: NonNullable<Entity['polyline']>,
+  state: DegradationState,
+  cache: EntityPropertyCache,
+  julian: JulianDate,
+): void {
+  const baseColor = (polyline.material as { color?: { getValue?: (t: JulianDate) => Color } } | undefined)
+    ?.color?.getValue?.(julian) ?? Color.WHITE;
+  const faded = baseColor.withAlpha(state.opacity);
+  const colorProp = setOrCreate(cache, 'polylineMaterialColor', faded);
+
+  if (state.isDashed) {
+    cache.polylineDashMaterial ??= new PolylineDashMaterialProperty({
+      color: colorProp,
+      dashLength: 12,
+    });
+    polyline.material = cache.polylineDashMaterial;
+    cache.polylineWasDashed = true;
+  } else if (cache.polylineWasDashed) {
+    cache.polylineSolidMaterial ??= new ColorMaterialProperty(colorProp);
+    polyline.material = cache.polylineSolidMaterial;
+    cache.polylineWasDashed = false;
+  }
+}
+
+/**
+ * Stable per-entity jitter offset from a deterministic hash of the id.
+ * Returns [x, y] in pixels, scaled by the current jitter intensity.
+ * The id-hash result is identical to the pure helper; the cache parameter
+ * is unused now but preserved for ABI parity until callers can be inlined.
+ */
+function computeJitterOffset(
+  id: string,
+  _cache: EntityPropertyCache,
+  intensity: number,
+): [number, number] {
+  return computeJitterPureOffset(id, intensity);
+}

--- a/src/components/gods-vision/GlobePillars.ts
+++ b/src/components/gods-vision/GlobePillars.ts
@@ -1,0 +1,129 @@
+/**
+ * GlobePillars — vertical intensity bars at conflict/disaster locations.
+ *
+ * Each event spawns a Cesium CylinderGraphics whose:
+ *   - length encodes how long the event has been active (20 km per hour
+ *     since timestamp, capped at 500 km),
+ *   - bottom radius encodes severity (5 km per severity unit, capped at 50 km),
+ *   - color matches the swimlane lane category (red conflicts, orange
+ *     disasters, yellow seismic).
+ *
+ * Total bar count is capped at MAX_PILLARS; ranking is by severity so the
+ * most critical events always render. Sources refresh every 10 s; that's
+ * coarse enough to skip Cesium scene churn but fine enough that a freshly
+ * arriving high-severity event reaches the user inside a single tick.
+ *
+ * Plan: docs/superpowers/plans/2026-04-13-gods-eye-4d.md (Task 7)
+ */
+
+import {
+  Cartesian3,
+  Color,
+  CustomDataSource,
+  Entity,
+  CylinderGraphics,
+  CallbackProperty,
+  type MaterialProperty,
+  type Viewer,
+} from 'cesium';
+import type { GlobeDataManager, EntityTimestampedSample } from '@/components/GlobeDataManager';
+
+const MAX_PILLARS = 100;
+const PILLAR_LAYERS: readonly string[] = ['conflicts', 'airstrikes', 'gdacs', 'cyclones', 'earthquakes'];
+const REFRESH_MS = 10_000;
+const HEIGHT_PER_HOUR_M = 20_000;
+const MAX_HEIGHT_M = 500_000;
+const RADIUS_PER_SEVERITY_M = 5000;
+const MAX_RADIUS_M = 50_000;
+
+const CATEGORY_COLORS: Record<string, Color> = {
+  conflicts:   Color.fromCssColorString('#ff3333').withAlpha(0.6),
+  airstrikes:  Color.fromCssColorString('#ff3333').withAlpha(0.7),
+  gdacs:       Color.fromCssColorString('#ffa500').withAlpha(0.6),
+  cyclones:    Color.fromCssColorString('#ffa500').withAlpha(0.5),
+  earthquakes: Color.fromCssColorString('#ffc800').withAlpha(0.5),
+};
+
+interface PillarEntity { layerName: string; cesium: Entity }
+
+export class GlobePillars {
+  private viewer: Viewer;
+  private dataManager: GlobeDataManager;
+  private source: CustomDataSource;
+  private pillars = new Map<string, PillarEntity>();
+  private destroyed = false;
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(viewer: Viewer, dataManager: GlobeDataManager) {
+    this.viewer = viewer;
+    this.dataManager = dataManager;
+    this.source = new CustomDataSource('4d-pillars');
+  }
+
+  mount(): void {
+    this.viewer.dataSources.add(this.source).catch((error: unknown) => {
+      // eslint-disable-next-line no-console
+      console.error('[GlobePillars] dataSources.add failed', error);
+    });
+    this.refresh();
+    this.refreshTimer = setInterval(() => {
+      if (!this.destroyed) this.refresh();
+    }, REFRESH_MS);
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    this.viewer.dataSources.remove(this.source, true);
+    this.pillars.clear();
+  }
+
+  get activePillarCount(): number { return this.pillars.size; }
+
+  private refresh(): void {
+    const candidates: (EntityTimestampedSample & { layerName: string })[] = [];
+    for (const layerName of PILLAR_LAYERS) {
+      const entities = this.dataManager.getLayerEntitiesWithTimestamps(layerName);
+      for (const e of entities) candidates.push({ ...e, layerName });
+    }
+    candidates.sort((a, b) => b.severity - a.severity);
+    const top = candidates.slice(0, MAX_PILLARS);
+
+    const seenIds = new Set<string>();
+    for (const e of top) {
+      seenIds.add(e.id);
+      if (this.pillars.has(e.id)) continue;
+
+      const nowMs = Date.now();
+      const durationHrs = Math.max(1, (nowMs - e.timeMs) / 3_600_000);
+      const heightM = Math.min(MAX_HEIGHT_M, durationHrs * HEIGHT_PER_HOUR_M);
+      const radiusM = Math.min(MAX_RADIUS_M, e.severity * RADIUS_PER_SEVERITY_M);
+      const color = CATEGORY_COLORS[e.layerName] ?? Color.WHITE.withAlpha(0.4);
+
+      const cesium = this.source.entities.add(new Entity({
+        position: Cartesian3.fromDegrees(e.lon, e.lat, heightM / 2),
+        cylinder: new CylinderGraphics({
+          length: heightM,
+          topRadius: radiusM * 0.3,
+          bottomRadius: radiusM,
+          material: new CallbackProperty(() => color, false) as unknown as MaterialProperty,
+          outline: true,
+          outlineColor: color.withAlpha(0.3),
+          outlineWidth: 1,
+          numberOfVerticalLines: 0,
+        }),
+      }));
+      this.pillars.set(e.id, { layerName: e.layerName, cesium });
+    }
+
+    for (const [id, pillar] of this.pillars) {
+      if (!seenIds.has(id)) {
+        this.source.entities.remove(pillar.cesium);
+        this.pillars.delete(id);
+      }
+    }
+  }
+}

--- a/src/components/gods-vision/GlobePlayback.ts
+++ b/src/components/gods-vision/GlobePlayback.ts
@@ -1,0 +1,180 @@
+/**
+ * GlobePlayback — three cinematic playback engines for God's Eye 4D.
+ *
+ * Modes:
+ *   • documentary — steady time advancement at the user's selected
+ *     speed multiplier; camera stays where the user placed it.
+ *   • director    — speed is steady but AutoFollowEngine drives the
+ *     camera to the highest-priority targets in view.
+ *   • heartbeat   — speed adapts to event density: dense buckets slow
+ *     playback (linger), sparse gaps fast-forward.
+ *
+ * Drives time via {@link GlobeTimeMachine.setTime}. Hosts a
+ * requestAnimationFrame loop that scales `dt` by the current effective
+ * speed, so the swimlane / globe layers update through the existing
+ * TimeMachine debounce.
+ *
+ * Plan: docs/superpowers/plans/2026-04-13-gods-eye-4d.md (Task 5)
+ */
+
+import type { GlobeTimeMachine } from '@/components/GlobeTimeMachine';
+import type { AutoFollowEngine } from '@/components/gods-vision/AutoFollowEngine';
+import type { EventBlock } from '@/components/GlobeDataManager';
+
+export type PlaybackMode = 'documentary' | 'director' | 'heartbeat';
+
+interface HeartbeatWindow {
+  startMs: number;
+  endMs: number;
+  density: number; // events overlapping this window
+}
+
+const HB_MIN_SPEED = 0.5;       // dense windows clamp at 0.5× user speed
+const HB_MAX_SPEED = 8;         // sparse gaps cap at 8× user speed
+const HB_WINDOW_MS = 3_600_000; // 1h density buckets
+const HB_DENSITY_FULL = 8;      // density at which we hit MIN speed
+
+export class GlobePlayback {
+  private timeMachine: GlobeTimeMachine;
+  private autoFollow: AutoFollowEngine | null;
+  private modeValue: PlaybackMode = 'documentary';
+  private rafId: number | null = null;
+  private lastFrame = 0;
+  private playingValue = false;
+  private destroyed = false;
+  private eventBlocks: EventBlock[] = [];
+  private heartbeatWindows: HeartbeatWindow[] = [];
+
+  private onModeChangeCb: ((mode: PlaybackMode) => void) | null = null;
+  private onPlayStateCb: ((playing: boolean) => void) | null = null;
+
+  constructor(timeMachine: GlobeTimeMachine, autoFollow: AutoFollowEngine | null) {
+    this.timeMachine = timeMachine;
+    this.autoFollow = autoFollow;
+  }
+
+  get mode(): PlaybackMode { return this.modeValue; }
+  get playing(): boolean { return this.playingValue; }
+
+  setOnModeChange(cb: (mode: PlaybackMode) => void): void { this.onModeChangeCb = cb; }
+  setOnPlayState(cb: (playing: boolean) => void): void { this.onPlayStateCb = cb; }
+
+  setMode(mode: PlaybackMode): void {
+    if (this.modeValue === mode) return;
+    const wasPlaying = this.playingValue;
+    if (wasPlaying) this.pause();
+    this.modeValue = mode;
+    this.onModeChangeCb?.(mode);
+    if (wasPlaying) this.play();
+  }
+
+  updateEventBlocks(blocks: EventBlock[]): void {
+    this.eventBlocks = blocks;
+    this.computeHeartbeatWindows();
+  }
+
+  play(): void {
+    if (this.playingValue || this.destroyed) return;
+    this.playingValue = true;
+    this.lastFrame = performance.now();
+
+    if (this.modeValue === 'director' && this.autoFollow) {
+      this.autoFollow.start();
+    }
+
+    const tick = (now: number): void => {
+      if (!this.playingValue || this.destroyed) return;
+      const dt = now - this.lastFrame;
+      this.lastFrame = now;
+
+      const baseSpeed = this.timeMachine.getSpeed();
+      const speedMultiplier = this.modeValue === 'heartbeat'
+        ? this.heartbeatSpeed(this.timeMachine.getCurrentMs())
+        : 1;
+      const effectiveSpeed = baseSpeed * speedMultiplier;
+
+      const nextMs = this.timeMachine.getCurrentMs() + dt * effectiveSpeed;
+      this.timeMachine.setTime(nextMs);
+
+      this.rafId = requestAnimationFrame(tick);
+    };
+    this.rafId = requestAnimationFrame(tick);
+    this.onPlayStateCb?.(true);
+  }
+
+  pause(): void {
+    if (!this.playingValue) return;
+    this.playingValue = false;
+    if (this.rafId != null) {
+      cancelAnimationFrame(this.rafId);
+      this.rafId = null;
+    }
+    if (this.modeValue === 'director' && this.autoFollow) {
+      this.autoFollow.stop();
+    }
+    this.onPlayStateCb?.(false);
+  }
+
+  toggle(): void {
+    if (this.playingValue) this.pause();
+    else this.play();
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    this.pause();
+    this.eventBlocks = [];
+    this.heartbeatWindows = [];
+  }
+
+  /**
+   * Look up the speed multiplier for the current time based on event density.
+   * High density → slow (close to HB_MIN_SPEED), low density → fast (HB_MAX_SPEED).
+   * Returns 1 when no window contains the time (treats it as average density).
+   */
+  private heartbeatSpeed(currentMs: number): number {
+    for (const win of this.heartbeatWindows) {
+      if (currentMs >= win.startMs && currentMs < win.endMs) {
+        if (win.density === 0) return HB_MAX_SPEED;
+        const normalized = Math.min(win.density / HB_DENSITY_FULL, 1);
+        return HB_MAX_SPEED * (1 - normalized) + HB_MIN_SPEED * normalized;
+      }
+    }
+    return 1;
+  }
+
+  private computeHeartbeatWindows(): void {
+    if (this.eventBlocks.length === 0) {
+      this.heartbeatWindows = [];
+      return;
+    }
+    let minMs = Number.POSITIVE_INFINITY;
+    let maxMs = Number.NEGATIVE_INFINITY;
+    for (const b of this.eventBlocks) {
+      if (b.startMs < minMs) minMs = b.startMs;
+      if (b.endMs > maxMs) maxMs = b.endMs;
+    }
+    if (!Number.isFinite(minMs) || !Number.isFinite(maxMs) || maxMs <= minMs) {
+      this.heartbeatWindows = [];
+      return;
+    }
+    // Clamp to a reasonable upper bound on window count to avoid pathological
+    // ranges (e.g. one ancient block + one future block creating thousands of
+    // empty buckets between them).
+    const totalSpan = maxMs - minMs;
+    const windowCount = Math.min(Math.ceil(totalSpan / HB_WINDOW_MS), 720);
+    const stepMs = totalSpan / windowCount;
+
+    const windows: HeartbeatWindow[] = [];
+    for (let i = 0; i < windowCount; i++) {
+      const start = minMs + i * stepMs;
+      const end = start + stepMs;
+      let count = 0;
+      for (const b of this.eventBlocks) {
+        if (b.startMs < end && b.endMs > start) count++;
+      }
+      windows.push({ startMs: start, endMs: end, density: count });
+    }
+    this.heartbeatWindows = windows;
+  }
+}

--- a/src/components/gods-vision/GlobePredictions.ts
+++ b/src/components/gods-vision/GlobePredictions.ts
@@ -1,0 +1,119 @@
+/**
+ * GlobePredictions — Tier 2 hover/click probability overlays.
+ *
+ * Renders one of:
+ *   • A flight / cyclone probability cone (translucent polygon + center
+ *     path) when {@link showCone} is called.
+ *   • Concentric aftershock rings around an earthquake epicenter when
+ *     {@link showAftershock} is called.
+ *
+ * Spec mandates max one active overlay at a time — every show*() call
+ * clears the previous one. Clearing also runs on Esc / clicking elsewhere
+ * (wired in by GodsEyeView in a follow-up).
+ *
+ * Plan: docs/superpowers/plans/2026-04-13-gods-eye-4d.md (Task 10)
+ */
+
+import {
+  Cartesian3,
+  Color,
+  CustomDataSource,
+  EllipseGraphics,
+  Entity,
+  HeightReference,
+  PolygonGraphics,
+  PolylineGraphics,
+  PolygonHierarchy,
+  type Viewer,
+} from 'cesium';
+import type { AftershockForecast, ForecastCone } from '@/services/forecast-engine';
+
+const CONE_COLOR_BY_TYPE: Record<ForecastCone['type'], Color> = {
+  cyclone: Color.fromCssColorString('#ffa500'),
+  flight:  Color.fromCssColorString('#00c8ff'),
+  fire:    Color.fromCssColorString('#ff6644'),
+  vessel:  Color.fromCssColorString('#4488ff'),
+};
+
+const AFTERSHOCK_COLOR = Color.fromCssColorString('#ffc800');
+const AFTERSHOCK_DISPLAY_THRESHOLD = 5; // only render M ≥ 5 rings; M4 rings are too noisy
+
+export class GlobePredictions {
+  private viewer: Viewer;
+  private source: CustomDataSource;
+  private activeEntities: Entity[] = [];
+
+  constructor(viewer: Viewer) {
+    this.viewer = viewer;
+    this.source = new CustomDataSource('4d-predictions');
+  }
+
+  mount(): void {
+    this.viewer.dataSources.add(this.source).catch((error: unknown) => {
+      // eslint-disable-next-line no-console
+      console.error('[GlobePredictions] dataSources.add failed', error);
+    });
+  }
+
+  destroy(): void {
+    this.clear();
+    this.viewer.dataSources.remove(this.source, true);
+  }
+
+  clear(): void {
+    for (const e of this.activeEntities) this.source.entities.remove(e);
+    this.activeEntities = [];
+  }
+
+  hasActive(): boolean {
+    return this.activeEntities.length > 0;
+  }
+
+  showCone(cone: ForecastCone): void {
+    this.clear();
+    const color = CONE_COLOR_BY_TYPE[cone.type];
+
+    if (cone.conePolygon.length >= 3) {
+      const positions = cone.conePolygon.map(p => Cartesian3.fromDegrees(p.lon, p.lat));
+      this.activeEntities.push(this.source.entities.add(new Entity({
+        polygon: new PolygonGraphics({
+          hierarchy: new PolygonHierarchy(positions),
+          material: color.withAlpha(0.08),
+          outline: true,
+          outlineColor: color.withAlpha(0.25),
+          heightReference: HeightReference.CLAMP_TO_GROUND,
+        }),
+      })));
+    }
+
+    if (cone.probablePath.length >= 2) {
+      const pathPositions = cone.probablePath.map(p => Cartesian3.fromDegrees(p.lon, p.lat));
+      this.activeEntities.push(this.source.entities.add(new Entity({
+        polyline: new PolylineGraphics({
+          positions: pathPositions,
+          width: 2,
+          material: color.withAlpha(0.5),
+          clampToGround: true,
+        }),
+      })));
+    }
+  }
+
+  showAftershock(forecast: AftershockForecast): void {
+    this.clear();
+    for (const ring of forecast.rings) {
+      if (ring.magnitudeThreshold !== AFTERSHOCK_DISPLAY_THRESHOLD) continue;
+      this.activeEntities.push(this.source.entities.add(new Entity({
+        position: Cartesian3.fromDegrees(forecast.epicenterLon, forecast.epicenterLat),
+        ellipse: new EllipseGraphics({
+          semiMajorAxis: ring.radiusKm * 1000,
+          semiMinorAxis: ring.radiusKm * 1000,
+          material: AFTERSHOCK_COLOR.withAlpha(ring.probability * 0.15),
+          outline: true,
+          outlineColor: AFTERSHOCK_COLOR.withAlpha(ring.probability * 0.3),
+          heightReference: HeightReference.CLAMP_TO_GROUND,
+        }),
+      })));
+    }
+  }
+}

--- a/src/components/gods-vision/GlobeSwimlane.ts
+++ b/src/components/gods-vision/GlobeSwimlane.ts
@@ -1,0 +1,308 @@
+/**
+ * GlobeSwimlane — multi-lane temporal timeline overlay for God's Eye 4D mode.
+ *
+ * DOM-based overlay (no Cesium primitives). Receives event blocks from
+ * GlobeDataManager and broadcasts time-scrub / event-click / lane-toggle
+ * intents back to the orchestrator (Globe4DManager).
+ *
+ * Spec: docs/superpowers/specs/2026-04-13-gods-eye-4d-design.md
+ * Plan: docs/superpowers/plans/2026-04-13-gods-eye-4d.md (Task 4)
+ */
+
+import type { EventBlock } from '@/components/GlobeDataManager';
+
+interface LaneConfig {
+  key: EventBlock['category'];
+  label: string;
+  color: string;
+}
+
+const LANES: readonly LaneConfig[] = [
+  { key: 'conflicts', label: 'CONFLICTS', color: '#ff3333' },
+  { key: 'disasters', label: 'DISASTERS', color: '#ffa500' },
+  { key: 'military',  label: 'MILITARY',  color: '#00c8ff' },
+  { key: 'seismic',   label: 'SEISMIC',   color: '#ffc800' },
+  { key: 'cyber',     label: 'CYBER',     color: '#00ffaa' },
+  { key: 'weather',   label: 'WEATHER',   color: '#8682ff' },
+] as const;
+
+const ZOOM_PRESETS: readonly { key: string; ms: number }[] = [
+  { key: '1h',  ms: 3_600_000 },
+  { key: '6h',  ms: 21_600_000 },
+  { key: '24h', ms: 86_400_000 },
+  { key: '7d',  ms: 604_800_000 },
+  { key: '30d', ms: 2_592_000_000 },
+] as const;
+
+const DEFAULT_ZOOM_KEY = '24h';
+const PAST_RATIO = 0.58; // 58% of viewport is past, 42% future
+const NOW_LINE_REFRESH_MS = 250;
+const TRACK_LEFT_PX = 70; // matches .ge-lane-label width
+
+export class GlobeSwimlane {
+  private container: HTMLElement;
+  private root: HTMLElement | null = null;
+  private lanesContainer: HTMLElement | null = null;
+  private nowLine: HTMLElement | null = null;
+  private tooltip: HTMLElement | null = null;
+  private collapsed = false;
+  private zoomKey = DEFAULT_ZOOM_KEY;
+  private zoomMs = ZOOM_PRESETS.find(z => z.key === DEFAULT_ZOOM_KEY)?.ms ?? 86_400_000;
+  private nowMs = Date.now();
+  private destroyed = false;
+  private blocks: EventBlock[] = [];
+  private zoomPills = new Map<string, HTMLElement>();
+  private laneTrackEls = new Map<EventBlock['category'], HTMLElement>();
+  private laneLabels = new Map<EventBlock['category'], HTMLElement>();
+  private refreshTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  private onTimeChangeCb: ((ms: number) => void) | null = null;
+  private onEventClickCb: ((block: EventBlock) => void) | null = null;
+  private onLaneToggleCb: ((category: EventBlock['category']) => void) | null = null;
+
+  constructor(container: HTMLElement) {
+    this.container = container;
+  }
+
+  setOnTimeChange(cb: (ms: number) => void): void { this.onTimeChangeCb = cb; }
+  setOnEventClick(cb: (block: EventBlock) => void): void { this.onEventClickCb = cb; }
+  setOnLaneToggle(cb: (category: EventBlock['category']) => void): void { this.onLaneToggleCb = cb; }
+
+  mount(): void {
+    if (this.root) return; // idempotent
+    this.root = document.createElement('div');
+    this.root.className = 'ge-swimlane expanded';
+    this.buildHeader();
+    this.buildLanes();
+    this.buildTooltip();
+    this.container.append(this.root);
+    this.startNowLineUpdate();
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    if (this.refreshTimeout != null) {
+      clearTimeout(this.refreshTimeout);
+      this.refreshTimeout = null;
+    }
+    this.root?.remove();
+    this.root = null;
+    this.tooltip?.remove();
+    this.tooltip = null;
+    this.zoomPills.clear();
+    this.laneTrackEls.clear();
+    this.laneLabels.clear();
+  }
+
+  updateBlocks(blocks: EventBlock[]): void {
+    this.blocks = blocks;
+    this.renderBlocks();
+  }
+
+  updateNow(ms: number): void {
+    this.nowMs = ms;
+    this.renderBlocks();
+  }
+
+  toggleCollapse(): void {
+    this.collapsed = !this.collapsed;
+    if (!this.root) return;
+    this.root.className = `ge-swimlane ${this.collapsed ? 'collapsed' : 'expanded'}`;
+    if (this.lanesContainer) {
+      this.lanesContainer.style.display = this.collapsed ? 'none' : '';
+    }
+  }
+
+  zoomIn(): void {
+    const idx = ZOOM_PRESETS.findIndex(z => z.key === this.zoomKey);
+    const next = idx > 0 ? ZOOM_PRESETS[idx - 1] : undefined;
+    if (next) this.setZoom(next.key);
+  }
+
+  zoomOut(): void {
+    const idx = ZOOM_PRESETS.findIndex(z => z.key === this.zoomKey);
+    const next = idx !== -1 && idx < ZOOM_PRESETS.length - 1 ? ZOOM_PRESETS[idx + 1] : undefined;
+    if (next) this.setZoom(next.key);
+  }
+
+  get isCollapsed(): boolean { return this.collapsed; }
+  get zoomLabel(): string { return this.zoomKey; }
+
+  private setZoom(key: string): void {
+    const preset = ZOOM_PRESETS.find(z => z.key === key);
+    if (!preset) return;
+    this.zoomKey = key;
+    this.zoomMs = preset.ms;
+    for (const [k, el] of this.zoomPills) {
+      el.classList.toggle('active', k === key);
+    }
+    this.renderBlocks();
+  }
+
+  private buildHeader(): void {
+    if (!this.root) return;
+    const header = document.createElement('div');
+    header.className = 'ge-swimlane-header';
+
+    const left = document.createElement('div');
+    left.className = 'ge-swimlane-header-left';
+    const title = document.createElement('div');
+    title.className = 'ge-swimlane-title';
+    title.textContent = '4D TIMELINE';
+    const zoomGroup = document.createElement('div');
+    zoomGroup.className = 'ge-pill-group';
+    for (const preset of ZOOM_PRESETS) {
+      const pill = document.createElement('button');
+      pill.type = 'button';
+      pill.className = `ge-pill${preset.key === this.zoomKey ? ' active' : ''}`;
+      pill.textContent = preset.key;
+      pill.addEventListener('click', () => this.setZoom(preset.key));
+      zoomGroup.append(pill);
+      this.zoomPills.set(preset.key, pill);
+    }
+    left.append(title, zoomGroup);
+
+    const right = document.createElement('div');
+    right.className = 'ge-swimlane-controls';
+    const collapseBtn = document.createElement('button');
+    collapseBtn.type = 'button';
+    collapseBtn.className = 'ge-pill';
+    collapseBtn.title = 'Collapse swimlane';
+    collapseBtn.textContent = '▼';
+    collapseBtn.addEventListener('click', () => this.toggleCollapse());
+    right.append(collapseBtn);
+
+    header.append(left, right);
+    this.root.append(header);
+  }
+
+  private buildLanes(): void {
+    if (!this.root) return;
+    this.lanesContainer = document.createElement('div');
+    this.lanesContainer.className = 'ge-swimlane-lanes';
+
+    this.nowLine = document.createElement('div');
+    this.nowLine.className = 'ge-now-line';
+    this.nowLine.title = 'Drag to scrub time';
+    const nowLabel = document.createElement('div');
+    nowLabel.className = 'ge-now-label';
+    nowLabel.textContent = 'NOW';
+    this.nowLine.append(nowLabel);
+    this.lanesContainer.append(this.nowLine);
+
+    this.nowLine.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      this.beginScrubDrag();
+    });
+
+    for (const lane of LANES) {
+      const row = document.createElement('div');
+      row.className = `ge-lane ge-lane-${lane.key}`;
+      row.style.setProperty('--ge-lane-color', lane.color);
+
+      const label = document.createElement('div');
+      label.className = 'ge-lane-label';
+      label.textContent = lane.label;
+      label.title = `Toggle ${lane.label.toLowerCase()} layer`;
+      label.addEventListener('click', () => this.onLaneToggleCb?.(lane.key));
+      this.laneLabels.set(lane.key, label);
+
+      const track = document.createElement('div');
+      track.className = 'ge-lane-track';
+      this.laneTrackEls.set(lane.key, track);
+
+      row.append(label, track);
+      this.lanesContainer.append(row);
+    }
+
+    this.root.append(this.lanesContainer);
+  }
+
+  private buildTooltip(): void {
+    this.tooltip = document.createElement('div');
+    this.tooltip.className = 'ge-swimlane-tooltip';
+    this.tooltip.style.display = 'none';
+    this.container.append(this.tooltip);
+  }
+
+  private beginScrubDrag(): void {
+    // The two arrow functions form a paired add/remove pair so they share
+    // closure state — extracting them to module scope would lose the `this`
+    // and bound-listener identity required for removeEventListener. The
+    // unicorn/consistent-function-scoping rule does not handle paired
+    // event-listener teardown well; disable on the two handlers below.
+    // eslint-disable-next-line unicorn/consistent-function-scoping
+    const onMove = (ev: MouseEvent): void => this.scrubFromClientX(ev.clientX);
+    // eslint-disable-next-line unicorn/consistent-function-scoping
+    const onUp = (): void => {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    };
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  }
+
+  private scrubFromClientX(clientX: number): void {
+    const track = this.laneTrackEls.values().next().value;
+    if (!track) return;
+    const rect = track.getBoundingClientRect();
+    const pct = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+    const windowStart = this.nowMs - this.zoomMs * PAST_RATIO;
+    const timeAtPct = windowStart + pct * this.zoomMs;
+    this.onTimeChangeCb?.(timeAtPct);
+  }
+
+  private renderBlocks(): void {
+    const now = this.nowMs;
+    const windowStart = now - this.zoomMs * PAST_RATIO;
+    const windowEnd = windowStart + this.zoomMs;
+
+    for (const [category, track] of this.laneTrackEls) {
+      while (track.firstChild) track.firstChild.remove();
+
+      const categoryBlocks = this.blocks.filter(b => b.category === category);
+      for (const block of categoryBlocks) {
+        if (block.endMs < windowStart || block.startMs > windowEnd) continue;
+        const leftPct = Math.max(0, ((block.startMs - windowStart) / this.zoomMs) * 100);
+        const widthPct = Math.max(0.5, Math.min(100 - leftPct, ((block.endMs - block.startMs) / this.zoomMs) * 100));
+        const el = document.createElement('div');
+        el.className = `ge-event-block ${block.isForecast ? 'forecast' : 'past'}`;
+        el.style.left = `${leftPct}%`;
+        el.style.width = `${widthPct}%`;
+        el.addEventListener('click', () => this.onEventClickCb?.(block));
+        el.addEventListener('mouseenter', (ev) => this.showTooltip(ev, block));
+        el.addEventListener('mouseleave', () => this.hideTooltip());
+        track.append(el);
+      }
+    }
+
+    if (this.nowLine) {
+      const pct = ((now - windowStart) / this.zoomMs) * 100;
+      this.nowLine.style.left = `calc(${TRACK_LEFT_PX}px + ${pct}%)`;
+    }
+  }
+
+  private showTooltip(e: MouseEvent, block: EventBlock): void {
+    if (!this.tooltip) return;
+    const name = block.name.length > 50 ? `${block.name.slice(0, 47)}...` : block.name;
+    const start = new Date(block.startMs).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    const end = new Date(block.endMs).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    this.tooltip.textContent = `${name} — ${start} to ${end}`;
+    this.tooltip.style.display = '';
+    this.tooltip.style.left = `${e.clientX + 12}px`;
+    this.tooltip.style.top = `${e.clientY - 24}px`;
+  }
+
+  private hideTooltip(): void {
+    if (this.tooltip) this.tooltip.style.display = 'none';
+  }
+
+  private startNowLineUpdate(): void {
+    const tick = (): void => {
+      if (this.destroyed) return;
+      this.renderBlocks();
+      this.refreshTimeout = setTimeout(tick, NOW_LINE_REFRESH_MS);
+    };
+    tick();
+  }
+}

--- a/src/components/gods-vision/GlobeTrails.ts
+++ b/src/components/gods-vision/GlobeTrails.ts
@@ -1,0 +1,288 @@
+/**
+ * GlobeTrails — comet-tail polyline trails behind moving entities.
+ *
+ * Each tracked entity gets a Float64Array ring buffer of (lon, lat, timeMs)
+ * tuples. Buffer length is bounded by MAX_POINTS_PER_TRAIL; total trail count
+ * is bounded by MAX_TRAILS. Points older than the per-layer window are
+ * trimmed on each refresh tick.
+ *
+ * Trails are rendered as N-1 individual segment polylines per trail so each
+ * segment can carry its own alpha (Cesium's entity-API ColorMaterialProperty
+ * is single-color). The tail segment is fully transparent and the head segment
+ * is fully opaque, with linear interpolation between them. A predictive
+ * segment past the head extrapolates one trail-length ahead using the most
+ * recent heading + speed and renders at half alpha to flag the uncertainty.
+ */
+
+import {
+  Cartesian3,
+  Color,
+  ColorMaterialProperty,
+  ConstantProperty,
+  CustomDataSource,
+  Entity,
+  PolylineGraphics,
+  PolylineDashMaterialProperty,
+  type Viewer,
+} from 'cesium';
+import type { GlobeDataManager } from '@/components/GlobeDataManager';
+
+interface TrailConfig {
+  layerName: string;
+  windowMs: number;
+  color: Color;
+  width: number;
+}
+
+const TRAIL_CONFIGS: readonly TrailConfig[] = [
+  { layerName: 'flights',     windowMs:  6 * 3_600_000, color: Color.fromCssColorString('#00c8ff'), width: 2 },
+  { layerName: 'vessels',     windowMs: 12 * 3_600_000, color: Color.fromCssColorString('#4488ff'), width: 1.5 },
+  { layerName: 'darkVessels', windowMs: 12 * 3_600_000, color: Color.fromCssColorString('#ff4444'), width: 1.5 },
+  { layerName: 'cyclones',    windowMs:  7 * 86_400_000, color: Color.fromCssColorString('#ffa500'), width: 3 },
+];
+
+const MAX_TRAILS = 200;
+const MAX_POINTS_PER_TRAIL = 50;
+const REFRESH_MS = 5000;
+const POINT_STRIDE = 3; // [lon, lat, timeMs]
+const PREDICTIVE_ALPHA = 0.35;
+const MAX_PREDICTIVE_DEG = 5; // never extrapolate more than ~550 km in the predictive segment
+
+interface SegmentSlot {
+  entity: Entity;
+  positions: ConstantProperty;
+  color: ConstantProperty;
+}
+
+interface TrailEntry {
+  entityId: string;
+  layerName: string;
+  buffer: Float64Array;
+  head: number;
+  count: number;
+  segments: SegmentSlot[];
+  predictive: SegmentSlot | null;
+  config: TrailConfig;
+}
+
+export class GlobeTrails {
+  private viewer: Viewer;
+  private dataManager: GlobeDataManager;
+  private source: CustomDataSource;
+  private trails = new Map<string, TrailEntry>();
+  private destroyed = false;
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(viewer: Viewer, dataManager: GlobeDataManager) {
+    this.viewer = viewer;
+    this.dataManager = dataManager;
+    this.source = new CustomDataSource('4d-trails');
+  }
+
+  mount(): void {
+    this.viewer.dataSources.add(this.source).catch((error: unknown) => {
+      // eslint-disable-next-line no-console
+      console.error('[GlobeTrails] dataSources.add failed', error);
+    });
+    this.refresh();
+    this.refreshTimer = setInterval(() => {
+      if (!this.destroyed) this.refresh();
+    }, REFRESH_MS);
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    this.viewer.dataSources.remove(this.source, true);
+    this.trails.clear();
+  }
+
+  get activeTrailCount(): number { return this.trails.size; }
+
+  private refresh(): void {
+    const seenIds = new Set<string>();
+
+    for (const config of TRAIL_CONFIGS) {
+      const positions = this.dataManager.getEntityPositionHistory(config.layerName);
+      for (const pos of positions) {
+        if (this.trails.size >= MAX_TRAILS && !this.trails.has(pos.id)) continue;
+        seenIds.add(pos.id);
+        let trail = this.trails.get(pos.id);
+        if (!trail) {
+          trail = this.createTrail(pos.id, config);
+          this.trails.set(pos.id, trail);
+        }
+        this.pushPoint(trail, pos.lon, pos.lat, pos.timeMs, config.windowMs);
+      }
+    }
+
+    for (const trail of this.trails.values()) {
+      this.renderTrail(trail);
+    }
+
+    // Drop trails whose entity disappeared.
+    for (const [id, trail] of this.trails) {
+      if (!seenIds.has(id)) {
+        this.removeTrail(trail);
+        this.trails.delete(id);
+      }
+    }
+  }
+
+  private createTrail(entityId: string, config: TrailConfig): TrailEntry {
+    const buffer = new Float64Array(MAX_POINTS_PER_TRAIL * POINT_STRIDE);
+    return {
+      entityId,
+      layerName: config.layerName,
+      buffer,
+      head: 0,
+      count: 0,
+      segments: [],
+      predictive: null,
+      config,
+    };
+  }
+
+  private pushPoint(trail: TrailEntry, lon: number, lat: number, timeMs: number, windowMs: number): void {
+    const idx = trail.head * POINT_STRIDE;
+    trail.buffer[idx] = lon;
+    trail.buffer[idx + 1] = lat;
+    trail.buffer[idx + 2] = timeMs;
+    trail.head = (trail.head + 1) % MAX_POINTS_PER_TRAIL;
+    if (trail.count < MAX_POINTS_PER_TRAIL) trail.count++;
+
+    const cutoff = Date.now() - windowMs;
+    while (trail.count > 0) {
+      const oldest = ((trail.head - trail.count + MAX_POINTS_PER_TRAIL) % MAX_POINTS_PER_TRAIL) * POINT_STRIDE;
+      if ((trail.buffer[oldest + 2] ?? 0) >= cutoff) break;
+      trail.count--;
+    }
+  }
+
+  /**
+   * Resolve the trail buffer to an ordered array of (lon, lat) pairs from
+   * tail (oldest) to head (newest).
+   */
+  private collectPoints(trail: TrailEntry): { lon: number; lat: number }[] {
+    if (trail.count === 0) return [];
+    const out: { lon: number; lat: number }[] = [];
+    for (let i = 0; i < trail.count; i++) {
+      const idx = ((trail.head - trail.count + i + MAX_POINTS_PER_TRAIL) % MAX_POINTS_PER_TRAIL) * POINT_STRIDE;
+      out.push({ lon: trail.buffer[idx] ?? 0, lat: trail.buffer[idx + 1] ?? 0 });
+    }
+    return out;
+  }
+
+  private renderTrail(trail: TrailEntry): void {
+    const points = this.collectPoints(trail);
+    const desiredSegments = Math.max(0, points.length - 1);
+
+    while (trail.segments.length > desiredSegments) {
+      const slot = trail.segments.pop();
+      if (slot) this.source.entities.remove(slot.entity);
+    }
+    while (trail.segments.length < desiredSegments) {
+      trail.segments.push(this.createSegmentSlot(trail.config.width, false));
+    }
+
+    for (let i = 0; i < desiredSegments; i++) {
+      const a = points[i];
+      const b = points[i + 1];
+      const slot = trail.segments[i];
+      if (!a || !b || !slot) continue;
+      const tailFrac = i / desiredSegments;
+      const headFrac = (i + 1) / desiredSegments;
+      const alpha = (tailFrac + headFrac) / 2; // average alpha across the segment
+      slot.positions.setValue([
+        Cartesian3.fromDegrees(a.lon, a.lat),
+        Cartesian3.fromDegrees(b.lon, b.lat),
+      ]);
+      slot.color.setValue(trail.config.color.withAlpha(alpha));
+    }
+
+    this.updatePredictiveSegment(trail, points);
+  }
+
+  /**
+   * Velocity-based predictive segment that extends one trail-length past the
+   * head using the average of the last few segments. Rendered as a low-alpha
+   * dashed polyline so the overall trail visually previews the next step.
+   */
+  private updatePredictiveSegment(trail: TrailEntry, points: { lon: number; lat: number }[]): void {
+    if (points.length < 2) {
+      if (trail.predictive) {
+        this.source.entities.remove(trail.predictive.entity);
+        trail.predictive = null;
+      }
+      return;
+    }
+
+    const head = points[points.length - 1]!;
+    // Average direction over the last few segments (smoother than raw last segment).
+    const sampleN = Math.min(5, points.length - 1);
+    let dLon = 0;
+    let dLat = 0;
+    for (let i = points.length - sampleN - 1; i < points.length - 1; i++) {
+      const p1 = points[i];
+      const p2 = points[i + 1];
+      if (!p1 || !p2) continue;
+      dLon += p2.lon - p1.lon;
+      dLat += p2.lat - p1.lat;
+    }
+    dLon /= sampleN;
+    dLat /= sampleN;
+
+    // Scale predictive vector to one trail-length, but cap to MAX_PREDICTIVE_DEG.
+    const trailLengthScale = sampleN > 0 ? (points.length - 1) / sampleN : 1;
+    let predLon = dLon * trailLengthScale;
+    let predLat = dLat * trailLengthScale;
+    const mag = Math.hypot(predLon, predLat);
+    if (mag > MAX_PREDICTIVE_DEG) {
+      const scale = MAX_PREDICTIVE_DEG / mag;
+      predLon *= scale;
+      predLat *= scale;
+    }
+    if (mag < 1e-6) {
+      // Stationary entity — drop any existing predictive segment.
+      if (trail.predictive) {
+        this.source.entities.remove(trail.predictive.entity);
+        trail.predictive = null;
+      }
+      return;
+    }
+
+    trail.predictive ??= this.createSegmentSlot(trail.config.width, true);
+    trail.predictive.positions.setValue([
+      Cartesian3.fromDegrees(head.lon, head.lat),
+      Cartesian3.fromDegrees(head.lon + predLon, head.lat + predLat),
+    ]);
+    trail.predictive.color.setValue(trail.config.color.withAlpha(PREDICTIVE_ALPHA));
+  }
+
+  private createSegmentSlot(width: number, dashed: boolean): SegmentSlot {
+    const positions = new ConstantProperty([Cartesian3.ZERO, Cartesian3.ZERO]);
+    const color = new ConstantProperty(Color.TRANSPARENT);
+    const material = dashed
+      ? new PolylineDashMaterialProperty({ color, dashLength: 8 })
+      : new ColorMaterialProperty(color);
+    const entity = this.source.entities.add(new Entity({
+      polyline: new PolylineGraphics({
+        positions,
+        width,
+        material,
+        clampToGround: true,
+      }),
+    }));
+    return { entity, positions, color };
+  }
+
+  private removeTrail(trail: TrailEntry): void {
+    for (const slot of trail.segments) this.source.entities.remove(slot.entity);
+    if (trail.predictive) this.source.entities.remove(trail.predictive.entity);
+    trail.segments.length = 0;
+    trail.predictive = null;
+  }
+}

--- a/src/components/gods-vision/degradation-math.ts
+++ b/src/components/gods-vision/degradation-math.ts
@@ -1,0 +1,69 @@
+/**
+ * Pure-math half of GlobeDegradation. No Cesium imports — testable in Node.
+ *
+ * Exponential decay confidence model:
+ *   raw = exp(-timeFromNow / τ)
+ *   confidence = max(CONFIDENCE_FLOOR, min(1, raw))
+ *
+ * Visual transitions are threshold-driven on the bounded confidence:
+ *   < DASH_THRESHOLD     → dashed polylines, faded labels
+ *   < BLUR_THRESHOLD     → reduced billboard scale, reduced point size
+ *   < JITTER_THRESHOLD   → deterministic per-id pixel jitter
+ *   < LABEL_THRESHOLD    → label hidden
+ *
+ * The confidence floor (5%) prevents entities at extreme forecast horizons
+ * from disappearing entirely — they degrade to ghosts but stay pickable.
+ */
+
+const DAY_MS = 86_400_000;
+
+export const CONFIDENCE_FLOOR = 0.05;
+export const DASH_THRESHOLD = 0.5;
+export const BLUR_THRESHOLD = 0.3;
+export const JITTER_THRESHOLD = 0.2;
+export const LABEL_THRESHOLD = 0.3;
+export const JITTER_MAX_PX = 6;
+
+export const LAYER_DECAY_TAU_MS: Record<string, number> = {
+  conflicts: 2.33 * DAY_MS,
+  airstrikes: 2.33 * DAY_MS,
+  earthquakes: 10 * DAY_MS,
+  gdacs: 0.67 * DAY_MS,
+  cyclones: 1.67 * DAY_MS,
+  fires: 0.67 * DAY_MS,
+};
+
+export interface DegradationState {
+  confidence: number;
+  opacity: number;
+  isDashed: boolean;
+  blur: number;
+  jitter: number;
+}
+
+export function computeDegradationState(timeFromNowMs: number, tauMs: number): DegradationState {
+  if (tauMs <= 0 || timeFromNowMs <= 0) {
+    return { confidence: 1, opacity: 1, isDashed: false, blur: 0, jitter: 0 };
+  }
+  const raw = Math.exp(-timeFromNowMs / tauMs);
+  const confidence = Math.max(CONFIDENCE_FLOOR, Math.min(1, raw));
+  return {
+    confidence,
+    opacity: confidence,
+    isDashed: confidence < DASH_THRESHOLD,
+    blur: confidence < BLUR_THRESHOLD ? (1 - confidence) * 2 : 0,
+    jitter: confidence < JITTER_THRESHOLD ? (1 - confidence) * 4 : 0,
+  };
+}
+
+/** Stable per-entity jitter offset from a deterministic hash of the id. */
+export function computeJitterOffset(id: string, intensity: number): [number, number] {
+  if (intensity <= 0) return [0, 0];
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = Math.trunc((hash << 5) - hash + (id.codePointAt(i) ?? 0));
+  }
+  const angle = ((hash & 0xFF_FF) / 0xFF_FF) * Math.PI * 2;
+  const magnitude = Math.min(1, intensity) * JITTER_MAX_PX;
+  return [Math.cos(angle) * magnitude, Math.sin(angle) * magnitude];
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 /* eslint-disable sonarjs/no-duplicated-branches, no-console, @typescript-eslint/prefer-nullish-coalescing, sonarjs/no-nested-conditional, sonarjs/slow-regex, sonarjs/anchor-precedence, sonarjs/regex-complexity, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-empty-function, @typescript-eslint/no-floating-promises, unicorn/prefer-top-level-await */
 import './styles/base-layer.css';
 import './styles/happy-theme.css';
+import './styles/gods-eye-4d.css';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import * as Sentry from '@sentry/browser';
 import { inject } from '@vercel/analytics';

--- a/src/services/forecast-engine.ts
+++ b/src/services/forecast-engine.ts
@@ -1,0 +1,410 @@
+/**
+ * Forecast engine — aggregates prediction shapes from existing data sources.
+ *
+ * Used by GlobePredictions (Task 10, Tier 2 hover/click cones) and
+ * GlobeBranching (Task 11, click-only scenario forks). Pure functions; no
+ * Cesium imports here so they're trivially unit-testable.
+ *
+ * The aftershock and conflict-branch math is simplified by design — the
+ * spec calls for production-grade ETAS / NHC track ensemble in a follow-up.
+ * The current models are good enough to render plausible Tier 2 overlays
+ * and to plug into the existing EMA forecast service.
+ *
+ * Plan: docs/superpowers/plans/2026-04-13-gods-eye-4d.md (Task 9)
+ */
+
+const DAY_MS = 86_400_000;
+const HOUR_MS = 3_600_000;
+const EARTH_RADIUS_KM = 6371;
+
+export interface ForecastPoint {
+  lat: number;
+  lon: number;
+  timeMs: number;
+  confidence: number;
+}
+
+export interface ForecastCone {
+  entityId: string;
+  type: 'cyclone' | 'flight' | 'fire' | 'vessel';
+  probablePath: ForecastPoint[];
+  /** Outer boundary as a closed polygon (caller closes the loop). */
+  conePolygon: { lat: number; lon: number }[];
+}
+
+export interface TrackPoint {
+  lat: number;
+  lon: number;
+  timeMs: number;
+}
+
+export interface AftershockRing {
+  radiusKm: number;
+  probability: number;
+  magnitudeThreshold: number;
+}
+
+export interface AftershockForecast {
+  entityId: string;
+  epicenterLat: number;
+  epicenterLon: number;
+  mainshockMagnitude: number;
+  rings: AftershockRing[];
+}
+
+export interface ScenarioBranch {
+  label: string;
+  probability: number;
+  outcome: 'escalation' | 'stalemate' | 'deescalation';
+  path: ForecastPoint[];
+  conditions: string;
+}
+
+export interface BranchingForecast {
+  entityId: string;
+  type: 'conflict' | 'cyclone';
+  branches: ScenarioBranch[];
+}
+
+/**
+ * Modified Omori-Utsu / Reasenberg-Jones aftershock probability over a 30-day
+ * window. The temporal rate of aftershocks of magnitude ≥ M' follows
+ *
+ *   λ(t) = K / (t + c)^p,
+ *
+ * where t is days since mainshock, p ≈ 1.1, c ≈ 0.1, and K scales with the
+ * difference between the mainshock magnitude and M' via Gutenberg-Richter:
+ *
+ *   K(M') = 10^(a + b*(Mmax - M' - 1)),    a ≈ -1.67, b ≈ 1.
+ *
+ * Cumulative count over [0, T] for p ≠ 1:
+ *
+ *   N(0..T; M') = K * (c^(1-p) - (T + c)^(1-p)) / (p - 1).
+ *
+ * Probability of at least one aftershock = 1 - exp(-N). Spatial confinement
+ * to a ring of radius R is approximated by a normalized r²/Rmax² area term,
+ * which avoids the brittle 1/(1 + R/50) heuristic the previous model used.
+ */
+const AFTERSHOCK_P = 1.1;
+const AFTERSHOCK_C = 0.1;
+const AFTERSHOCK_A = -1.67;
+const AFTERSHOCK_B = 1;
+const AFTERSHOCK_WINDOW_DAYS = 30;
+const AFTERSHOCK_RMAX_KM = 100;
+
+function aftershockExpectedCount(
+  mainshockMag: number,
+  thresholdMag: number,
+  windowDays: number,
+): number {
+  if (thresholdMag >= mainshockMag) return 0;
+  const k = Math.pow(10, AFTERSHOCK_A + AFTERSHOCK_B * (mainshockMag - thresholdMag - 1));
+  const exponent = 1 - AFTERSHOCK_P;
+  const integrated = (Math.pow(AFTERSHOCK_C, exponent) - Math.pow(windowDays + AFTERSHOCK_C, exponent))
+    / (AFTERSHOCK_P - 1);
+  return Math.max(0, k * integrated);
+}
+
+export function computeAftershockForecast(
+  entityId: string,
+  lat: number,
+  lon: number,
+  magnitude: number,
+): AftershockForecast {
+  const rings: AftershockRing[] = [];
+
+  for (const radiusKm of [25, 50, 100]) {
+    const areaFraction = Math.min(1, (radiusKm / AFTERSHOCK_RMAX_KM) ** 2);
+    for (const magThreshold of [4, 5, 6]) {
+      const expected = aftershockExpectedCount(magnitude, magThreshold, AFTERSHOCK_WINDOW_DAYS);
+      const prob = 1 - Math.exp(-expected * areaFraction);
+      rings.push({
+        radiusKm,
+        probability: Math.min(0.95, Math.max(0.01, prob)),
+        magnitudeThreshold: magThreshold,
+      });
+    }
+  }
+
+  return {
+    entityId,
+    epicenterLat: lat,
+    epicenterLon: lon,
+    mainshockMagnitude: magnitude,
+    rings,
+  };
+}
+
+export interface ConflictBranchOptions {
+  /** Front-line / theater bearing in degrees (0=N, 90=E). If omitted, a
+   *  deterministic per-entity bearing is used so branches still differ. */
+  headingDeg?: number;
+  /** Optional advance speed (km/day). Caps at 25 km/day; defaults to 5. */
+  speedKmPerDay?: number;
+}
+
+const DEG_TO_RAD = Math.PI / 180;
+
+function deterministicBearing(seed: string): number {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) {
+    h = Math.trunc((h << 5) - h + (seed.codePointAt(i) ?? 0));
+  }
+  return ((Math.abs(h) % 360) - 180) * DEG_TO_RAD;
+}
+
+/**
+ * Conflict escalation branches from an EMA trend signal.
+ *  emaTrend ∈ [-1, 1]   negative = de-escalating, positive = escalating.
+ * Branch bearings are derived from the supplied front-line heading (or a
+ * deterministic per-entity bearing fallback): stalemate keeps the heading,
+ * escalation forks ±60° (new fronts), de-escalation backs along heading + 180°.
+ * Returns three branches whose probabilities sum to 1 (within rounding).
+ */
+export function computeConflictBranches(
+  entityId: string,
+  lat: number,
+  lon: number,
+  emaTrend: number,
+  opts: ConflictBranchOptions = {},
+): BranchingForecast {
+  const escalateP = Math.max(0.05, Math.min(0.8, 0.3 + emaTrend * 0.4));
+  const deescalateP = Math.max(0.05, Math.min(0.8, 0.3 - emaTrend * 0.4));
+  const stalemateP = Math.max(0.05, 1 - escalateP - deescalateP);
+
+  const headingRad = opts.headingDeg === undefined
+    ? deterministicBearing(entityId)
+    : opts.headingDeg * DEG_TO_RAD;
+  const speedKmDay = Math.max(0.5, Math.min(25, opts.speedKmPerDay ?? 5));
+  // Rough km → degree conversion at the entity's latitude.
+  const kmPerDeg = 111;
+  const lonScale = Math.max(0.1, Math.cos(lat * DEG_TO_RAD));
+
+  const makePath = (bearingRad: number, speedFactor: number): ForecastPoint[] => {
+    const points: ForecastPoint[] = [];
+    const stepDeg = (speedKmDay * speedFactor) / kmPerDeg;
+    for (let i = 0; i <= 7; i++) {
+      const confidence = Math.max(0.1, 1 - i / 7);
+      points.push({
+        lat: lat + Math.cos(bearingRad) * stepDeg * i,
+        lon: lon + (Math.sin(bearingRad) * stepDeg * i) / lonScale,
+        timeMs: Date.now() + i * DAY_MS,
+        confidence,
+      });
+    }
+    return points;
+  };
+
+  return {
+    entityId,
+    type: 'conflict',
+    branches: [
+      {
+        label: 'De-escalation',
+        probability: deescalateP,
+        outcome: 'deescalation',
+        path: makePath(headingRad + Math.PI, 0.5),
+        conditions: 'Ceasefire negotiations progress, external pressure increases',
+      },
+      {
+        label: 'Stalemate',
+        probability: stalemateP,
+        outcome: 'stalemate',
+        path: makePath(headingRad, 0.3),
+        conditions: 'Current tempo maintained, no significant territorial changes',
+      },
+      {
+        label: 'Escalation',
+        probability: escalateP,
+        outcome: 'escalation',
+        path: makePath(headingRad + (Math.PI / 3), 1),
+        conditions: 'New fronts open, external actors intervene, weapons escalation',
+      },
+    ],
+  };
+}
+
+/**
+ * NHC-style cone of uncertainty for a tropical cyclone. Track-relative
+ * cross-track and along-track positional errors grow as σ = a · t^b with
+ * a_ct≈35 km, a_at≈55 km, b≈0.6 (t in days; matches NHC 24-h increment
+ * statistics). The cone polygon is built from the cross-track 1-σ envelope
+ * around 5 forecast hops at +24 h, +48 h, +72 h, +96 h, +120 h.
+ *
+ * `track` is the entity's historical positions (chronologically oldest →
+ * newest, latest is current). At least two points are required to derive
+ * a heading and translation speed; with only one point a deterministic
+ * fallback heading from the entity id is used and translation speed
+ * defaults to 12 kt (~22 km/h).
+ */
+const CYCLONE_SIGMA_CT_A = 35;
+const CYCLONE_SIGMA_AT_A = 55;
+const CYCLONE_SIGMA_B = 0.6;
+const CYCLONE_FORECAST_DAYS = [1, 2, 3, 4, 5];
+const CYCLONE_DEFAULT_SPEED_KMH = 22;
+
+export function computeCycloneCone(
+  entityId: string,
+  track: TrackPoint[],
+): ForecastCone | null {
+  const tail = track[track.length - 1];
+  if (!tail) return null;
+
+  const { lat: lat0, lon: lon0, timeMs: t0 } = tail;
+  const heading = deriveHeading(track, entityId);
+  const speedKmh = deriveSpeed(track) ?? CYCLONE_DEFAULT_SPEED_KMH;
+
+  const probablePath: ForecastPoint[] = [
+    { lat: lat0, lon: lon0, timeMs: t0, confidence: 1 },
+  ];
+  const rightEnvelope: { lat: number; lon: number }[] = [];
+  const leftEnvelope: { lat: number; lon: number }[] = [];
+
+  const lonScale = Math.max(0.1, Math.cos(lat0 * DEG_TO_RAD));
+
+  for (const days of CYCLONE_FORECAST_DAYS) {
+    const distKm = speedKmh * 24 * days;
+    const dLat = (distKm / EARTH_RADIUS_KM) * Math.cos(heading) * (180 / Math.PI);
+    const dLon = (distKm / EARTH_RADIUS_KM) * Math.sin(heading) * (180 / Math.PI) / lonScale;
+    const fLat = lat0 + dLat;
+    const fLon = lon0 + dLon;
+    const sigmaCt = CYCLONE_SIGMA_CT_A * Math.pow(days, CYCLONE_SIGMA_B);
+    const sigmaAt = CYCLONE_SIGMA_AT_A * Math.pow(days, CYCLONE_SIGMA_B);
+
+    probablePath.push({
+      lat: fLat,
+      lon: fLon,
+      timeMs: t0 + days * DAY_MS,
+      confidence: Math.max(0.1, 1 - days / 6),
+    });
+
+    const perpRight = heading + Math.PI / 2;
+    rightEnvelope.push({
+      lat: fLat + (sigmaCt / EARTH_RADIUS_KM) * Math.cos(perpRight) * (180 / Math.PI),
+      lon: fLon + (sigmaCt / EARTH_RADIUS_KM) * Math.sin(perpRight) * (180 / Math.PI) / lonScale,
+    });
+    const perpLeft = heading - Math.PI / 2;
+    leftEnvelope.push({
+      lat: fLat + (sigmaCt / EARTH_RADIUS_KM) * Math.cos(perpLeft) * (180 / Math.PI),
+      lon: fLon + (sigmaCt / EARTH_RADIUS_KM) * Math.sin(perpLeft) * (180 / Math.PI) / lonScale,
+    });
+
+    // Tail-extension along-track at the outermost point (Day 5) to produce
+    // an endcap, scaled by sigmaAt so the cone bulges outward at the tip.
+    if (days === CYCLONE_FORECAST_DAYS[CYCLONE_FORECAST_DAYS.length - 1]) {
+      rightEnvelope.push({
+        lat: fLat + (sigmaAt / EARTH_RADIUS_KM) * Math.cos(heading) * (180 / Math.PI),
+        lon: fLon + (sigmaAt / EARTH_RADIUS_KM) * Math.sin(heading) * (180 / Math.PI) / lonScale,
+      });
+    }
+  }
+
+  const reversedLeft: { lat: number; lon: number }[] = [];
+  for (let i = leftEnvelope.length - 1; i >= 0; i--) {
+    const v = leftEnvelope[i];
+    if (v) reversedLeft.push(v);
+  }
+  const conePolygon: { lat: number; lon: number }[] = [
+    { lat: lat0, lon: lon0 },
+    ...rightEnvelope,
+    ...reversedLeft,
+  ];
+
+  return { entityId, type: 'cyclone', probablePath, conePolygon };
+}
+
+/**
+ * Heading from the most recent two track points (great-circle initial bearing).
+ * Falls back to a deterministic-by-id bearing if there's only one sample.
+ */
+function deriveHeading(track: TrackPoint[], entityId: string): number {
+  if (track.length < 2) return deterministicBearing(entityId);
+  const a = track[track.length - 2];
+  const b = track[track.length - 1];
+  if (!a || !b) return deterministicBearing(entityId);
+  const φ1 = a.lat * DEG_TO_RAD;
+  const φ2 = b.lat * DEG_TO_RAD;
+  const Δλ = (b.lon - a.lon) * DEG_TO_RAD;
+  const y = Math.sin(Δλ) * Math.cos(φ2);
+  const x = Math.cos(φ1) * Math.sin(φ2) - Math.sin(φ1) * Math.cos(φ2) * Math.cos(Δλ);
+  return Math.atan2(y, x);
+}
+
+/**
+ * Translation speed (km/h) from the most recent two samples. Returns null
+ * when the samples are coincident in time so callers can fall back to a
+ * climatological default.
+ */
+function deriveSpeed(track: TrackPoint[]): number | null {
+  if (track.length < 2) return null;
+  const a = track[track.length - 2];
+  const b = track[track.length - 1];
+  if (!a || !b) return null;
+  const dtH = (b.timeMs - a.timeMs) / HOUR_MS;
+  if (!Number.isFinite(dtH) || dtH <= 0) return null;
+  const distKm = haversineKm(a.lat, a.lon, b.lat, b.lon);
+  return distKm / dtH;
+}
+
+function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const dφ = (lat2 - lat1) * DEG_TO_RAD;
+  const dλ = (lon2 - lon1) * DEG_TO_RAD;
+  const a = Math.sin(dφ / 2) ** 2
+    + Math.cos(lat1 * DEG_TO_RAD) * Math.cos(lat2 * DEG_TO_RAD) * Math.sin(dλ / 2) ** 2;
+  return 2 * EARTH_RADIUS_KM * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+/**
+ * Extrapolate a flight along its current heading using a great-circle
+ * approximation. Returns 9 forecast points (every 15 min for 2 h) plus a
+ * cone polygon that widens linearly with time.
+ */
+export function computeFlightCone(
+  entityId: string,
+  lat: number,
+  lon: number,
+  headingDeg: number,
+  speedKnots: number,
+): ForecastCone {
+  const headingRad = (headingDeg * Math.PI) / 180;
+  const speedKmH = speedKnots * 1.852;
+  const points: ForecastPoint[] = [];
+
+  for (let hours = 0; hours <= 2; hours += 0.25) {
+    const distKm = speedKmH * hours;
+    const dLat = (distKm / EARTH_RADIUS_KM) * Math.cos(headingRad) * (180 / Math.PI);
+    const dLon = (distKm / EARTH_RADIUS_KM) * Math.sin(headingRad) * (180 / Math.PI) / Math.cos((lat * Math.PI) / 180);
+    const confidence = Math.max(0.1, 1 - hours / 2);
+    points.push({
+      lat: lat + dLat,
+      lon: lon + dLon,
+      timeMs: Date.now() + hours * HOUR_MS,
+      confidence,
+    });
+  }
+
+  const spreadRate = 0.002; // ° per hour, lateral
+  const conePolygon: { lat: number; lon: number }[] = [];
+  for (const p of points) {
+    const hours = (p.timeMs - Date.now()) / HOUR_MS;
+    const spread = spreadRate * hours;
+    const perpRad = headingRad + Math.PI / 2;
+    conePolygon.push({
+      lat: p.lat + Math.cos(perpRad) * spread,
+      lon: p.lon + Math.sin(perpRad) * spread,
+    });
+  }
+  for (let i = points.length - 1; i >= 0; i--) {
+    const p = points[i];
+    if (!p) continue;
+    const hours = (p.timeMs - Date.now()) / HOUR_MS;
+    const spread = spreadRate * hours;
+    const perpRad = headingRad - Math.PI / 2;
+    conePolygon.push({
+      lat: p.lat + Math.cos(perpRad) * spread,
+      lon: p.lon + Math.sin(perpRad) * spread,
+    });
+  }
+
+  return { entityId, type: 'flight', probablePath: points, conePolygon };
+}

--- a/src/styles/gods-eye-4d.css
+++ b/src/styles/gods-eye-4d.css
@@ -1,0 +1,287 @@
+/*
+ * God's Eye 4D Mode — Styling
+ *
+ * Foundation styles for the 4D temporal extension. This file ships ahead of
+ * the visual feature set so future PRs (swimlane, playback transport,
+ * degradation, trails) only need to add component-specific rules.
+ *
+ * Activated when document.body has the `gods-eye-4d-active` class.
+ *
+ * Spec: docs/superpowers/specs/2026-04-13-gods-eye-4d-design.md
+ * Plan: docs/superpowers/plans/2026-04-13-gods-eye-4d.md
+ */
+
+/* ── HUD: 4D mode badge ──────────────────────────────────────────────────── */
+
+.ge-hud-4d-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, rgba(140, 90, 255, 0.95), rgba(96, 60, 200, 0.95));
+  color: #fff;
+  font: 600 10px/1 "SF Pro Text", -apple-system, BlinkMacSystemFont, sans-serif;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 0 0 1px rgba(180, 140, 255, 0.45), 0 4px 12px rgba(120, 80, 220, 0.35);
+}
+
+.ge-hud-4d-badge::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #ffe9c0;
+  box-shadow: 0 0 6px #ffd58a;
+}
+
+.ge-hud-4d-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: rgba(140, 90, 255, 0.18);
+  color: rgba(220, 200, 255, 0.95);
+  font: 500 10px/1.2 "SF Mono", ui-monospace, monospace;
+  letter-spacing: 0.04em;
+}
+
+/* ── Body class: subtle ambient affordance when 4D is on ──────────────── */
+
+body.gods-eye-4d-active .gods-eye-time-machine {
+  /* The simple scrubber gets a subtle violet outline so it's clear that
+   * 4D is active even before the swimlane component lands in a future PR. */
+  box-shadow: 0 0 0 1px rgba(140, 90, 255, 0.35), 0 4px 16px rgba(0, 0, 0, 0.35);
+  transition: box-shadow 0.25s ease;
+}
+
+/* ── Swimlane container ─────────────────────────────────────────────────── */
+
+.ge-swimlane {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  bottom: 96px; /* clears the time-machine scrubber at 84px */
+  pointer-events: auto;
+  background: rgba(8, 10, 14, 0.86);
+  border: 1px solid rgba(140, 90, 255, 0.32);
+  border-radius: 12px;
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.55);
+  color: #d8d8e8;
+  font: 500 11px/1.3 "SF Pro Text", -apple-system, BlinkMacSystemFont, sans-serif;
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  z-index: 8;
+  overflow: hidden;
+  transition: max-height 0.25s ease, padding 0.25s ease;
+}
+
+.ge-swimlane.expanded {
+  max-height: 220px;
+  padding: 8px 10px 10px;
+}
+
+.ge-swimlane.collapsed {
+  max-height: 36px;
+  padding: 6px 10px;
+}
+
+.ge-swimlane-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.ge-swimlane-header-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.ge-swimlane-title {
+  font: 600 10px/1 "SF Pro Text", -apple-system, BlinkMacSystemFont, sans-serif;
+  letter-spacing: 0.12em;
+  color: rgba(200, 180, 255, 0.85);
+}
+
+.ge-swimlane-controls {
+  display: flex;
+  gap: 6px;
+}
+
+/* ── Pills (zoom presets, collapse, future playback transport) ────────── */
+
+.ge-pill-group {
+  display: inline-flex;
+  gap: 3px;
+  padding: 2px;
+  border-radius: 6px;
+  background: rgba(20, 20, 30, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.ge-pill {
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font: 500 10px/1.4 "SF Mono", ui-monospace, monospace;
+  color: rgba(200, 200, 220, 0.65);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.ge-pill:hover {
+  color: #fff;
+  background: rgba(140, 90, 255, 0.18);
+}
+
+.ge-pill.active {
+  color: #fff;
+  background: linear-gradient(135deg, rgba(140, 90, 255, 0.95), rgba(96, 60, 200, 0.95));
+}
+
+/* ── Lanes ────────────────────────────────────────────────────────────── */
+
+.ge-swimlane-lanes {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ge-lane {
+  display: flex;
+  align-items: center;
+  height: 22px;
+}
+
+.ge-lane-label {
+  width: 70px;
+  flex-shrink: 0;
+  font: 600 9px/1 "SF Mono", ui-monospace, monospace;
+  letter-spacing: 0.08em;
+  color: var(--ge-lane-color, rgba(220, 220, 240, 0.85));
+  cursor: pointer;
+  text-align: right;
+  padding-right: 8px;
+  user-select: none;
+  transition: opacity 0.12s ease;
+}
+
+.ge-lane-label:hover { opacity: 0.7; }
+
+.ge-lane-track {
+  position: relative;
+  flex: 1;
+  height: 18px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+/* ── Event blocks ─────────────────────────────────────────────────────── */
+
+.ge-event-block {
+  position: absolute;
+  top: 2px;
+  bottom: 2px;
+  background: var(--ge-lane-color, #888);
+  border-radius: 2px;
+  cursor: pointer;
+  transition: transform 0.12s ease, filter 0.12s ease;
+}
+
+.ge-event-block.past {
+  background: var(--ge-lane-color, #888);
+  opacity: 0.85;
+}
+
+.ge-event-block.forecast {
+  background: var(--ge-lane-color, #888);
+  opacity: 0.5;
+  background-image: repeating-linear-gradient(
+    45deg,
+    rgba(255, 255, 255, 0.18) 0,
+    rgba(255, 255, 255, 0.18) 3px,
+    transparent 3px,
+    transparent 6px
+  );
+}
+
+.ge-event-block:hover {
+  filter: brightness(1.3);
+  transform: scaleY(1.15);
+  z-index: 2;
+}
+
+/* Per-lane color CSS variables (set inline by GlobeSwimlane), the lane
+ * color cascades into .ge-event-block via var(--ge-lane-color). */
+.ge-lane-conflicts  { --ge-lane-color: #ff3333; }
+.ge-lane-disasters  { --ge-lane-color: #ffa500; }
+.ge-lane-military   { --ge-lane-color: #00c8ff; }
+.ge-lane-seismic    { --ge-lane-color: #ffc800; }
+.ge-lane-cyber      { --ge-lane-color: #00ffaa; }
+.ge-lane-weather    { --ge-lane-color: #8682ff; }
+
+/* ── NOW line ─────────────────────────────────────────────────────────── */
+
+.ge-now-line {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: #00e5ff;
+  box-shadow: 0 0 8px rgba(0, 229, 255, 0.7);
+  cursor: ew-resize;
+  z-index: 5;
+  pointer-events: auto;
+}
+
+.ge-now-label {
+  position: absolute;
+  top: -16px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 1px 6px;
+  background: rgba(0, 229, 255, 0.95);
+  color: #001018;
+  border-radius: 3px;
+  font: 700 9px/1 "SF Mono", ui-monospace, monospace;
+  letter-spacing: 0.1em;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+/* ── Tooltip ──────────────────────────────────────────────────────────── */
+
+.ge-swimlane-tooltip {
+  position: fixed;
+  pointer-events: none;
+  padding: 6px 10px;
+  background: rgba(8, 10, 14, 0.97);
+  border: 1px solid rgba(140, 90, 255, 0.45);
+  border-radius: 6px;
+  font: 500 11px/1.4 "SF Pro Text", -apple-system, BlinkMacSystemFont, sans-serif;
+  color: #fff;
+  z-index: 100;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  max-width: 320px;
+}
+
+/* ── Playback transport — placeholder ──────────────────────────────────── */
+
+.ge-playback-transport {
+  /* Reserved for play/pause/speed/mode pills (Task 5 follow-up). */
+}
+
+/* ── Degradation pipeline hooks — placeholder ──────────────────────────── */
+
+/* Reality-degradation styling is applied per-entity by GlobeDegradation.ts
+ * via Cesium primitive properties; no DOM-level CSS is needed for the
+ * Cesium-rendered effects. The hooks exist here in case the swimlane
+ * blocks need matching degradation styling. */


### PR DESCRIPTION
Direct port of the God's Eye 4D globe system from World Monitor into Crystal Ball's Gods Vision module. All functionality preserved; adapted to CB's import paths, naming conventions, and existing infrastructure.

## Modules ported

- **Pure math** — `degradation-math.ts` (exponential decay confidence model), `forecast-engine.ts` (Omori-Utsu aftershocks, NHC cyclone cones, conflict branches)
- **Cesium primitives** — `GlobeDegradation` (reality-decay opacity / dash / blur / jitter), `GlobeTrails` (per-segment fade + velocity prediction), `GlobePillars` (intensity cylinders), `GlobePredictions` (cones + aftershock rings), `GlobeBranching` (scenario-fork polylines)
- **DOM** — `GlobeSwimlane` (6-lane temporal timeline), `gods-eye-4d.css`
- **Orchestration** — `GlobePlayback` (Documentary / Director / Heartbeat), `Globe4DManager`

## Foundation augmentations

- **GlobeTimeMachine** — added `getCurrentMs`, `getSpeed`, `isPlaying`, `isLive`, `onTimeChange` for 4D consumers
- **GlobeDataManager** — added `EventBlock`, `EntityPositionSample`, `EntityTimestampedSample` interfaces and `getEntityPositionHistory`, `getLayerEntitiesWithTimestamps`, `getEventBlocks` methods
- **AutoFollowEngine** — added `temporalWeight` (±30 min 2×, ±6 h 0.5×, log-linear between) + `refreshAtTime` so the AI Director camera tracks events at playback time, not wall-clock NOW
- **GlobeHUD** — added 4D badge with playback-mode label

## Keybindings (active in Gods Vision view)

- `T` — toggle 4D mode
- `D` / `I` / `H` — Documentary / Director / Heartbeat playback (4D only)
- `Tab` — collapse swimlane
- `[` / `]` — cycle zoom presets (1h / 6h / 24h / 7d / 30d)
- `Esc` — clear active Tier 2 overlay (cone / aftershock / branches)

## Adaptations from WM → CB

| WM | CB |
|---|---|
| `src/components/gods-eye/...` | `src/components/gods-vision/...` |
| `GodsEyeView.ts` | `GodsVisionView.ts` |
| `AppMode` 5-mode space (peace/finance/war/disaster/ghost) | CB 2-mode space (ghost/gods-vision); mode multipliers skipped per scope, only temporal weighting ported |
| WM had Esc-Tier2-clear positioned after Esc-exit (dead code) | CB places Tier2-clear before Esc-exit so the binding actually fires |

## Validation

- `npm run typecheck:all` — zero errors after every commit
- 15 commits, one logical module each, in dependency order

Plan: [docs/superpowers/plans/2026-04-30-gods-vision-4d-port.md](docs/superpowers/plans/2026-04-30-gods-vision-4d-port.md)