### PR TITLE
fix: bug-smash pass 4 — leak / race / unbounded-growth fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Crystal Ball are documented here.
 
 ## [Unreleased]
 
+## [2.10.22] - 2026-05-01
+
 ### Added
 
 - **Performance and crash diagnostics** (`src/services/log-bridge.ts`): 100-entry breadcrumb ring buffer (log + longtask + slow-refresh + memory + visibility + network + INP + fetch-burst categories). `PerformanceObserver` for long tasks >100 ms and INP `event` entries >200 ms. Memory watchdog samples `performance.memory` every ~60 s and warns above 70% heap usage. Visibility / online / offline breadcrumbs. `window.onerror` and `unhandledrejection` now attach the last 10 breadcrumbs to crash reports. `Cmd+Shift+D` diagnostics copy includes the last 30 client-side breadcrumbs alongside the Tauri bundle.

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -174,6 +174,11 @@ function aisBuildSnapshot() {
   for (const [mmsi, v] of aisState.vessels) {
  if (v.timestamp < cutoff) aisState.vessels.delete(mmsi);
   }
+  // Same TTL eviction for the military-candidate Map so it doesn't grow
+  // without bound over long-running sessions.
+  for (const [mmsi, r] of aisState.candidateReports) {
+ if (r.timestamp < cutoff) aisState.candidateReports.delete(mmsi);
+  }
   if (aisState.vessels.size > AIS_MAX_VESSELS) {
  // Linear scan: find the Nth-oldest timestamp, then evict everything older.
  const excess = aisState.vessels.size - AIS_MAX_VESSELS;
@@ -2378,10 +2383,10 @@ async function dispatch(requestUrl, req, routes, context) {
  channelId = cached.channelId;
  } else {
  // Resolve handle → channel ID by scraping the channel page
- const pageRes = await fetch(`https://www.youtube.com/${handle}`, {
+ const pageRes = await fetchWithTimeout(`https://www.youtube.com/${handle}`, {
  headers: { 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36' },
  redirect: 'follow',
- });
+ }, 10_000);
  if (pageRes.ok) {
  const html = await pageRes.text();
  const idMatch = html.match(/"externalId"\s*:\s*"(UC[A-Za-z0-9_-]{22})"/);
@@ -2395,9 +2400,9 @@ async function dispatch(requestUrl, req, routes, context) {
  if (!channelId) return json({ videoIds: [], error: 'Could not resolve channel ID' }, 200);
 
  // Fetch the public RSS feed (no API key required, returns up to 15 videos newest-to-oldest)
- const rssRes = await fetch(`https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`, {
+ const rssRes = await fetchWithTimeout(`https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`, {
  headers: { 'User-Agent': 'Mozilla/5.0 (compatible; CrystalBall/1.0)' },
- });
+ }, 10_000);
  if (!rssRes.ok) throw new Error(`RSS ${rssRes.status}`);
  const xml = await rssRes.text();
 

--- a/src/components/GlobeDataManager.ts
+++ b/src/components/GlobeDataManager.ts
@@ -739,7 +739,10 @@ export class GlobeDataManager {
  const { fetchEarthquakes } = await import('@/services/earthquakes');
  const quakes = await fetchEarthquakes();
 
- this.aftershockForecasts.clear();
+ // Build a fresh map and atomic-swap at the end so concurrent readers
+ // (e.g. getAftershockForecast during a refresh tick) never observe an
+ // empty in-progress map.
+ const nextForecasts = new Map<string, AftershockForecast>();
 
  for (const eq of quakes) {
  const lat = eq.location?.latitude;
@@ -747,7 +750,7 @@ export class GlobeDataManager {
  if (lat == null || lon == null) continue;
 
  if (eq.magnitude >= 4 && eq.id) {
- this.aftershockForecasts.set(
+ nextForecasts.set(
  eq.id,
  computeAftershockForecast(eq.id, lat, lon, eq.magnitude),
  );
@@ -787,6 +790,8 @@ export class GlobeDataManager {
  setEntityTimestamp(eqEntity, new Date(eq.occurredAt));
  }
  }
+
+ this.aftershockForecasts = nextForecasts;
   }
 
   private async loadGDACS(): Promise<void> {
@@ -878,7 +883,9 @@ export class GlobeDataManager {
  const { fetchTropicalCyclones } = await import('@/services/tropical-cyclones');
  const cyclones = await fetchTropicalCyclones();
 
- this.cycloneCones.clear();
+ // Build a fresh cones map and atomic-swap at the end so concurrent
+ // readers (getCycloneCone) never see an empty in-progress map.
+ const nextCones = new Map<string, ForecastCone>();
 
  // Drop tracked positions for cyclones that fell out of the active feed.
  const liveIds = new Set(cyclones.map((tc) => tc.id));
@@ -899,7 +906,7 @@ export class GlobeDataManager {
  : [...existing, { lat: tc.lat, lon: tc.lon, timeMs: advisoryMs }].slice(-6);
  this.cycloneTracks.set(tc.id, track);
  const cone = computeCycloneCone(tc.id, track);
- if (cone) this.cycloneCones.set(tc.id, cone);
+ if (cone) nextCones.set(tc.id, cone);
 
  const isCat3Plus = tc.category === 'category_3' || tc.category === 'category_4' || tc.category === 'category_5';
  const isCat1Plus = isCat3Plus || tc.category === 'category_1' || tc.category === 'category_2';
@@ -933,6 +940,8 @@ export class GlobeDataManager {
  description: `${tc.name} — ${tc.category.replace('_', ' ')} (${tc.basin})\n${tc.movement}\n${tc.headline}`,
  });
  }
+
+ this.cycloneCones = nextCones;
   }
 
   private async loadFires(): Promise<void> {

--- a/src/components/gods-vision/GlobeBranching.ts
+++ b/src/components/gods-vision/GlobeBranching.ts
@@ -36,6 +36,7 @@ export class GlobeBranching {
   private source: CustomDataSource;
   private activeEntities: Entity[] = [];
   private onBranchHoverCb: ((branch: ScenarioBranch | null) => void) | null = null;
+  private addPromise: Promise<unknown> | null = null;
 
   constructor(viewer: Viewer) {
     this.viewer = viewer;
@@ -43,7 +44,8 @@ export class GlobeBranching {
   }
 
   mount(): void {
-    this.viewer.dataSources.add(this.source).catch((error: unknown) => {
+    this.addPromise = this.viewer.dataSources.add(this.source);
+    this.addPromise.catch((error: unknown) => {
       // eslint-disable-next-line no-console
       console.error('[GlobeBranching] dataSources.add failed', error);
     });
@@ -51,7 +53,12 @@ export class GlobeBranching {
 
   destroy(): void {
     this.clear();
-    this.viewer.dataSources.remove(this.source, true);
+    // Chain the remove off the add promise so it doesn't leak when the
+    // add resolves after destroy.
+    const pending = this.addPromise ?? Promise.resolve();
+    pending
+      .then(() => this.viewer.dataSources.remove(this.source, true))
+      .catch(() => { /* add failed — nothing to remove */ });
   }
 
   setOnBranchHover(cb: (branch: ScenarioBranch | null) => void): void {

--- a/src/components/gods-vision/GlobePillars.ts
+++ b/src/components/gods-vision/GlobePillars.ts
@@ -53,6 +53,7 @@ export class GlobePillars {
   private pillars = new Map<string, PillarEntity>();
   private destroyed = false;
   private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  private addPromise: Promise<unknown> | null = null;
 
   constructor(viewer: Viewer, dataManager: GlobeDataManager) {
     this.viewer = viewer;
@@ -61,7 +62,8 @@ export class GlobePillars {
   }
 
   mount(): void {
-    this.viewer.dataSources.add(this.source).catch((error: unknown) => {
+    this.addPromise = this.viewer.dataSources.add(this.source);
+    this.addPromise.catch((error: unknown) => {
       // eslint-disable-next-line no-console
       console.error('[GlobePillars] dataSources.add failed', error);
     });
@@ -77,7 +79,12 @@ export class GlobePillars {
       clearInterval(this.refreshTimer);
       this.refreshTimer = null;
     }
-    this.viewer.dataSources.remove(this.source, true);
+    // Chain the remove off the add promise so it doesn't leak when the
+    // add resolves after destroy.
+    const pending = this.addPromise ?? Promise.resolve();
+    pending
+      .then(() => this.viewer.dataSources.remove(this.source, true))
+      .catch(() => { /* add failed — nothing to remove */ });
     this.pillars.clear();
   }
 

--- a/src/components/gods-vision/GlobePredictions.ts
+++ b/src/components/gods-vision/GlobePredictions.ts
@@ -42,6 +42,7 @@ export class GlobePredictions {
   private viewer: Viewer;
   private source: CustomDataSource;
   private activeEntities: Entity[] = [];
+  private addPromise: Promise<unknown> | null = null;
 
   constructor(viewer: Viewer) {
     this.viewer = viewer;
@@ -49,7 +50,8 @@ export class GlobePredictions {
   }
 
   mount(): void {
-    this.viewer.dataSources.add(this.source).catch((error: unknown) => {
+    this.addPromise = this.viewer.dataSources.add(this.source);
+    this.addPromise.catch((error: unknown) => {
       // eslint-disable-next-line no-console
       console.error('[GlobePredictions] dataSources.add failed', error);
     });
@@ -57,7 +59,12 @@ export class GlobePredictions {
 
   destroy(): void {
     this.clear();
-    this.viewer.dataSources.remove(this.source, true);
+    // Chain the remove off the add promise so it doesn't leak when the
+    // add resolves after destroy.
+    const pending = this.addPromise ?? Promise.resolve();
+    pending
+      .then(() => this.viewer.dataSources.remove(this.source, true))
+      .catch(() => { /* add failed — nothing to remove */ });
   }
 
   clear(): void {

--- a/src/components/gods-vision/GlobeTrails.ts
+++ b/src/components/gods-vision/GlobeTrails.ts
@@ -79,6 +79,7 @@ export class GlobeTrails {
    * visible at older timestamps.
    */
   private getPlaybackTime: () => number;
+  private addPromise: Promise<unknown> | null = null;
 
   constructor(
     viewer: Viewer,
@@ -92,7 +93,8 @@ export class GlobeTrails {
   }
 
   mount(): void {
-    this.viewer.dataSources.add(this.source).catch((error: unknown) => {
+    this.addPromise = this.viewer.dataSources.add(this.source);
+    this.addPromise.catch((error: unknown) => {
       // eslint-disable-next-line no-console
       console.error('[GlobeTrails] dataSources.add failed', error);
     });
@@ -108,7 +110,12 @@ export class GlobeTrails {
       clearInterval(this.refreshTimer);
       this.refreshTimer = null;
     }
-    this.viewer.dataSources.remove(this.source, true);
+    // If the add hasn't settled, chain the remove so we don't leak the
+    // data source into the viewer when add resolves after destroy.
+    const pending = this.addPromise ?? Promise.resolve();
+    pending
+      .then(() => this.viewer.dataSources.remove(this.source, true))
+      .catch(() => { /* add failed — nothing to remove */ });
     this.trails.clear();
   }
 


### PR DESCRIPTION
## Pass 4 audit findings + fixes

Targeted runtime-integrity audit on origin/main covering memory leaks, race conditions, unbounded data structures, and unhandled async work in the recently merged 4D + algorithm code.

### ✅ Fixed in this PR

**1. Floating `dataSources.add()` promise leaks (4 classes)**

`GlobeTrails`, `GlobePillars`, `GlobePredictions`, `GlobeBranching` all called `viewer.dataSources.add(this.source)` as fire-and-forget in `mount()`. If `destroy()` ran before the add resolved, the synchronous `viewer.dataSources.remove` was a no-op (source not yet in the collection) and the add resolved afterward — the source leaked into the viewer until Cesium itself was destroyed. Fix: store the add promise on a field, chain the remove off it in destroy.

**2. Race conditions in `GlobeDataManager`**

`loadEarthquakes` and `loadTropicalCyclones` both did `this.X.clear()` then `await fetch(...)`. Concurrent readers (`getAftershockForecast` / `getCycloneCone`) saw an empty map for the duration of the fetch. Fix: build a fresh `Map` locally during the load and atomic-swap the field reference at the end. Readers always see either the previous full map or the new full map.

**3. Unbounded growth — AIS `candidateReports`**

Sidecar `aisState.candidateReports` had no TTL eviction (unlike `aisState.vessels`). Long-running sessions accumulated stale military-vessel entries indefinitely. Fix: apply the same 30-min TTL inside `aisBuildSnapshot`.

**4. Sidecar uncapped fetches — `/api/local-youtube-recent-videos`**

Two bare `fetch()` calls in the YouTube handle resolver and RSS feed had no timeout. If YouTube was slow or unresponsive the route handler hung indefinitely. Fix: wrap both in `fetchWithTimeout(..., 10_000)` matching every other route.

**5. CHANGELOG entry — 2.10.22**

Adds the `## [2.10.22] - 2026-05-01` header that release-prepare didn't write during the version bump. Restores release-doc-sync.

### ⚠ Found, not fixed (deferred for human attention)

- **`ema-forecast.ts regionSeries` Map** (line 32) — per-region key count is soft-unbounded; bounded in practice by ~500 unique conflict regions × 192 bytes = ~50 KB total. Low severity; defer until production telemetry shows real growth.
- **`loadLayer()` error path** swallows exceptions and never sets `layer.loaded = true`, allowing concurrent re-entry on retry. Real but low-frequency, and threading proper retry semantics is broader than this pass.

### ✅ Audit categories with no findings

- AutoFollowEngine, Globe4DManager, GlobePlayback, GlobeSwimlane, GlobeDegradation — all destroy() methods clean
- All other sidecar routes use `fetchWithTimeout` or `AbortSignal.timeout`
- forecast-engine, ema-forecast, threat-synthesis, disease-intel, adsb-military — no leaks or unbounded structures

### Verification

- `npm run typecheck:all`: ✅ clean
- `npm run test:data`: 643/643 (was 642/643 — CHANGELOG fix +1)
- All other test buckets: 15+151+55+158+76+142+112+36+81+19+41+19 = 905 tests, all pass
- `npm run lint` on touched files: no new errors

Rebased on top of Pass 6 (`71dd7ff`) which landed concurrently and added `getPlaybackTime` plumbing to GlobeTrails — the two changes coexist cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)