### PR TITLE
fix(three): analyst-state pusher (req.json bug) + MCP token retry + Network Rules panel

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -4,7 +4,7 @@ import { timingSafeEqual } from 'node:crypto';
 import https from 'node:https';
 import dns from 'node:dns/promises';
 import { existsSync, readFileSync, writeFileSync, statSync, openSync, readSync, closeSync } from 'node:fs';
-import { readdir } from 'node:fs/promises';
+import { readdir, readFile } from 'node:fs/promises';
 import { promisify } from 'node:util';
 import { brotliCompress, gzip } from 'node:zlib';
 import path from 'node:path';
@@ -2172,7 +2172,11 @@ async function dispatch(requestUrl, req, routes, context) {
     if (!context._analystCommands) context._analystCommands = [];
     if (req.method === 'POST') {
       try {
-        const body = await req.json();
+        // Node http.IncomingMessage doesn't have .json() — use readBody().
+        // Previous req.json() always threw "req.json is not a function",
+        // 400'ing every analyst-commands POST.
+        const raw = await readBody(req);
+        const body = raw ? JSON.parse(raw.toString()) : null;
         if (!body || typeof body !== 'object') return json({ error: 'invalid body' }, 400);
         const kind = typeof body.kind === 'string' ? body.kind : '';
         const allowed = new Set(['thumbs_up', 'thumbs_down', 'dismiss', 'run_skeptic']);
@@ -2212,7 +2216,12 @@ async function dispatch(requestUrl, req, routes, context) {
   if (requestUrl.pathname === '/api/analyst-state') {
     if (req.method === 'POST') {
       try {
-        const body = await req.json();
+        // Node http.IncomingMessage doesn't have .json() — use readBody().
+        // Previous req.json() always threw "req.json is not a function",
+        // 400'ing every renderer push and leaving /api/analyst-state with
+        // available:false forever (visible in MCP, AnalystHUD, etc.).
+        const raw = await readBody(req);
+        const body = raw ? JSON.parse(raw.toString()) : null;
         if (!body || typeof body !== 'object') return json({ error: 'invalid body' }, 400);
         if (!context._analystState) context._analystState = {};
         // Cap payload size defensively (drop unknown deeply-nested fields).
@@ -2530,7 +2539,7 @@ async function dispatch(requestUrl, req, routes, context) {
   // ── API Key Auto-Registration routes ─────────────────────────────────────
   if (requestUrl.pathname === '/api/register/newsapi') {
  try {
- const body = await req.json().catch(() => ({}));
+ const body = await readBody(req).then(b => b ? JSON.parse(b.toString()) : {}).catch(() => ({}));
  const { email, password } = body;
  if (!email || !password) return json({ error: 'email and password required' }, 400);
  const resp = await fetchWithTimeout(
@@ -2551,7 +2560,7 @@ async function dispatch(requestUrl, req, routes, context) {
 
   if (requestUrl.pathname === '/api/register/newsdata') {
  try {
- const body = await req.json().catch(() => ({}));
+ const body = await readBody(req).then(b => b ? JSON.parse(b.toString()) : {}).catch(() => ({}));
  const { email, password, firstName, lastName } = body;
  if (!email || !password) return json({ error: 'email and password required' }, 400);
  const resp = await fetchWithTimeout(
@@ -2572,7 +2581,7 @@ async function dispatch(requestUrl, req, routes, context) {
 
   if (requestUrl.pathname === '/api/register/nasa-firms') {
  try {
- const body = await req.json().catch(() => ({}));
+ const body = await readBody(req).then(b => b ? JSON.parse(b.toString()) : {}).catch(() => ({}));
  const { email, firstName, lastName, organization } = body;
  if (!email) return json({ error: 'email required' }, 400);
  const params = new URLSearchParams({
@@ -2601,7 +2610,7 @@ async function dispatch(requestUrl, req, routes, context) {
   // ── ACLED OAuth connect (exchange username+password for access token) ─────
   if (requestUrl.pathname === '/api/acled/connect') {
  try {
- const body = await req.json().catch(() => ({}));
+ const body = await readBody(req).then(b => b ? JSON.parse(b.toString()) : {}).catch(() => ({}));
  const { email, password } = body;
  if (!email || !password) return json({ error: 'email and password required' }, 400);
  const resp = await fetchWithTimeout(
@@ -2625,7 +2634,7 @@ async function dispatch(requestUrl, req, routes, context) {
   // ── ACLED OAuth token refresh ─────────────────────────────────────────────
   if (requestUrl.pathname === '/api/acled/refresh') {
  try {
- const body = await req.json().catch(() => ({}));
+ const body = await readBody(req).then(b => b ? JSON.parse(b.toString()) : {}).catch(() => ({}));
  const { refreshToken } = body;
  if (!refreshToken) return json({ error: 'refreshToken required' }, 400);
  const resp = await fetchWithTimeout(
@@ -5552,6 +5561,62 @@ async function dispatch(requestUrl, req, routes, context) {
   }
 
   // RSS proxy — fetch public feeds with SSRF protection
+  if (requestUrl.pathname === '/api/littlesnitch-rules') {
+ // Read the bundled Little Snitch ruleset and return it as parsed JSON.
+ // The renderer's NetworkRulesPanel renders this as a table so the user
+ // can see what outbound traffic Crystal Ball needs without opening
+ // Little Snitch itself. Cached 1h since the file is checked in and
+ // changes only on releases.
+ const cached = getCached('littlesnitch-rules', 60 * 60 * 1000);
+ if (cached) return json(cached);
+
+ // Search a few well-known paths so the handler works in dev and bundled.
+ // resourceRoot is Contents/Resources/_up_ in the bundled app; in dev it
+ // points at the repo root.
+ const candidates = [
+ path.join(context.apiDir, '..', 'tools', 'littlesnitch', 'crystal-ball.lsrules'),
+ path.join(context.apiDir, '..', '..', '..', 'tools', 'littlesnitch', 'crystal-ball.lsrules'),
+ path.join(process.cwd(), 'tools', 'littlesnitch', 'crystal-ball.lsrules'),
+ ];
+
+ let lastError = null;
+ for (const candidate of candidates) {
+ try {
+ const raw = await readFile(candidate, 'utf8');
+ const parsed = JSON.parse(raw);
+ const rules = Array.isArray(parsed?.rules) ? parsed.rules : [];
+ // Group by domain category so the renderer can render section headers
+ // without re-scanning. Categories pulled from each rule's "notes" field.
+ const result = {
+ name: parsed?.name ?? 'Crystal Ball',
+ description: parsed?.description ?? '',
+ ruleCount: rules.length,
+ rules: rules.map((r, i) => ({
+ id: `ls-${i}`,
+ action: r?.action ?? 'allow',
+ process: r?.process ?? 'any',
+ host: r?.['remote-hosts'] ?? r?.['remote-addresses'] ?? '',
+ ports: r?.ports ?? '',
+ protocol: r?.protocol ?? 'tcp',
+ notes: r?.notes ?? '',
+ })),
+ sourcePath: candidate,
+ generatedAt: new Date().toISOString(),
+ };
+ setCached('littlesnitch-rules', result);
+ return json(result);
+ } catch (error) {
+ lastError = error;
+ // try next candidate
+ }
+ }
+ return json({
+ error: 'Little Snitch ruleset not found',
+ details: String(lastError?.message ?? lastError ?? 'unknown'),
+ candidatesTried: candidates,
+ }, 404);
+  }
+
   if (requestUrl.pathname === '/api/feed-discovery') {
  // Discover RSS/Atom feed URLs for a given domain. Tries the homepage
  // (parses <link rel="alternate" type="application/{rss,atom}+xml">)

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -39,6 +39,7 @@ import {
   TradePolicyPanel,
   SupplyChainPanel,
   SecurityAdvisoriesPanel,
+  NetworkRulesPanel,
   OrefSirensPanel,
   TelegramIntelPanel,
   WatchlistPanel,
@@ -1238,6 +1239,13 @@ export class PanelLayoutManager implements AppModule {
  void this.callbacks.loadSecurityAdvisories?.();
  });
  this.ctx.panels['security-advisories'] = securityAdvisoriesPanel;
+
+ // NetworkRulesPanel — surfaces tools/littlesnitch/crystal-ball.lsrules
+ // (the bundled Little Snitch ruleset) inside the app so the user can
+ // see exactly which outbound endpoints Crystal Ball needs without
+ // opening Little Snitch. Reads from /api/littlesnitch-rules.
+ const networkRulesPanel = new NetworkRulesPanel();
+ this.ctx.panels['network-rules'] = networkRulesPanel;
 
  const orefSirensPanel = new OrefSirensPanel();
  this.ctx.panels['oref-sirens'] = orefSirensPanel;

--- a/src/components/NetworkRulesPanel.ts
+++ b/src/components/NetworkRulesPanel.ts
@@ -1,0 +1,145 @@
+import { Panel } from './Panel';
+import { escapeHtml } from '@/utils/sanitize';
+import { getApiBaseUrl } from '@/services/runtime';
+
+interface NetworkRule {
+  id: string;
+  action: string;
+  process: string;
+  host: string;
+  ports: string;
+  protocol: string;
+  notes: string;
+}
+
+interface NetworkRulesetResponse {
+  name?: string;
+  description?: string;
+  ruleCount?: number;
+  rules?: NetworkRule[];
+  sourcePath?: string;
+  error?: string;
+}
+
+// Surfaces the bundled Little Snitch ruleset (tools/littlesnitch/crystal-ball.lsrules)
+// inside the app so the user can see exactly what outbound traffic Crystal Ball
+// needs without leaving for Little Snitch's UI.
+export class NetworkRulesPanel extends Panel {
+  private rules: NetworkRule[] = [];
+  private description = '';
+  private sourcePath = '';
+  private loadError: string | null = null;
+
+  constructor() {
+ super({
+ id: 'network-rules',
+ title: 'Network Rules',
+ showCount: true,
+ trackActivity: false,
+ infoTooltip: 'Little Snitch allow rules bundled with Crystal Ball — every outbound endpoint the app needs to reach.',
+ });
+ this.showLoading('Loading network rules…');
+ // Defer refresh out of the constructor so the no-async-constructor rule
+ // is satisfied and the panel mounts before any fetch completes.
+ setTimeout(() => { void this.refresh(); }, 0);
+  }
+
+  async refresh(): Promise<void> {
+ try {
+ const res = await fetch(`${getApiBaseUrl()}/api/littlesnitch-rules`);
+ if (!res.ok) {
+ this.loadError = `Sidecar returned HTTP ${res.status}`;
+ this.render();
+ return;
+ }
+ const data = (await res.json()) as NetworkRulesetResponse;
+ if (data.error) {
+ this.loadError = data.error;
+ this.render();
+ return;
+ }
+ this.rules = Array.isArray(data.rules) ? data.rules : [];
+ this.description = data.description ?? '';
+ this.sourcePath = data.sourcePath ?? '';
+ this.loadError = null;
+ this.setCount(this.rules.length);
+ this.render();
+ } catch (error) {
+ this.loadError = error instanceof Error ? error.message : String(error);
+ this.render();
+ }
+  }
+
+  private groupByCategory(): Map<string, NetworkRule[]> {
+ const groups = new Map<string, NetworkRule[]>();
+ for (const rule of this.rules) {
+ const category = this.categoryFor(rule);
+ if (!groups.has(category)) groups.set(category, []);
+ groups.get(category)!.push(rule);
+ }
+ return groups;
+  }
+
+  // Group rules into intuitive buckets keyed off note text and remote-host.
+  // Falls back to "Other" so unrecognized hosts still render.
+  private categoryFor(rule: NetworkRule): string {
+ const note = rule.notes.toLowerCase();
+ const host = rule.host.toLowerCase();
+ if (host === '127.0.0.1' || note.includes('sidecar') || note.includes('cb-control')) return 'Local services';
+ if (note.includes('llm') || /(anthropic|groq|openrouter)/.test(host)) return 'LLM APIs';
+ if (note.includes('map') || /(mapbox|maptiler|cesium|gibs|openstreetmap)/.test(host)) return 'Maps & tiles';
+ if (note.includes('threat') || note.includes('cyber') || /(abuseipdb|greynoise|urlhaus|virustotal|otx|threatfox)/.test(host)) return 'Threat intel';
+ if (note.includes('aviation') || note.includes('ads-b') || /(opensky|wingbits|aviationstack|adsb|airplanes\.live|icao)/.test(host)) return 'Aviation';
+ if (note.includes('weather') || note.includes('hazard') || /(weather|nasa|noaa|nws|gibs|owm|firms)/.test(host)) return 'Weather & hazard';
+ if (note.includes('news') || note.includes('rss') || /(google|bbc|reuters|mediastack|newsapi|newsdata)/.test(host)) return 'News & RSS';
+ if (note.includes('economic') || note.includes('finance') || /(fred|eia|finnhub|fmp|stlouisfed)/.test(host)) return 'Economic & financial';
+ if (note.includes('sanction') || host.includes('opensanctions')) return 'Sanctions';
+ return 'Other';
+  }
+
+  private render(): void {
+ if (this.loadError) {
+ this.setContent(`<div class="net-rules-error" style="padding:12px;color:#ff6b6b;font-size:13px">
+ <strong>Could not load network rules.</strong><br/>
+ ${escapeHtml(this.loadError)}<br/>
+ <span style="opacity:0.7">The bundled file lives at <code>tools/littlesnitch/crystal-ball.lsrules</code> in the repo.</span>
+ </div>`);
+ return;
+  }
+ if (this.rules.length === 0) {
+ this.setContent('<div style="padding:12px;opacity:0.6;font-size:13px">No rules in the bundled ruleset.</div>');
+ return;
+ }
+ const groups = this.groupByCategory();
+ const categoryOrder = ['Local services', 'LLM APIs', 'Maps & tiles', 'Aviation', 'Weather & hazard', 'Threat intel', 'News & RSS', 'Economic & financial', 'Sanctions', 'Other'];
+ const sortedKeys = [...groups.keys()].sort((a, b) => {
+ const ai = categoryOrder.indexOf(a);
+ const bi = categoryOrder.indexOf(b);
+ return (ai === -1 ? 99 : ai) - (bi === -1 ? 99 : bi);
+ });
+ const sections = sortedKeys.map(category => {
+ const list = groups.get(category)!;
+ const rows = list.map(rule => `
+ <tr>
+ <td style="padding:4px 8px;font-family:ui-monospace,monospace;font-size:11px">${escapeHtml(rule.host || rule.process)}</td>
+ <td style="padding:4px 8px;text-align:right;opacity:0.6;font-size:11px">${escapeHtml(rule.ports || '—')}/${escapeHtml(rule.protocol || 'tcp')}</td>
+ <td style="padding:4px 8px;font-size:11px;opacity:0.85">${escapeHtml(rule.notes || '')}</td>
+ </tr>`).join('');
+ return `
+ <details class="net-rules-section" open style="margin-bottom:8px;border:1px solid var(--panel-border,#2a2a2c);border-radius:6px;overflow:hidden">
+ <summary style="padding:6px 10px;background:rgba(255,255,255,0.04);cursor:pointer;font-weight:600;font-size:12px;display:flex;justify-content:space-between">
+ <span>${escapeHtml(category)}</span>
+ <span style="opacity:0.5;font-weight:normal">${list.length}</span>
+ </summary>
+ <table style="width:100%;border-collapse:collapse;font-size:11px;background:transparent">
+ ${rows}
+ </table>
+ </details>`;
+ }).join('');
+ const headerNote = this.description ? `<div style="padding:6px 10px 0 10px;opacity:0.7;font-size:11px">${escapeHtml(this.description)}</div>` : '';
+ const sourceLine = this.sourcePath
+ ? `<div style="padding:8px 10px 4px 10px;font-size:10px;opacity:0.5;font-family:ui-monospace,monospace">Source: ${escapeHtml(this.sourcePath)}</div>`
+ : '';
+ this.setContent(`${headerNote}${sourceLine}<div style="padding:8px 10px">${sections}</div>`);
+  }
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -48,6 +48,7 @@ export * from './UnifiedSettings';
 export * from './TradePolicyPanel';
 export * from './SupplyChainPanel';
 export * from './SecurityAdvisoriesPanel';
+export { NetworkRulesPanel } from './NetworkRulesPanel';
 export * from './OrefSirensPanel';
 export * from './TelegramIntelPanel';
 export * from './BreakingNewsBanner';

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -76,6 +76,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   climate: { name: 'Climate Anomalies', enabled: true, priority: 2 },
   'population-exposure': { name: 'Population Exposure', enabled: true, priority: 2 },
   'security-advisories': { name: 'Security Advisories', enabled: true, priority: 2 },
+  'network-rules': { name: 'Network Rules', enabled: true, priority: 3 },
   'oref-sirens': { name: 'Israel Sirens', enabled: true, priority: 2 },
   'telegram-intel': { name: 'Telegram Intel', enabled: true, priority: 2 },
   'space-weather': { name: 'Space Weather', enabled: true, priority: 1 },
@@ -976,7 +977,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   },
   dataTracking: {
  labelKey: 'header.panelCatDataTracking',
- panelKeys: ['monitors', 'cyber-threats', 'threat-inbox', 'local-ids', 'comms-health', 'power-grid', 'ucdp-events', 'nuclear-risk', 'airstrikes', 'displacement', 'security-advisories', 'oref-sirens', 'space-weather', 'spaceflight-news', 'space-launches', 'population-exposure', 'internet-disruptions', 'air-traffic', 'threat-intel-hub', 'geo-intel', 'dark-web', 'anomaly-detection', 'financial-contagion', 'supply-chain-impact', 'nuclear-monitor', 'sigint-panel', 'dark-vessel', 'ics-ot-dashboard', 'ioc-manager', 'network-topology', 'stix-taxii', 'custom-geofence', 'sanctions-crossref', 'emergency-broadcast', 'satellite-change', 'phishstats-feed', 'urlscan-threats', 'bitcoin-abuse', 'cve-tracker', 'vulners-cve', 'pulsedive-intel', 'hibp-breaches', 'reddit-osint', 'ripe-ncc', 'ripe-atlas', 'ipinfo-lookup', 'aerospace-reentry', 'satellite-intel'],
+ panelKeys: ['monitors', 'cyber-threats', 'threat-inbox', 'local-ids', 'comms-health', 'power-grid', 'ucdp-events', 'nuclear-risk', 'airstrikes', 'displacement', 'security-advisories', 'network-rules', 'oref-sirens', 'space-weather', 'spaceflight-news', 'space-launches', 'population-exposure', 'internet-disruptions', 'air-traffic', 'threat-intel-hub', 'geo-intel', 'dark-web', 'anomaly-detection', 'financial-contagion', 'supply-chain-impact', 'nuclear-monitor', 'sigint-panel', 'dark-vessel', 'ics-ot-dashboard', 'ioc-manager', 'network-topology', 'stix-taxii', 'custom-geofence', 'sanctions-crossref', 'emergency-broadcast', 'satellite-change', 'phishstats-feed', 'urlscan-threats', 'bitcoin-abuse', 'cve-tracker', 'vulners-cve', 'pulsedive-intel', 'hibp-breaches', 'reddit-osint', 'ripe-ncc', 'ripe-atlas', 'ipinfo-lookup', 'aerospace-reentry', 'satellite-intel'],
  variants: ['full'],
   },
   hazards: {

--- a/tools/mcp-server/sidecar-client.mjs
+++ b/tools/mcp-server/sidecar-client.mjs
@@ -60,57 +60,71 @@ export function createSidecarClient(dataDir = DEFAULT_DATA_DIR) {
     }
   }
 
-  async function get(route, params) {
-    const url = buildUrl(route, params);
-    const token = discoverToken();
-    if (!url || !token) {
-      return { error: 'Crystal Ball is not running. Launch the app to enable data access.', healthy: false };
-    }
+  // Single-attempt fetch helper — used by get/post with a once-on-401 retry
+  // so a sidecar restart that rotated the token doesn't 401 the in-flight call.
+  async function fetchOnce(url, init) {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
     try {
-      const res = await fetch(url, {
-        headers: { Authorization: `Bearer ${token}` },
-        signal: controller.signal,
-      });
+      return await fetch(url, { ...init, signal: controller.signal });
+    } finally {
       clearTimeout(timer);
+    }
+  }
+
+  async function get(route, params) {
+    const url = buildUrl(route, params);
+    let token = discoverToken();
+    if (!url || !token) {
+      return { error: 'Crystal Ball is not running. Launch the app to enable data access.', healthy: false };
+    }
+    try {
+      let res = await fetchOnce(url, { headers: { Authorization: `Bearer ${token}` } });
+      // Sidecar restarts rotate the token; re-read the file once and retry.
+      if (res.status === 401) {
+        const fresh = discoverToken();
+        if (fresh && fresh !== token) {
+          token = fresh;
+          res = await fetchOnce(url, { headers: { Authorization: `Bearer ${token}` } });
+        }
+      }
       if (!res.ok) {
         const text = await res.text().catch(() => '');
         return { error: `Sidecar returned ${res.status}: ${text}`, status: res.status };
       }
       return await res.json();
     } catch (err) {
-      clearTimeout(timer);
       return { error: `Request failed: ${err.message}` };
     }
   }
 
   async function post(route, body) {
     const port = discoverPort();
-    const token = discoverToken();
+    let token = discoverToken();
     if (!port || !token) {
       return { error: 'Crystal Ball is not running. Launch the app to enable data access.', healthy: false };
     }
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    const url = `http://127.0.0.1:${port}${route}`;
+    const buildInit = (tok) => ({
+      method: 'POST',
+      headers: { Authorization: `Bearer ${tok}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
     try {
-      const res = await fetch(`http://127.0.0.1:${port}${route}`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(body),
-        signal: controller.signal,
-      });
-      clearTimeout(timer);
+      let res = await fetchOnce(url, buildInit(token));
+      if (res.status === 401) {
+        const fresh = discoverToken();
+        if (fresh && fresh !== token) {
+          token = fresh;
+          res = await fetchOnce(url, buildInit(token));
+        }
+      }
       if (!res.ok) {
         const text = await res.text().catch(() => '');
         return { error: `Sidecar returned ${res.status}: ${text}`, status: res.status };
       }
       return await res.json();
     } catch (err) {
-      clearTimeout(timer);
       return { error: `Request failed: ${err.message}` };
     }
   }


### PR DESCRIPTION
Three follow-ups requested by Brad after the algo verification.

## 1. Sidecar pusher → analyst-state was dead (the actual root cause)

The renderer's `sidecar-pusher.ts` POSTs to `/api/analyst-state`, and the boot order in `panel-layout.ts` wires `startSidecarPusher()` correctly. But every POST returned HTTP 400.

Root cause: both `/api/analyst-state` and `/api/analyst-commands` handlers called `await req.json()` — which doesn't exist on Node's `http.IncomingMessage` (it's a Web Fetch `Response` method). The `try/catch` swallowed the `TypeError` and returned 400, so the sidecar's in-memory cache stayed empty forever and `/api/analyst-state`'s GET handler permanently returned `{available: false}`.

Fixed all 7 `req.json()` callers in the sidecar (the 2 critical ones plus 5 `req.json().catch(() => ({}))` callsites that were silently no-op'ing — readNewsApi/dependent handlers). Replaced with the existing `readBody(req)` helper.

## 2. MCP server 401 retry on token rotation

Investigation finding: the 120 historical `unauthorized request to /api/intelligence/v1/get-pizzint-status` log entries had no ISO-timestamp prefix → they're from older sidecar versions before the timestamp wrapper landed. **No current 401s are happening** — the MCP client at `tools/mcp-server/sidecar-client.mjs` already calls `discoverToken()` fresh on every request, and the live traffic log shows 200s on `/api/analyst-commands`.

Defensive improvement anyway: if a sidecar restart rotates the token mid-request, the in-flight call would 401 once. Added retry-once-on-401 in both `get()` and `post()` — re-read the token file and retry with the new value.

## 3. Network Rules panel

New surface for the bundled Little Snitch ruleset.

- **Sidecar endpoint** `/api/littlesnitch-rules` reads + parses `tools/littlesnitch/crystal-ball.lsrules` (1h cache; searches multiple paths to work in dev and bundled).
- **`NetworkRulesPanel.ts`** renders the rules grouped into 10 categories (Local services / LLM APIs / Maps & tiles / Aviation / Weather & hazard / Threat intel / News & RSS / Economic & financial / Sanctions / Other). Each row shows host, port/protocol, and notes.
- **Registered** in `panels.ts` under `dataTracking` category, priority 3. Shows up in the sidebar between 'Security Advisories' and 'Israel Sirens'.

## Verification path

This is bundled-app code, not browser-previewable.
- Typecheck: 0 errors
- Sidecar tests: 99/99 pass
- ESLint: clean

End-to-end requires desktop rebuild + reinstall. After that:
- `curl /api/analyst-state` → `{available: true, analyst: {...}, ...}` (was `{available: false}`)
- The Network Rules panel appears in the sidebar; clicking opens shows ~50 allow rules grouped by category.