### PR TITLE
fix(forecast): bug-scan pass 1 — aftershock M6 filter, cyclone heading, DOT cams diagnostic

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -7155,7 +7155,10 @@ async function dispatch(requestUrl, req, routes, context) {
  const resp = await fetchWithTimeout(feed.url, {
  headers: { 'User-Agent': 'CrystalBall/1.0', Accept: 'application/json' },
  }, 10_000);
- if (!resp.ok) return [];
+ if (!resp.ok) {
+ console.warn(`[dot-traffic-cams] ${feed.state} feed HTTP ${resp.status}`);
+ return [];
+ }
  const data = await resp.json();
  const cams = [];
  if (feed.parser === 'caltrans') {

--- a/src/components/GlobeDataManager.ts
+++ b/src/components/GlobeDataManager.ts
@@ -36,6 +36,7 @@ import {
   computeCycloneCone,
   type AftershockForecast,
   type ForecastCone,
+  type TrackPoint,
 } from '@/services/forecast-engine';
 
 import {
@@ -360,6 +361,10 @@ export class GlobeDataManager {
   private cameraMoveSub: (() => void) | null = null;
   private aftershockForecasts = new Map<string, AftershockForecast>();
   private cycloneCones = new Map<string, ForecastCone>();
+  // Persists across loadTropicalCyclones() calls so we can derive an actual
+  // heading from successive advisories. The single-point fallback (random
+  // hash bearing) only fires for first-sighting cyclones.
+  private cycloneTracks = new Map<string, TrackPoint[]>();
 
   constructor(viewer: Viewer) {
  this.viewer = viewer;
@@ -875,11 +880,25 @@ export class GlobeDataManager {
 
  this.cycloneCones.clear();
 
+ // Drop tracked positions for cyclones that fell out of the active feed.
+ const liveIds = new Set(cyclones.map((tc) => tc.id));
+ for (const id of this.cycloneTracks.keys()) {
+ if (!liveIds.has(id)) this.cycloneTracks.delete(id);
+ }
+
  for (const tc of cyclones) {
  const advisoryMs = tc.advisoryTime instanceof Date ? tc.advisoryTime.getTime() : Date.now();
- const cone = computeCycloneCone(tc.id, [
- { lat: tc.lat, lon: tc.lon, timeMs: advisoryMs },
- ]);
+ const existing = this.cycloneTracks.get(tc.id) ?? [];
+ const last = existing[existing.length - 1];
+ // Append only when the advisory has actually progressed; the upstream
+ // feed re-serves the same advisory on every poll until a new one lands,
+ // and duplicate timestamps would not change the derived heading.
+ const isSameAdvisory = last?.timeMs === advisoryMs && last?.lat === tc.lat && last?.lon === tc.lon;
+ const track = isSameAdvisory
+ ? existing
+ : [...existing, { lat: tc.lat, lon: tc.lon, timeMs: advisoryMs }].slice(-6);
+ this.cycloneTracks.set(tc.id, track);
+ const cone = computeCycloneCone(tc.id, track);
  if (cone) this.cycloneCones.set(tc.id, cone);
 
  const isCat3Plus = tc.category === 'category_3' || tc.category === 'category_4' || tc.category === 'category_5';

--- a/src/components/gods-vision/GlobePredictions.ts
+++ b/src/components/gods-vision/GlobePredictions.ts
@@ -102,7 +102,7 @@ export class GlobePredictions {
   showAftershock(forecast: AftershockForecast): void {
     this.clear();
     for (const ring of forecast.rings) {
-      if (ring.magnitudeThreshold !== AFTERSHOCK_DISPLAY_THRESHOLD) continue;
+      if (ring.magnitudeThreshold < AFTERSHOCK_DISPLAY_THRESHOLD) continue;
       this.activeEntities.push(this.source.entities.add(new Entity({
         position: Cartesian3.fromDegrees(forecast.epicenterLon, forecast.epicenterLat),
         ellipse: new EllipseGraphics({


### PR DESCRIPTION
## Bug-Scan Pass 1 — Runtime integrity sweep on 4D + algorithm code

Targeted bug scan over the files merged in PRs #212–#216 (gods-vision/, services/forecast-engine.ts, ema-forecast.ts, threat-synthesis.ts, disease-intel.ts, adsb-military.ts, GlobeDataManager forecast wiring, sidecar routes from #212).

### Bugs found and fixed in this PR

**1. `GlobePredictions.ts:105` — M6 aftershock rings silently dropped**
- The constant comment says `// only render M ≥ 5 rings; M4 rings are too noisy`
- The code used `!==` against `AFTERSHOCK_DISPLAY_THRESHOLD` (= 5), so even for an M7+ mainshock the engine generates 9 rings (3 radii × {M4, M5, M6}) but only the 3 M5 rings rendered
- Fix: change `!==` to `<`. M5 and M6 both render now; M4 still dropped per the comment

**2. `GlobeDataManager.ts:880` — cyclone forecast cones pointed in random directions**
- `computeCycloneCone(tc.id, [{lat, lon, timeMs}])` was called with a single-point track
- `forecast-engine` requires `track.length >= 2` to derive heading; with one point it falls back to `deterministicBearing(entityId)` (a hash of the cyclone string id)
- Result: every cyclone cone rendered an arbitrary heading unrelated to the storm's actual motion
- Fix: added `cycloneTracks: Map<string, TrackPoint[]>` that accumulates advisories across refreshes, keeps the last 6 points per cyclone, and prunes entries that drop out of the live feed. Real heading kicks in on the 2nd refresh; first-sighting still uses the fallback (unavoidable without track history)

**3. `local-api-server.mjs:7150` — DOT traffic cams swallowed upstream errors**
- Inner `Promise.allSettled` mapper returned `[]` on `!resp.ok` with no log
- 401/429/503 from Caltrans or 511.ny.org showed up as "no cameras" with no diagnostic trace
- Fix: `console.warn` with the feed state and HTTP status when non-OK

### Bugs found, NOT fixed — needs human attention

**`GlobeTrails.ts:157` — `Date.now()` cutoff vs playback-time entity timestamps**
- `pushPoint` trims stale points using `Date.now() - windowMs`
- During 4D historical playback, `getEntityPositionHistory` returns entities filtered by `applyTimeFilter`, but the `pos.timeMs` it surfaces is the entity's actual property-bag timestamp (event time), not the current playback time
- All trail points end up older than `Date.now() - 6h` and the trim loop drops the entire buffer to `count = 0`, so trails go invisible during historical scrubbing
- Fix is small but design-sensitive: needs to either (a) plumb a playback-time reference from `TimeMachine` into `GlobeTrails`, or (b) compute the trim reference as `max(Date.now(), latestSeenTimeMs)` from the current refresh. Wanted a human call on intended playback semantics first.

### Verified clean (no findings)

`AutoFollowEngine.ts`, `Globe4DManager.ts`, `GlobeDegradation.ts`, `GlobePlayback.ts`, `GlobeBranching.ts`, `GlobePillars.ts`, `degradation-math.ts`, `ema-forecast.ts`, `threat-synthesis.ts`, `disease-intel.ts`, `adsb-military.ts`, sidecar `/api/windy-webcams` handler.

### Verification

- `npm run typecheck:all`: ✅ clean
- `npm run lint` on touched files: ✅ no new errors
- `npm run test:data`: 638/645 pass — same 7 pre-existing failures (CHANGELOG + vault-intro), unchanged by this PR
- `test:adsb` / `test:diagnostics` / `test:algorithms` / `test:intelligence` / `test:weather` / `test:insights` / `test:shortage` / `test:reasoning` / `test:ops` / `test:settings` / `test:providers` / `test:personal`: all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)