### PR TITLE
fix(sweep): USNI region drift + ParallelAnalysis null-type guard + lsrules + JSDoc

### DIFF
--- a/server/crystalball/military/v1/get-usni-fleet-report.ts
+++ b/server/crystalball/military/v1/get-usni-fleet-report.ts
@@ -95,6 +95,13 @@ const REGION_COORDS: Record<string, { lat: number; lon: number }> = {
   'Baltic Sea': { lat: 58.0, lon: 20.0 },
   'Black Sea': { lat: 43.5, lon: 34.0 },
   'Bay of Bengal': { lat: 14.0, lon: 87.0 },
+  'Sulu Sea': { lat: 8.5, lon: 120.0 },
+  'South Atlantic': { lat: -30.0, lon: -15.0 },
+  // Straits & canals
+  'Bab el-Mandeb Strait': { lat: 12.5, lon: 43.5 },
+  'Strait of Hormuz': { lat: 26.5, lon: 56.5 },
+  'Taiwan Strait': { lat: 24.5, lon: 119.5 },
+  'Suez Canal': { lat: 30.0, lon: 32.5 },
   Yokosuka: { lat: 35.29, lon: 139.67 },
   Japan: { lat: 35.29, lon: 139.67 },
   Sasebo: { lat: 33.16, lon: 129.72 },
@@ -112,6 +119,13 @@ const REGION_COORDS: Record<string, { lat: number; lon: number }> = {
   'Houston, Texas': { lat: 29.76, lon: -95.37 },
   'Souda Bay': { lat: 35.49, lon: 24.08 },
   Naples: { lat: 40.84, lon: 14.25 },
+  // Additional US bases that appear in USNI Fleet Tracker posts
+  Bremerton: { lat: 47.57, lon: -122.63 },
+  Everett: { lat: 47.97, lon: -122.22 },
+  'Kings Bay': { lat: 30.8, lon: -81.56 },
+  Bangor: { lat: 47.73, lon: -122.71 },
+  // Alternate spelling of Rota
+  'Rota Spain': { lat: 36.63, lon: -6.35 },
 };
 
 function getRegionCoords(regionText: string): { lat: number; lon: number } | null {

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -292,7 +292,7 @@ export class PanelLayoutManager implements AppModule {
   private readonly applyTimeRangeFilterDebounced: () => void;
   private readonly _onUpdateState = () => { this.renderSidebarUpdateBtn(); };
 
-  /** Saved panel order from before a mode switch so Peace Mode can restore it. */
+  /** Saved panel order from before a Ghost-mode switch so the default state can restore it. */
   private _preModeOrder: string[] = [];
 
   /** Panels always kept at the top regardless of mode (video feeds / live streams). */
@@ -1568,9 +1568,15 @@ export class PanelLayoutManager implements AppModule {
   }
 
   /**
- * Reorder the panels grid to surface the most relevant panels for the
- * active mode. Anchors (live-news, live-webcams) always stay at the top.
- * Returning to Peace Mode restores the user's original order.
+ * Reorder the panels grid so anchors (live-news, live-webcams) stay at
+ * the top and the unified priority panel list (formerly per-mode, now
+ * always-on) floats just below them. Returning to the default state
+ * restores the user's original order.
+ *
+ * The `_mode` parameter is retained for the legacy `wm:mode-changed`
+ * event listener — the only canonical modes today are Ghost and
+ * Gods-Vision; Finance/War/Disaster are gone and their priority
+ * lists are unioned.
  */
   private _applyModePanelOrder(_mode: AppMode | null): void {
  const grid = document.getElementById('panelsGrid');
@@ -1581,9 +1587,12 @@ export class PanelLayoutManager implements AppModule {
  .map(el => (el as HTMLElement).dataset.panel ?? '')
  .filter(k => k.length > 0);
 
- // Mode collapse: former per-mode panel priorities (Finance / War / Disaster)
- // are now merged into a single always-on priority list. Anchors stay first,
- // then the union of all elevated-mode priority panels, then the rest.
+ // The three "PRIORITY" arrays below were originally per-mode (Finance /
+ // War / Disaster) but the modes were collapsed in the mode-manager
+ // refactor — only Ghost and Gods-Vision survived. The arrays are kept
+ // (under their historical names) and unioned into a single always-on
+ // priority list. Anchors stay first, then the priority union, then
+ // the rest.
  if (this._preModeOrder.length === 0) {
  this._preModeOrder = [...currentKeys];
  }

--- a/src/services/parallel-analysis.ts
+++ b/src/services/parallel-analysis.ts
@@ -243,9 +243,9 @@ class ParallelAnalysisService {
  // upstream NER service returns no entities, which previously threw
  // "filter is not a function" inside this hot path.
  const list: NEREntity[] = Array.isArray(entities) ? entities : [];
- const locations = list.filter(e => e.type.includes('LOC'));
- const people = list.filter(e => e.type.includes('PER'));
- const orgs = list.filter(e => e.type.includes('ORG'));
+ const locations = list.filter(e => e.type?.includes('LOC'));
+ const people = list.filter(e => e.type?.includes('PER'));
+ const orgs = list.filter(e => e.type?.includes('ORG'));
 
  const geopoliticalLocations = locations.filter(e =>
  FLASHPOINT_KEYWORDS.some(fp => e.text.toLowerCase().includes(fp))

--- a/tools/littlesnitch/crystal-ball.lsrules
+++ b/tools/littlesnitch/crystal-ball.lsrules
@@ -344,7 +344,47 @@
       "remote-hosts": "gibs.earthdata.nasa.gov",
       "ports": "443",
       "protocol": "tcp",
-      "notes": "NASA GIBS satellite imagery"
+      "notes": "NASA GIBS satellite imagery + GOES weather tiles"
+    },
+    {
+      "action": "allow",
+      "process": "any",
+      "remote-hosts": "api.adsb.lol",
+      "ports": "443",
+      "protocol": "tcp",
+      "notes": "ADS-B fallback (free, no key) — military flights"
+    },
+    {
+      "action": "allow",
+      "process": "any",
+      "remote-hosts": "api.airplanes.live",
+      "ports": "443",
+      "protocol": "tcp",
+      "notes": "ADS-B fallback (free, no key) — military flights"
+    },
+    {
+      "action": "allow",
+      "process": "any",
+      "remote-hosts": "opendata.adsb.fi",
+      "ports": "443",
+      "protocol": "tcp",
+      "notes": "ADS-B fallback (free, no key) — military flights"
+    },
+    {
+      "action": "allow",
+      "process": "any",
+      "remote-hosts": "api.opensanctions.org",
+      "ports": "443",
+      "protocol": "tcp",
+      "notes": "OpenSanctions catalog API (sanctions dataset metadata)"
+    },
+    {
+      "action": "allow",
+      "process": "any",
+      "remote-hosts": "data.opensanctions.org",
+      "ports": "443",
+      "protocol": "tcp",
+      "notes": "OpenSanctions bulk dataset downloads"
     },
     {
       "action": "allow",


### PR DESCRIPTION
Comprehensive sweep PR catching 4 things from today's diagnostic pass.

1. **USNI server-side region map drift**. `server/crystalball/military/v1/get-usni-fleet-report.ts` had its own `REGION_COORDS` map separate from `src/config/military.ts USNI_REGION_COORDINATES`. PR #238 only updated the frontend; the server map (which produces the 'Unknown region' warnings in `local-api.log`) was missing 4 straits (Bab el-Mandeb / Hormuz / Taiwan / Suez), 4 US bases (Bremerton / Everett / Kings Bay / Bangor), 'Rota Spain' alias, plus 'Sulu Sea' + 'South Atlantic' that were the active live warnings. Now in sync.

2. **ParallelAnalysis null-type guard**. PR #239's `Array.isArray(entities)` fix protected against undefined entities array; individual entries with undefined `.type` still threw `Cannot read properties of undefined (reading 'includes')` inside the filter callback. Optional-chained all three type accesses (LOC/PER/ORG).

3. **Little Snitch ruleset** missing 5 hosts that landed today: `api.adsb.lol`, `api.airplanes.live`, `opendata.adsb.fi` (military flights fallback chain), `api.opensanctions.org` + `data.opensanctions.org` (catalog rewrite).

4. **panel-layout.ts JSDoc**. `_preModeOrder` + `_applyModePanelOrder` still referenced 'Peace Mode' and 'per-mode panel priorities (Finance / War / Disaster)' even though the modes were collapsed to {ghost, gods-vision, null}. Updated to reflect the unified-priority reality.

## What I checked but didn't change

- **Tests + typecheck**: 1,089 / 1,089 pass across 14 suites; typecheck:all clean
- **http:// feeds**: 0 (BBC Persian was the last; PR #243 made it https)
- **YouTube channel IDs**: only S2 Underground hardcoded (already fixed); rest dynamic
- **/api/analyst-state**: still returns `{available: false}` — reasoning loop pusher isn't firing. Pre-existing, not caused by today's PRs. Separate diagnostic.
- **Other duplicate config**: no others as bad as the USNI drift; `aviation/index.ts` has a small enum→string map that doesn't drift, `feeds.ts SOURCE_REGION_MAP` is unrelated (UI labels)
- **Version bump 2.10.23 NOT included** — should be cut via `npm run release:prepare -- --bump patch --push` per the project's tag-driven release path (writes CHANGELOG, syncs all version files, triggers build-desktop.yml). Manual version edits would skip those steps. Recommended given today's 7+ PRs of fixes.