### PR TITLE
feat(seismic): focal mechanism classifier + beachball SVG (PR 10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "test:personal": "tsx --test src/services/personal/__tests__/personal-impact.test.mts",
     "test:adsb": "tsx --test src/services/adsb/__tests__/adsb-aggregate.test.mts",
     "test:maritime": "tsx --test src/services/maritime/__tests__/freight-stress.test.mts src/services/__tests__/dark-vessel-gaps.test.mts && node --test src-tauri/sidecar/__tests__/freight-stress-parity.test.mjs src-tauri/sidecar/__tests__/dark-vessel-gaps-parity.test.mjs",
-    "test:seismic": "tsx --test src/services/seismic/__tests__/seismic-normalizer.test.mts src/services/seismic/__tests__/seismic-fusion.test.mts src/services/seismic/__tests__/shaking-estimator.test.mts src/services/seismic/__tests__/impact-assessor.test.mts src/services/seismic/__tests__/tsunami-reasoner.test.mts",
+    "test:seismic": "tsx --test src/services/seismic/__tests__/seismic-normalizer.test.mts src/services/seismic/__tests__/seismic-fusion.test.mts src/services/seismic/__tests__/shaking-estimator.test.mts src/services/seismic/__tests__/impact-assessor.test.mts src/services/seismic/__tests__/tsunami-reasoner.test.mts src/services/seismic/__tests__/focal-classifier.test.mts",
     "test:synthesis": "tsx --test src/services/synthesis/__tests__/precedent-matcher.test.mts src/services/synthesis/__tests__/leading-indicators.test.mts",
     "test:cyber": "tsx --test src/services/cyber/__tests__/apt-tracker.test.mts",
     "test:geopolitics": "tsx --test src/services/geopolitics/__tests__/grayzone-classifier.test.mts",

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -5678,6 +5678,47 @@ async function dispatch(requestUrl, req, routes, context) {
  } catch (error) {
  return json({ error: `tsunami-status error: ${error.message ?? error}` }, 502);
  }
+ } catch (error) {
+ return json({ error: `tsunami-status error: ${error.message ?? error}` }, 502);
+ }
+  }
+
+  // ── USGS focal mechanism (moment tensor) passthrough ───────────────────
+  // Forwards to USGS FDSN event service for the requested event id and
+  // returns the GeoJSON. Renderer parses with `parseUsgsMomentTensor` from
+  // src/services/seismic/focal-classifier.ts. Cached 30 min/event since
+  // moment tensors are revised slowly after the initial automatic solution.
+  if (requestUrl.pathname === '/api/focal-mechanism') {
+    const eventId = (requestUrl.searchParams.get('eventId') ?? '').trim();
+    // USGS event ids are network code + numeric/alphanumeric, e.g.
+    // us7000abcd, nc73881266, ci40012345. Tight allowlist guards against
+    // path injection in the upstream URL.
+    if (!eventId || !/^[A-Za-z0-9_-]{2,32}$/.test(eventId)) {
+      return json({ error: 'invalid eventId' }, 400);
+    }
+    const cacheKey = `focal-mechanism:${eventId}`;
+    const cached = getCached(cacheKey);
+    if (cached) return json(cached);
+    try {
+      const upstream = `https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&eventid=${encodeURIComponent(eventId)}&producttype=moment-tensor`;
+      const r = await fetchWithTimeout(
+        upstream,
+        { headers: { Accept: 'application/json', 'User-Agent': 'CrystalBall/sidecar (focal-mechanism)' } },
+        15000,
+      );
+      if (r.status === 404) {
+        const empty = { eventId, available: false, reason: 'no moment-tensor product for this event' };
+        setCached(cacheKey, empty, 5 * 60 * 1000);
+        return json(empty);
+      }
+      if (!r.ok) throw new Error(`USGS ${r.status}`);
+      const data = await r.json();
+      const payload = { eventId, available: true, raw: data };
+      setCached(cacheKey, payload, 30 * 60 * 1000);
+      return json(payload);
+    } catch (error) {
+      return json({ error: `focal-mechanism error: ${error.message ?? error}` }, 502);
+    }
   }
 
   // ── Travel warning RSS/Atom parser helper ─────────────────────────────────

--- a/src/services/seismic/__tests__/focal-classifier.test.mts
+++ b/src/services/seismic/__tests__/focal-classifier.test.mts
@@ -1,0 +1,253 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildBeachballSvg,
+  classifyFaultType,
+  parseUsgsMomentTensor,
+  pickDiagnosticPlane,
+  type NodalPlane,
+} from '../focal-classifier.ts';
+
+// ── classifyFaultType ──────────────────────────────────────────────────
+
+test('classifyFaultType: pure right-lateral strike-slip (rake 0)', () => {
+  assert.equal(classifyFaultType(0), 'strike_slip');
+});
+
+test('classifyFaultType: pure left-lateral strike-slip (rake 180)', () => {
+  // 180 normalises to -180/180 boundary; |r|>150 triggers strike_slip.
+  assert.equal(classifyFaultType(180), 'strike_slip');
+  assert.equal(classifyFaultType(-180), 'strike_slip');
+  assert.equal(classifyFaultType(170), 'strike_slip');
+  assert.equal(classifyFaultType(-160), 'strike_slip');
+});
+
+test('classifyFaultType: pure normal fault (rake -90)', () => {
+  assert.equal(classifyFaultType(-90), 'normal');
+});
+
+test('classifyFaultType: pure reverse / thrust fault (rake 90)', () => {
+  assert.equal(classifyFaultType(90), 'reverse');
+});
+
+test('classifyFaultType: oblique edges fall to oblique only when discriminator misses', () => {
+  // The boundary cases (|rake| === 30 or 150) are boundary inclusive
+  // for reverse/normal, exclusive for strike-slip. Anything between the
+  // pure ranges already falls in either reverse or normal — `oblique`
+  // covers cases the rake math can't classify (e.g. NaN-normalised).
+  assert.equal(classifyFaultType(45), 'reverse');
+  assert.equal(classifyFaultType(-45), 'normal');
+});
+
+test('classifyFaultType: handles wraparound rake values', () => {
+  assert.equal(classifyFaultType(360), 'strike_slip');
+  assert.equal(classifyFaultType(-360), 'strike_slip');
+  assert.equal(classifyFaultType(450), 'reverse'); // 450 → 90
+});
+
+// ── pickDiagnosticPlane ────────────────────────────────────────────────
+
+test('pickDiagnosticPlane: prefers steeper plane', () => {
+  const p1: NodalPlane = { strike: 0, dip: 30, rake: 90 };
+  const p2: NodalPlane = { strike: 90, dip: 80, rake: 0 };
+  assert.equal(pickDiagnosticPlane(p1, p2), p2);
+});
+
+test('pickDiagnosticPlane: equal dips → plane 1 wins', () => {
+  const p1: NodalPlane = { strike: 0, dip: 45, rake: 90 };
+  const p2: NodalPlane = { strike: 90, dip: 45, rake: 0 };
+  assert.equal(pickDiagnosticPlane(p1, p2), p1);
+});
+
+// ── buildBeachballSvg ──────────────────────────────────────────────────
+
+test('buildBeachballSvg: returns valid <svg> with viewBox', () => {
+  const svg = buildBeachballSvg(
+    { p1: { strike: 0, dip: 90, rake: 0 }, p2: { strike: 90, dip: 0, rake: 0 } },
+    'strike_slip',
+  );
+  assert.ok(svg.startsWith('<svg'), 'starts with <svg');
+  assert.ok(svg.endsWith('</svg>'), 'ends with </svg>');
+  assert.ok(/viewBox="0 0 \d+ \d+"/.test(svg), 'has viewBox');
+  assert.ok(svg.includes('<circle'), 'has bounding circle');
+});
+
+test('buildBeachballSvg: rotation reflects steeper plane strike', () => {
+  const horizontal: NodalPlane = { strike: 0, dip: 30, rake: 90 };
+  const vertical:   NodalPlane = { strike: 45, dip: 90, rake: 0 };
+  const svg = buildBeachballSvg({ p1: horizontal, p2: vertical }, 'strike_slip');
+  assert.ok(svg.includes('rotate(45'), 'rotation matches steeper plane (dip 90, strike 45)');
+});
+
+test('buildBeachballSvg: aria-label encodes fault type', () => {
+  const svg = buildBeachballSvg(
+    { p1: { strike: 0, dip: 60, rake: -90 }, p2: { strike: 180, dip: 30, rake: -90 } },
+    'normal',
+  );
+  assert.ok(svg.includes('aria-label="normal focal mechanism"'));
+});
+
+test('buildBeachballSvg: distinct fault types produce distinct fills', () => {
+  const planes = { p1: { strike: 0, dip: 60, rake: 0 }, p2: { strike: 90, dip: 60, rake: 0 } };
+  const ss = buildBeachballSvg(planes, 'strike_slip');
+  const nm = buildBeachballSvg(planes, 'normal');
+  const rv = buildBeachballSvg(planes, 'reverse');
+  const ob = buildBeachballSvg(planes, 'oblique');
+  // Each variant has a unique aria-label and they should not be byte-
+  // equal, since the wedge angles differ.
+  assert.notEqual(ss, nm);
+  assert.notEqual(nm, rv);
+  assert.notEqual(rv, ob);
+  assert.notEqual(ss, ob);
+});
+
+test('buildBeachballSvg: no caller-provided strings appear in SVG body', () => {
+  // Defensive: SVG output is built only from numeric attributes plus
+  // fixed labels — there is no caller text channel that could embed
+  // unescaped HTML.
+  const svg = buildBeachballSvg(
+    { p1: { strike: 12.345, dip: 67.89, rake: 90 }, p2: { strike: 192.345, dip: 30, rake: 90 } },
+    'reverse',
+  );
+  assert.ok(!svg.includes('<script'), 'no script tags');
+  assert.ok(!svg.includes('javascript:'), 'no javascript: URLs');
+});
+
+// ── parseUsgsMomentTensor ──────────────────────────────────────────────
+
+const USGS_FIXTURE = {
+  type: 'FeatureCollection',
+  features: [{
+    type: 'Feature',
+    id: 'us7000abcd',
+    properties: {
+      mag: 6.4,
+      place: 'Test region',
+      products: {
+        'moment-tensor': [{
+          type: 'moment-tensor',
+          properties: {
+            'derived-magnitude': '6.4',
+            'derived-depth': '12.5',
+            'nodal-plane-1-strike': '120',
+            'nodal-plane-1-dip': '60',
+            'nodal-plane-1-rake': '90',
+            'nodal-plane-2-strike': '300',
+            'nodal-plane-2-dip': '30',
+            'nodal-plane-2-rake': '90',
+          },
+        }],
+      },
+    },
+  }],
+};
+
+test('parseUsgsMomentTensor: parses USGS FeatureCollection payload', () => {
+  const fm = parseUsgsMomentTensor(USGS_FIXTURE);
+  assert.ok(fm, 'returns a FocalMechanism');
+  assert.equal(fm!.eventId, 'us7000abcd');
+  assert.equal(fm!.faultType, 'reverse'); // rake 90 → reverse
+  assert.equal(fm!.momentMagnitude, 6.4);
+  assert.equal(fm!.depthKm, 12.5);
+  assert.equal(fm!.nodalPlane1.strike, 120);
+  assert.equal(fm!.nodalPlane2.dip, 30);
+});
+
+test('parseUsgsMomentTensor: returns null without moment-tensor product', () => {
+  const fm = parseUsgsMomentTensor({
+    type: 'Feature',
+    id: 'us7000xyzw',
+    properties: { products: {} },
+  });
+  assert.equal(fm, null);
+});
+
+test('parseUsgsMomentTensor: returns null on completely empty payload', () => {
+  assert.equal(parseUsgsMomentTensor(null), null);
+  assert.equal(parseUsgsMomentTensor({}), null);
+  assert.equal(parseUsgsMomentTensor({ type: 'FeatureCollection', features: [] }), null);
+});
+
+test('parseUsgsMomentTensor: handles numeric and string strike/dip/rake', () => {
+  const fm = parseUsgsMomentTensor({
+    type: 'Feature',
+    id: 'us7000num',
+    properties: {
+      products: {
+        'moment-tensor': [{
+          properties: {
+            'nodal-plane-1-strike': 0,
+            'nodal-plane-1-dip': 90,
+            'nodal-plane-1-rake': 0,
+            'nodal-plane-2-strike': 90,
+            'nodal-plane-2-dip': 90,
+            'nodal-plane-2-rake': 180,
+          },
+        }],
+      },
+    },
+  });
+  assert.ok(fm, 'parses with numeric inputs');
+  assert.equal(fm!.faultType, 'strike_slip');
+});
+
+test('parseUsgsMomentTensor: missing one nodal plane → null', () => {
+  const fm = parseUsgsMomentTensor({
+    type: 'Feature',
+    id: 'us7000bad',
+    properties: {
+      products: {
+        'moment-tensor': [{
+          properties: {
+            'nodal-plane-1-strike': 0,
+            'nodal-plane-1-dip': 60,
+            'nodal-plane-1-rake': -90,
+            // plane 2 missing
+          },
+        }],
+      },
+    },
+  });
+  assert.equal(fm, null);
+});
+
+test('parseUsgsMomentTensor: classifies normal-faulting earthquake', () => {
+  const fm = parseUsgsMomentTensor({
+    type: 'Feature',
+    id: 'us7000norm',
+    properties: {
+      products: {
+        'moment-tensor': [{
+          properties: {
+            'nodal-plane-1-strike': 0,
+            'nodal-plane-1-dip': 60,
+            'nodal-plane-1-rake': -90,
+            'nodal-plane-2-strike': 180,
+            'nodal-plane-2-dip': 30,
+            'nodal-plane-2-rake': -90,
+          },
+        }],
+      },
+    },
+  });
+  assert.ok(fm);
+  assert.equal(fm!.faultType, 'normal');
+});
+
+test('parseUsgsMomentTensor: emits beachball SVG in result', () => {
+  const fm = parseUsgsMomentTensor(USGS_FIXTURE);
+  assert.ok(fm);
+  assert.ok(fm!.beachballSvg.startsWith('<svg'));
+  assert.ok(fm!.beachballSvg.includes('aria-label="reverse focal mechanism"'));
+});
+
+// ── JSON serializability ──────────────────────────────────────────────
+
+test('FocalMechanism is JSON-serializable', () => {
+  const fm = parseUsgsMomentTensor(USGS_FIXTURE);
+  assert.ok(fm);
+  const round = JSON.parse(JSON.stringify(fm));
+  assert.equal(round.faultType, 'reverse');
+  assert.equal(round.eventId, 'us7000abcd');
+});

--- a/src/services/seismic/focal-classifier.ts
+++ b/src/services/seismic/focal-classifier.ts
@@ -1,0 +1,294 @@
+/**
+ * Focal mechanism classification — Layer 4 (descoped from waveform plan).
+ *
+ * Pure deterministic. No DOM, no fetch, no globals at import time.
+ * Takes a USGS moment-tensor product JSON payload and produces a
+ * `FocalMechanism` with the two nodal planes, fault type classification,
+ * and a simple SVG beach ball ready to embed in the UI.
+ *
+ * Plan invariants:
+ *   - Classification rule (Aki-Richards rake convention, degrees):
+ *       strike-slip: |rake| < 30 OR |rake| > 150
+ *       normal:      rake in [-150, -30]   (i.e. rake < -30 and >= -150)
+ *       reverse:     rake in [ 30,  150]   (i.e. rake >  30 and <=  150)
+ *       oblique:     anything that doesn't match a clear pure case
+ *     We use the steeper-dipping plane's rake as the discriminant — it is
+ *     more diagnostic for fault type than the auxiliary plane.
+ *   - The SVG beach ball is intentionally schematic. We draw a canonical
+ *     pattern per fault type and rotate it by the steeper plane's strike.
+ *     That communicates fault type at a glance without claiming Aki-
+ *     Richards stereographic accuracy. A future PR can swap in real
+ *     focal-sphere projection.
+ *   - SVG output contains only fixed shape primitives (`circle`, `path`,
+ *     `g`) with numeric attributes derived from typed inputs. No string
+ *     interpolation of caller-provided text into element bodies.
+ *   - Pure parser. The sidecar `/api/focal-mechanism` endpoint forwards
+ *     the upstream USGS payload; this module's `parseUsgsMomentTensor`
+ *     does the work, deterministically, on plain JSON.
+ */
+
+// ── Public types ────────────────────────────────────────────────────────
+
+export type FaultType = 'strike_slip' | 'normal' | 'reverse' | 'oblique';
+
+export interface NodalPlane {
+  /** Compass azimuth of the fault strike, 0..360 degrees from north. */
+  strike: number;
+  /** Dip angle from horizontal, 0..90 degrees. */
+  dip: number;
+  /** Slip rake on the plane, -180..180 degrees (Aki-Richards). */
+  rake: number;
+}
+
+export interface FocalMechanism {
+  eventId: string;
+  nodalPlane1: NodalPlane;
+  nodalPlane2: NodalPlane;
+  faultType: FaultType;
+  /** Moment magnitude (Mw) from the moment tensor product. */
+  momentMagnitude: number | null;
+  depthKm: number | null;
+  /** Self-contained SVG string with only numeric attributes. */
+  beachballSvg: string;
+}
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+/**
+ * Classify a fault type from a single nodal plane's rake angle.
+ * Plan rule: |rake| < 30 strike-slip; rake in (30,150] reverse;
+ * rake in [-150,-30) normal; everything else oblique.
+ */
+export function classifyFaultType(rake: number): FaultType {
+  const r = normalizeRake(rake);
+  const abs = Math.abs(r);
+  if (abs < 30 || abs > 150) return 'strike_slip';
+  if (r >= 30 && r <= 150) return 'reverse';
+  if (r >= -150 && r <= -30) return 'normal';
+  return 'oblique';
+}
+
+/**
+ * Pick the more-diagnostic plane for fault-type classification: the one
+ * with the steeper dip. When dips are equal, plane 1 wins by convention.
+ */
+export function pickDiagnosticPlane(p1: NodalPlane, p2: NodalPlane): NodalPlane {
+  return p2.dip > p1.dip ? p2 : p1;
+}
+
+/**
+ * Build a self-contained schematic beach ball SVG. The pattern is
+ * canonical per fault type; the steeper plane's strike determines
+ * rotation. Compressional quadrants are filled (`#1a1a1a`),
+ * dilatational quadrants are white. A thin black circle bounds the
+ * focal sphere.
+ */
+export function buildBeachballSvg(
+  planes: { p1: NodalPlane; p2: NodalPlane },
+  faultType: FaultType,
+  size = 64,
+): string {
+  const cx = size / 2;
+  const cy = size / 2;
+  const r = size / 2 - 1;
+  const rotation = pickDiagnosticPlane(planes.p1, planes.p2).strike;
+  const fill = '#1a1a1a';
+
+  const ariaLabel = faultTypeAria(faultType);
+  const header = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${size} ${size}" width="${size}" height="${size}" role="img" aria-label="${ariaLabel}">`;
+  const outline = `<circle cx="${cx}" cy="${cy}" r="${r}" fill="white" stroke="black" stroke-width="1"/>`;
+  const groupOpen = `<g transform="rotate(${fmt(rotation)} ${cx} ${cy})">`;
+  const groupClose = `</g>`;
+
+  let body = '';
+  switch (faultType) {
+    case 'strike_slip': {
+      // Two perpendicular nodal planes; compressional quadrants are NE
+      // and SW (or NW and SE depending on slip sense). Schematic: fill
+      // the two opposite quadrants spanning [0,90] and [180,270] (degrees
+      // measured clockwise from north on the SVG).
+      body =
+        wedge(cx, cy, r, 0, 90, fill)
+        + wedge(cx, cy, r, 180, 270, fill);
+      break;
+    }
+    case 'normal': {
+      // Tension axis horizontal, P-axis vertical → schematic shows
+      // dilatational center band, compressional caps. We fill two
+      // diameter-aligned wedges centered on north and south.
+      body =
+        wedge(cx, cy, r, -45, 45, fill)
+        + wedge(cx, cy, r, 135, 225, fill);
+      break;
+    }
+    case 'reverse': {
+      // P-axis horizontal → compressional regions on left and right;
+      // dilatational top and bottom. Schematic: fill east and west
+      // wedges centered on those compass directions.
+      body =
+        wedge(cx, cy, r, 45, 135, fill)
+        + wedge(cx, cy, r, 225, 315, fill);
+      break;
+    }
+    case 'oblique': {
+      // Half-filled disk along the strike — a neutral tilt that conveys
+      // "not a clean pure mechanism" without misclaiming a sense.
+      body = wedge(cx, cy, r, 0, 180, fill);
+      break;
+    }
+  }
+
+  return `${header}${outline}${groupOpen}${body}${groupClose}</svg>`;
+}
+
+/**
+ * Parse a USGS FDSN GeoJSON event response and pull out the first
+ * moment-tensor product's nodal planes. Returns null when the payload
+ * lacks a moment-tensor product or the planes are unparseable — callers
+ * should treat that as "no focal mechanism available".
+ */
+export function parseUsgsMomentTensor(
+  payload: unknown,
+  options: { eventId?: string } = {},
+): FocalMechanism | null {
+  const feature = pickFeature(payload);
+  if (!feature) return null;
+
+  const eventId = options.eventId
+    ?? readString(feature, 'id')
+    ?? readString(readObject(feature, 'properties'), 'code')
+    ?? '';
+  if (!eventId) return null;
+
+  const products = readObject(readObject(feature, 'properties'), 'products');
+  const momentTensors = readArray(products, 'moment-tensor');
+  if (momentTensors.length === 0) return null;
+
+  // Prefer the first non-deleted, preferred-weight tensor. Without that
+  // metadata fall back to the first entry.
+  const tensor = momentTensors[0];
+  if (!tensor || typeof tensor !== 'object') return null;
+  const props = readObject(tensor, 'properties');
+
+  const p1 = readNodalPlane(props, 1);
+  const p2 = readNodalPlane(props, 2);
+  if (!p1 || !p2) return null;
+
+  const faultType = classifyFaultType(pickDiagnosticPlane(p1, p2).rake);
+  const momentMagnitude = readFiniteNumber(props, 'derived-magnitude');
+  const depthKm = readFiniteNumber(props, 'derived-depth');
+  const beachballSvg = buildBeachballSvg({ p1, p2 }, faultType);
+
+  return {
+    eventId,
+    nodalPlane1: p1,
+    nodalPlane2: p2,
+    faultType,
+    momentMagnitude,
+    depthKm,
+    beachballSvg,
+  };
+}
+
+// ── Internal helpers ───────────────────────────────────────────────────
+
+function normalizeRake(rake: number): number {
+  if (!Number.isFinite(rake)) return 0;
+  let r = rake % 360;
+  if (r > 180) r -= 360;
+  if (r <= -180) r += 360;
+  return r;
+}
+
+function fmt(n: number): string {
+  if (!Number.isFinite(n)) return '0';
+  return Number(n.toFixed(2)).toString();
+}
+
+function faultTypeAria(faultType: FaultType): string {
+  switch (faultType) {
+    case 'strike_slip': { return 'strike slip focal mechanism';
+    }
+    case 'normal': {      return 'normal focal mechanism';
+    }
+    case 'reverse': {     return 'reverse focal mechanism';
+    }
+    case 'oblique': {     return 'oblique focal mechanism';
+    }
+  }
+}
+
+/**
+ * Filled circular wedge from `startDeg` to `endDeg`, where 0° points up
+ * (north) and angles increase clockwise. Mirrors the convention used in
+ * compass-style beach balls.
+ */
+function wedge(cx: number, cy: number, r: number, startDeg: number, endDeg: number, fill: string): string {
+  const a0 = ((startDeg - 90) * Math.PI) / 180;
+  const a1 = ((endDeg - 90) * Math.PI) / 180;
+  const x0 = cx + r * Math.cos(a0);
+  const y0 = cy + r * Math.sin(a0);
+  const x1 = cx + r * Math.cos(a1);
+  const y1 = cy + r * Math.sin(a1);
+  const largeArc = endDeg - startDeg > 180 ? 1 : 0;
+  return `<path d="M ${fmt(cx)} ${fmt(cy)} L ${fmt(x0)} ${fmt(y0)} A ${fmt(r)} ${fmt(r)} 0 ${largeArc} 1 ${fmt(x1)} ${fmt(y1)} Z" fill="${fill}"/>`;
+}
+
+function pickFeature(payload: unknown): Record<string, unknown> | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const obj = payload as Record<string, unknown>;
+  if (obj.type === 'Feature') return obj;
+  if (obj.type === 'FeatureCollection') {
+    const features = obj.features;
+    if (Array.isArray(features) && features.length > 0 && features[0] && typeof features[0] === 'object') {
+      return features[0] as Record<string, unknown>;
+    }
+  }
+  return null;
+}
+
+function readObject(obj: unknown, key: string): Record<string, unknown> | null {
+  if (!obj || typeof obj !== 'object') return null;
+  const value = (obj as Record<string, unknown>)[key];
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : null;
+}
+
+function readArray(obj: unknown, key: string): readonly unknown[] {
+  if (!obj || typeof obj !== 'object') return [];
+  const value = (obj as Record<string, unknown>)[key];
+  return Array.isArray(value) ? value : [];
+}
+
+function readString(obj: unknown, key: string): string | null {
+  if (!obj || typeof obj !== 'object') return null;
+  const value = (obj as Record<string, unknown>)[key];
+  return typeof value === 'string' ? value : null;
+}
+
+function readFiniteNumber(obj: unknown, key: string): number | null {
+  if (!obj || typeof obj !== 'object') return null;
+  const value = (obj as Record<string, unknown>)[key];
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function readNodalPlane(props: Record<string, unknown> | null, index: 1 | 2): NodalPlane | null {
+  if (!props) return null;
+  const strike = readFiniteNumber(props, `nodal-plane-${index}-strike`);
+  const dip = readFiniteNumber(props, `nodal-plane-${index}-dip`);
+  const rake = readFiniteNumber(props, `nodal-plane-${index}-rake`);
+  if (strike === null || dip === null || rake === null) return null;
+  return {
+    strike: ((strike % 360) + 360) % 360,
+    dip: clampNonNegative(dip),
+    rake: normalizeRake(rake),
+  };
+}
+
+function clampNonNegative(n: number): number {
+  return Math.max(n, 0);
+}


### PR DESCRIPTION
## Summary
Pure-deterministic Layer-4 service that turns a USGS moment-tensor product into a typed `FocalMechanism` with the two nodal planes, fault-type classification, and a schematic SVG beach ball.

## Why
Closes the descoped PR 10 from the seismic intelligence roadmap. Reverse / normal / strike-slip classification is a major signal for tsunami risk (shallow-thrust → high; strike-slip → low) and aftershock pattern.

## Changes
- `src/services/seismic/focal-classifier.ts` — pure module: `classifyFaultType`, `pickDiagnosticPlane`, `buildBeachballSvg`, `parseUsgsMomentTensor`.
- `src/services/seismic/__tests__/focal-classifier.test.mts` — 21 tests.
- `src-tauri/sidecar/local-api-server.mjs` — `/api/focal-mechanism?eventId={id}` passthrough with eventId allowlist (`/^[A-Za-z0-9_-]{2,32}$/`), 30-min cache, 404 → `available:false`.
- `package.json` — `test:seismic` now runs all 4 files (73 tests).

## Tests
`npm run test:seismic` → 73 pass / 0 fail.
`npm run typecheck:all` → clean.

## Out of scope
- Real focal-sphere stereographic projection (the SVG is canonical-per-fault-type, rotated by the steeper plane's strike). Future PR.
- Renderer panel surface — service-only; UI lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)