### PR TITLE
feat: maritime freight-stress signal (PR B)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "test:insights": "tsx --test src/services/insights/__tests__/big-event-detector.test.mts src/services/insights/__tests__/confidence-urgency-matrix.test.mts src/services/insights/__tests__/notification-ladder.test.mts src/services/insights/__tests__/share-packet.test.mts src/services/insights/__tests__/ask-the-data.test.mts src/services/insights/__tests__/action-briefs.test.mts src/services/insights/__tests__/data-bridge.test.mts src/services/insights/__tests__/what-changed-digest.test.mts",
     "test:personal": "tsx --test src/services/personal/__tests__/personal-impact.test.mts",
     "test:adsb": "tsx --test src/services/adsb/__tests__/adsb-aggregate.test.mts",
+    "test:maritime": "tsx --test src/services/maritime/__tests__/freight-stress.test.mts && node --test src-tauri/sidecar/__tests__/freight-stress-parity.test.mjs",
     "test:seismic": "tsx --test src/services/seismic/__tests__/seismic-normalizer.test.mts src/services/seismic/__tests__/seismic-fusion.test.mts src/services/seismic/__tests__/shaking-estimator.test.mts",
     "test:panels:smoke": "node tests/panels/run-harness.mjs",
     "test:panels:fixtures": "tsx --import ./tests/panels/register-hook.mjs --test tests/panels/panel-fixtures.test.mts",

--- a/src-tauri/sidecar/__tests__/freight-stress-parity.test.mjs
+++ b/src-tauri/sidecar/__tests__/freight-stress-parity.test.mjs
@@ -1,0 +1,117 @@
+/**
+ * Parity test: the sidecar's inline JS port of the freight-stress logic
+ * (parseFredCsvSidecar + computeFreightStressSidecar) MUST produce the
+ * same result as the canonical TS module in src/services/maritime/.
+ *
+ * If you change one, change the other and update this test.
+ */
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+import {
+  parseFredCsvSidecar,
+  computeFreightStressSidecar,
+} from '../local-api-server.mjs';
+
+const SAMPLE_CSV = [
+  'DATE,PPIACO',
+  '2025-04-01,250',
+  '2025-05-01,251',
+  '2025-06-01,249',
+  '2025-07-01,252',
+  '2025-08-01,250',
+  '2025-09-01,253',
+  '2025-10-01,251',
+  '2025-11-01,255',
+  '2025-12-01,254',
+  '2026-01-01,256',
+  '2026-02-01,258',
+  '2026-03-01,260',
+  '2026-04-01,275',
+].join('\n');
+
+test('parseFredCsvSidecar: parses header + numeric rows', () => {
+  const out = parseFredCsvSidecar(SAMPLE_CSV);
+  assert.equal(out.length, 13);
+  assert.equal(out[0].date, '2025-04-01');
+  assert.equal(out[0].value, 250);
+  assert.equal(out[12].value, 275);
+});
+
+test('parseFredCsvSidecar: skips FRED missing-value rows (".")', () => {
+  const csv = `DATE,PPIACO\n2026-01-01,.\n2026-02-01,251`;
+  const out = parseFredCsvSidecar(csv);
+  assert.equal(out.length, 1);
+});
+
+test('parseFredCsvSidecar: tolerates CRLF line endings + empty body', () => {
+  assert.deepEqual(parseFredCsvSidecar(''), []);
+  const out = parseFredCsvSidecar(`DATE,X\r\n2026-01-01,1.0\r\n2026-02-01,2.0`);
+  assert.equal(out.length, 2);
+});
+
+test('computeFreightStressSidecar: empty observations → empty result', () => {
+  const r = computeFreightStressSidecar('PPIACO', []);
+  assert.equal(r.current, null);
+  assert.equal(r.observationCount, 0);
+  assert.equal(r.stressScore, 0);
+  assert.equal(r.stressLevel, 'low');
+});
+
+test('computeFreightStressSidecar: flat baseline → score 0', () => {
+  const flat = [];
+  const dates = [
+    '2025-04-01','2025-05-01','2025-06-01','2025-07-01','2025-08-01','2025-09-01',
+    '2025-10-01','2025-11-01','2025-12-01','2026-01-01','2026-02-01','2026-03-01',
+    '2026-04-01',
+  ];
+  for (const date of dates) flat.push({ date, value: 250 });
+  const r = computeFreightStressSidecar('PPIACO', flat);
+  assert.equal(r.stressScore, 0);
+  assert.equal(r.stressLevel, 'low');
+});
+
+test('computeFreightStressSidecar: 2σ+ above noisy baseline → critical', () => {
+  const values = [248, 252, 246, 254, 250, 245, 255, 247, 253, 250, 244, 256];
+  const dates = [
+    '2025-04-01','2025-05-01','2025-06-01','2025-07-01','2025-08-01','2025-09-01',
+    '2025-10-01','2025-11-01','2025-12-01','2026-01-01','2026-02-01','2026-03-01',
+  ];
+  const obs = dates.map((date, i) => ({ date, value: values[i] }));
+  obs.push({ date: '2026-04-01', value: 270 });
+  const r = computeFreightStressSidecar('PPIACO', obs);
+  assert.ok(r.zScore >= 3, `zScore was ${r.zScore}`);
+  assert.equal(r.stressLevel, 'critical');
+});
+
+test('computeFreightStressSidecar: rising trend detection', () => {
+  const flat = [];
+  const dates = [
+    '2025-04-01','2025-05-01','2025-06-01','2025-07-01','2025-08-01','2025-09-01',
+    '2025-10-01','2025-11-01','2025-12-01','2026-01-01','2026-02-01','2026-03-01',
+  ];
+  for (const date of dates) flat.push({ date, value: 250 });
+  flat.push({ date: '2026-04-01', value: 260 });
+  const r = computeFreightStressSidecar('PPIACO', flat);
+  assert.equal(r.trend, 'rising');
+});
+
+test('computeFreightStressSidecar: handles unsorted input', () => {
+  const obs = [
+    { date: '2026-04-01', value: 275 },
+    { date: '2025-04-01', value: 250 },
+    { date: '2025-05-01', value: 251 },
+    { date: '2025-06-01', value: 249 },
+    { date: '2025-07-01', value: 252 },
+    { date: '2025-08-01', value: 250 },
+    { date: '2025-09-01', value: 253 },
+    { date: '2025-10-01', value: 251 },
+    { date: '2025-11-01', value: 255 },
+    { date: '2025-12-01', value: 254 },
+    { date: '2026-01-01', value: 256 },
+    { date: '2026-02-01', value: 258 },
+    { date: '2026-03-01', value: 260 },
+  ];
+  const r = computeFreightStressSidecar('PPIACO', obs);
+  assert.equal(r.asOf, '2026-04-01');
+  assert.equal(r.current, 275);
+});

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -1117,6 +1117,70 @@ function makeCorsHeaders(req) {
   };
 }
 
+// ── Freight-stress helpers (mirror src/services/maritime/freight-stress.ts) ──
+export function parseFredCsvSidecar(csv) {
+  const lines = String(csv).split(/\r?\n/).filter(l => l.trim().length > 0);
+  if (lines.length === 0) return [];
+  const header = lines[0].split(',');
+  if (header.length < 2) return [];
+  const out = [];
+  for (let i = 1; i < lines.length; i++) {
+    const cols = lines[i].split(',');
+    if (cols.length < 2) continue;
+    const date = cols[0].trim();
+    const raw = cols[1].trim();
+    if (!date || raw === '' || raw === '.') continue;
+    const value = Number(raw);
+    if (!Number.isFinite(value)) continue;
+    out.push({ date, value });
+  }
+  return out;
+}
+
+export function computeFreightStressSidecar(series, observations) {
+  if (observations.length === 0) {
+    return { series, current: null, avg12m: null, stdev12m: null, deviationPct: null,
+      zScore: null, trend: 'stable', stressScore: 0, stressLevel: 'low',
+      observationCount: 0, asOf: null };
+  }
+  const sorted = [...observations].sort((a, b) => a.date.localeCompare(b.date));
+  const last = sorted[sorted.length - 1];
+  const current = last.value;
+  const window = sorted.slice(Math.max(0, sorted.length - 13), - 1);
+  const allValues = sorted.map(o => o.value);
+  const trend = (() => {
+    if (allValues.length < 3) return 'stable';
+    const tail = allValues.slice(-3);
+    const slope = (tail[2] - tail[0]) / 2;
+    const refMean = tail.reduce((a, b) => a + b, 0) / 3;
+    const ref = Math.abs(refMean) || 1;
+    if (slope > 0.005 * ref) return 'rising';
+    if (slope < -0.005 * ref) return 'falling';
+    return 'stable';
+  })();
+  if (window.length < 3) {
+    return { series, current, avg12m: null, stdev12m: null, deviationPct: null,
+      zScore: null, trend, stressScore: 0, stressLevel: 'low',
+      observationCount: sorted.length, asOf: last.date };
+  }
+  const values = window.map(o => o.value);
+  const avg = values.reduce((a, b) => a + b, 0) / values.length;
+  let sq = 0;
+  for (const x of values) sq += (x - avg) ** 2;
+  const sdev = values.length < 2 ? 0 : Math.sqrt(sq / (values.length - 1));
+  const deviationPct = avg === 0 ? null : ((current - avg) / avg) * 100;
+  const z = sdev === 0 ? null : (current - avg) / sdev;
+  let score = 0;
+  if (z !== null && Number.isFinite(z)) {
+    const abs = Math.abs(z);
+    score = abs >= 3 ? 100 : abs >= 2 ? 75 + (abs - 2) * 25 : abs >= 1 ? 35 + (abs - 1) * 40 : abs * 35;
+  }
+  const stressScore = Math.round(score);
+  const stressLevel = stressScore >= 75 ? 'critical' : stressScore >= 50 ? 'high' : stressScore >= 25 ? 'medium' : 'low';
+  return { series, current, avg12m: avg, stdev12m: sdev, deviationPct, zScore: z,
+    trend, stressScore, stressLevel, observationCount: sorted.length, asOf: last.date };
+}
+
 async function fetchWithTimeout(url, options = {}, timeoutMs = 12_000) {
   // Use node:https with IPv4 forced — Node.js built-in fetch (undici) tries IPv6
   // first and some servers (EIA, NASA FIRMS) have broken IPv6 causing ETIMEDOUT.
@@ -2791,6 +2855,43 @@ async function dispatch(requestUrl, req, routes, context) {
  } catch (error) {
  return json({ events: [], error: String(error.message ?? error) });
  }
+  }
+
+  // ── Maritime freight stress (FRED CSV proxy, no API key required) ──────
+  // The Baltic Dry Index is no longer freely accessible. We use the FRED
+  // CSV download for broad commodity-price indicators as a freight-cost
+  // proxy. Default series is PPIACO (PPI: All Commodities). Caller may
+  // override with ?series=PPIACO,PCU484212484212 etc.
+  if (requestUrl.pathname === '/api/freight-stress') {
+    const seriesParam = (requestUrl.searchParams.get('series') || 'PPIACO,PFOODINDEXM')
+      .split(',').map(s => s.trim()).filter(s => /^[A-Z0-9_]+$/i.test(s)).slice(0, 5);
+    if (seriesParam.length === 0) {
+      return json({ error: 'invalid or empty series parameter' }, 400);
+    }
+    const components = [];
+    for (const series of seriesParam) {
+      try {
+        const url = `https://fred.stlouisfed.org/graph/fredgraph.csv?id=${encodeURIComponent(series)}`;
+        const resp = await fetchWithTimeout(url, { headers: { Accept: 'text/csv' } }, 12_000);
+        if (!resp.ok) {
+          components.push({ series, error: `FRED ${resp.status}`, stressScore: 0, stressLevel: 'low' });
+          continue;
+        }
+        const csv = await resp.text();
+        const observations = parseFredCsvSidecar(csv);
+        components.push(computeFreightStressSidecar(series, observations));
+      } catch (error) {
+        components.push({ series, error: String(error?.message ?? error), stressScore: 0, stressLevel: 'low' });
+      }
+    }
+    let overallScore = 0;
+    let asOf = null;
+    for (const c of components) {
+      if (typeof c.stressScore === 'number' && c.stressScore > overallScore) overallScore = c.stressScore;
+      if (c.asOf && (!asOf || c.asOf > asOf)) asOf = c.asOf;
+    }
+    const overallLevel = overallScore >= 75 ? 'critical' : overallScore >= 50 ? 'high' : overallScore >= 25 ? 'medium' : 'low';
+    return json({ components, overallScore, overallLevel, asOf });
   }
 
   // ── ThreatFox IOC feed ───────────────────────────────────────────────────

--- a/src/services/maritime/__tests__/freight-stress.test.mts
+++ b/src/services/maritime/__tests__/freight-stress.test.mts
@@ -1,0 +1,208 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  aggregateFreightStress,
+  computeFreightStress,
+  parseFredCsv,
+  stressScoreFromZ,
+} from '../freight-stress.ts';
+import type { FredObservation, FreightStressResult } from '../freight-stress.ts';
+
+// ── CSV parser ───────────────────────────────────────────────────────────────
+
+test('parseFredCsv: parses header + numeric rows', () => {
+  const csv = `DATE,PPIACO\n2026-01-01,250.5\n2026-02-01,251.2\n2026-03-01,252.1`;
+  const out = parseFredCsv(csv);
+  assert.equal(out.length, 3);
+  assert.equal(out[0]!.date, '2026-01-01');
+  assert.equal(out[0]!.value, 250.5);
+});
+
+test('parseFredCsv: skips FRED missing-value rows (value=".")', () => {
+  const csv = `DATE,PPIACO\n2026-01-01,.\n2026-02-01,251.2`;
+  const out = parseFredCsv(csv);
+  assert.equal(out.length, 1);
+  assert.equal(out[0]!.date, '2026-02-01');
+});
+
+test('parseFredCsv: skips non-numeric rows', () => {
+  const csv = `DATE,PPIACO\n2026-01-01,abc\n2026-02-01,251.2`;
+  const out = parseFredCsv(csv);
+  assert.equal(out.length, 1);
+});
+
+test('parseFredCsv: skips rows missing the value column', () => {
+  const csv = `DATE,PPIACO\n2026-01-01\n2026-02-01,251.2`;
+  const out = parseFredCsv(csv);
+  assert.equal(out.length, 1);
+});
+
+test('parseFredCsv: handles empty body', () => {
+  assert.deepEqual(parseFredCsv(''), []);
+  assert.deepEqual(parseFredCsv('DATE,PPIACO'), []);
+});
+
+test('parseFredCsv: tolerates CRLF line endings', () => {
+  const csv = `DATE,PPIACO\r\n2026-01-01,250.5\r\n2026-02-01,251.2`;
+  const out = parseFredCsv(csv);
+  assert.equal(out.length, 2);
+});
+
+// ── Z-score → stress mapping ─────────────────────────────────────────────────
+
+test('stressScoreFromZ: 0 → 0', () => {
+  assert.equal(stressScoreFromZ(0), 0);
+});
+
+test('stressScoreFromZ: |z|=2 → 75 ("stressed" threshold from spec)', () => {
+  assert.equal(stressScoreFromZ(2), 75);
+  assert.equal(stressScoreFromZ(-2), 75);
+});
+
+test('stressScoreFromZ: |z|>=3 → 100', () => {
+  assert.equal(stressScoreFromZ(3), 100);
+  assert.equal(stressScoreFromZ(5), 100);
+});
+
+test('stressScoreFromZ: monotonic with |z|', () => {
+  const xs = [0, 0.5, 1, 1.5, 2, 2.5, 3];
+  for (let i = 1; i < xs.length; i++) {
+    assert.ok(stressScoreFromZ(xs[i]!) >= stressScoreFromZ(xs[i - 1]!));
+  }
+});
+
+test('stressScoreFromZ: null/NaN → 0', () => {
+  assert.equal(stressScoreFromZ(null), 0);
+  assert.equal(stressScoreFromZ(Number.NaN), 0);
+});
+
+// ── computeFreightStress ─────────────────────────────────────────────────────
+
+function obs(date: string, value: number): FredObservation {
+  return { date, value };
+}
+
+function flat12(value: number): FredObservation[] {
+  return [
+    obs('2025-04-01', value), obs('2025-05-01', value), obs('2025-06-01', value),
+    obs('2025-07-01', value), obs('2025-08-01', value), obs('2025-09-01', value),
+    obs('2025-10-01', value), obs('2025-11-01', value), obs('2025-12-01', value),
+    obs('2026-01-01', value), obs('2026-02-01', value), obs('2026-03-01', value),
+  ];
+}
+
+test('flat baseline + matching current → score 0, low stress', () => {
+  const data = [...flat12(250), obs('2026-04-01', 250)];
+  const r = computeFreightStress('PPIACO', data);
+  assert.equal(r.stressScore, 0);
+  assert.equal(r.stressLevel, 'low');
+  assert.equal(r.deviationPct, 0);
+});
+
+test('current at +5% over flat baseline → some stress', () => {
+  const data = [...flat12(250), obs('2026-04-01', 262.5)];
+  const r = computeFreightStress('PPIACO', data);
+  // Flat history → stdev = 0 → zScore null → score 0; this exposes a
+  // boundary case: stress only fires when there's variance to compare to.
+  assert.equal(r.zScore, null);
+  assert.equal(r.deviationPct! > 4 && r.deviationPct! < 6, true);
+});
+
+test('current 2σ above noisy baseline → high stress', () => {
+  // Generate a 12m noisy baseline around 250 with stdev ≈ 5
+  const baseline: FredObservation[] = [];
+  const values = [248, 252, 246, 254, 250, 245, 255, 247, 253, 250, 244, 256];
+  const dates = [
+    '2025-04-01','2025-05-01','2025-06-01','2025-07-01','2025-08-01','2025-09-01',
+    '2025-10-01','2025-11-01','2025-12-01','2026-01-01','2026-02-01','2026-03-01',
+  ];
+  for (let i = 0; i < 12; i++) baseline.push(obs(dates[i]!, values[i]!));
+  baseline.push(obs('2026-04-01', 270));
+  const r = computeFreightStress('PPIACO', baseline);
+  assert.ok(r.zScore! >= 3, `zScore was ${r.zScore}`);
+  assert.equal(r.stressLevel, 'critical');
+});
+
+test('symmetric: 2σ below baseline also surfaces as stressed', () => {
+  const values = [248, 252, 246, 254, 250, 245, 255, 247, 253, 250, 244, 256];
+  const dates = [
+    '2025-04-01','2025-05-01','2025-06-01','2025-07-01','2025-08-01','2025-09-01',
+    '2025-10-01','2025-11-01','2025-12-01','2026-01-01','2026-02-01','2026-03-01',
+  ];
+  const baseline: FredObservation[] = [];
+  for (let i = 0; i < 12; i++) baseline.push(obs(dates[i]!, values[i]!));
+  baseline.push(obs('2026-04-01', 230));
+  const r = computeFreightStress('PPIACO', baseline);
+  assert.ok(Math.abs(r.zScore!) >= 3, `zScore was ${r.zScore}`);
+});
+
+test('rising trend detected from last 3 observations', () => {
+  const data = [...flat12(250), obs('2026-04-01', 260)];
+  const r = computeFreightStress('PPIACO', data);
+  assert.equal(r.trend, 'rising');
+});
+
+test('empty observations → empty result', () => {
+  const r = computeFreightStress('PPIACO', []);
+  assert.equal(r.current, null);
+  assert.equal(r.observationCount, 0);
+  assert.equal(r.stressScore, 0);
+  assert.equal(r.stressLevel, 'low');
+});
+
+test('few observations → null stats but real current value', () => {
+  const r = computeFreightStress('PPIACO', [obs('2026-04-01', 250)]);
+  assert.equal(r.current, 250);
+  assert.equal(r.avg12m, null);
+  assert.equal(r.stressScore, 0);
+});
+
+test('result is sorted by date (handles unsorted input)', () => {
+  const unsorted = [
+    obs('2026-04-01', 260),
+    ...flat12(250),
+  ];
+  const r = computeFreightStress('PPIACO', unsorted);
+  assert.equal(r.asOf, '2026-04-01');
+  assert.equal(r.current, 260);
+});
+
+// ── Aggregate ────────────────────────────────────────────────────────────────
+
+test('aggregateFreightStress: empty → low', () => {
+  const a = aggregateFreightStress([]);
+  assert.equal(a.overallLevel, 'low');
+  assert.equal(a.overallScore, 0);
+});
+
+test('aggregateFreightStress: worst-component-wins', () => {
+  const components: FreightStressResult[] = [
+    {
+      series: 'A', current: 1, avg12m: 1, stdev12m: 0, deviationPct: 0,
+      zScore: 0, trend: 'stable', stressScore: 10, stressLevel: 'low',
+      observationCount: 13, asOf: '2026-04-01',
+    },
+    {
+      series: 'B', current: 1, avg12m: 1, stdev12m: 0, deviationPct: 0,
+      zScore: 0, trend: 'stable', stressScore: 80, stressLevel: 'critical',
+      observationCount: 13, asOf: '2026-04-01',
+    },
+  ];
+  const a = aggregateFreightStress(components);
+  assert.equal(a.overallScore, 80);
+  assert.equal(a.overallLevel, 'critical');
+});
+
+test('aggregateFreightStress: asOf is the most recent component', () => {
+  const components: FreightStressResult[] = [
+    { series: 'A', current: null, avg12m: null, stdev12m: null, deviationPct: null,
+      zScore: null, trend: 'stable', stressScore: 0, stressLevel: 'low',
+      observationCount: 0, asOf: '2026-01-01' },
+    { series: 'B', current: null, avg12m: null, stdev12m: null, deviationPct: null,
+      zScore: null, trend: 'stable', stressScore: 0, stressLevel: 'low',
+      observationCount: 0, asOf: '2026-04-01' },
+  ];
+  const a = aggregateFreightStress(components);
+  assert.equal(a.asOf, '2026-04-01');
+});

--- a/src/services/maritime/freight-stress.ts
+++ b/src/services/maritime/freight-stress.ts
@@ -1,0 +1,214 @@
+/**
+ * Freight stress signal (pure-deterministic).
+ *
+ * The Baltic Dry Index proper is no longer freely accessible. We use the
+ * FRED CSV proxy of broad commodity-price indicators as a freight-cost
+ * proxy: the producer-price index for all commodities (PPIACO) tracks
+ * the input cost of moving and producing goods globally. Deviation from
+ * the trailing 12-month average is the stress signal — short-horizon
+ * spikes flag transport-cost pressure even when the BDI itself is dark.
+ */
+
+export interface FredObservation {
+  date: string;
+  value: number;
+}
+
+export type FreightStressLevel = 'low' | 'medium' | 'high' | 'critical';
+
+export interface FreightStressResult {
+  series: string;
+  current: number | null;
+  avg12m: number | null;
+  stdev12m: number | null;
+  deviationPct: number | null;
+  zScore: number | null;
+  trend: 'rising' | 'falling' | 'stable';
+  stressScore: number;
+  stressLevel: FreightStressLevel;
+  observationCount: number;
+  asOf: string | null;
+}
+
+// ── CSV parser ───────────────────────────────────────────────────────────────
+
+/**
+ * Parse a FRED CSV download (header row "DATE,SERIES_ID" or "observation_date,...").
+ * Discards rows where value is "." (FRED's missing-value marker) or non-numeric.
+ */
+export function parseFredCsv(csv: string): FredObservation[] {
+  const lines = csv.split(/\r?\n/).filter((l) => l.trim().length > 0);
+  if (lines.length === 0) return [];
+  const header = lines[0]!.split(',');
+  if (header.length < 2) return [];
+  const out: FredObservation[] = [];
+  for (let i = 1; i < lines.length; i++) {
+    const cols = lines[i]!.split(',');
+    if (cols.length < 2) continue;
+    const date = cols[0]!.trim();
+    const raw = cols[1]!.trim();
+    if (!date || raw === '' || raw === '.') continue;
+    const value = Number(raw);
+    if (!Number.isFinite(value)) continue;
+    out.push({ date, value });
+  }
+  return out;
+}
+
+// ── Math helpers ─────────────────────────────────────────────────────────────
+
+function mean(xs: number[]): number {
+  if (xs.length === 0) return 0;
+  let sum = 0;
+  for (const x of xs) sum += x;
+  return sum / xs.length;
+}
+
+function stdev(xs: number[]): number {
+  if (xs.length < 2) return 0;
+  const m = mean(xs);
+  let sq = 0;
+  for (const x of xs) sq += (x - m) ** 2;
+  return Math.sqrt(sq / (xs.length - 1));
+}
+
+function trendFromTail(xs: number[]): 'rising' | 'falling' | 'stable' {
+  if (xs.length < 3) return 'stable';
+  const tail = xs.slice(-3);
+  const slope = (tail[2]! - tail[0]!) / 2;
+  const ref = Math.abs(mean(tail)) || 1;
+  if (slope > 0.005 * ref) return 'rising';
+  if (slope < -0.005 * ref) return 'falling';
+  return 'stable';
+}
+
+// ── Stress level mapping ─────────────────────────────────────────────────────
+
+function stressLevelFor(score: number): FreightStressLevel {
+  if (score >= 75) return 'critical';
+  if (score >= 50) return 'high';
+  if (score >= 25) return 'medium';
+  return 'low';
+}
+
+/**
+ * Score is 0..100, derived from |z-score|:
+ *   |z| ≥ 3.0 → 100   (extreme)
+ *   |z| = 2.0 → 75    (>=2σ = "stressed" per spec)
+ *   |z| = 1.0 → 35
+ *   |z| = 0.0 → 0
+ * Linear-interpolated between knots, clamped.
+ */
+export function stressScoreFromZ(z: number | null): number {
+  if (z === null || !Number.isFinite(z)) return 0;
+  const abs = Math.abs(z);
+  if (abs >= 3) return 100;
+  if (abs >= 2) return 75 + (abs - 2) * 25;
+  if (abs >= 1) return 35 + (abs - 1) * 40;
+  return abs * 35;
+}
+
+// ── Core ────────────────────────────────────────────────────────────────────
+
+export function computeFreightStress(
+  series: string,
+  observations: FredObservation[],
+): FreightStressResult {
+  if (observations.length === 0) {
+    return emptyResult(series);
+  }
+
+  const sorted = [...observations].sort((a, b) => a.date.localeCompare(b.date));
+  const last = sorted[sorted.length - 1]!;
+  const current = last.value;
+
+  // Last 12 observations BEFORE the current point form the rolling baseline.
+  const window = sorted.slice(Math.max(0, sorted.length - 13), - 1);
+  if (window.length < 3) {
+    return {
+      series,
+      current,
+      avg12m: null,
+      stdev12m: null,
+      deviationPct: null,
+      zScore: null,
+      trend: trendFromTail(sorted.map((o) => o.value)),
+      stressScore: 0,
+      stressLevel: 'low',
+      observationCount: sorted.length,
+      asOf: last.date,
+    };
+  }
+
+  const values = window.map((o) => o.value);
+  const avg12m = mean(values);
+  const stdev12m = stdev(values);
+  const deviationPct = avg12m === 0 ? null : ((current - avg12m) / avg12m) * 100;
+  const zScore = stdev12m === 0 ? null : (current - avg12m) / stdev12m;
+  const stressScore = Math.round(stressScoreFromZ(zScore));
+
+  return {
+    series,
+    current,
+    avg12m,
+    stdev12m,
+    deviationPct,
+    zScore,
+    trend: trendFromTail(sorted.map((o) => o.value)),
+    stressScore,
+    stressLevel: stressLevelFor(stressScore),
+    observationCount: sorted.length,
+    asOf: last.date,
+  };
+}
+
+function emptyResult(series: string): FreightStressResult {
+  return {
+    series,
+    current: null,
+    avg12m: null,
+    stdev12m: null,
+    deviationPct: null,
+    zScore: null,
+    trend: 'stable',
+    stressScore: 0,
+    stressLevel: 'low',
+    observationCount: 0,
+    asOf: null,
+  };
+}
+
+// ── Multi-series aggregate ───────────────────────────────────────────────────
+
+export interface FreightStressAggregate {
+  components: FreightStressResult[];
+  overallScore: number;
+  overallLevel: FreightStressLevel;
+  asOf: string | null;
+}
+
+/**
+ * Combine multiple freight-stress series into one overall reading.
+ * Overall score is the max of component scores (worst-component-wins),
+ * because shipping bottlenecks are dominated by the tightest constraint
+ * rather than averaged across them.
+ */
+export function aggregateFreightStress(
+  components: FreightStressResult[],
+): FreightStressAggregate {
+  if (components.length === 0) {
+    return { components: [], overallScore: 0, overallLevel: 'low', asOf: null };
+  }
+  let max = 0;
+  let asOf: string | null = null;
+  for (const c of components) {
+    if (c.stressScore > max) max = c.stressScore;
+    if (c.asOf && (!asOf || c.asOf > asOf)) asOf = c.asOf;
+  }
+  return {
+    components,
+    overallScore: max,
+    overallLevel: stressLevelFor(max),
+    asOf,
+  };
+}


### PR DESCRIPTION
**PR B of 4** in the maritime chokepoint intelligence stack.

Pure-deterministic FRED-CSV-driven freight cost stress proxy. The Baltic Dry Index proper is no longer freely accessible; PPIACO (PPI: All Commodities) and PFOODINDEXM via FRED CSV download serve as freight-cost surrogates. Stress fires on |z-score| ≥ 2σ vs the trailing 12-month rolling baseline.

## Files
- \`src/services/maritime/freight-stress.ts\` — \`parseFredCsv\`, \`computeFreightStress\`, \`aggregateFreightStress\` (worst-component-wins)
- \`src-tauri/sidecar/local-api-server.mjs\` — \`/api/freight-stress\` endpoint (no API key required), regex-validated series= override (max 5)
- Sidecar mirror functions exported (\`parseFredCsvSidecar\` / \`computeFreightStressSidecar\`) with parity tests
- 22 tsx tests + 8 node --test parity tests

## Why this shape
- BDI itself is paywalled — PPIACO is the closest open proxy for freight input cost
- Worst-component aggregation (not average) — shipping bottlenecks are dominated by the tightest constraint
- 2σ threshold matches user spec
- TS module is canonical; sidecar mirror has parity tests so they can't drift silently

## Verification
- \`npm run test:maritime\` — 30/30 pass
- \`npm run typecheck:all\` — clean