### PR TITLE
[codex] fix QA regressions after panel/weather changes

### DIFF
--- a/src/services/data-freshness.ts
+++ b/src/services/data-freshness.ts
@@ -4,7 +4,7 @@
  * showing misleading "all clear" when we actually have no data.
  */
 
-import { getCSSColor } from '@/utils';
+import { getCSSColor } from '@/utils/theme-colors';
 
 export type DataSourceId =
   | 'acled' // Protests/conflicts

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -1,7 +1,8 @@
 import { isDesktopRuntime, toRuntimeUrl } from '../services/runtime';
 import { getPersistentCache, setPersistentCache } from '../services/persistent-cache';
 
-const isDev = import.meta.env.DEV;
+const VITE_ENV = (import.meta as { env?: { DEV?: boolean } }).env ?? {};
+const isDev = VITE_ENV.DEV === true;
 const RESPONSE_CACHE_PREFIX = 'api-response:';
 
 interface CachedResponsePayload {
@@ -65,7 +66,7 @@ async function fetchAndPersist(url: string): Promise<Response> {
  const body = await response.clone().text();
  void setPersistentCache(buildResponseCacheKey(url), toCachedPayload(url, response, body));
  } catch (error) {
- console.warn('[proxy] Failed to persist API response cache', error);
+ console.warn('[proxy] Failed to persist API response cache', error); // eslint-disable-line no-console
  }
   }
   return response;
@@ -81,7 +82,7 @@ export async function fetchWithProxy(url: string): Promise<Response> {
 
   if (cached?.data) {
  void fetchAndPersist(url).catch((error) => {
- console.warn('[proxy] Background refresh failed for cached API response', error);
+ console.warn('[proxy] Background refresh failed for cached API response', error); // eslint-disable-line no-console
  });
  return toResponse(cached.data);
   }

--- a/tests/panel-order-regression.test.mjs
+++ b/tests/panel-order-regression.test.mjs
@@ -35,7 +35,7 @@ describe('panel order regressions', () => {
  );
  assert.match(
  readFileSync(resolve(root, 'src/app/panel-layout.ts'), 'utf8'),
- /private static readonly DISASTER_PRIORITY = \[[\s\S]*?'saved-places'[\s\S]*?'tropical-cyclones'[\s\S]*?'nws-alerts'[\s\S]*?'weather'/,
+ /private static readonly DISASTER_PRIORITY = \[[\s\S]*?'saved-places'[\s\S]*?'tropical-cyclones'[\s\S]*?'nws-alerts'[\s\S]*?'global-weather'[\s\S]*?'weather-radar'/,
  'disaster mode should lift saved places and storm panels ahead of generic disaster feeds',
  );
   });


### PR DESCRIPTION
## Issue

Recent panel/weather changes left two regression gates stale under the bare Node/tsx test environment:

- the disaster-mode panel-order regression still expected the legacy `weather` panel id even though the app now promotes `global-weather` and `weather-radar`;
- `src/utils/proxy.ts` assumed Vite's `import.meta.env` exists, which crashes Node-based tests that import services through the WPC weather parser path.

A related import path in `data-freshness` pulled the full `@/utils` barrel into Node tests, which can transitively load browser/Vite-only helpers such as `import.meta.glob`.

## Fix

- Update the disaster-mode regression assertion to match the current storm panel ids.
- Guard Vite env access in `proxy.ts` so Node/tsx tests treat dev mode as false instead of crashing.
- Import `getCSSColor` directly from `theme-colors` to avoid browser-only barrel side effects in Node tests.

## Validation

Lost-feature checks confirmed the recent closed duplicate PRs are represented in current `main`, including mission ledger/weather bridge, panel smoke harness, SatelliteIntel overhead/pass tracking, algorithm registry/evaluation/safe adjustment, Little Snitch rules, Wingbits, and iMessage paths.

Passed locally:

- `npm run secrets:scan`
- `npm audit --audit-level=moderate`
- `npm run lint:conflicts`
- `npm run lockfile:check`
- `npm run version:check`
- `npm run typecheck:all`
- `npm run test:sidecar`
- `npm run test:data`
- `npm run build`
- `npm run test:weather`
- `npm run test:panels:smoke`
- `npm run test:algorithms`
- `npx eslint --quiet src/utils/proxy.ts src/services/data-freshness.ts tests/panel-order-regression.test.mjs`
- `git diff --check -- src/utils/proxy.ts src/services/data-freshness.ts tests/panel-order-regression.test.mjs`


## Cross-Agent Review

Cross-agent review: Claude reviewed on 2026-05-04; outcome: accepted risk.

Claude review disposition: no blocking bugs found. The direct `getCSSColor` import is verified by `npm run typecheck:all` and `npm run build`; the `import.meta.env` guard is intentional for Node/tsx test execution; inline `no-console` suppressions are scoped to the two existing cache-refresh warnings.
