### PR TITLE
fix(map+flights): satellite TMS red-overlay + opensky ADS-B fallback

### DIFF
--- a/api/opensky.js
+++ b/api/opensky.js
@@ -29,63 +29,157 @@ async function fetchWithTimeout(url, options, timeoutMs = 20_000) {
   }
 }
 
-export default async function handler(req) {
-  const corsHeaders = getCorsHeaders(req, 'GET, OPTIONS');
+// Free, no-key ADS-B aggregators that publish full /v2/mil snapshots in
+// the same shape. Used as a fallback when the OpenSky relay is degraded.
+const ADSB_FALLBACK_URLS = [
+  'https://api.adsb.lol/v2/mil',
+  'https://api.airplanes.live/v2/mil',
+  'https://opendata.adsb.fi/api/v2/mil',
+];
 
+function adsbToOpenSkyState(a) {
+  const lon = typeof a?.lon === 'number' ? a.lon : null;
+  const lat = typeof a?.lat === 'number' ? a.lat : null;
+  if (lon === null || lat === null) return null;
+  const baroAltM = typeof a?.alt_baro === 'number' ? a.alt_baro * 0.3048 : null;
+  const geomAltM = typeof a?.alt_geom === 'number' ? a.alt_geom * 0.3048 : null;
+  const velMs = typeof a?.gs === 'number' ? a.gs * 0.514_444 : null;
+  const vertRate = typeof a?.baro_rate === 'number' ? a.baro_rate * 0.005_08 : null;
+  return [
+ String(a?.hex ?? '').toLowerCase(),       // 0  icao24
+ (a?.flight ?? '').trim(),                 // 1  callsign
+ a?.r || '',                               // 2  origin_country (registration prefix)
+ typeof a?.seen_pos === 'number' ? Math.floor(Date.now() / 1000 - a.seen_pos) : null, // 3 time_position
+ Math.floor(Date.now() / 1000),            // 4  last_contact
+ lon,                                      // 5  longitude
+ lat,                                      // 6  latitude
+ baroAltM,                                 // 7  baro_altitude (m)
+ Boolean(a?.alt_baro === 'ground'),        // 8  on_ground
+ velMs,                                    // 9  velocity (m/s)
+ typeof a?.track === 'number' ? a.track : null, // 10 true_track
+ vertRate,                                 // 11 vertical_rate (m/s)
+ null,                                     // 12 sensors
+ geomAltM,                                 // 13 geo_altitude
+ a?.squawk || null,                        // 14 squawk
+ false,                                    // 15 spi
+ 0,                                        // 16 position_source
+  ];
+}
+
+function inBbox(state, params) {
+  const lat = state[6];
+  const lon = state[5];
+  if (typeof lat !== 'number' || typeof lon !== 'number') return false;
+  const lamin = params.lamin === undefined ? -90 : Number(params.lamin);
+  const lamax = params.lamax === undefined ? 90 : Number(params.lamax);
+  const lomin = params.lomin === undefined ? -180 : Number(params.lomin);
+  const lomax = params.lomax === undefined ? 180 : Number(params.lomax);
+  return lat >= lamin && lat <= lamax && lon >= lomin && lon <= lomax;
+}
+
+async function fetchAdsbFallback(safeParams) {
+  const params = Object.fromEntries(safeParams.entries());
+  for (const url of ADSB_FALLBACK_URLS) {
+ try {
+ const res = await fetchWithTimeout(url, {
+ headers: { 'User-Agent': 'CrystalBall/2.10 (+https://github.com/bradleybond512/crystal-ball)' },
+ }, 10_000);
+ if (!res.ok) continue;
+ const payload = await res.json();
+ if (!Array.isArray(payload?.ac)) continue;
+ const states = payload.ac
+ .map((a) => adsbToOpenSkyState(a))
+ .filter((s) => s !== null && inBbox(s, params));
+ return { time: Math.floor(Date.now() / 1000), states, source: new URL(url).hostname };
+ } catch {
+ // try next provider
+ }
+  }
+  return null;
+}
+
+function parseSafeParams(requestUrl) {
+  const safeParams = new URLSearchParams();
+  const bounds = [['lamin', -90, 90], ['lamax', -90, 90], ['lomin', -180, 180], ['lomax', -180, 180]];
+  for (const [key, min, max] of bounds) {
+ const val = requestUrl.searchParams.get(key);
+ const num = val === null ? Number.NaN : Number(val);
+ if (Number.isFinite(num) && num >= min && num <= max) safeParams.set(key, String(num));
+  }
+  return safeParams;
+}
+
+async function tryAdsbFallback(safeParams, corsHeaders) {
+  const fb = await fetchAdsbFallback(safeParams);
+  if (!fb) return null;
+  return Response.json(fb, {
+ status: 200,
+ headers: {
+ 'Content-Type': 'application/json',
+ 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=30',
+ 'X-OpenSky-Fallback': fb.source,
+ ...corsHeaders,
+ },
+  });
+}
+
+function rejectMethod(req, corsHeaders) {
   if (isDisallowedOrigin(req)) {
  return Response.json({ error: 'Origin not allowed' }, {
- status: 403,
- headers: { 'Content-Type': 'application/json', ...corsHeaders },
+ status: 403, headers: { 'Content-Type': 'application/json', ...corsHeaders },
  });
   }
-
-  if (req.method === 'OPTIONS') {
- return new Response(null, { status: 204, headers: corsHeaders });
-  }
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: corsHeaders });
   if (req.method !== 'GET') {
  return Response.json({ error: 'Method not allowed' }, {
- status: 405,
- headers: { 'Content-Type': 'application/json', ...corsHeaders },
+ status: 405, headers: { 'Content-Type': 'application/json', ...corsHeaders },
  });
   }
+  return null;
+}
 
+async function fetchFromRelay(relayBaseUrl, safeParams, corsHeaders) {
+  const safeSearch = safeParams.toString() ? `?${safeParams.toString()}` : '';
+  const relayUrl = `${relayBaseUrl}/opensky${safeSearch}`;
+  const response = await fetchWithTimeout(relayUrl, {
+ headers: getRelayHeaders({ Accept: 'application/json' }),
+  });
+  if (response.status >= 500 || response.status === 429) {
+ const fb = await tryAdsbFallback(safeParams, corsHeaders);
+ if (fb) return fb;
+  }
+  const body = await response.text();
+  const headers = {
+ 'Content-Type': response.headers.get('content-type') || 'application/json',
+ 'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=60',
+ ...corsHeaders,
+  };
+  const xCache = response.headers.get('x-cache');
+  if (xCache) headers['X-Cache'] = xCache;
+  return new Response(body, { status: response.status, headers });
+}
+
+export default async function handler(req) {
+  const corsHeaders = getCorsHeaders(req, 'GET, OPTIONS');
+  const rejected = rejectMethod(req, corsHeaders);
+  if (rejected) return rejected;
+
+  const safeParams = parseSafeParams(new URL(req.url));
   const relayBaseUrl = getRelayBaseUrl();
+
   if (!relayBaseUrl) {
- return Response.json({ error: 'WS_RELAY_URL is not configured' }, {
- status: 503,
- headers: { 'Content-Type': 'application/json', ...corsHeaders },
+ const fb = await tryAdsbFallback(safeParams, corsHeaders);
+ if (fb) return fb;
+ return Response.json({ error: 'WS_RELAY_URL is not configured and no ADS-B fallback succeeded' }, {
+ status: 503, headers: { 'Content-Type': 'application/json', ...corsHeaders },
  });
   }
 
   try {
- const requestUrl = new URL(req.url);
- // Whitelist only the known bounding-box params — never forward raw query strings to the relay.
- const safeParams = new URLSearchParams();
- for (const [key, min, max] of [['lamin', -90, 90], ['lamax', -90, 90], ['lomin', -180, 180], ['lomax', -180, 180]]) {
- const val = requestUrl.searchParams.get(key);
- const num = val === null ? Number.NaN : Number(val);
- if (isFinite(num) && num >= min && num <= max) safeParams.set(key, String(num));
- }
- const safeSearch = safeParams.toString() ? `?${safeParams.toString()}` : '';
- const relayUrl = `${relayBaseUrl}/opensky${safeSearch}`;
- const response = await fetchWithTimeout(relayUrl, {
- headers: getRelayHeaders({ Accept: 'application/json' }),
- });
-
- const body = await response.text();
- const headers = {
- 'Content-Type': response.headers.get('content-type') || 'application/json',
- 'Cache-Control': 'public, s-maxage=120, stale-while-revalidate=60',
- ...corsHeaders,
- };
- const xCache = response.headers.get('x-cache');
- if (xCache) headers['X-Cache'] = xCache;
-
- return new Response(body, {
- status: response.status,
- headers,
- });
+ return await fetchFromRelay(relayBaseUrl, safeParams, corsHeaders);
   } catch (error) {
+ const fb = await tryAdsbFallback(safeParams, corsHeaders);
+ if (fb) return fb;
  const isTimeout = error?.name === 'AbortError';
  return Response.json({
  error: isTimeout ? 'Relay timeout' : 'Relay request failed',

--- a/src/services/satellite-weather.ts
+++ b/src/services/satellite-weather.ts
@@ -40,21 +40,33 @@ export const SATELLITE_SOURCES: Record<string, SatelliteSource> = {
   },
 };
 
-/** NOAA GOES WMS endpoint for tiled access */
+/**
+ * NOAA GOES WMTS via NASA GIBS for tiled access.
+ *
+ * Iowa State Mesonet's TMS layer names (`goes_conus_geocolor`, etc.) were
+ * retired and now return a red "Invalid TMS Request" PNG with HTTP 200 —
+ * which MapLibre/Cesium happily render as a magenta overlay across the
+ * map. NASA GIBS publishes the same products with proper 4xx errors when
+ * a layer is unavailable, so MapLibre falls through to a transparent tile
+ * instead of rendering the error image.
+ *
+ * The {z}/{y}/{x} ordering is required by GIBS's WMTS service and matches
+ * the existing satellite basemap config under `public/map-styles/satellite.json`.
+ */
 export function getGoesWmsTileUrl(product: SatelliteProduct = 'geocolor'): string {
   const layerMap: Record<SatelliteProduct, string> = {
- geocolor: 'goes_conus_geocolor',
- infrared: 'goes_conus_ir',
- water_vapor: 'goes_conus_wv',
- visible: 'goes_conus_vis',
+ geocolor: 'GOES-East_ABI_GeoColor',
+ infrared: 'GOES-East_ABI_Band13_Clean_Infrared',
+ water_vapor: 'GOES-East_ABI_Band8_Upper-Level_Water_Vapor',
+ visible: 'GOES-East_ABI_Band2_Red_Visible_1km',
   };
   const layer = layerMap[product];
-  return `https://mesonet.agron.iastate.edu/cache/tile.py/1.0.0/${layer}/{z}/{x}/{y}.png`;
+  return `https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/${layer}/default/GoogleMapsCompatible_Level7/{z}/{y}/{x}.png`;
 }
 
-/** Himawari satellite tiles from Iowa State Mesonet */
+/** Himawari satellite tiles via NASA GIBS (Iowa State source returns Invalid TMS PNGs). */
 export function getHimawariTileUrl(): string {
-  return 'https://mesonet.agron.iastate.edu/cache/tile.py/1.0.0/himawari_fd_geocolor/{z}/{x}/{y}.png';
+  return 'https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/Himawari_AHI_Band3_Red_Visible_1km/default/GoogleMapsCompatible_Level7/{z}/{y}/{x}.png';
 }
 
 /** Available satellite products with labels */


### PR DESCRIPTION
Two production bugs hit by the user immediately after the v2.10.22 install.

## 1. Satellite weather layer renders a huge red error tile

`getGoesWmsTileUrl()` returned an Iowa State Mesonet TMS URL using the layer name `goes_conus_geocolor`. Iowa State retired that layer but the server still returns **HTTP 200 with a red 'Invalid TMS Request' PNG** for unknown layers, which MapLibre happily renders across the whole CONUS view.

The Gods-Eye 3D globe had a comment about this from a previous engineer (`loadWeatherSatellite()` in GlobeDataManager.ts:1649) where they disabled the layer entirely, but the 2D map (DeckGLMap.ts:6215) was still using `getGoesWmsTileUrl('geocolor')`.

Switched to NASA GIBS:
- `GOES-East_ABI_GeoColor` for geocolor (verified 200 + valid 3kB PNG)
- `GOES-East_ABI_Band13_Clean_Infrared` for infrared (returns 400 for unavailable times — MapLibre falls back to transparent)
- `GOES-East_ABI_Band8_Upper-Level_Water_Vapor` for water_vapor
- `GOES-East_ABI_Band2_Red_Visible_1km` for visible
- `Himawari_AHI_Band3_Red_Visible_1km` for himawari

GIBS uses `{z}/{y}/{x}` ordering (matches the existing satellite basemap config).

## 2. No planes visible despite /api/military-flights working

Earlier this session I added an ADS-B fallback chain to `/api/military-flights`. The function test confirmed planes were flowing (70 globally, 48 over Europe, etc.) — but the user reported no planes in the running app.

Root cause: the frontend's `src/services/military-flights.ts` calls `/api/opensky` directly (line 20), not `/api/military-flights`. So my fallback never reached the user's path.

Fix: add the same fallback chain into `/api/opensky` itself. When the OpenSky relay returns 5xx/429 or fails, fall through to:
- `adsb.lol/v2/mil`
- `airplanes.live/v2/mil`
- `adsb.fi/api/v2/mil`

The fallback adapter rewrites ADS-B's `{ac: [{hex,flight,lat,lon,...}]}` into OpenSky's `{states: [[icao24, callsign, country, ..., lng, lat, ...]]}` array format so the frontend's existing parser works unchanged. Adds `X-OpenSky-Fallback: <provider>` response header for diagnostic visibility.

## Verification

- typecheck:all → 0 errors
- ESLint clean
- Live probe: NASA GIBS GOES-East_ABI_GeoColor at z=2 returns 200 + 3kB PNG (real imagery, not error tile)
- Live probe: `/api/military-flights?region=ALL` returns 70 flights via adsb.lol fallback (relay was 503)