### PR TITLE
Register SatelliteIntelPanel in panel-smoke-registry

### DIFF
--- a/tests/panels/panel-smoke-registry.mts
+++ b/tests/panels/panel-smoke-registry.mts
@@ -153,6 +153,7 @@ export const PANEL_SMOKE_REGISTRY: Record<string, SmokeFactory> = {
   'sanctions-crossref': wrap(async () => { const m = await import('@/components/SanctionsCrossRefPanel'); return new m.SanctionsCrossRefPanel(); }),
   'satellite-change': wrap(async () => { const m = await import('@/components/SatelliteChangePanel'); return new m.SatelliteChangePanel(); }),
   'satellite-fires': wrap(async () => { const m = await import('@/components/SatelliteFiresPanel'); return new m.SatelliteFiresPanel(); }),
+  'satellite-intel': wrap(async () => { const m = await import('@/components/SatelliteIntelPanel'); return new m.SatelliteIntelPanel(); }),
   'scenario-simulator': wrap(async () => { const m = await import('@/components/ScenarioSimulatorPanel'); return new m.ScenarioSimulatorPanel(); }),
   'security-advisories': wrap(async () => { const m = await import('@/components/SecurityAdvisoriesPanel'); return new m.SecurityAdvisoriesPanel(); }),
   'service-status': wrap(async () => { const m = await import('@/components/ServiceStatusPanel'); return new m.ServiceStatusPanel(); }),


### PR DESCRIPTION
Follow-up to #212 — surfaced during the post-merge review pass.

After SatelliteIntelPanel landed, `npm run test:panels:smoke` reported it as
`skipped (no factory in registry)` — the documented gap-audit state. Adding
the one-line factory entry brings the panel into the harness; it now reports
as `degraded` (correct empty-state banner) like the other satellite panels.

Verified locally: typecheck clean, smoke harness 235/235 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)