### PR TITLE
fix(map): center-anchor map icons so planes don't float north of their geo position

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -388,7 +388,7 @@ const ICON_DRAW_FNS: Record<string, IconDrawFn> = {
 
  
 let _iconAtlas: any = null;
-let _iconMapping: Record<string, { x: number; y: number; width: number; height: number; mask: boolean }> | null = null;
+let _iconMapping: Record<string, { x: number; y: number; width: number; height: number; anchorX: number; anchorY: number; mask: boolean }> | null = null;
 
 // DeckGL accepts HTMLCanvasElement at runtime but types only allow string | Texture
  
@@ -407,14 +407,25 @@ function getIconAtlas(): any {
     ctx.translate(i * ICON_SIZE, 0);
     ICON_DRAW_FNS[name!]!(ctx);
     ctx.restore();
-    mapping[name!] = { x: i * ICON_SIZE, y: 0, width: ICON_SIZE, height: ICON_SIZE, mask: true };
+    // Anchor each icon at its center, not the DeckGL default of bottom-center.
+    // Without explicit anchorY, every icon (planes, cyclones, fires, …) is
+    // drawn with its bottom edge at the geo point — visually offset upward
+    // by half the icon height. The displacement is in screen pixels, so it
+    // looks larger at low zoom and becomes obvious once you pan in close
+    // enough to compare planes against runways.
+    mapping[name!] = {
+      x: i * ICON_SIZE, y: 0,
+      width: ICON_SIZE, height: ICON_SIZE,
+      anchorX: ICON_SIZE / 2, anchorY: ICON_SIZE / 2,
+      mask: true,
+    };
   }
   _iconAtlas = canvas;
   _iconMapping = mapping;
   return canvas;
 }
 
-function getIconMapping(): Record<string, { x: number; y: number; width: number; height: number; mask: boolean }> {
+function getIconMapping(): Record<string, { x: number; y: number; width: number; height: number; anchorX: number; anchorY: number; mask: boolean }> {
   if (!_iconMapping) getIconAtlas();
   return _iconMapping!;
 }


### PR DESCRIPTION
## Symptom

Reported: planes appear in the wrong place on the 2D map — visually offset from where they should be, especially noticeable when panning in close enough to compare against airport runways.

## Root cause

DeckGL's `IconLayer` `iconMapping` defaults to anchoring icons at **bottom-center** (`anchorY = height`) when `anchorX` / `anchorY` are omitted from the mapping entry. Crystal Ball's [`iconMapping`](src/components/DeckGLMap.ts#L410) relied on those defaults, so every icon (planes, cyclones, fires, ships, fighters, …) was drawn with its bottom edge pinned to the geo point — visually displaced upward by ~half the icon height (16 px) in screen pixels.

The offset is fixed in pixels but corresponds to a varying geographic distance depending on zoom: invisible at world zoom, but obvious once you pan in close enough to compare planes against runways or ships against ports.

## Fix

Explicitly set `anchorX = anchorY = ICON_SIZE / 2` (center-anchor) in the `iconMapping`. All current icon shapes (`triangleUp`, `hexagon`, `square`, `circle`, `diamond`, `star`, `airplane`, `fighter`, `ship`, `satellite`, `earthquake`, `fire`, `lightning`, `rocket`, `anchor`, `crosshair`, `biohazard`, `shield`, `cloud`, `turbine`, `chart`, `bank`) are designed to be visually centered within their 32×32 cell, so center-anchor is correct for all of them — no per-icon override needed.

Type signatures for `_iconMapping` and `getIconMapping()` updated to include the new anchor fields.

## Verification

- `npm run typecheck:all`: ✅ clean
- Map renders without errors in vite dev preview
- **Live ADS-B verification requires the Tauri sidecar** — vite dev returns HTML for `/api/adsb` so plane positions can't be observed in the dev preview. A desktop build will show planes settling onto runways/airports instead of floating north of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)