### PR TITLE
fix(freshness+lint): mid-slice (26 services) — evacuation-router → nuclear-monitor

### DIFF
--- a/src/services/air-quality.ts
+++ b/src/services/air-quality.ts
@@ -2,6 +2,7 @@
 // Docs: https://open-meteo.com/en/docs/air-quality-api
 // Covers US AQI, European AQI, PM2.5, PM10, ozone, NO2, SO2
 import { getApiBaseUrl } from '@/services/runtime';
+import { dataFreshness } from '@/services/data-freshness';
 
 export interface AirQualityReading {
   city: string;
@@ -113,21 +114,27 @@ export async function fetchGlobalAirQuality(): Promise<AirQualityReading[]> {
  return cache.readings;
   }
 
-  // Fetch all cities in parallel (stagger to avoid rate limiting)
-  const results = await Promise.allSettled(
- MONITORED_CITIES.map(c => fetchCityAQ(c)),
-  );
+  try {
+    // Fetch all cities in parallel (stagger to avoid rate limiting)
+    const results = await Promise.allSettled(
+   MONITORED_CITIES.map(c => fetchCityAQ(c)),
+    );
 
-  const readings: AirQualityReading[] = [];
-  for (const r of results) {
- if (r.status === 'fulfilled' && r.value) readings.push(r.value);
+    const readings: AirQualityReading[] = [];
+    for (const r of results) {
+   if (r.status === 'fulfilled' && r.value) readings.push(r.value);
+    }
+
+    // Sort worst AQI first
+    readings.sort((a, b) => b.aqi - a.aqi);
+
+    cache = { readings, fetchedAt: Date.now() };
+    dataFreshness.recordUpdate('air-quality', readings.length);
+    return readings;
+  } catch (error) {
+    dataFreshness.recordError('air-quality', String(error));
+    return cache?.readings ?? [];
   }
-
-  // Sort worst AQI first
-  readings.sort((a, b) => b.aqi - a.aqi);
-
-  cache = { readings, fetchedAt: Date.now() };
-  return readings;
 }
 
 export interface AirQualityAlert {

--- a/src/services/combatant-commands.ts
+++ b/src/services/combatant-commands.ts
@@ -1,3 +1,5 @@
+import { dataFreshness } from '@/services/data-freshness';
+
 export type CombatantCommand =
   | 'CENTCOM'
   | 'INDOPACOM'
@@ -51,9 +53,12 @@ function proxyFeedUrl(feedUrl: string): string {
   return `/api/rss-proxy?url=${encodeURIComponent(feedUrl)}`;
 }
 
+// eslint-disable-next-line sonarjs/slow-regex -- bounded HTML-tag stripping; input is RSS feed body, not user-controlled
+const HTML_TAG_RE = /<[^>]*>/g;
+
 function stripHtml(html: string): string {
   return html
- .replace(/<[^>]+>/g, ' ')
+ .replace(HTML_TAG_RE, ' ')
  .replace(/&amp;/g, '&')
  .replace(/&lt;/g, '<')
  .replace(/&gt;/g, '>')
@@ -152,6 +157,7 @@ const SEVERITY_ORDER: Record<CommandRelease['severity'], number> = {
 export async function fetchCombatantCommands(): Promise<CommandRelease[]> {
   if (_cache && Date.now() - _cache.ts < CACHE_TTL_MS) return _cache.items;
 
+  try {
   const results = await Promise.allSettled(
  FEEDS.map(async ({ command, url }) => {
  const res = await fetch(proxyFeedUrl(url), {
@@ -187,7 +193,12 @@ export async function fetchCombatantCommands(): Promise<CommandRelease[]> {
 
   const items = deduped.slice(0, 60);
   _cache = { items, ts: Date.now() };
+  dataFreshness.recordUpdate('combatant-commands', items.length);
   return items;
+  } catch (error) {
+  dataFreshness.recordError('combatant-commands', String(error));
+  return _cache?.items ?? [];
+  }
 }
 
 export function commandSeverityClass(severity: CommandRelease['severity']): string {

--- a/src/services/cpc-outlook.ts
+++ b/src/services/cpc-outlook.ts
@@ -4,6 +4,8 @@
  * Products: RCM (Regional Climate Monthly), HLS (Seasonal Hazard), REC (Record Events)
  */
 
+import { dataFreshness } from '@/services/data-freshness';
+
 export type ClimateOutlookType =
   | 'monthly-discussion'
   | 'seasonal-hazard'
@@ -58,7 +60,7 @@ async function fetchProductList(type: string, limit: number): Promise<NWSProduct
  signal: AbortSignal.timeout(12_000),
  });
  if (!res.ok) return [];
- const json: NWSProductListResponse = await res.json();
+ const json = (await res.json()) as NWSProductListResponse;
  return json['@graph'] ?? [];
   } catch {
  return [];
@@ -159,7 +161,7 @@ function computeOutlookSeverity(
 function safeDate(raw: string | null | undefined): Date {
   if (!raw) return new Date();
   const d = new Date(raw);
-  return isNaN(d.getTime()) ? new Date() : d;
+  return Number.isNaN(d.getTime()) ? new Date() : d;
 }
 
 async function processProductList(
@@ -219,41 +221,47 @@ const SEVERITY_ORDER: Record<ClimateOutlook['severity'], number> = {
 export async function fetchCpcOutlooks(): Promise<ClimateOutlook[]> {
   if (cache && Date.now() - cache.ts < CACHE_TTL_MS) return cache.data;
 
-  // Fetch product lists in parallel
-  const [rcmResult, hlsResult, recResult] = await Promise.allSettled([
- fetchProductList('RCM', 5),
- fetchProductList('HLS', 5),
- fetchProductList('REC', 5),
-  ]);
+  try {
+    // Fetch product lists in parallel
+    const [rcmResult, hlsResult, recResult] = await Promise.allSettled([
+   fetchProductList('RCM', 5),
+   fetchProductList('HLS', 5),
+   fetchProductList('REC', 5),
+    ]);
 
-  const rcmItems = rcmResult.status === 'fulfilled' ? rcmResult.value : [];
-  const hlsItems = hlsResult.status === 'fulfilled' ? hlsResult.value : [];
-  const recItems = recResult.status === 'fulfilled' ? recResult.value : [];
+    const rcmItems = rcmResult.status === 'fulfilled' ? rcmResult.value : [];
+    const hlsItems = hlsResult.status === 'fulfilled' ? hlsResult.value : [];
+    const recItems = recResult.status === 'fulfilled' ? recResult.value : [];
 
-  // Fetch product texts in parallel across all lists (up to 2 per list)
-  const [rcmOutlooks, hlsOutlooks, recOutlooks] = await Promise.allSettled([
- processProductList(rcmItems, 2),
- processProductList(hlsItems, 2),
- processProductList(recItems, 2),
-  ]);
+    // Fetch product texts in parallel across all lists (up to 2 per list)
+    const [rcmOutlooks, hlsOutlooks, recOutlooks] = await Promise.allSettled([
+   processProductList(rcmItems, 2),
+   processProductList(hlsItems, 2),
+   processProductList(recItems, 2),
+    ]);
 
-  const all: ClimateOutlook[] = [
- ...(rcmOutlooks.status === 'fulfilled' ? rcmOutlooks.value : []),
- ...(hlsOutlooks.status === 'fulfilled' ? hlsOutlooks.value : []),
- ...(recOutlooks.status === 'fulfilled' ? recOutlooks.value : []),
-  ];
+    const all: ClimateOutlook[] = [
+   ...(rcmOutlooks.status === 'fulfilled' ? rcmOutlooks.value : []),
+   ...(hlsOutlooks.status === 'fulfilled' ? hlsOutlooks.value : []),
+   ...(recOutlooks.status === 'fulfilled' ? recOutlooks.value : []),
+    ];
 
-  if (all.length === 0) return cache?.data ?? [];
+    if (all.length === 0) return cache?.data ?? [];
 
-  all.sort((a, b) => {
- const sev = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
- if (sev !== 0) return sev;
- return b.issuanceTime.getTime() - a.issuanceTime.getTime();
-  });
+    all.sort((a, b) => {
+   const sev = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+   if (sev !== 0) return sev;
+   return b.issuanceTime.getTime() - a.issuanceTime.getTime();
+    });
 
-  const data = all.slice(0, 15);
-  cache = { data, ts: Date.now() };
-  return data;
+    const data = all.slice(0, 15);
+    cache = { data, ts: Date.now() };
+    dataFreshness.recordUpdate('cpc-outlook', data.length);
+    return data;
+  } catch (error) {
+    dataFreshness.recordError('cpc-outlook', String(error));
+    throw error;
+  }
 }
 
 export function cpcSeverityClass(severity: ClimateOutlook['severity']): string {

--- a/src/services/cyber-extra.ts
+++ b/src/services/cyber-extra.ts
@@ -7,6 +7,7 @@
  */
 import { getApiBaseUrl } from '@/services/runtime';
 import { isFeatureAvailable } from '@/services/runtime-config';
+import { dataFreshness } from '@/services/data-freshness';
 import type { CyberThreat } from '@/types';
 
 // ── Feed-specific interfaces ──────────────────────────────────────────────────
@@ -111,12 +112,17 @@ export async function fetchThreatFoxIOCs(): Promise<CyberThreat[]> {
   if (cached) return cached;
   try {
  const res = await fetch(`${getApiBaseUrl()}/api/threatfox-iocs`, { method: 'GET' });
- if (!res.ok) return [];
+ if (!res.ok) {
+ dataFreshness.recordError('cyber-extra', `threatfox: ${res.status}`);
+ return [];
+ }
  const data = (await res.json()) as CyberThreat[];
  if (!Array.isArray(data)) return [];
  setCached('threatfox', data);
+ dataFreshness.recordUpdate('cyber-extra', data.length);
  return data;
-  } catch {
+  } catch (error) {
+ dataFreshness.recordError('cyber-extra', String(error));
  return [];
   }
 }

--- a/src/services/data-freshness.ts
+++ b/src/services/data-freshness.ts
@@ -45,6 +45,82 @@ export type DataSourceId =
   | 'faa_weather_cams' // FAA weather camera network
   | 'adsb' // ADS-B live aircraft tracking (OpenSky)
   | 'adsb-military' // Military ADS-B flight tracking
+    | "maritime-safety"
+    | "inciweb"
+    | "cisa-advisories"
+    | "nuclear-monitor"
+    | "marine-hazards"
+    | "disease-outbreak"
+    | "avalanche-hazard"
+    | "evacuation-router"
+    | "disease-intel"
+    | "wpc-winter-weather"
+    | "fema-disasters"
+    | "power-grid-alerts"
+    | "wpc-excessive-rainfall"
+    | "congress-defense"
+    | "flood-gauges"
+    | "telegram-intel"
+    | "spaceflight-news"
+    | "rainviewer-radar"
+    | "lightning"
+    | "copernicus-cems"
+    | "faa-nas-status"
+    | "phmsa-pipeline"
+    | "air-quality"
+    | "radiation-monitoring"
+    | "dam-safety"
+    | "nrc-nuclear"
+    | "offline-alert-cache"
+    | "spc-outlook"
+    | "aerospace-reentry"
+    | "un-security-council"
+    | "oref-alerts"
+    | "wildfire-smoke"
+    | "offline-map-cache"
+    | "spc-mesoscale"
+    | "s2-underground"
+    | "federal-register"
+    | "hazmat-incidents"
+    | "power-grid"
+    | "gps-interference"
+    | "faa-cameras"
+    | "combatant-commands"
+    | "water-quality"
+    | "allied-military"
+    | "ofac-sanctions"
+    | "amtrak-alerts"
+    | "tropical-cyclones"
+    | "fdic-failures"
+    | "internet-outages"
+    | "drought-monitor"
+    | "hdx-crisis"
+    | "oil-spill-tracker"
+    | "inpe-fires"
+    | "cyber-extra"
+    | "ntsb-investigations"
+    | "aviation-hazards"
+    | "habsos"
+    | "wsb-sentiment"
+    | "ecdc-surveillance"
+    | "volcano-alerts"
+    | "space-weather"
+    | "food-insecurity"
+    | "space-launches"
+    | "iaea-nuclear"
+    | "live-news"
+    | "dsca-arms-transfers"
+    | "ripe-atlas"
+    | "foreign-mil-news"
+    | "cpc-outlook"
+    | "noaa-buoys"
+    | "world-bank"
+    | "nws-alerts"
+    | "state-dept-advisories"
+    | "tsunami-alerts"
+    | "supply-chain-impact"
+    | "faa-tfrs"
+    | "usgs-pager"
   | 'webcams'; // Aggregated webcam feeds (Windy + DOT + YouTube)
 
 export type FreshnessStatus = 'fresh' | 'stale' | 'very_stale' | 'no_data' | 'disabled' | 'error';
@@ -121,6 +197,82 @@ const SOURCE_METADATA: Record<DataSourceId, { name: string; requiredForRisk: boo
   adsb: { name: 'ADS-B Aircraft', requiredForRisk: false, panelId: 'air-traffic' },
   'adsb-military': { name: 'Military ADS-B', requiredForRisk: false, panelId: 'geo-intel' },
   webcams: { name: 'Webcam Aggregator', requiredForRisk: false, panelId: 'live-webcams' },
+  "maritime-safety": { name: "Maritime Safety", requiredForRisk: false },
+  "inciweb": { name: "Inciweb", requiredForRisk: false },
+  "cisa-advisories": { name: "Cisa Advisories", requiredForRisk: false },
+  "nuclear-monitor": { name: "Nuclear Monitor", requiredForRisk: false },
+  "marine-hazards": { name: "Marine Hazards", requiredForRisk: false },
+  "disease-outbreak": { name: "Disease Outbreak", requiredForRisk: false },
+  "avalanche-hazard": { name: "Avalanche Hazard", requiredForRisk: false },
+  "evacuation-router": { name: "Evacuation Router", requiredForRisk: false },
+  "disease-intel": { name: "Disease Intel", requiredForRisk: false },
+  "wpc-winter-weather": { name: "Wpc Winter Weather", requiredForRisk: false },
+  "fema-disasters": { name: "Fema Disasters", requiredForRisk: false },
+  "power-grid-alerts": { name: "Power Grid Alerts", requiredForRisk: false },
+  "wpc-excessive-rainfall": { name: "Wpc Excessive Rainfall", requiredForRisk: false },
+  "congress-defense": { name: "Congress Defense", requiredForRisk: false },
+  "flood-gauges": { name: "Flood Gauges", requiredForRisk: false },
+  "telegram-intel": { name: "Telegram Intel", requiredForRisk: false },
+  "spaceflight-news": { name: "Spaceflight News", requiredForRisk: false },
+  "rainviewer-radar": { name: "Rainviewer Radar", requiredForRisk: false },
+  "lightning": { name: "Lightning", requiredForRisk: false },
+  "copernicus-cems": { name: "Copernicus Cems", requiredForRisk: false },
+  "faa-nas-status": { name: "Faa Nas Status", requiredForRisk: false },
+  "phmsa-pipeline": { name: "Phmsa Pipeline", requiredForRisk: false },
+  "air-quality": { name: "Air Quality", requiredForRisk: false },
+  "radiation-monitoring": { name: "Radiation Monitoring", requiredForRisk: false },
+  "dam-safety": { name: "Dam Safety", requiredForRisk: false },
+  "nrc-nuclear": { name: "Nrc Nuclear", requiredForRisk: false },
+  "offline-alert-cache": { name: "Offline Alert Cache", requiredForRisk: false },
+  "spc-outlook": { name: "Spc Outlook", requiredForRisk: false },
+  "aerospace-reentry": { name: "Aerospace Reentry", requiredForRisk: false },
+  "un-security-council": { name: "Un Security Council", requiredForRisk: false },
+  "oref-alerts": { name: "Oref Alerts", requiredForRisk: false },
+  "wildfire-smoke": { name: "Wildfire Smoke", requiredForRisk: false },
+  "offline-map-cache": { name: "Offline Map Cache", requiredForRisk: false },
+  "spc-mesoscale": { name: "Spc Mesoscale", requiredForRisk: false },
+  "s2-underground": { name: "S2 Underground", requiredForRisk: false },
+  "federal-register": { name: "Federal Register", requiredForRisk: false },
+  "hazmat-incidents": { name: "Hazmat Incidents", requiredForRisk: false },
+  "power-grid": { name: "Power Grid", requiredForRisk: false },
+  "gps-interference": { name: "Gps Interference", requiredForRisk: false },
+  "faa-cameras": { name: "Faa Cameras", requiredForRisk: false },
+  "combatant-commands": { name: "Combatant Commands", requiredForRisk: false },
+  "water-quality": { name: "Water Quality", requiredForRisk: false },
+  "allied-military": { name: "Allied Military", requiredForRisk: false },
+  "ofac-sanctions": { name: "Ofac Sanctions", requiredForRisk: false },
+  "amtrak-alerts": { name: "Amtrak Alerts", requiredForRisk: false },
+  "tropical-cyclones": { name: "Tropical Cyclones", requiredForRisk: false },
+  "fdic-failures": { name: "Fdic Failures", requiredForRisk: false },
+  "internet-outages": { name: "Internet Outages", requiredForRisk: false },
+  "drought-monitor": { name: "Drought Monitor", requiredForRisk: false },
+  "hdx-crisis": { name: "Hdx Crisis", requiredForRisk: false },
+  "oil-spill-tracker": { name: "Oil Spill Tracker", requiredForRisk: false },
+  "inpe-fires": { name: "Inpe Fires", requiredForRisk: false },
+  "cyber-extra": { name: "Cyber Extra", requiredForRisk: false },
+  "ntsb-investigations": { name: "Ntsb Investigations", requiredForRisk: false },
+  "aviation-hazards": { name: "Aviation Hazards", requiredForRisk: false },
+  "habsos": { name: "Habsos", requiredForRisk: false },
+  "wsb-sentiment": { name: "Wsb Sentiment", requiredForRisk: false },
+  "ecdc-surveillance": { name: "Ecdc Surveillance", requiredForRisk: false },
+  "volcano-alerts": { name: "Volcano Alerts", requiredForRisk: false },
+  "space-weather": { name: "Space Weather", requiredForRisk: false },
+  "food-insecurity": { name: "Food Insecurity", requiredForRisk: false },
+  "space-launches": { name: "Space Launches", requiredForRisk: false },
+  "iaea-nuclear": { name: "Iaea Nuclear", requiredForRisk: false },
+  "live-news": { name: "Live News", requiredForRisk: false },
+  "dsca-arms-transfers": { name: "Dsca Arms Transfers", requiredForRisk: false },
+  "ripe-atlas": { name: "Ripe Atlas", requiredForRisk: false },
+  "foreign-mil-news": { name: "Foreign Mil News", requiredForRisk: false },
+  "cpc-outlook": { name: "Cpc Outlook", requiredForRisk: false },
+  "noaa-buoys": { name: "Noaa Buoys", requiredForRisk: false },
+  "world-bank": { name: "World Bank", requiredForRisk: false },
+  "nws-alerts": { name: "Nws Alerts", requiredForRisk: false },
+  "state-dept-advisories": { name: "State Dept Advisories", requiredForRisk: false },
+  "tsunami-alerts": { name: "Tsunami Alerts", requiredForRisk: false },
+  "supply-chain-impact": { name: "Supply Chain Impact", requiredForRisk: false },
+  "faa-tfrs": { name: "Faa Tfrs", requiredForRisk: false },
+  "usgs-pager": { name: "Usgs Pager", requiredForRisk: false },
 };
 
 class DataFreshnessTracker {
@@ -401,6 +553,84 @@ const INTELLIGENCE_GAP_MESSAGES: Record<DataSourceId, string> = {
   adsb: 'Live aircraft positions unavailable—ADS-B tracking offline',
   'adsb-military': 'Military aircraft positions unavailable—military ADS-B tracking offline',
   webcams: 'Webcam feeds unavailable—Windy/DOT/YouTube aggregation offline',
+  // Per-service gap messages added in Pass 7 freshness wiring. Generic by default;
+  // refine individual entries when the service ships dedicated copy.
+  "maritime-safety": "Maritime safety data unavailable",
+  "inciweb": "Wildfire incident data unavailable",
+  "cisa-advisories": "CISA advisory feed unavailable",
+  "nuclear-monitor": "Nuclear monitor data unavailable",
+  "marine-hazards": "Marine hazard data unavailable",
+  "disease-outbreak": "Disease outbreak data unavailable",
+  "avalanche-hazard": "Avalanche hazard data unavailable",
+  "evacuation-router": "Evacuation routing data unavailable",
+  "disease-intel": "Disease intelligence data unavailable",
+  "wpc-winter-weather": "WPC winter-weather data unavailable",
+  "fema-disasters": "FEMA disaster data unavailable",
+  "power-grid-alerts": "Power-grid alerts unavailable",
+  "wpc-excessive-rainfall": "WPC excessive-rainfall data unavailable",
+  "congress-defense": "Congress defense data unavailable",
+  "flood-gauges": "Flood-gauge data unavailable",
+  "telegram-intel": "Telegram intel data unavailable",
+  "spaceflight-news": "Spaceflight news unavailable",
+  "rainviewer-radar": "RainViewer radar unavailable",
+  "lightning": "Lightning-strike data unavailable",
+  "copernicus-cems": "Copernicus CEMS data unavailable",
+  "faa-nas-status": "FAA NAS status unavailable",
+  "phmsa-pipeline": "PHMSA pipeline data unavailable",
+  "air-quality": "Air-quality data unavailable",
+  "radiation-monitoring": "Radiation monitoring data unavailable",
+  "dam-safety": "Dam-safety data unavailable",
+  "nrc-nuclear": "NRC nuclear data unavailable",
+  "spc-outlook": "SPC outlook data unavailable",
+  "aerospace-reentry": "Aerospace reentry data unavailable",
+  "un-security-council": "UN Security Council data unavailable",
+  "oref-alerts": "Oref alerts unavailable",
+  "wildfire-smoke": "Wildfire-smoke data unavailable",
+  "spc-mesoscale": "SPC mesoscale discussion data unavailable",
+  "federal-register": "Federal Register data unavailable",
+  "hazmat-incidents": "HAZMAT incident data unavailable",
+  "power-grid": "Power-grid data unavailable",
+  "gps-interference": "GPS interference data unavailable",
+  "faa-cameras": "FAA camera data unavailable",
+  "combatant-commands": "Combatant commands data unavailable",
+  "water-quality": "Water-quality data unavailable",
+  "allied-military": "Allied military data unavailable",
+  "ofac-sanctions": "OFAC sanctions data unavailable",
+  "amtrak-alerts": "Amtrak alerts unavailable",
+  "tropical-cyclones": "Tropical-cyclone data unavailable",
+  "fdic-failures": "FDIC bank-failure data unavailable",
+  "internet-outages": "Internet outage data unavailable",
+  "drought-monitor": "Drought monitor data unavailable",
+  "hdx-crisis": "HDX crisis data unavailable",
+  "oil-spill-tracker": "Oil-spill tracker unavailable",
+  "inpe-fires": "INPE fire data unavailable",
+  "cyber-extra": "Cyber extras data unavailable",
+  "ntsb-investigations": "NTSB investigations unavailable",
+  "aviation-hazards": "Aviation-hazard data unavailable",
+  "habsos": "HABSOS data unavailable",
+  "wsb-sentiment": "WSB sentiment data unavailable",
+  "ecdc-surveillance": "ECDC surveillance data unavailable",
+  "volcano-alerts": "Volcano alerts unavailable",
+  "space-weather": "Space-weather data unavailable",
+  "food-insecurity": "Food-insecurity data unavailable",
+  "space-launches": "Space-launch data unavailable",
+  "iaea-nuclear": "IAEA nuclear data unavailable",
+  "live-news": "Live news feed unavailable",
+  "dsca-arms-transfers": "DSCA arms-transfer data unavailable",
+  "ripe-atlas": "RIPE Atlas data unavailable",
+  "foreign-mil-news": "Foreign military news unavailable",
+  "cpc-outlook": "CPC outlook data unavailable",
+  "noaa-buoys": "NOAA buoy data unavailable",
+  "world-bank": "World Bank data unavailable",
+  "nws-alerts": "NWS alerts unavailable",
+  "state-dept-advisories": "State Department advisories unavailable",
+  "tsunami-alerts": "Tsunami alerts unavailable",
+  "supply-chain-impact": "Supply-chain impact data unavailable",
+  "faa-tfrs": "FAA TFR data unavailable",
+  "usgs-pager": "USGS PAGER data unavailable",
+  "offline-alert-cache": "Offline alert cache unavailable",
+  "offline-map-cache": "Offline map cache unavailable",
+  "s2-underground": "S2 Underground feed unavailable",
 };
 
 /**

--- a/src/services/disease-intel.ts
+++ b/src/services/disease-intel.ts
@@ -4,6 +4,7 @@
 
 import { getApiBaseUrl } from '@/services/runtime';
 import { iso3ToIso2Code, nameToCountryCode } from '@/services/country-geometry';
+import { dataFreshness } from '@/services/data-freshness';
 
 // ── Nextstrain variant frequency ─────────────────────────────────────────────
 
@@ -84,27 +85,33 @@ let _cache: { data: DiseaseIntelData; ts: number } | null = null;
 export async function fetchDiseaseIntel(): Promise<DiseaseIntelData> {
   if (_cache && Date.now() - _cache.ts < CACHE_TTL_MS) return _cache.data;
 
-  const base = getApiBaseUrl();
-  const res = await fetch(`${base}/api/disease-intel`, { signal: AbortSignal.timeout(25_000) });
-  if (!res.ok) throw new Error(`disease-intel: ${res.status}`);
+  try {
+    const base = getApiBaseUrl();
+    const res = await fetch(`${base}/api/disease-intel`, { signal: AbortSignal.timeout(25_000) });
+    if (!res.ok) throw new Error(`disease-intel: ${res.status}`);
 
-  const raw = await res.json() as {
- nextstrain: unknown;
- covidCountries: unknown;
- reliefweb: unknown;
- whoDon: unknown;
-  };
+    const raw = await res.json() as {
+   nextstrain: unknown;
+   covidCountries: unknown;
+   reliefweb: unknown;
+   whoDon: unknown;
+    };
 
-  const data: DiseaseIntelData = {
- variants: parseNextstrain(raw.nextstrain),
- covidCountries: parseCovidCountries(raw.covidCountries),
- epidemicEvents: parseEpidemicEvents(raw.reliefweb),
- whoDon: parseWhoDon(raw.whoDon),
- fetchedAt: new Date(),
-  };
+    const data: DiseaseIntelData = {
+   variants: parseNextstrain(raw.nextstrain),
+   covidCountries: parseCovidCountries(raw.covidCountries),
+   epidemicEvents: parseEpidemicEvents(raw.reliefweb),
+   whoDon: parseWhoDon(raw.whoDon),
+   fetchedAt: new Date(),
+    };
 
-  _cache = { data, ts: Date.now() };
-  return data;
+    _cache = { data, ts: Date.now() };
+    dataFreshness.recordUpdate('disease-intel', data.covidCountries.length + data.epidemicEvents.length + data.whoDon.length);
+    return data;
+  } catch (error) {
+    dataFreshness.recordError('disease-intel', String(error));
+    throw error;
+  }
 }
 
 // ── Parsers ───────────────────────────────────────────────────────────────────

--- a/src/services/drought-monitor.ts
+++ b/src/services/drought-monitor.ts
@@ -4,6 +4,8 @@
  * Returns weekly drought conditions by state. Data updates once a week (Thursdays).
  */
 
+import { dataFreshness } from '@/services/data-freshness';
+
 export type DroughtLevel = 'D0' | 'D1' | 'D2' | 'D3' | 'D4';
 
 export interface DroughtState {
@@ -136,9 +138,70 @@ interface RawDroughtRow {
 }
 
 function toNum(v: number | string | undefined): number {
-  if (v === undefined || v === null) return 0;
+  if (v === undefined) return 0;
   const n = typeof v === 'string' ? Number.parseFloat(v) : v;
-  return isNaN(n) ? 0 : n;
+  return Number.isNaN(n) ? 0 : n;
+}
+
+const SEVERITY_ORDER: Record<DroughtState['severity'], number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+  none: 4,
+};
+
+function parseDroughtRow(row: RawDroughtRow): { state: DroughtState; mapDateStr: string } | null {
+  const stateName = row.State ?? '';
+  if (!stateName) return null;
+
+  const none = toNum(row.None);
+  const d0 = toNum(row.D0);
+  const d1 = toNum(row.D1);
+  const d2 = toNum(row.D2);
+  const d3 = toNum(row.D3);
+  const d4 = toNum(row.D4);
+
+  // Only include states with any D1+ drought
+  if (d1 + d2 + d3 + d4 <= 0) return null;
+
+  const mapDateStr = row.MapDate ?? row.ReleaseDate ?? '';
+  const validStartStr = row.ValidStart ?? mapDateStr;
+  const validEndStr = row.ValidEnd ?? mapDateStr;
+
+  const validStart = validStartStr ? new Date(validStartStr) : new Date();
+  const validEnd = validEndStr ? new Date(validEndStr) : new Date();
+
+  const maxLevel = computeMaxLevel(d0, d1, d2, d3, d4);
+  const severity = computeSeverity(d0, d1, d2, d3, d4);
+  const stateAbbr = resolveAbbr(stateName);
+
+  return {
+ state: {
+ id: `drought-${stateAbbr.toLowerCase()}`,
+ state: stateName,
+ stateAbbr,
+ validStart,
+ validEnd,
+ none,
+ d0,
+ d1,
+ d2,
+ d3,
+ d4,
+ maxLevel,
+ severity,
+ },
+ mapDateStr,
+  };
+}
+
+function sortDroughtStates(states: DroughtState[]): DroughtState[] {
+  return [...states].sort((a, b) => {
+ const sd = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+ if (sd !== 0) return sd;
+ return (b.d3 + b.d4) - (a.d3 + a.d4);
+  });
 }
 
 export async function fetchDroughtMonitor(): Promise<DroughtSummary> {
@@ -156,67 +219,18 @@ export async function fetchDroughtMonitor(): Promise<DroughtSummary> {
  if (!Array.isArray(json)) return cache?.summary ?? emptyDroughtSummary();
 
  let validDate: Date | null = null;
- const states: DroughtState[] = [];
+ const collected: DroughtState[] = [];
 
  for (const row of json) {
- const stateName = row.State ?? '';
- if (!stateName) continue;
-
- const none = toNum(row.None);
- const d0 = toNum(row.D0);
- const d1 = toNum(row.D1);
- const d2 = toNum(row.D2);
- const d3 = toNum(row.D3);
- const d4 = toNum(row.D4);
-
- // Only include states with any D1+ drought
- if (d1 + d2 + d3 + d4 <= 0) continue;
-
- const mapDateStr = row.MapDate ?? row.ReleaseDate ?? '';
- const validStartStr = row.ValidStart ?? mapDateStr;
- const validEndStr = row.ValidEnd ?? mapDateStr;
-
- const validStart = validStartStr ? new Date(validStartStr) : new Date();
- const validEnd = validEndStr ? new Date(validEndStr) : new Date();
-
- if (!validDate && mapDateStr) {
- validDate = new Date(mapDateStr);
+ const parsed = parseDroughtRow(row);
+ if (!parsed) continue;
+ if (!validDate && parsed.mapDateStr) {
+ validDate = new Date(parsed.mapDateStr);
+ }
+ collected.push(parsed.state);
  }
 
- const maxLevel = computeMaxLevel(d0, d1, d2, d3, d4);
- const severity = computeSeverity(d0, d1, d2, d3, d4);
- const stateAbbr = resolveAbbr(stateName);
-
- states.push({
- id: `drought-${stateAbbr.toLowerCase()}`,
- state: stateName,
- stateAbbr,
- validStart,
- validEnd,
- none,
- d0,
- d1,
- d2,
- d3,
- d4,
- maxLevel,
- severity,
- });
- }
-
- // Sort: most severe first, then by d3+d4 percentage descending
- const sOrder: Record<DroughtState['severity'], number> = {
- critical: 0,
- high: 1,
- medium: 2,
- low: 3,
- none: 4,
- };
- states.sort((a, b) => {
- const sd = sOrder[a.severity] - sOrder[b.severity];
- if (sd !== 0) return sd;
- return (b.d3 + b.d4) - (a.d3 + a.d4);
- });
+ const states = sortDroughtStates(collected);
 
  // National D3+D4 percentage — simple average across all states in response
  let nationalD3D4Pct = 0;
@@ -233,8 +247,10 @@ export async function fetchDroughtMonitor(): Promise<DroughtSummary> {
  };
 
  cache = { summary, fetchedAt: Date.now() };
+ dataFreshness.recordUpdate('drought-monitor', summary.states.length);
  return summary;
-  } catch {
+  } catch (error) {
+ dataFreshness.recordError('drought-monitor', String(error));
  return cache?.summary ?? emptyDroughtSummary();
   }
 }

--- a/src/services/evacuation-router.ts
+++ b/src/services/evacuation-router.ts
@@ -1,5 +1,6 @@
 import { getApiBaseUrl, isDesktopRuntime } from './runtime';
 import { getSavedPlaces, type SavedPlace } from './saved-places';
+import { dataFreshness } from './data-freshness';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -160,11 +161,18 @@ async function fetchOsrmRoute(from: LatLon, to: LatLon, waypoints: LatLon[]): Pr
  ? `${getApiBaseUrl()}/api/osrm-route?coords=${encodeURIComponent(coords)}`
  : `https://router.project-osrm.org/route/v1/driving/${coords}?${params}`;
 
-  const resp = await fetch(url);
-  if (!resp.ok) {
+  try {
+ const resp = await fetch(url);
+ if (!resp.ok) {
  throw new Error(`OSRM request failed: HTTP ${resp.status}`);
+ }
+ const data = await resp.json() as OsrmResponse;
+ dataFreshness.recordUpdate('evacuation-router', data.routes?.length ?? 0);
+ return data;
+  } catch (error) {
+ dataFreshness.recordError('evacuation-router', String(error));
+ throw error;
   }
-  return resp.json() as Promise<OsrmResponse>;
 }
 
 // ── Public API ───────────────────────────────────────────────────────────────

--- a/src/services/faa-cameras.ts
+++ b/src/services/faa-cameras.ts
@@ -1,6 +1,7 @@
 import { getApiBaseUrl } from '@/services/runtime';
 import type { NWSAlert } from '@/services/nws-alerts';
 import type { GDACSEvent } from '@/services/gdacs';
+import { dataFreshness } from '@/services/data-freshness';
 
 export interface FAACamera {
   id: string;
@@ -47,11 +48,16 @@ export async function fetchFAACameras(): Promise<FAACamera[]> {
  const res = await fetch(`${getApiBaseUrl()}/api/faa-cameras`, {
  signal: AbortSignal.timeout(15_000),
  });
- if (!res.ok) return cache?.data ?? [];
+ if (!res.ok) {
+ dataFreshness.recordError('faa-cameras', `HTTP ${res.status}`);
+ return cache?.data ?? [];
+ }
  const data = parseFAACamerasResponse(await res.json());
  cache = { data, ts: Date.now() };
+ dataFreshness.recordUpdate('faa-cameras', data.length);
  return data;
-  } catch {
+  } catch (error) {
+ dataFreshness.recordError('faa-cameras', String(error));
  return cache?.data ?? [];
   }
 }

--- a/src/services/faa-nas-status.ts
+++ b/src/services/faa-nas-status.ts
@@ -6,6 +6,8 @@
  * Free, no authentication, CORS-enabled.
  */
 
+import { dataFreshness } from './data-freshness';
+
 export type NasDelayType = 'departure' | 'arrival' | 'ground-stop' | 'ground-delay' | 'closure' | 'general';
 
 export interface NasDelay {
@@ -62,8 +64,11 @@ function parseDelayMinutes(delayStr: string): number | null {
   const normalized = delayStr.toLowerCase().trim();
 
   // Match "2 hrs 15 mins", "1 hr 20 mins", "45 mins", "1 hr", "2 hours", etc.
+  // Patterns are bounded to small inputs from FAA API; backtracking risk is bounded.
+  /* eslint-disable sonarjs/slow-regex */
   const hoursMatch = /(\d+)\s*hr(?:s|ours?)?/.exec(normalized);
   const minsMatch = /(\d+)\s*min(?:s|utes?)?/.exec(normalized);
+  /* eslint-enable sonarjs/slow-regex */
 
   const hours = hoursMatch ? Number.parseInt(hoursMatch[1] ?? '0', 10) : 0;
   const minutes = minsMatch ? Number.parseInt(minsMatch[1] ?? '0', 10) : 0;
@@ -175,8 +180,10 @@ export async function fetchNasStatus(): Promise<NasStatus> {
   );
 
   const delays: NasDelay[] = [];
+  let rejectedCount = 0;
   for (const r of results) {
  if (r.status === 'fulfilled' && r.value) delays.push(r.value);
+ else if (r.status === 'rejected') rejectedCount++;
   }
 
   // Sort: critical first, then by delay minutes desc
@@ -195,6 +202,11 @@ export async function fetchNasStatus(): Promise<NasStatus> {
   };
 
   cache = { status, fetchedAt: Date.now() };
+  if (rejectedCount === results.length) {
+ dataFreshness.recordError('faa-nas-status', `all ${rejectedCount} airport requests failed`);
+  } else {
+ dataFreshness.recordUpdate('faa-nas-status', delays.length);
+  }
   return status;
 }
 

--- a/src/services/faa-tfrs.ts
+++ b/src/services/faa-tfrs.ts
@@ -9,6 +9,8 @@
  *  - Type 14: Space operations (launch corridor hazard)
  */
 
+import { dataFreshness } from './data-freshness';
+
 export interface FaaTfr {
   id: string;
   notamId: string;
@@ -53,7 +55,7 @@ function scoreSeverity(type: string, notamClass: string): FaaTfr['severity'] {
 function parseDate(str: string | null | undefined): Date | null {
   if (!str) return null;
   const d = new Date(str);
-  return isNaN(d.getTime()) ? null : d;
+  return Number.isNaN(d.getTime()) ? null : d;
 }
 
 function getText(el: Element, tag: string): string {
@@ -104,8 +106,9 @@ export async function fetchFaaTfrs(): Promise<FaaTfr[]> {
  const severity = scoreSeverity(type, notamClass);
  const description = `TFR ${notamId}: ${type} near ${city}, ${state}`.trim();
 
+ const idSuffix = notamId || `${facilityDesig}-${startStr}`;
  tfrs.push({
- id: `tfr-${notamId || `${facilityDesig}-${startStr}`}`,
+ id: `tfr-${idSuffix}`,
  notamId,
  facilityDesig,
  type,
@@ -126,8 +129,10 @@ export async function fetchFaaTfrs(): Promise<FaaTfr[]> {
  .slice(0, 50);
 
  cache = { tfrs: alertable, fetchedAt: Date.now() };
+ dataFreshness.recordUpdate('faa-tfrs', alertable.length);
  return alertable;
-  } catch {
+  } catch (error) {
+ dataFreshness.recordError('faa-tfrs', String(error));
  return cache?.tfrs ?? [];
   }
 }

--- a/src/services/fdic-failures.ts
+++ b/src/services/fdic-failures.ts
@@ -3,6 +3,8 @@
  * Source: https://banks.data.fdic.gov/api/failures (free, public, CORS-enabled)
  */
 
+import { dataFreshness } from './data-freshness';
+
 export type BankResolutionType = 'purchase-assumption' | 'payout' | 'open-bank-assistance' | 'other';
 
 export interface BankFailure {
@@ -97,10 +99,11 @@ export async function fetchBankFailures(): Promise<FdicFailureSummary> {
  });
 
  if (!res.ok) {
+ dataFreshness.recordError('fdic-failures', `HTTP ${res.status}`);
  return cache?.data ?? { failures: [], totalFailuresLastYear: 0, totalAssetsCoveredM: 0, fetchedAt: new Date() };
  }
 
- const json: FdicResponse = await res.json();
+ const json = await res.json() as FdicResponse;
  const twoYearsAgo = new Date(now - 2 * 365 * 24 * 60 * 60 * 1000);
  const oneYearAgo = new Date(now - 365 * 24 * 60 * 60 * 1000);
 
@@ -146,8 +149,10 @@ export async function fetchBankFailures(): Promise<FdicFailureSummary> {
  };
 
  cache = { data: summary, ts: now };
+ dataFreshness.recordUpdate('fdic-failures', failures.length);
  return summary;
-  } catch {
+  } catch (error) {
+ dataFreshness.recordError('fdic-failures', String(error));
  return (
  cache?.data ?? { failures: [], totalFailuresLastYear: 0, totalAssetsCoveredM: 0, fetchedAt: new Date() }
  );

--- a/src/services/federal-register.ts
+++ b/src/services/federal-register.ts
@@ -1,4 +1,5 @@
 import { getApiBaseUrl } from '@/services/runtime';
+import { dataFreshness } from '@/services/data-freshness';
 
 export interface FederalDocument {
   id: string;
@@ -18,12 +19,17 @@ export async function fetchFederalRegister(): Promise<FederalDocument[]> {
   if (_cache && Date.now() - _cacheTs < CACHE_TTL_MS) return _cache;
   try {
  const res = await fetch(`${getApiBaseUrl()}/api/federal-register`, { signal: AbortSignal.timeout(8000) });
- if (!res.ok) return [];
+ if (!res.ok) {
+ dataFreshness.recordError('federal-register', `HTTP ${res.status}`);
+ return [];
+ }
  const data = await res.json() as { documents: FederalDocument[] };
  _cache = Array.isArray(data.documents) ? data.documents : [];
  _cacheTs = Date.now();
+ dataFreshness.recordUpdate('federal-register', _cache.length);
  return _cache;
-  } catch {
+  } catch (error) {
+ dataFreshness.recordError('federal-register', String(error));
  return [];
   }
 }

--- a/src/services/fema-disasters.ts
+++ b/src/services/fema-disasters.ts
@@ -12,6 +12,8 @@
  * serious enough to warrant federal response resources.
  */
 
+import { dataFreshness } from './data-freshness';
+
 export type FemaDeclarationType =
   | 'DR' // Major Disaster Declaration
   | 'EM' // Emergency Declaration
@@ -34,6 +36,7 @@ export interface FemaDeclaration {
   id: string;
   disasterNumber: number;
   declarationType: FemaDeclarationType;
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- FEMA API returns either a known incidentType or a freeform string from new categories
   incidentType: FemaIncidentType | string;
   declarationTitle: string;
   state: string;
@@ -63,6 +66,7 @@ export interface FemaShelter {
   capacity: number | null;
   currentOccupancy: number | null;
   disasterNumber: number | null;
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- FEMA API may return values outside the known set
   shelterStatus: 'Open' | 'Closed' | 'Full' | string;
   acceptingEvacuees: boolean;
   petFriendly: boolean;
@@ -140,17 +144,22 @@ export async function fetchFemaDeclarations(daysBack = 90): Promise<FemaDeclarat
  const since = new Date(Date.now() - daysBack * 24 * 3_600_000).toISOString().slice(0, 10);
  const url = `${FEMA_API}/DisasterDeclarationsSummaries?$filter=declarationDate ge '${since}'&$orderby=declarationDate desc&$top=100&$format=json`;
  const res = await fetch(url, { signal: AbortSignal.timeout(12_000), headers: { Accept: 'application/json' } });
- if (!res.ok) return declarationsCache?.items ?? [];
+ if (!res.ok) {
+ dataFreshness.recordError('fema-disasters', `declarations HTTP ${res.status}`);
+ return declarationsCache?.items ?? [];
+ }
 
- const data: FemaApiResponse<FemaApiDeclaration> = await res.json();
+ const data = await res.json() as FemaApiResponse<FemaApiDeclaration>;
  const raw = data.DisasterDeclarationsSummaries ?? [];
 
  const items: FemaDeclaration[] = raw.map(d => {
  const declType = (d.declarationType ?? 'DR') as FemaDeclarationType;
  const incType = d.incidentType ?? 'Other';
  const isOpen = !d.closeoutDate && !d.closeoutDatetime && !d.disasterCloseoutDate;
+ // eslint-disable-next-line sonarjs/pseudo-random -- ID jitter, not security-sensitive
+ const fallbackId = Math.random();
  return {
- id: `fema-${d.disasterNumber ?? Math.random()}`,
+ id: `fema-${d.disasterNumber ?? fallbackId}`,
  disasterNumber: d.disasterNumber ?? 0,
  declarationType: declType,
  incidentType: incType,
@@ -174,8 +183,10 @@ export async function fetchFemaDeclarations(daysBack = 90): Promise<FemaDeclarat
  });
 
  declarationsCache = { items, fetchedAt: Date.now() };
+ dataFreshness.recordUpdate('fema-disasters', items.length);
  return items;
-  } catch {
+  } catch (error) {
+ dataFreshness.recordError('fema-disasters', String(error));
  return declarationsCache?.items ?? [];
   }
 }
@@ -188,13 +199,18 @@ export async function fetchFemaShelters(): Promise<FemaShelter[]> {
   try {
  const url = `${FEMA_API}/OpenedShelters?$filter=shelterStatus eq 'Open'&$top=200&$format=json`;
  const res = await fetch(url, { signal: AbortSignal.timeout(12_000), headers: { Accept: 'application/json' } });
- if (!res.ok) return sheltersCache?.items ?? [];
+ if (!res.ok) {
+ dataFreshness.recordError('fema-disasters', `shelters HTTP ${res.status}`);
+ return sheltersCache?.items ?? [];
+ }
 
- const data: FemaApiResponse<FemaApiShelter> = await res.json();
+ const data = await res.json() as FemaApiResponse<FemaApiShelter>;
  const raw = data.OpenedShelters ?? [];
 
- const items: FemaShelter[] = raw.map(s => ({
- id: `shelter-${s.shelterId ?? `${s.shelterName}-${s.city}`}`,
+ const items: FemaShelter[] = raw.map(s => {
+ const shelterIdFallback = `${s.shelterName}-${s.city}`;
+ return {
+ id: `shelter-${s.shelterId ?? shelterIdFallback}`,
  shelterName: s.shelterName ?? 'Unknown Shelter',
  address: s.address1 ?? '',
  city: s.city ?? '',
@@ -209,11 +225,14 @@ export async function fetchFemaShelters(): Promise<FemaShelter[]> {
  acceptingEvacuees: s.acceptingEvacuees ?? true,
  petFriendly: s.petFriendly ?? false,
  accessibilityCompliant: s.ada ?? false,
- }));
+ };
+ });
 
  sheltersCache = { items, fetchedAt: Date.now() };
+ dataFreshness.recordUpdate('fema-disasters', items.length);
  return items;
-  } catch {
+  } catch (error) {
+ dataFreshness.recordError('fema-disasters', String(error));
  return sheltersCache?.items ?? [];
   }
 }

--- a/src/services/flood-gauges.ts
+++ b/src/services/flood-gauges.ts
@@ -6,6 +6,8 @@
  * Returns gauges currently at or above flood stage across the US.
  */
 
+import { dataFreshness } from './data-freshness';
+
 export interface FloodGauge {
   id: string;
   siteNo: string;
@@ -46,7 +48,7 @@ let cache: { gauges: FloodGauge[]; fetchedAt: number } | null = null;
 function toNumber(v: number | string | null | undefined): number | null {
   if (v === null || v === undefined || v === '') return null;
   const n = Number(v);
-  return isNaN(n) ? null : n;
+  return Number.isNaN(n) ? null : n;
 }
 
 function mapCategory(status: string): FloodGauge['floodCategory'] | null {
@@ -66,9 +68,12 @@ export async function fetchFloodGauges(): Promise<FloodGauge[]> {
  signal: AbortSignal.timeout(12_000),
  headers: { Accept: 'application/json' },
  });
- if (!res.ok) return cache?.gauges ?? [];
+ if (!res.ok) {
+ dataFreshness.recordError('flood-gauges', `HTTP ${res.status}`);
+ return cache?.gauges ?? [];
+ }
 
- const data: WaterWatchResponse = await res.json();
+ const data = await res.json() as WaterWatchResponse;
  const sites = data.sites ?? data.site ?? [];
 
  const gauges: FloodGauge[] = [];
@@ -104,8 +109,10 @@ export async function fetchFloodGauges(): Promise<FloodGauge[]> {
  gauges.sort((a, b) => order[a.floodCategory] - order[b.floodCategory]);
 
  cache = { gauges, fetchedAt: Date.now() };
+ dataFreshness.recordUpdate('flood-gauges', gauges.length);
  return gauges;
-  } catch {
+  } catch (error) {
+ dataFreshness.recordError('flood-gauges', String(error));
  return cache?.gauges ?? [];
   }
 }

--- a/src/services/food-insecurity.ts
+++ b/src/services/food-insecurity.ts
@@ -12,6 +12,8 @@
  * Phase 4 = Emergency  Phase 5 = Catastrophe/Famine
  */
 
+import { dataFreshness } from './data-freshness';
+
 export type IpcPhase = 1 | 2 | 3 | 4 | 5;
 
 export interface FoodInsecurityAlert {
@@ -68,11 +70,14 @@ async function fetchFewsNet(): Promise<FoodInsecurityAlert[]> {
  const items = doc.querySelectorAll('item');
  return [...items].slice(0, 30).map((item, i) => {
  const title = item.querySelector('title')?.textContent?.trim() ?? '';
+ // RSS description from controlled FEWS NET feed; backtracking risk bounded.
+ // eslint-disable-next-line sonarjs/slow-regex
  const description = (item.querySelector('description')?.textContent ?? '').replace(/<[^>]+>/g, '').trim();
  const link = item.querySelector('link')?.textContent?.trim() ?? '';
  const pubDateStr = item.querySelector('pubDate')?.textContent?.trim() ?? '';
 
- // FEWS NET titles often start with country name
+ // FEWS NET titles often start with country name; bounded input.
+ /* eslint-disable-next-line sonarjs/slow-regex */
  const countryMatch = /^([A-Z][a-zA-Z\s]+?)(?:\s*[-–:|]|\s+Food)/.exec(title);
  const country = countryMatch?.[1]?.trim() ?? 'Unknown';
 
@@ -120,7 +125,7 @@ async function fetchIpc(): Promise<FoodInsecurityAlert[]> {
  });
  if (!res.ok) return [];
 
- const data: IpcResponse = await res.json();
+ const data = await res.json() as IpcResponse;
  const records: IpcRecord[] = data.body ?? data.data ?? [];
 
  // Filter to IPC Phase 3+ (Crisis or worse)
@@ -128,8 +133,9 @@ async function fetchIpc(): Promise<FoodInsecurityAlert[]> {
  .filter(r => (r.phase ?? 0) >= 3)
  .map(r => {
  const phase = (r.phase ?? null) as IpcPhase | null;
+ const idFallback = `${r.country_code}-${r.period}`;
  return {
- id: `ipc-${r.id ?? `${r.country_code}-${r.period}`}`,
+ id: `ipc-${r.id ?? idFallback}`,
  country: r.country ?? 'Unknown',
  countryCode: r.country_code ?? '',
  title: r.title ?? `IPC Phase ${phase} — ${r.country}`,
@@ -165,6 +171,11 @@ export async function fetchFoodInsecurityAlerts(): Promise<FoodInsecurityAlert[]
   combined.sort((a, b) => sOrder[a.severity] - sOrder[b.severity] || b.pubDate.getTime() - a.pubDate.getTime());
 
   cache = { alerts: combined.slice(0, 60), fetchedAt: Date.now() };
+  if (fewsResult.status === 'rejected' && ipcResult.status === 'rejected') {
+ dataFreshness.recordError('food-insecurity', 'both FEWS NET and IPC requests rejected');
+  } else {
+ dataFreshness.recordUpdate('food-insecurity', cache.alerts.length);
+  }
   return cache.alerts;
 }
 

--- a/src/services/foreign-mil-news.ts
+++ b/src/services/foreign-mil-news.ts
@@ -9,6 +9,8 @@
  * Cache TTL: 15 minutes.
  */
 
+import { dataFreshness } from './data-freshness';
+
 export type MilNewsSource = 'Russia-MoD' | 'China-PLA' | 'TASS' | 'Xinhua' | 'RT' | 'Other';
 
 export interface ForeignMilNewsItem {
@@ -48,10 +50,13 @@ interface MilCache {
 
 let _cache: MilCache | null = null;
 
+// Keyword filter for news article relevance — input is bounded RSS feed text.
+// eslint-disable-next-line sonarjs/regex-complexity
 const MILITARY_KEYWORDS = /military|army|navy|air force|missile|nuclear|weapon|exercise|drill|troops|soldier|combat|submarine|warship|hypersonic|strategic|defense|deterrence|conflict|operation|deploy|patrol/i;
 
 function stripHtml(html: string): string {
   return html
+ // eslint-disable-next-line sonarjs/slow-regex -- HTML stripping on bounded RSS content
  .replace(/<[^>]+>/g, ' ')
  .replace(/&amp;/g, '&')
  .replace(/&lt;/g, '<')
@@ -221,6 +226,11 @@ export async function fetchForeignMilNews(): Promise<ForeignMilNewsItem[]> {
 
   const items = deduped.slice(0, 50);
   _cache = { items, fetchedAt: Date.now() };
+  if (results.every(r => r.status === 'rejected')) {
+ dataFreshness.recordError('foreign-mil-news', `all ${results.length} feed requests rejected`);
+  } else {
+ dataFreshness.recordUpdate('foreign-mil-news', items.length);
+  }
   return items;
 }
 

--- a/src/services/gps-interference.ts
+++ b/src/services/gps-interference.ts
@@ -1,5 +1,6 @@
 import { cellToLatLng } from 'h3-js';
 import { getApiBaseUrl } from '@/services/runtime';
+import { dataFreshness } from '@/services/data-freshness';
 
 export interface GpsJamHex {
   h3: string;
@@ -37,7 +38,10 @@ export async function fetchGpsInterference(): Promise<GpsJamData | null> {
  const resp = await fetch(`${base}/api/gpsjam`, {
  signal: AbortSignal.timeout(20_000),
  });
- if (!resp.ok) return cachedData;
+ if (!resp.ok) {
+ dataFreshness.recordError('gps-interference', `HTTP ${resp.status}`);
+ return cachedData;
+ }
 
  const raw = await resp.json() as {
  date: string;
@@ -75,8 +79,10 @@ export async function fetchGpsInterference(): Promise<GpsJamData | null> {
  hexes,
  };
  cachedAt = now;
+ dataFreshness.recordUpdate('gps-interference', hexes.length);
  return cachedData;
-  } catch {
+  } catch (error) {
+ dataFreshness.recordError('gps-interference', String(error));
  return cachedData;
   }
 }
@@ -85,12 +91,13 @@ export function getGpsInterferenceByRegion(data: GpsJamData): Record<string, Gps
   const regions: Record<string, GpsJamHex[]> = {};
   for (const hex of data.hexes) {
  const region = classifyRegion(hex.lat, hex.lon);
- if (!regions[region]) regions[region] = [];
+ regions[region] ??= [];
  regions[region].push(hex);
   }
   return regions;
 }
 
+// eslint-disable-next-line sonarjs/cognitive-complexity -- flat region lookup table; refactor would obscure the geographic boundaries
 function classifyRegion(lat: number, lon: number): string {
   if (lat >= 29 && lat <= 42 && lon >= 43 && lon <= 63) return 'iran-iraq';
   if (lat >= 31 && lat <= 37 && lon >= 35 && lon <= 43) return 'levant';

--- a/src/services/habsos.ts
+++ b/src/services/habsos.ts
@@ -4,6 +4,8 @@
  * Fallback: NOAA NCCOS HAB bulletin RSS
  */
 
+import { dataFreshness } from './data-freshness';
+
 export type HabSpecies =
   | 'Karenia'
   | 'Alexandrium'
@@ -133,7 +135,7 @@ function parseEsriDate(raw: number | string | null | undefined): Date {
   if (raw === null || raw === undefined) return new Date();
   if (typeof raw === 'number') return new Date(raw);
   const parsed = new Date(raw);
-  return isNaN(parsed.getTime()) ? new Date() : parsed;
+  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
 }
 
 function fromEsriFeatures(features: EsriFeature[]): HabObservation[] {
@@ -159,15 +161,17 @@ function fromEsriFeatures(features: EsriFeature[]): HabObservation[] {
  a.CELLCOUNT !== null && a.CELLCOUNT !== undefined ? Number(a.CELLCOUNT) : null;
  const severity = computeHabSeverity(species, cellCount, impacts);
 
+ // eslint-disable-next-line sonarjs/pseudo-random -- ID jitter, not security-sensitive
+ const fallbackId = Math.random().toString(36).slice(2);
  results.push({
- id: `habsos-${a.OBJECTID ?? Math.random().toString(36).slice(2)}`,
+ id: `habsos-${a.OBJECTID ?? fallbackId}`,
  description: description || details || 'HAB observation',
  species,
  region,
  state,
  lat: a.Y ?? null,
  lon: a.X ?? null,
- cellCount: cellCount !== null && !isNaN(cellCount) ? cellCount : null,
+ cellCount: cellCount !== null && !Number.isNaN(cellCount) ? cellCount : null,
  sampleDate,
  affectedArea: a.AFFECTED_AREA ?? '',
  impacts,
@@ -180,6 +184,7 @@ function fromEsriFeatures(features: EsriFeature[]): HabObservation[] {
 
 function stripHtml(html: string): string {
   return html
+ // eslint-disable-next-line sonarjs/slow-regex -- HTML stripping on bounded RSS content
  .replace(/<[^>]+>/g, ' ')
  .replace(/&amp;/g, '&')
  .replace(/&lt;/g, '<')
@@ -194,9 +199,9 @@ function stripHtml(html: string): string {
 function extractText(xml: string, tag: string): string {
   const cdataRe = new RegExp(String.raw`<${tag}[^>]*><!\[CDATA\[([\s\S]*?)\]\]><\/${tag}>`, 'i');
   const plainRe = new RegExp(String.raw`<${tag}[^>]*>([\s\S]*?)<\/${tag}>`, 'i');
-  const cdataMatch = xml.match(cdataRe);
+  const cdataMatch = cdataRe.exec(xml);
   if (cdataMatch) return (cdataMatch[1] ?? '').trim();
-  const plainMatch = xml.match(plainRe);
+  const plainMatch = plainRe.exec(xml);
   if (plainMatch) return stripHtml(plainMatch[1] ?? '').trim();
   return '';
 }
@@ -217,7 +222,7 @@ function fromRssFallback(xmlText: string): HabObservation[] {
  const pubDateStr = extractText(block, 'pubDate');
 
  const sampleDate = pubDateStr ? new Date(pubDateStr) : new Date();
- if (isNaN(sampleDate.getTime()) || sampleDate.getTime() < cutoff) continue;
+ if (Number.isNaN(sampleDate.getTime()) || sampleDate.getTime() < cutoff) continue;
 
  const combinedText = title + ' ' + description;
  const species = detectSpecies(null, combinedText);
@@ -264,7 +269,7 @@ export async function fetchHabObservations(): Promise<HabObservation[]> {
   try {
  const res = await fetch(ESRI_URL, { signal: AbortSignal.timeout(12_000) });
  if (res.ok) {
- const json: EsriResponse = await res.json();
+ const json = await res.json() as EsriResponse;
  if (Array.isArray(json.features) && json.features.length > 0) {
  observations = fromEsriFeatures(json.features);
  }
@@ -287,7 +292,10 @@ export async function fetchHabObservations(): Promise<HabObservation[]> {
  }
   }
 
-  if (observations.length === 0) return cache?.data ?? [];
+  if (observations.length === 0) {
+ dataFreshness.recordError('habsos', 'no observations from ESRI or RSS fallback');
+ return cache?.data ?? [];
+  }
 
   observations.sort((a, b) => {
  const sev = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
@@ -297,6 +305,7 @@ export async function fetchHabObservations(): Promise<HabObservation[]> {
 
   const data = observations.slice(0, 40);
   cache = { data, ts: Date.now() };
+  dataFreshness.recordUpdate('habsos', data.length);
   return data;
 }
 

--- a/src/services/hazmat-incidents.ts
+++ b/src/services/hazmat-incidents.ts
@@ -14,6 +14,8 @@
  * and the IAEA/NRC nuclear services.
  */
 
+import { dataFreshness } from './data-freshness';
+
 export interface HazmatIncident {
   id: string;
   title: string;
@@ -87,6 +89,8 @@ function scoreSeverity(title: string, description: string): HazmatIncident['seve
 }
 
 function extractState(text: string): string {
+  // Bounded input from RSS feeds; backtracking risk negligible.
+  // eslint-disable-next-line sonarjs/regex-complexity
   const stateMatch = /\b([A-Z]{2})\b(?=\s*\d{5}|,\s+USA?|,\s+United States)/.exec(text);
   if (stateMatch?.[1]) return stateMatch[1];
   const states = [
@@ -123,6 +127,7 @@ async function fetchRss(feedUrl: string, source: HazmatIncident['source']): Prom
 
  for (const item of items) {
  const title = item.querySelector('title')?.textContent?.trim() ?? '';
+ // eslint-disable-next-line sonarjs/slow-regex -- HTML stripping on bounded RSS content
  const description = (item.querySelector('description')?.textContent ?? '').replace(/<[^>]+>/g, '').trim();
  const link = item.querySelector('link')?.textContent?.trim() ?? '';
  const pubDateStr = item.querySelector('pubDate')?.textContent?.trim() ?? '';
@@ -171,7 +176,8 @@ export async function fetchHazmatIncidents(): Promise<HazmatIncident[]> {
   // Dedupe by title
   const seen = new Set<string>();
   const deduped: HazmatIncident[] = [];
-  for (const i of combined.sort((a, b) => b.reportedAt.getTime() - a.reportedAt.getTime())) {
+  const sortedCombined = [...combined].sort((a, b) => b.reportedAt.getTime() - a.reportedAt.getTime());
+  for (const i of sortedCombined) {
  const key = i.title.toLowerCase().replace(/\W/g, '').slice(0, 40);
  if (!seen.has(key)) {
  seen.add(key);
@@ -184,6 +190,11 @@ export async function fetchHazmatIncidents(): Promise<HazmatIncident[]> {
  .slice(0, 50);
 
   cache = { incidents: recent, fetchedAt: Date.now() };
+  if ([epaResult, csbResult, phmsaResult].every(r => r.status === 'rejected')) {
+ dataFreshness.recordError('hazmat-incidents', 'all 3 RSS feeds rejected');
+  } else {
+ dataFreshness.recordUpdate('hazmat-incidents', recent.length);
+  }
   return recent;
 }
 

--- a/src/services/hdx-crisis.ts
+++ b/src/services/hdx-crisis.ts
@@ -1,4 +1,5 @@
 import { getApiBaseUrl } from '@/services/runtime';
+import { dataFreshness } from '@/services/data-freshness';
 
 export type CrisisType = 'conflict' | 'displacement' | 'food-insecurity' | 'disease' | 'disaster' | 'other';
 
@@ -24,14 +25,17 @@ export async function fetchHdxCrises(): Promise<HumanitarianCrisis[]> {
   try {
  const res = await fetch(`${getApiBaseUrl()}/api/hdx-crises`, { signal: AbortSignal.timeout(15_000) });
  if (!res.ok) {
+ dataFreshness.recordError('hdx-crisis', `HTTP ${res.status}`);
  _cache = { crises: [], ts: Date.now() };
  return [];
  }
  const raw = await res.json() as (HumanitarianCrisis & { updatedAt: string })[];
  const crises = raw.map(r => ({ ...r, updatedAt: new Date(r.updatedAt) }));
  _cache = { crises, ts: Date.now() };
+ dataFreshness.recordUpdate('hdx-crisis', crises.length);
  return crises;
-  } catch {
+  } catch (error) {
+ dataFreshness.recordError('hdx-crisis', String(error));
  _cache = { crises: [], ts: Date.now() };
  return [];
   }

--- a/src/services/iaea-nuclear.ts
+++ b/src/services/iaea-nuclear.ts
@@ -8,6 +8,10 @@
  * Complements the US-only NRC nuclear service with global coverage.
  */
 
+/* eslint-disable sonarjs/slow-regex -- regexes parse bounded IAEA RSS text */
+
+import { dataFreshness } from './data-freshness';
+
 export interface IaeaEvent {
   id: string;
   title: string;
@@ -121,7 +125,8 @@ export async function fetchIaeaEvents(): Promise<IaeaEvent[]> {
   // Dedupe by URL
   const seen = new Set<string>();
   const deduped: IaeaEvent[] = [];
-  for (const e of combined.sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime())) {
+  const sortedCombined = [...combined].sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime());
+  for (const e of sortedCombined) {
  if (!seen.has(e.url)) {
  seen.add(e.url);
  deduped.push(e);
@@ -134,6 +139,11 @@ export async function fetchIaeaEvents(): Promise<IaeaEvent[]> {
  .slice(0, 40);
 
   cache = { events: recent, fetchedAt: Date.now() };
+  if (newsResult.status === 'rejected' && prResult.status === 'rejected') {
+ dataFreshness.recordError('iaea-nuclear', 'both IAEA RSS feeds rejected');
+  } else {
+ dataFreshness.recordUpdate('iaea-nuclear', recent.length);
+  }
   return recent;
 }
 

--- a/src/services/inciweb.ts
+++ b/src/services/inciweb.ts
@@ -13,8 +13,14 @@
  *  - Cause (lightning, human, under investigation)
  *
  * Complements VIIRS/MODIS satellite heat detection with human-operated data.
+ *
+ * Wired to data-freshness telemetry.
  * VIIRS shows where fire pixels are; InciWeb shows the human response.
  */
+
+/* eslint-disable sonarjs/slow-regex, sonarjs/regex-complexity, sonarjs/no-nested-template-literals -- regexes parse bounded InciWeb RSS text */
+
+import { dataFreshness } from './data-freshness';
 
 export interface IncidentReport {
   id: string;
@@ -64,10 +70,11 @@ function detectIncidentType(title: string, description: string): IncidentReport[
 
 function extractNumber(text: string, patterns: RegExp[]): number | null {
   for (const pattern of patterns) {
+ // eslint-disable-next-line sonarjs/prefer-regexp-exec -- API receives RegExp[]
  const match = text.match(pattern);
  if (match?.[1]) {
  const num = Number.parseFloat(match[1].replace(/,/g, ''));
- if (!isNaN(num)) return num;
+ if (!Number.isNaN(num)) return num;
  }
   }
   return null;
@@ -196,6 +203,11 @@ export async function fetchInciwebIncidents(): Promise<IncidentReport[]> {
   });
 
   cache = { incidents: incidents.slice(0, 80), fetchedAt: Date.now() };
+  if (mainResult.status === 'rejected' && evacResult.status === 'rejected') {
+ dataFreshness.recordError('inciweb', 'both InciWeb RSS feeds rejected');
+  } else {
+ dataFreshness.recordUpdate('inciweb', cache.incidents.length);
+  }
   return cache.incidents;
 }
 

--- a/src/services/inpe-fires.ts
+++ b/src/services/inpe-fires.ts
@@ -1,4 +1,5 @@
 import { getApiBaseUrl } from '@/services/runtime';
+import { dataFreshness } from '@/services/data-freshness';
 
 export interface InpeHotspot {
   id: string;
@@ -23,14 +24,17 @@ export async function fetchInpeFires(): Promise<InpeHotspot[]> {
   try {
  const res = await fetch(`${getApiBaseUrl()}/api/inpe-fires`, { signal: AbortSignal.timeout(15_000) });
  if (!res.ok) {
+ dataFreshness.recordError('inpe-fires', `HTTP ${res.status}`);
  _cache = { hotspots: [], ts: Date.now() };
  return [];
  }
  const raw = await res.json() as (InpeHotspot & { acqTime: string })[];
  const hotspots = raw.map(h => ({ ...h, acqTime: new Date(h.acqTime) }));
  _cache = { hotspots, ts: Date.now() };
+ dataFreshness.recordUpdate('inpe-fires', hotspots.length);
  return hotspots;
-  } catch {
+  } catch (error) {
+ dataFreshness.recordError('inpe-fires', String(error));
  _cache = { hotspots: [], ts: Date.now() };
  return [];
   }

--- a/src/services/internet-outages.ts
+++ b/src/services/internet-outages.ts
@@ -8,6 +8,8 @@
  * to document government-ordered internet shutdowns.
  */
 
+import { dataFreshness } from './data-freshness';
+
 export interface IodaOutage {
   id: string;
   entityType: 'country' | 'asn' | 'region';
@@ -67,9 +69,12 @@ export async function fetchIodaOutages(): Promise<IodaOutage[]> {
  signal: AbortSignal.timeout(12_000),
  headers: { Accept: 'application/json' },
  });
- if (!res.ok) return cache?.outages ?? [];
+ if (!res.ok) {
+ dataFreshness.recordError('internet-outages', `HTTP ${res.status}`);
+ return cache?.outages ?? [];
+ }
 
- const data: IodaResponse = await res.json();
+ const data = await res.json() as IodaResponse;
  const alerts: IodaAlert[] = data.data ?? data.alerts ?? [];
 
  const outages: IodaOutage[] = alerts
@@ -79,8 +84,10 @@ export async function fetchIodaOutages(): Promise<IodaOutage[]> {
  const startTime = new Date(a.from * 1000);
  const endTime = a.until ? new Date(a.until * 1000) : null;
  const isOngoing = !endTime || endTime.getTime() > Date.now();
- const entityType = (a.entity?.type === 'country' ? 'country'
- : (a.entity?.type === 'asn' ? 'asn' : 'region')) as IodaOutage['entityType'];
+ let entityType: IodaOutage['entityType'];
+ if (a.entity?.type === 'country') entityType = 'country';
+ else if (a.entity?.type === 'asn') entityType = 'asn';
+ else entityType = 'region';
 
  return {
  id: `ioda-${a.entity?.code ?? i}-${a.from}`,
@@ -106,8 +113,10 @@ export async function fetchIodaOutages(): Promise<IodaOutage[]> {
  });
 
  cache = { outages: outages.slice(0, 50), fetchedAt: Date.now() };
+ dataFreshness.recordUpdate('internet-outages', cache.outages.length);
  return cache.outages;
-  } catch {
+  } catch (error) {
+ dataFreshness.recordError('internet-outages', String(error));
  return cache?.outages ?? [];
   }
 }

--- a/src/services/lightning.ts
+++ b/src/services/lightning.ts
@@ -9,6 +9,8 @@
  * We use the tile overlay for map visualization.
  */
 
+import { dataFreshness } from './data-freshness';
+
 export interface LightningStrike {
   lat: number;
   lon: number;
@@ -36,7 +38,10 @@ export async function fetchLightningStrikes(): Promise<LightningStrike[]> {
  signal: AbortSignal.timeout(8000),
  headers: { Accept: 'application/json' },
  });
- if (!res.ok) return cache?.strikes ?? [];
+ if (!res.ok) {
+ dataFreshness.recordError('lightning', `HTTP ${res.status}`);
+ return cache?.strikes ?? [];
+ }
 
  const data = await res.json() as BlitzStrike[];
 
@@ -48,8 +53,10 @@ export async function fetchLightningStrikes(): Promise<LightningStrike[]> {
  }));
 
  cache = { strikes, fetchedAt: Date.now() };
+ dataFreshness.recordUpdate('lightning', strikes.length);
  return strikes;
-  } catch {
+  } catch (error) {
+ dataFreshness.recordError('lightning', String(error));
  return cache?.strikes ?? [];
   }
 }

--- a/src/services/live-news.ts
+++ b/src/services/live-news.ts
@@ -1,4 +1,5 @@
 import { isDesktopRuntime, getRemoteApiBaseUrl } from '@/services/runtime';
+import { dataFreshness } from '@/services/data-freshness';
 
 interface LiveVideoInfo {
   videoId: string | null;
@@ -18,12 +19,15 @@ export async function fetchLiveVideoInfo(channelHandle: string): Promise<LiveVid
  const baseUrl = isDesktopRuntime() ? getRemoteApiBaseUrl() : '';
  const res = await fetch(`${baseUrl}/api/youtube/live?channel=${encodeURIComponent(channelHandle)}`);
  if (!res.ok) throw new Error('API error');
- const data = await res.json();
- const videoId = data.videoId || null;
- const hlsUrl = data.hlsUrl || null;
+ const data = await res.json() as { videoId?: string | null; hlsUrl?: string | null };
+ const videoId = data.videoId ?? null;
+ const hlsUrl = data.hlsUrl ?? null;
  liveVideoCache.set(channelHandle, { videoId, hlsUrl, timestamp: Date.now() });
+ dataFreshness.recordUpdate('live-news', videoId ? 1 : 0);
  return { videoId, hlsUrl };
   } catch (error) {
+ dataFreshness.recordError('live-news', String(error));
+ // eslint-disable-next-line no-console
  console.warn(`[LiveNews] Failed to fetch live info for ${channelHandle}:`, error);
  return { videoId: null, hlsUrl: null };
   }

--- a/src/services/marine-hazards.ts
+++ b/src/services/marine-hazards.ts
@@ -4,6 +4,10 @@
  * Data source: NWS Alerts API (direct — CORS enabled) + High Seas Forecasts
  */
 
+/* eslint-disable sonarjs/slow-regex -- regexes parse bounded NWS alert text */
+
+import { dataFreshness } from './data-freshness';
+
 export type MarineHazardType =
   | 'storm-surge'
   | 'high-surf'
@@ -147,7 +151,7 @@ function computeSeverity(
 function safeDate(raw: string | null | undefined): Date {
   if (!raw) return new Date();
   const d = new Date(raw);
-  return isNaN(d.getTime()) ? new Date() : d;
+  return Number.isNaN(d.getTime()) ? new Date() : d;
 }
 
 async function fetchAlerts(): Promise<MarineHazard[]> {
@@ -157,14 +161,16 @@ async function fetchAlerts(): Promise<MarineHazard[]> {
   });
   if (!res.ok) return [];
 
-  const json: NWSAlertsResponse = await res.json();
+  const json = await res.json() as NWSAlertsResponse;
   const features = json.features ?? [];
   const now = new Date();
   const results: MarineHazard[] = [];
 
   for (const feature of features) {
  const p = feature.properties ?? {};
- const id = feature.id ?? p.id ?? Math.random().toString(36).slice(2);
+ // eslint-disable-next-line sonarjs/pseudo-random -- ID jitter, not security-sensitive
+ const idFallback = Math.random().toString(36).slice(2);
+ const id = feature.id ?? p.id ?? idFallback;
  const event = p.event ?? '';
  const expires = safeDate(p.expires);
 
@@ -204,7 +210,7 @@ async function checkHighSeasForecasts(): Promise<boolean> {
  });
  if (!res.ok) return false;
 
- const json: NWSProductListResponse = await res.json();
+ const json = await res.json() as NWSProductListResponse;
  const products = json['@graph'] ?? [];
  if (products.length === 0) return false;
 
@@ -270,6 +276,11 @@ export async function fetchMarineHazards(): Promise<MarineHazard[]> {
  .slice(0, 50);
 
   cache = { data, ts: Date.now() };
+  if (alertsResult.status === 'rejected' && extremeHsfResult.status === 'rejected') {
+ dataFreshness.recordError('marine-hazards', 'both NWS alerts and HSF requests rejected');
+  } else {
+ dataFreshness.recordUpdate('marine-hazards', data.length);
+  }
   return data;
 }
 

--- a/src/services/maritime-safety.ts
+++ b/src/services/maritime-safety.ts
@@ -7,6 +7,9 @@
  * hydrographic office notices to mariners.
  */
 
+
+import { dataFreshness } from './data-freshness';
+
 export interface MaritimeWarning {
   id: string;
   msgYear: number;
@@ -95,7 +98,7 @@ function scoreSeverity(category: MaritimeWarning['category']): MaritimeWarning['
 function parseDate(str: string | null | undefined): Date | null {
   if (!str) return null;
   const d = new Date(str);
-  return isNaN(d.getTime()) ? null : d;
+  return Number.isNaN(d.getTime()) ? null : d;
 }
 
 export async function fetchMaritimeWarnings(): Promise<MaritimeWarning[]> {
@@ -106,9 +109,12 @@ export async function fetchMaritimeWarnings(): Promise<MaritimeWarning[]> {
  signal: AbortSignal.timeout(15_000),
  headers: { Accept: 'application/json' },
  });
- if (!res.ok) return cache?.warnings ?? [];
+ if (!res.ok) {
+ dataFreshness.recordError('maritime-safety', `HTTP ${res.status}`);
+ return cache?.warnings ?? [];
+ }
 
- const data: NgaMsiResponse = await res.json();
+ const data = await res.json() as NgaMsiResponse;
  const items: NgaMsiWarning[] = data.broadcastWarn ?? data.items ?? [];
 
  const now = Date.now();
@@ -152,8 +158,10 @@ export async function fetchMaritimeWarnings(): Promise<MaritimeWarning[]> {
  .slice(0, 100);
 
  cache = { warnings: filtered, fetchedAt: Date.now() };
+ dataFreshness.recordUpdate('maritime-safety', filtered.length);
  return filtered;
-  } catch {
+  } catch (error) {
+ dataFreshness.recordError('maritime-safety', String(error));
  return cache?.warnings ?? [];
   }
 }

--- a/src/services/noaa-buoys.ts
+++ b/src/services/noaa-buoys.ts
@@ -12,10 +12,16 @@
  *  - Rapid pressure drops (bomb cyclogenesis)
  *  - Extreme wind events over open ocean
  *
+ * Wired to data-freshness telemetry under 'noaa-buoys'.
+ *
  * NOAA Hurricane Reconnaissance (NOAA/AFRES WC-130J/P-3):
  *  - Flight tracks at https://www.nhc.noaa.gov/recon/
  *  - Real-time fixes via NHC Vortex Data Messages (VDMs)
  */
+
+/* eslint-disable sonarjs/slow-regex, sonarjs/regex-complexity, sonarjs/cognitive-complexity, sonarjs/no-nested-template-literals -- file-level: regexes parse bounded NHC VDM RSS text + NDBC station XML, complexity is in the parsers */
+
+import { dataFreshness } from './data-freshness';
 
 export interface BuoyObservation {
   stationId: string;
@@ -100,7 +106,7 @@ function parseBuoyLine(line: string, headers: string[]): Record<string, string> 
 function toNum(val: string | undefined): number | null {
   if (!val || val === 'MM' || val === 'N/A') return null;
   const n = Number.parseFloat(val);
-  return isNaN(n) ? null : n;
+  return Number.isNaN(n) ? null : n;
 }
 
 function computeAlertCondition(obs: Partial<BuoyObservation>): { isAlert: boolean; reason: string; severity: BuoyObservation['severity'] } {
@@ -260,6 +266,11 @@ export async function fetchBuoyAlerts(): Promise<BuoyObservation[]> {
  });
 
   buoyCache = { observations, fetchedAt: Date.now() };
+  if (results.every(r => r.status === 'rejected')) {
+ dataFreshness.recordError('noaa-buoys', `all ${results.length} buoy fetches rejected`);
+  } else {
+ dataFreshness.recordUpdate('noaa-buoys', observations.length);
+  }
   return observations;
 }
 

--- a/src/services/nrc-nuclear.ts
+++ b/src/services/nrc-nuclear.ts
@@ -7,6 +7,8 @@
  * unusual events, reactor trips, radiological releases.
  */
 
+import { dataFreshness } from './data-freshness';
+
 export interface NrcEvent {
   id: string;
   title: string;
@@ -69,7 +71,10 @@ export async function fetchNrcEvents(): Promise<NrcEvent[]> {
 
   try {
  const res = await fetch(rssProxyUrl(NRC_RSS), { signal: AbortSignal.timeout(12_000) });
- if (!res.ok) return cache?.events ?? [];
+ if (!res.ok) {
+ dataFreshness.recordError('nrc-nuclear', `HTTP ${res.status}`);
+ return cache?.events ?? [];
+ }
 
  const text = await res.text();
  const parser = new DOMParser();
@@ -93,7 +98,10 @@ export async function fetchNrcEvents(): Promise<NrcEvent[]> {
 
  const rawKey = (title + pubDateStr).slice(0, 60);
  let shortId = '';
- try { shortId = btoa(unescape(encodeURIComponent(rawKey))).slice(0, 20); } catch { shortId = rawKey.replace(/\W/g, '').slice(0, 20); }
+ try {
+ const utf8 = new TextEncoder().encode(rawKey);
+ shortId = btoa(String.fromCodePoint(...utf8)).slice(0, 20);
+ } catch { shortId = rawKey.replace(/\W/g, '').slice(0, 20); }
  events.push({
  id: `nrc-${shortId}`,
  title,
@@ -112,8 +120,10 @@ export async function fetchNrcEvents(): Promise<NrcEvent[]> {
  .slice(0, 30);
 
  cache = { events: recent, fetchedAt: Date.now() };
+ dataFreshness.recordUpdate('nrc-nuclear', recent.length);
  return recent;
-  } catch {
+  } catch (error) {
+ dataFreshness.recordError('nrc-nuclear', String(error));
  return cache?.events ?? [];
   }
 }

--- a/src/services/ntsb-investigations.ts
+++ b/src/services/ntsb-investigations.ts
@@ -3,6 +3,10 @@
  * Sources: NTSB RSS feeds via rss-proxy
  */
 
+/* eslint-disable sonarjs/slow-regex, sonarjs/regex-complexity -- regexes parse bounded NTSB RSS feeds */
+
+import { dataFreshness } from './data-freshness';
+
 export type NtsbMode =
   | 'aviation'
   | 'rail'
@@ -135,6 +139,7 @@ function detectGoTeam(title: string, description: string): boolean {
 }
 
 function extractNumber(text: string, pattern: RegExp): number {
+  // eslint-disable-next-line sonarjs/prefer-regexp-exec -- API receives RegExp arg
   const m = text.match(pattern);
   return m?.[1] ? Number.parseInt(m[1] ?? '0', 10) : 0;
 }
@@ -168,11 +173,12 @@ function computeSeverity(
 function titleHash(title: string): string {
   let h = 0;
   for (let i = 0; i < title.length; i++) {
- h = ((h << 5) - h + title.charCodeAt(i)) | 0;
+ h = Math.trunc((h << 5) - h + (title.codePointAt(i) ?? 0));
   }
   return `ntsb-${Math.abs(h)}`;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- _feedUrl reserved for future per-feed routing
 function parseFeedXml(text: string, _feedUrl: string): NtsbInvestigation[] {
   const parser = new DOMParser();
   const doc = parser.parseFromString(text, 'text/xml');
@@ -278,6 +284,11 @@ export async function fetchNtsbInvestigations(): Promise<NtsbInvestigation[]> {
  .slice(0, 30);
 
   cache = { data: filtered, ts: now };
+  if (results.every(r => r.status === 'rejected')) {
+ dataFreshness.recordError('ntsb-investigations', `all ${results.length} feeds rejected`);
+  } else {
+ dataFreshness.recordUpdate('ntsb-investigations', filtered.length);
+  }
   return filtered;
 }
 

--- a/src/services/nuclear-monitor.ts
+++ b/src/services/nuclear-monitor.ts
@@ -11,6 +11,7 @@
  */
 import { getApiBaseUrl } from '@/services/runtime';
 import { loadProximityConfig, haversineKm } from '@/services/proximity-filter';
+import { dataFreshness } from '@/services/data-freshness';
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -410,5 +411,10 @@ export async function fetchNuclearStatus(): Promise<NuclearMonitorData> {
   };
 
   cache = { data, fetchedAt: Date.now() };
+  if (stationsResult.status === 'rejected' && anomaliesResult.status === 'rejected') {
+ dataFreshness.recordError('nuclear-monitor', 'both RadNet and seismic anomaly requests rejected');
+  } else {
+ dataFreshness.recordUpdate('nuclear-monitor', stations.length + seismicAnomalies.length);
+  }
   return data;
 }


### PR DESCRIPTION
Mid-slice batch (positions 16-45 of unwired list) for freshness wiring + lint cleanup.

Targeted to merge into \`claude/freshness-wiring\` (NOT main) so the front and middle streams merge cleanly.

## Files wired (26)

**Batch 1 (13):** evacuation-router, faa-cameras, faa-nas-status, faa-tfrs, fdic-failures, federal-register, fema-disasters, flood-gauges, food-insecurity, foreign-mil-news, gps-interference, habsos, hazmat-incidents

**Batch 2 (13):** hdx-crisis, iaea-nuclear, inciweb, inpe-fires, internet-outages, lightning, live-news, marine-hazards, maritime-safety, noaa-buoys, nrc-nuclear, ntsb-investigations, nuclear-monitor

## Skipped (4)
\`financial-contagion.ts\`, \`forecast-overlay.ts\`, \`intelligence-briefing.ts\`, \`news-translation.ts\` — matched the cached-files grep but are derivative services (no direct upstream fetch). Don't have a source ID in the data-freshness enum and shouldn't.

## Wiring pattern

Following the \`adsb-military.ts\` reference:
- \`dataFreshness.recordUpdate(sourceId, count)\` after successful fetch+parse
- \`dataFreshness.recordError(sourceId, message)\` in catch + on \`!res.ok\`
- For composite services (Promise.allSettled across 2-3 feeds): record error only when **all** feeds rejected; record update otherwise

## Lint fixes applied

- \`isNaN\` → \`Number.isNaN\`
- \`||=\` → \`??=\` for nullish-coalescing assignment
- \`const x: T = await res.json()\` → \`as\` cast for \`@typescript-eslint/no-unsafe-assignment\`
- Nested template literals lifted to local consts
- \`combined.sort(...)\` → \`[...combined].sort(...)\` for \`no-misleading-array-reverse\`
- \`unescape()\` (deprecated) replaced with TextEncoder + btoa(fromCodePoint)
- \`charCodeAt\` → \`codePointAt\`, \`fromCharCode\` → \`fromCodePoint\`, \`| 0\` → \`Math.trunc\`
- Ternary-in-cast (\`internet-outages\`) lifted to explicit if/else
- Pseudo-random ID jitter — inline \`sonarjs/pseudo-random\` disable with rationale
- File-level \`sonarjs/slow-regex\` / \`regex-complexity\` / \`cognitive-complexity\` disables for parsers of bounded RSS/XML feeds (NWS, NHC VDM, NTSB, IAEA, InciWeb)

## Validation

- \`npm run typecheck:all\` clean after each batch (zero errors)
- \`npx eslint <26 files>\` clean (zero errors, zero warnings)
- 2 commits, one per batch