### PR TITLE
fix(security): bug-smash pass 5 — block proto-pollution + bounds-validate lat/lon

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -116,6 +116,21 @@ function wmMissingKeys() {
   });
 }
 
+/**
+ * Parse + bounds-validate a lat/lon pair from query string params.
+ * Returns null if either is missing, non-finite, or outside the valid range.
+ * Lat must be in [-90, 90]; lon in [-180, 180]. Used by routes that interpolate
+ * coords into upstream URLs to prevent invalid-range queries and cache pollution.
+ */
+function parseLatLon(latRaw, lonRaw) {
+  if (latRaw == null || lonRaw == null) return null;
+  const lat = Number(latRaw);
+  const lon = Number(lonRaw);
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+  if (lat < -90 || lat > 90 || lon < -180 || lon > 180) return null;
+  return { lat, lon };
+}
+
 const brotliCompressAsync = promisify(brotliCompress);
 const gzipAsync = promisify(gzip);
 
@@ -3865,10 +3880,12 @@ async function dispatch(requestUrl, req, routes, context) {
 
   // ── Air Quality proxy (Open-Meteo, no API key, forwards lat/lon) ──────────
   if (requestUrl.pathname === '/api/air-quality-proxy') {
- const lat = requestUrl.searchParams.get('lat');
- const lon = requestUrl.searchParams.get('lon');
- if (!lat || !lon) return json({ error: 'Missing lat or lon query parameters' }, 400);
- const aqUrl = `https://air-quality-api.open-meteo.com/v1/air-quality?latitude=${encodeURIComponent(lat)}&longitude=${encodeURIComponent(lon)}&current=us_aqi,pm2_5,pm10,ozone,nitrogen_dioxide&timezone=auto`;
+ const coords = parseLatLon(
+ requestUrl.searchParams.get('lat'),
+ requestUrl.searchParams.get('lon'),
+ );
+ if (!coords) return json({ error: 'Missing or invalid lat/lon query parameters' }, 400);
+ const aqUrl = `https://air-quality-api.open-meteo.com/v1/air-quality?latitude=${coords.lat}&longitude=${coords.lon}&current=us_aqi,pm2_5,pm10,ozone,nitrogen_dioxide&timezone=auto`;
  try {
  const resp = await fetchWithTimeout(aqUrl, { headers: { Accept: 'application/json', 'User-Agent': CHROME_UA } }, 15_000);
  if (!resp.ok) return json({ error: `air-quality upstream error: ${resp.status}` }, 502);
@@ -6167,10 +6184,14 @@ async function dispatch(requestUrl, req, routes, context) {
  const cached = getCached(cacheKey, CACHE_TTL);
  if (cached) return json(cached);
 
- const lat = Number(requestUrl.searchParams.get('lat'));
- const lon = Number(requestUrl.searchParams.get('lon'));
+ const coords = parseLatLon(
+ requestUrl.searchParams.get('lat'),
+ requestUrl.searchParams.get('lon'),
+ );
  const dist = Number(requestUrl.searchParams.get('dist') ?? '250');
- const hasArea = Number.isFinite(lat) && Number.isFinite(lon) && Number.isFinite(dist);
+ const hasArea = coords != null && Number.isFinite(dist) && dist > 0 && dist <= 500;
+ const lat = coords?.lat ?? 0;
+ const lon = coords?.lon ?? 0;
 
  const SOURCE_TIMEOUT = 3000;
 
@@ -6736,11 +6757,16 @@ async function dispatch(requestUrl, req, routes, context) {
 
   // ── HIFLD critical infrastructure (hospitals, urgent care) ──────────────
   if (requestUrl.pathname === '/api/hifld-infrastructure') {
- const lat = parseFloat(requestUrl.searchParams.get('lat') ?? '0');
- const lon = parseFloat(requestUrl.searchParams.get('lon') ?? '0');
- const radiusMiles = parseFloat(requestUrl.searchParams.get('radius') ?? '50');
-
- if (!lat || !lon) return json({ assets: [] });
+ const coords = parseLatLon(
+ requestUrl.searchParams.get('lat'),
+ requestUrl.searchParams.get('lon'),
+ );
+ if (!coords) return json({ assets: [] });
+ const { lat, lon } = coords;
+ const radiusMilesRaw = parseFloat(requestUrl.searchParams.get('radius') ?? '50');
+ const radiusMiles = Number.isFinite(radiusMilesRaw) && radiusMilesRaw > 0 && radiusMilesRaw <= 500
+ ? radiusMilesRaw
+ : 50;
 
  const cached = getCached(`hifld-${lat.toFixed(2)}-${lon.toFixed(2)}`, 24 * 60 * 60 * 1000);
  if (cached) return json(cached);

--- a/src/services/alert-fatigue.ts
+++ b/src/services/alert-fatigue.ts
@@ -21,10 +21,27 @@ interface FatigueState {
 
 let state: FatigueState = { ackTimestamps: [], lastWarningTs: 0, bulkDismissCount: 0 };
 
+/**
+ * Pick-list copy: only known FatigueState keys are accepted with type-checked
+ * values. Prevents prototype pollution via `__proto__` / `constructor` keys
+ * in attacker-controlled localStorage values.
+ */
+function pickFatigueState(raw: unknown): Partial<FatigueState> {
+  if (!raw || typeof raw !== 'object') return {};
+  const r = raw as Record<string, unknown>;
+  const out: Partial<FatigueState> = {};
+  if (Array.isArray(r.ackTimestamps)) {
+    out.ackTimestamps = r.ackTimestamps.filter((t): t is number => typeof t === 'number');
+  }
+  if (typeof r.lastWarningTs === 'number') out.lastWarningTs = r.lastWarningTs;
+  if (typeof r.bulkDismissCount === 'number') out.bulkDismissCount = r.bulkDismissCount;
+  return out;
+}
+
 function load(): void {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw) state = { ...state, ...(JSON.parse(raw) as Partial<FatigueState>) };
+    if (raw) state = { ...state, ...pickFatigueState(JSON.parse(raw)) };
   } catch { /* noop */ }
 }
 

--- a/src/services/runtime-config.ts
+++ b/src/services/runtime-config.ts
@@ -819,11 +819,28 @@ function readEnvSecret(key: RuntimeSecretKey): string {
   return typeof envValue === 'string' ? envValue.trim() : '';
 }
 
+/**
+ * Pick-list copy: only keys present in {@link defaultToggles} are accepted.
+ * Prevents prototype pollution via `__proto__` / `constructor` keys in
+ * attacker-controlled localStorage values.
+ */
+function pickKnownToggles(
+  raw: unknown,
+): Partial<Record<RuntimeFeatureId, boolean>> {
+  if (!raw || typeof raw !== 'object') return {};
+  const out: Partial<Record<RuntimeFeatureId, boolean>> = {};
+  for (const key of Object.keys(defaultToggles) as RuntimeFeatureId[]) {
+ const value = (raw as Record<string, unknown>)[key];
+ if (typeof value === 'boolean') out[key] = value;
+  }
+  return out;
+}
+
 function readStoredToggles(): Record<RuntimeFeatureId, boolean> {
   try {
  const stored = localStorage.getItem(TOGGLES_STORAGE_KEY);
  if (!stored) return { ...defaultToggles };
- const parsed = JSON.parse(stored) as Partial<Record<RuntimeFeatureId, boolean>>;
+ const parsed = pickKnownToggles(JSON.parse(stored));
  return { ...defaultToggles, ...parsed };
   } catch {
  return { ...defaultToggles };
@@ -956,7 +973,7 @@ if (typeof window !== 'undefined') {
  void loadDesktopSecrets();
  } else if (e.key === TOGGLES_STORAGE_KEY && e.newValue) {
  try {
- const parsed = JSON.parse(e.newValue) as Partial<Record<RuntimeFeatureId, boolean>>;
+ const parsed = pickKnownToggles(JSON.parse(e.newValue));
  Object.assign(runtimeConfig.featureToggles, parsed);
  notifyConfigChanged();
  } catch { /* ignore malformed JSON */ }


### PR DESCRIPTION
Bug-Smash Pass 5 — security and data validation audit. Five areas scanned; three fixed.

## Audit results

| # | Area | Verdict |
|---|---|---|
| 1 | Sidecar input validation | ⚠ 3 lat/lon routes lacked range bounds — fixed |
| 2 | Hardcoded API keys / secrets | ✅ Clean — all via process.env, .env in .gitignore |
| 3 | Prototype pollution in localStorage merges | 🔴 2 services vulnerable — fixed |
| 4 | CORS / origin allowlist on sidecar | ✅ Clean — `getSidecarCorsOrigin` regex allowlist |
| 5 | XSS via innerHTML in panels | ✅ Clean — every external interpolation uses `escapeHtml` |

## Fixes

### 1. Prototype pollution — `src/services/runtime-config.ts`
Two sites merged \`JSON.parse(localStorage)\` into shared state without filtering:
- \`readStoredToggles()\` at L822 — \`{ ...defaultToggles, ...parsed }\`
- \`storage\` event listener at L957 — \`Object.assign(runtimeConfig.featureToggles, parsed)\`

A malicious same-origin tab writing \`__proto__\` into \`TOGGLES_STORAGE_KEY\` could pollute \`Object.prototype\` globally on the next storage event.

**Fix:** \`pickKnownToggles()\` copies only keys present in \`defaultToggles\` and only when value is boolean. Untyped/unknown keys silently dropped.

### 2. Prototype pollution — `src/services/alert-fatigue.ts:27`
\`load()\` did \`{ ...state, ...JSON.parse(localStorage) }\`. Same attack class.

**Fix:** \`pickFatigueState()\` copies only \`ackTimestamps\` (filtered to numbers), \`lastWarningTs\`, \`bulkDismissCount\` with type checks.

### 3. lat/lon bounds — `src-tauri/sidecar/local-api-server.mjs`
Three routes interpolated unvalidated lat/lon into upstream URLs:
- \`/api/air-quality-proxy\` (L3852) → open-meteo
- \`/api/adsb-aggregate\` (L6124) → airplanes.live / adsb.fi / adsb.lol
- \`/api/hifld-infrastructure\` (L6698) → ArcGIS FeatureServer

\`Number.isFinite\` alone passed values like 999 through, polluting upstream caches and producing 4xx storms.

**Fix:** New \`parseLatLon(latRaw, lonRaw)\` helper requires lat ∈ [-90, 90] and lon ∈ [-180, 180]; returns null otherwise. \`/api/hifld-infrastructure\` also clamps the \`radius\` param to (0, 500] miles.

## Validation
- \`npm run typecheck:all\` — zero errors
- \`npx tsx --test src-tauri/sidecar/*.test.mjs\` — 94/94 pass
- \`npm run test:settings\` — 19/19 pass
- \`npm run test:reasoning\` — 36/36 pass

## Not changed (judged out of scope, low risk)
- \`/api/reddit-geo\` and \`/api/local-youtube-recent-videos\` accept user-supplied subreddit / channel handle interpolated into upstream URL paths. Naturally constrained by upstream URL structure (Reddit/YouTube reject malformed paths with 404), but a format-whitelist would harden further. Flagged for follow-up.
- LAYER_WEIGHTS coverage gaps in AutoFollowEngine — already documented in Bug Scan Pass 2; not a security issue.