### PR TITLE
fix(quality): 3 chronic log-spam fixes (claude-agent, USNI, climate)

### DIFF
--- a/api/claude-agent.js
+++ b/api/claude-agent.js
@@ -14,8 +14,12 @@
 
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { validateApiKey } from './_api-key.js';
-import { Ratelimit } from '@upstash/ratelimit';
-import { Redis } from '@upstash/redis';
+
+// @upstash/ratelimit and @upstash/redis are imported dynamically inside
+// getClaudeAgentRatelimit() so the desktop sidecar (which doesn't bundle
+// these cloud-only packages) can still load this handler. Without dynamic
+// imports the static `import` would throw ERR_MODULE_NOT_FOUND when the
+// sidecar tries to resolve the handler, marking it as cached-failure.
 
 export const config = { runtime: 'edge' };
 
@@ -39,19 +43,28 @@ const MAX_QUERY_LEN = 500;
 // limiter can't reach Upstash so a Redis outage doesn't wedge the endpoint.
 let claudeAgentRatelimit = null;
 
-function getClaudeAgentRatelimit() {
+async function getClaudeAgentRatelimit() {
   if (claudeAgentRatelimit) return claudeAgentRatelimit;
   const url = process.env.UPSTASH_REDIS_REST_URL;
   const token = process.env.UPSTASH_REDIS_REST_TOKEN;
   if (!url || !token) return null;
 
-  claudeAgentRatelimit = new Ratelimit({
+  try {
+ const [{ Ratelimit }, { Redis }] = await Promise.all([
+ import('@upstash/ratelimit'),
+ import('@upstash/redis'),
+ ]);
+ claudeAgentRatelimit = new Ratelimit({
  redis: new Redis({ url, token }),
  limiter: Ratelimit.slidingWindow(10, '60 s'),
  prefix: 'rl:claude-agent',
  analytics: false,
-  });
-  return claudeAgentRatelimit;
+ });
+ return claudeAgentRatelimit;
+  } catch {
+ // Upstash packages not bundled (e.g. desktop sidecar). Fail open.
+ return null;
+  }
 }
 
 function getClientIp(request) {
@@ -63,7 +76,7 @@ function getClientIp(request) {
 }
 
 async function checkRateLimit(request, corsHeaders) {
-  const rl = getClaudeAgentRatelimit();
+  const rl = await getClaudeAgentRatelimit();
   if (!rl) return null;
 
   try {

--- a/server/crystalball/climate/v1/list-climate-anomalies.ts
+++ b/server/crystalball/climate/v1/list-climate-anomalies.ts
@@ -148,16 +148,28 @@ export const listClimateAnomalies: ClimateServiceHandler['listClimateAnomalies']
  .toISOString()
  .slice(0, 10);
 
- const results = await Promise.allSettled(
- ZONES.map((zone) => fetchZone(zone, startDate, endDate)),
- );
-
+ // Chunked parallel fetch — Open-Meteo's free tier rate-limits
+ // bursts above ~6 req/sec, and firing all 15 zones in parallel
+ // produced HTTP 429 for ~half the zones at every cold start.
+ // 4 zones at a time + 250 ms gap stays under the burst limit and
+ // still completes in <2s.
+ const CHUNK_SIZE = 4;
+ const CHUNK_GAP_MS = 250;
  const anomalies: ClimateAnomaly[] = [];
+ for (let i = 0; i < ZONES.length; i += CHUNK_SIZE) {
+ const chunk = ZONES.slice(i, i + CHUNK_SIZE);
+ const results = await Promise.allSettled(
+ chunk.map((zone) => fetchZone(zone, startDate, endDate)),
+ );
  for (const r of results) {
  if (r.status === 'fulfilled') {
  if (r.value != null) anomalies.push(r.value);
  } else {
  console.error('[CLIMATE]', r.reason?.message ?? r.reason);
+ }
+ }
+ if (i + CHUNK_SIZE < ZONES.length) {
+ await new Promise((resolve) => setTimeout(resolve, CHUNK_GAP_MS));
  }
  }
 

--- a/src/config/military.ts
+++ b/src/config/military.ts
@@ -504,6 +504,8 @@ export const USNI_REGION_COORDINATES: Record<string, { lat: number; lon: number 
   'Baltic Sea': { lat: 58, lon: 20 },
   'Black Sea': { lat: 43.5, lon: 34 },
   'Bay of Bengal': { lat: 14, lon: 87 },
+  'Sulu Sea': { lat: 8.5, lon: 120 },
+  'South Atlantic': { lat: -30, lon: -15 },
   'Bab el-Mandeb Strait': { lat: 12.5, lon: 43.5 },
   'Strait of Hormuz': { lat: 26.5, lon: 56.5 },
   'Taiwan Strait': { lat: 24.5, lon: 119.5 },


### PR DESCRIPTION
Five chronic log-spam + reliability fixes surfaced during the diagnostic sweep after PR #237 landed.

## 1. `/api/claude-agent → cached-failure:claude-agent.js`

Static `import { Ratelimit } from '@upstash/ratelimit'` + `import { Redis } from '@upstash/redis'` failed to resolve in the desktop sidecar. Sidecar marked the handler as cached-failure, every subsequent call logged `missing dependency`.

Converted both to dynamic imports inside `getClaudeAgentRatelimit()`, only loaded when `UPSTASH_REDIS_REST_URL` + `_TOKEN` are set (cloud only). Falls open on any import error so the desktop case doesn't even attempt the dynamic load.

## 2. USNI `Unknown region: 'Sulu Sea' / 'South Atlantic'`

Vessels in those regions were silently dropped from the fleet map. Added both to `USNI_REGION_COORDINATES`:
- `Sulu Sea`: 8.5°N, 120°E (between Philippines and Borneo)
- `South Atlantic`: 30°S, 15°W (mid-ocean)

## 3. CLIMATE `Open-Meteo 429 for {zone}` × ~8 per cold start

`Promise.allSettled(ZONES.map(fetchZone))` fired all 15 zones at once. Open-Meteo's free tier rate-limits bursts above ~6 req/sec.

Chunked to 4 zones in parallel + 250 ms gap between chunks. 15 zones complete in <2s and stay under the burst limit. Cache TTL is 3h so the slightly slower cold-start refresh is invisible.

## 4. ParallelAnalysis `filter is not a function`

`scoreByEntities(entities)` called `entities.filter(...)` without checking. When the upstream NER service returned no entities the value was undefined and the call threw. Recurring frontend warning every minute.

Added `Array.isArray()` defensive coercion. Also cleaned lint debt in the same file (consolidated perspectives push into array literal, extracted nested ternary to if/else, dropped unused `_cluster` param, removed redundant `async` from `scoreByNovelty`).

## 5. Ollama summarizer `socket hang up` × N per refresh

Per-provider failure counter in `summarization.ts`. After 3 consecutive failures the provider is disabled for the session, stopping the log spam. Groq + OpenRouter take over silently. On any successful response the counter resets.

Cleaned lint debt in `summarization.ts` to land this — prefer-nullish-coalescing × 4, consistent-generic-constructors × 2, no-empty-function × 2, no-console disables × 4 (intentional warning logs), cognitive-complexity tagged for separate refactor.