### PR TITLE
Bug Scan Pass 3: harden disease-intel + register-interest + computePasses

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -2453,12 +2453,8 @@ async function dispatch(requestUrl, req, routes, context) {
  return json({ error: 'Registration service not configured — use cloud endpoint directly' }, 503);
  }
  try {
- const body = await new Promise((resolve, reject) => {
- const chunks = [];
- req.on('data', c => chunks.push(c));
- req.on('end', () => resolve(Buffer.concat(chunks).toString()));
- req.on('error', reject);
- });
+ const bodyBuf = await readBody(req);
+ const body = bodyBuf ? bodyBuf.toString() : '';
  const parsed = JSON.parse(body);
  const email = parsed.email;
  if (!email || typeof email !== 'string' || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
@@ -3621,10 +3617,18 @@ async function dispatch(requestUrl, req, routes, context) {
  fetchWithTimeout(WHO_DON_URL, { headers: { Accept: 'application/json', 'User-Agent': CHROME_UA } }, 15_000),
  ]);
 
- const nextstrain = nsRes.status  === 'fulfilled' && nsRes.value.ok  ? await nsRes.value.json()  : null;
- const covidCountries = dsRes.status  === 'fulfilled' && dsRes.value.ok  ? await dsRes.value.json()  : null;
- const reliefweb = rwRes.status  === 'fulfilled' && rwRes.value.ok  ? await rwRes.value.json()  : null;
- const whoDon = whoRes.status === 'fulfilled' && whoRes.value.ok ? await whoRes.value.json() : null;
+ // Per-source JSON parsing — one bad response shouldn't kill the others.
+ const safeJson = async (settled) => {
+ if (settled.status !== 'fulfilled' || !settled.value.ok) return null;
+ try { return await settled.value.json(); } catch { return null; }
+ };
+
+ const [nextstrain, covidCountries, reliefweb, whoDon] = await Promise.all([
+ safeJson(nsRes),
+ safeJson(dsRes),
+ safeJson(rwRes),
+ safeJson(whoRes),
+ ]);
 
  const result = { nextstrain, covidCountries, reliefweb, whoDon, fetchedAt: new Date().toISOString() };
  setCached('disease-intel', result);

--- a/src/components/SatelliteIntelPanel.ts
+++ b/src/components/SatelliteIntelPanel.ts
@@ -73,7 +73,12 @@ export class SatelliteIntelPanel extends Panel {
 
   private triggerComputePasses(): void {
     const places = getSavedPlaces().map(p => ({ id: p.id, name: p.name, lat: p.lat, lon: p.lon }));
-    void computePasses(places);
+    computePasses(places).catch((error) => {
+      // The catalog fetcher already swallows network errors via its circuit
+      // breaker, so reaching this branch means the contract changed. Log loudly.
+      // eslint-disable-next-line no-console
+      console.warn('[SatelliteIntelPanel] computePasses rejected:', error);
+    });
   }
 
   private classificationBadge(classification: string): string {


### PR DESCRIPTION
Three issues found while scanning the integration surface (sidecar routes, panels, body cap, error swallowing) for crash paths under degraded upstreams.

## Findings + fixes

### 1. \`/api/disease-intel\` — single non-JSON response killed all 4 sources
**Before:** [local-api-server.mjs:3624-3627](src-tauri/sidecar/local-api-server.mjs#L3624-L3627) called \`await rs.value.json()\` for nextstrain / disease.sh / reliefweb / who-don inside the outer try block. If any one of the four returned non-JSON (HTML error page, gateway response, partial body), the whole route returned 502 and the other three sources were thrown away.

**After:** wrapped each \`.json()\` in a \`safeJson\` helper that returns \`null\` on parse failure. Partial data now surfaces correctly — three healthy upstreams keep working when one is broken.

### 2. \`/api/register-interest\` — bypassed the 16MB body cap
**Before:** [local-api-server.mjs:2456-2461](src-tauri/sidecar/local-api-server.mjs#L2456-L2461) read the POST body via a manual \`req.on('data')\` chunk reader that bypassed the \`readBody()\` cap added in #212. An unbounded body could exhaust memory.

**After:** swapped to the capped \`readBody()\` helper so the 413 + socket-destroy guard applies on this route too.

This was the only bypass — verified by grepping for \`req.on('data'\` across the whole sidecar.

### 3. \`SatelliteIntelPanel.triggerComputePasses\` — silent unhandled rejection
**Before:** [SatelliteIntelPanel.ts:74-77](src/components/SatelliteIntelPanel.ts#L74-L77) had \`void computePasses(places)\` which discarded the promise. The catalog circuit breaker currently swallows fetch errors and returns \`[]\`, so this is safe today — but if the breaker contract ever changes, the rejection would silently leak.

**After:** added a defensive \`.catch()\` that logs loudly with a comment explaining why reaching this branch indicates a contract violation rather than a normal upstream outage.

## Audit results (no fix needed)

- **Empty-state rendering** (panel) — verified: \`renderOverhead\` and \`renderPasses\` both render the documented \`panel-empty\` HTML when their respective getters return \`[]\`. Confirmed in browser preview: panel boots with all three empty states + tooltip text correct.
- **webcam-sources graceful degradation** — \`getWebcamFeeds\` uses \`Promise.allSettled\` so per-source failures don't cascade. Each source's outer \`try/catch\` returns \`[]\` on failure. Already correct.
- **adsb-military and the 4 new routes** — all have outer \`try/catch\` that returns 502 (or stale cache) on failure, and \`(data?.foo ?? [])\` guards against missing fields.
- **\`console.error\` swallowing** — silent \`catch {}\` blocks in \`webcam-sources.ts\` and \`satellite-propagator.worker.ts\` are intentional graceful-degradation patterns (the merge layer reports via \`dataFreshness\` and the worker would be too noisy logging per-bad-TLE). No fix.

## Verification

- \`npm run typecheck:all\` — clean
- \`npm run test:sidecar\` — 99/99 pass (same baseline as before, no test added because the JSON-fragility change is a per-source isolation refactor, not a new contract)
- \`npm run test:panels:smoke\` — 235/235 pass; \`satellite-intel\` reports as \`degraded\` with the empty-state banner (correct)
- Browser preview: panel renders all three sections + empty-state messages, no new console errors related to the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)