### PR TITLE
feat(seismic): historical analog matcher (PR 11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "test:personal": "tsx --test src/services/personal/__tests__/personal-impact.test.mts",
     "test:adsb": "tsx --test src/services/adsb/__tests__/adsb-aggregate.test.mts",
     "test:maritime": "tsx --test src/services/maritime/__tests__/freight-stress.test.mts src/services/__tests__/dark-vessel-gaps.test.mts && node --test src-tauri/sidecar/__tests__/freight-stress-parity.test.mjs src-tauri/sidecar/__tests__/dark-vessel-gaps-parity.test.mjs",
-    "test:seismic": "tsx --test src/services/seismic/__tests__/seismic-normalizer.test.mts src/services/seismic/__tests__/seismic-fusion.test.mts src/services/seismic/__tests__/shaking-estimator.test.mts src/services/seismic/__tests__/impact-assessor.test.mts src/services/seismic/__tests__/tsunami-reasoner.test.mts src/services/seismic/__tests__/focal-classifier.test.mts",
+    "test:seismic": "tsx --test src/services/seismic/__tests__/seismic-normalizer.test.mts src/services/seismic/__tests__/seismic-fusion.test.mts src/services/seismic/__tests__/shaking-estimator.test.mts src/services/seismic/__tests__/impact-assessor.test.mts src/services/seismic/__tests__/tsunami-reasoner.test.mts src/services/seismic/__tests__/focal-classifier.test.mts src/services/seismic/__tests__/sequence-matcher.test.mts",
     "test:synthesis": "tsx --test src/services/synthesis/__tests__/precedent-matcher.test.mts src/services/synthesis/__tests__/leading-indicators.test.mts",
     "test:cyber": "tsx --test src/services/cyber/__tests__/apt-tracker.test.mts",
     "test:geopolitics": "tsx --test src/services/geopolitics/__tests__/grayzone-classifier.test.mts",

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -5721,6 +5721,65 @@ async function dispatch(requestUrl, req, routes, context) {
     }
   }
 
+  // ── USGS historical analog catalog passthrough ─────────────────────────
+  // Forwards to USGS FDSN event service for events within a 50 km / ±0.5 M
+  // / ±30 km depth box around the query location, last 50 years up to 1
+  // year before the query event. Renderer ranks via
+  // `findHistoricalAnalogs` from src/services/seismic/sequence-matcher.ts.
+  // Cached per-query for 24 h; the historical catalog moves slowly.
+  if (requestUrl.pathname === '/api/historical-analogs') {
+    const lat = Number(requestUrl.searchParams.get('lat'));
+    const lon = Number(requestUrl.searchParams.get('lon'));
+    const mag = Number(requestUrl.searchParams.get('magnitude'));
+    const radiusKm = Number(requestUrl.searchParams.get('radiusKm') ?? 50);
+    const magDelta = Number(requestUrl.searchParams.get('magnitudeDelta') ?? 0.5);
+    const beforeMs = Number(requestUrl.searchParams.get('beforeMs') ?? Date.now());
+    if (
+      !Number.isFinite(lat) || lat < -90 || lat > 90
+      || !Number.isFinite(lon) || lon < -180 || lon > 180
+      || !Number.isFinite(mag) || mag < 0 || mag > 10
+      || !Number.isFinite(radiusKm) || radiusKm <= 0 || radiusKm > 500
+      || !Number.isFinite(magDelta) || magDelta <= 0 || magDelta > 2
+      || !Number.isFinite(beforeMs) || beforeMs <= 0
+    ) {
+      return json({ error: 'invalid query (lat/lon/magnitude/radiusKm/magnitudeDelta/beforeMs)' }, 400);
+    }
+    const cacheKey = `historical-analogs:${lat.toFixed(2)}:${lon.toFixed(2)}:${mag.toFixed(2)}:${radiusKm}:${magDelta}:${Math.floor(beforeMs / (24 * 60 * 60 * 1000))}`;
+    const cached = getCached(cacheKey);
+    if (cached) return json(cached);
+    try {
+      // Last 50 years up to (beforeMs - 1 year) so the event itself
+      // can't appear as its own analog.
+      const startTime = new Date(beforeMs - 50 * 365 * 24 * 60 * 60 * 1000).toISOString();
+      const endTime = new Date(beforeMs - 365 * 24 * 60 * 60 * 1000).toISOString();
+      const params = new URLSearchParams({
+        format: 'geojson',
+        latitude: String(lat),
+        longitude: String(lon),
+        maxradiuskm: String(radiusKm),
+        minmagnitude: String(Math.max(0, mag - magDelta)),
+        maxmagnitude: String(mag + magDelta),
+        starttime: startTime,
+        endtime: endTime,
+        orderby: 'magnitude',
+        limit: '100',
+      });
+      const upstream = `https://earthquake.usgs.gov/fdsnws/event/1/query?${params.toString()}`;
+      const r = await fetchWithTimeout(
+        upstream,
+        { headers: { Accept: 'application/json', 'User-Agent': 'CrystalBall/sidecar (historical-analogs)' } },
+        20000,
+      );
+      if (!r.ok) throw new Error(`USGS ${r.status}`);
+      const data = await r.json();
+      const payload = { lat, lon, magnitude: mag, radiusKm, magnitudeDelta: magDelta, raw: data };
+      setCached(cacheKey, payload, 24 * 60 * 60 * 1000);
+      return json(payload);
+    } catch (error) {
+      return json({ error: `historical-analogs error: ${error.message ?? error}` }, 502);
+    }
+  }
+
   // ── Travel warning RSS/Atom parser helper ─────────────────────────────────
   function parseTravelWarnings(xml, source) {
  const isAtom = source !== 'DFAT';

--- a/src/services/seismic/__tests__/sequence-matcher.test.mts
+++ b/src/services/seismic/__tests__/sequence-matcher.test.mts
@@ -1,0 +1,289 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  DEFAULT_MATCH_WEIGHTS,
+  DEFAULT_SEARCH_BOX,
+  findHistoricalAnalogs,
+  parseUsgsCatalog,
+  scoreAnalog,
+  type CatalogEvent,
+  type QueryEvent,
+} from '../sequence-matcher.ts';
+
+const QUERY: QueryEvent = {
+  id: 'us7000new',
+  lat: 35.0,
+  lon: -118.0,
+  depthKm: 10,
+  magnitude: 6.5,
+  faultType: 'reverse',
+};
+
+function cat(overrides: Partial<CatalogEvent> & { id: string }): CatalogEvent {
+  return {
+    id: overrides.id,
+    lat: overrides.lat ?? 35.0,
+    lon: overrides.lon ?? -118.0,
+    depthKm: 'depthKm' in overrides ? overrides.depthKm! : 10,
+    magnitude: overrides.magnitude ?? 6.5,
+    occurredAt: overrides.occurredAt ?? '2010-01-01T00:00:00Z',
+    place: overrides.place,
+    faultType: overrides.faultType,
+    subsequentLargestAftershock: overrides.subsequentLargestAftershock,
+    subsequentTsunamiObserved: overrides.subsequentTsunamiObserved,
+    notes: overrides.notes,
+  };
+}
+
+// ── scoreAnalog: search-box gating ─────────────────────────────────────
+
+test('scoreAnalog: drops candidate beyond max radius', () => {
+  // Two degrees of longitude at 35°N is ~182 km — outside the 50 km box.
+  const result = scoreAnalog(QUERY, cat({ id: 'far', lon: -116 }));
+  assert.equal(result, null);
+});
+
+test('scoreAnalog: drops candidate beyond magnitude delta', () => {
+  const result = scoreAnalog(QUERY, cat({ id: 'big', magnitude: 7.5 }));
+  assert.equal(result, null);
+});
+
+test('scoreAnalog: drops candidate beyond depth delta when both known', () => {
+  const result = scoreAnalog(QUERY, cat({ id: 'deep', depthKm: 80 }));
+  assert.equal(result, null);
+});
+
+test('scoreAnalog: keeps candidate when only one depth is known', () => {
+  const result = scoreAnalog(QUERY, cat({ id: 'no-depth', depthKm: null }));
+  assert.ok(result, 'candidate is in scope');
+  assert.equal(result!.components.depth, 0.5, 'neutral depth score');
+});
+
+test('scoreAnalog: drops candidate with the same id as the query', () => {
+  const result = scoreAnalog(QUERY, cat({ id: QUERY.id }));
+  assert.equal(result, null);
+});
+
+// ── scoreAnalog: ranking-relevant scoring rules ────────────────────────
+
+test('scoreAnalog: perfect colocated, same-magnitude, same-depth, same-fault', () => {
+  const result = scoreAnalog(QUERY, cat({
+    id: 'twin', lat: QUERY.lat, lon: QUERY.lon, depthKm: 10, magnitude: 6.5,
+    faultType: 'reverse',
+  }));
+  assert.ok(result);
+  assert.equal(result!.components.location, 1);
+  assert.equal(result!.components.magnitude, 1);
+  assert.equal(result!.components.depth, 1);
+  assert.equal(result!.components.focal, 1);
+  assert.equal(result!.matchScore, 1);
+});
+
+test('scoreAnalog: focal mismatch costs 10% of the total weight', () => {
+  const matching = scoreAnalog(QUERY, cat({
+    id: 'a', faultType: 'reverse',
+  }))!;
+  const mismatch = scoreAnalog(QUERY, cat({
+    id: 'b', faultType: 'normal',
+  }))!;
+  assert.ok(matching.matchScore > mismatch.matchScore);
+  assert.equal(mismatch.components.focal, 0);
+});
+
+test('scoreAnalog: focal type missing on the candidate is neutral, not penalty', () => {
+  const matching = scoreAnalog(QUERY, cat({ id: 'a', faultType: 'reverse' }))!;
+  const unknown  = scoreAnalog(QUERY, cat({ id: 'b' }))!;
+  const mismatch = scoreAnalog(QUERY, cat({ id: 'c', faultType: 'normal' }))!;
+  assert.ok(matching.matchScore > unknown.matchScore);
+  assert.ok(unknown.matchScore > mismatch.matchScore);
+});
+
+test('scoreAnalog: matchScore stays in [0, 1]', () => {
+  const result = scoreAnalog(QUERY, cat({
+    id: 'edge', lat: QUERY.lat, lon: QUERY.lon - 0.4, magnitude: 6.95,
+    depthKm: 39, faultType: 'normal',
+  }));
+  assert.ok(result);
+  assert.ok(result!.matchScore >= 0 && result!.matchScore <= 1);
+});
+
+// ── findHistoricalAnalogs: ranking + cap ───────────────────────────────
+
+test('findHistoricalAnalogs: returns top-5 by score', () => {
+  const events: CatalogEvent[] = [
+    cat({ id: 'best',   lat: QUERY.lat, lon: QUERY.lon, magnitude: 6.5, depthKm: 10, faultType: 'reverse' }),
+    cat({ id: 'good',   lat: QUERY.lat + 0.05, lon: QUERY.lon, magnitude: 6.4, depthKm: 12, faultType: 'reverse' }),
+    cat({ id: 'mid',    lat: QUERY.lat + 0.1, lon: QUERY.lon, magnitude: 6.3, depthKm: 20 }),
+    cat({ id: 'okay',   lat: QUERY.lat + 0.2, lon: QUERY.lon, magnitude: 6.6, depthKm: 30 }),
+    cat({ id: 'meh',    lat: QUERY.lat + 0.3, lon: QUERY.lon, magnitude: 6.7, depthKm: 35 }),
+    cat({ id: 'worst',  lat: QUERY.lat + 0.4, lon: QUERY.lon, magnitude: 6.0, depthKm: 38, faultType: 'normal' }),
+  ];
+  const ranked = findHistoricalAnalogs(QUERY, events);
+  assert.equal(ranked.length, 5);
+  assert.equal(ranked[0]!.analogEventId, 'best');
+  // Worst-ranked should be 'worst' if it sneaks into top-5; if not, the
+  // top-5 must not include it.
+  assert.ok(!ranked.find((r) => r.analogEventId === 'worst'));
+});
+
+test('findHistoricalAnalogs: limit option overrides default of 5', () => {
+  const events: CatalogEvent[] = Array.from({ length: 10 }, (_, i) =>
+    cat({
+      id: `e${i}`,
+      lat: QUERY.lat + i * 0.01,
+      lon: QUERY.lon,
+      magnitude: 6.5,
+      depthKm: 10,
+    }),
+  );
+  const ranked = findHistoricalAnalogs(QUERY, events, { limit: 3 });
+  assert.equal(ranked.length, 3);
+});
+
+test('findHistoricalAnalogs: out-of-scope candidates are filtered before ranking', () => {
+  const events: CatalogEvent[] = [
+    cat({ id: 'in', lat: QUERY.lat, lon: QUERY.lon }),
+    cat({ id: 'far',   lat: QUERY.lat + 5, lon: QUERY.lon }), // ~556 km
+    cat({ id: 'big',   magnitude: 8.0 }),
+    cat({ id: 'deep',  depthKm: 80 }),
+  ];
+  const ranked = findHistoricalAnalogs(QUERY, events);
+  assert.equal(ranked.length, 1);
+  assert.equal(ranked[0]!.analogEventId, 'in');
+});
+
+test('findHistoricalAnalogs: ranking is deterministic on score ties', () => {
+  // Same score on every component → ties broken by smaller distance.
+  const events: CatalogEvent[] = [
+    cat({ id: 'b', lat: QUERY.lat, lon: QUERY.lon - 0.2 }),
+    cat({ id: 'a', lat: QUERY.lat, lon: QUERY.lon - 0.1 }),
+    cat({ id: 'c', lat: QUERY.lat, lon: QUERY.lon - 0.3 }),
+  ];
+  const r1 = findHistoricalAnalogs(QUERY, events);
+  const r2 = findHistoricalAnalogs(QUERY, [...events].reverse());
+  assert.deepEqual(
+    r1.map((r) => r.analogEventId),
+    r2.map((r) => r.analogEventId),
+  );
+  // Closest first (a is at 0.1° west, b at 0.2°, c at 0.3°).
+  assert.equal(r1[0]!.analogEventId, 'a');
+});
+
+test('findHistoricalAnalogs: empty catalog returns empty array', () => {
+  const ranked = findHistoricalAnalogs(QUERY, []);
+  assert.deepEqual(ranked, []);
+});
+
+// ── Custom weights ────────────────────────────────────────────────────
+
+test('scoreAnalog: custom weights normalise correctly', () => {
+  // All-zero except focal → focal score equals matchScore.
+  const result = scoreAnalog(
+    QUERY,
+    cat({ id: 'x', lat: QUERY.lat + 0.4, lon: QUERY.lon, magnitude: 7.0, faultType: 'reverse' }),
+    { location: 0, magnitude: 0, depth: 0, focal: 1 },
+  );
+  assert.ok(result);
+  assert.equal(result!.matchScore, result!.components.focal);
+});
+
+test('scoreAnalog: zero-weight bag yields zero matchScore (defensive)', () => {
+  const result = scoreAnalog(
+    QUERY,
+    cat({ id: 'x' }),
+    { location: 0, magnitude: 0, depth: 0, focal: 0 },
+  );
+  assert.ok(result);
+  assert.equal(result!.matchScore, 0);
+});
+
+// ── parseUsgsCatalog ──────────────────────────────────────────────────
+
+const USGS_CATALOG_FIXTURE = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      id: 'ci40012345',
+      properties: {
+        mag: 6.4,
+        place: 'Searles Valley',
+        time: 1562383668000,
+      },
+      geometry: { type: 'Point', coordinates: [-117.5, 35.7, 8.7] },
+    },
+    {
+      type: 'Feature',
+      id: 'ci39126079',
+      properties: {
+        mag: 6.5,
+        place: 'Ridgecrest',
+        time: 1562383200000,
+      },
+      geometry: { type: 'Point', coordinates: [-117.6, 35.8, 12.0] },
+    },
+    // Garbage feature: missing mag — must be skipped.
+    {
+      type: 'Feature',
+      id: 'bad',
+      properties: { time: 1 },
+      geometry: { type: 'Point', coordinates: [0, 0] },
+    },
+  ],
+};
+
+test('parseUsgsCatalog: parses valid features, drops malformed ones', () => {
+  const events = parseUsgsCatalog(USGS_CATALOG_FIXTURE);
+  assert.equal(events.length, 2);
+  assert.equal(events[0]!.id, 'ci40012345');
+  assert.equal(events[0]!.magnitude, 6.4);
+  assert.equal(events[0]!.depthKm, 8.7);
+});
+
+test('parseUsgsCatalog: handles non-object payloads', () => {
+  assert.deepEqual(parseUsgsCatalog(null), []);
+  assert.deepEqual(parseUsgsCatalog(42), []);
+  assert.deepEqual(parseUsgsCatalog({ features: 'not-an-array' }), []);
+});
+
+test('parseUsgsCatalog: end-to-end from upstream JSON to ranked analogs', () => {
+  const catalog = parseUsgsCatalog(USGS_CATALOG_FIXTURE);
+  const ranked = findHistoricalAnalogs(
+    {
+      id: 'us7000foo',
+      lat: 35.7,
+      lon: -117.5,
+      depthKm: 10,
+      magnitude: 6.5,
+    },
+    catalog,
+  );
+  assert.equal(ranked.length, 2);
+  assert.equal(ranked[0]!.analogEventId, 'ci40012345'); // co-located
+});
+
+// ── Defaults exposed ──────────────────────────────────────────────────
+
+test('default weights sum to 1', () => {
+  const sum =
+    DEFAULT_MATCH_WEIGHTS.location
+    + DEFAULT_MATCH_WEIGHTS.magnitude
+    + DEFAULT_MATCH_WEIGHTS.depth
+    + DEFAULT_MATCH_WEIGHTS.focal;
+  assert.ok(Math.abs(sum - 1) < 1e-9, `weights sum to ${sum}`);
+});
+
+test('default search box matches plan (50 km / 0.5 M / 30 km)', () => {
+  assert.equal(DEFAULT_SEARCH_BOX.maxRadiusKm, 50);
+  assert.equal(DEFAULT_SEARCH_BOX.maxMagnitudeDelta, 0.5);
+  assert.equal(DEFAULT_SEARCH_BOX.maxDepthDeltaKm, 30);
+});
+
+// ── JSON serializability ──────────────────────────────────────────────
+
+test('HistoricalAnalog is JSON-serializable', () => {
+  const analog = scoreAnalog(QUERY, cat({ id: 'a' }))!;
+  const round = JSON.parse(JSON.stringify(analog));
+  assert.equal(round.analogEventId, 'a');
+});

--- a/src/services/seismic/sequence-matcher.ts
+++ b/src/services/seismic/sequence-matcher.ts
@@ -1,0 +1,317 @@
+/**
+ * Historical sequence pattern matching — Layer 5.
+ *
+ * Pure deterministic. No DOM, no fetch, no globals at import time.
+ * Given a query event (the new earthquake) and a catalog of historical
+ * candidates (typically pulled from USGS FDSN within a 50 km / ±0.5 M /
+ * ±30 km depth box), `findHistoricalAnalogs` produces the top-K analogs
+ * ranked by a weighted match score in [0, 1].
+ *
+ * Plan invariants:
+ *   - Location is the dominant signal (40% weight). Magnitude is next
+ *     (30%), then depth (20%), then focal mechanism similarity (10%).
+ *     Weights are exposed via `MatchWeights` so callers can experiment.
+ *   - Missing data does not invent confidence: when a candidate's depth
+ *     or fault type is unknown, those components score 0.5 (neutral) so
+ *     the analog isn't penalised for thin metadata.
+ *   - Pure ranking. Sidecar `/api/historical-analogs?eventId={id}` is a
+ *     thin USGS FDSN passthrough; this module does the scoring and
+ *     ranking deterministically over plain JSON.
+ *   - Self-matches are excluded. A candidate with the same id as the
+ *     query is silently dropped — the new event must not appear as its
+ *     own analog.
+ */
+
+import type { FaultType } from './focal-classifier';
+
+// ── Public types ────────────────────────────────────────────────────────
+
+export interface QueryEvent {
+  /** Stable id for self-match exclusion. */
+  id: string;
+  lat: number;
+  lon: number;
+  /** Hypocentral depth in km. `null` when unknown. */
+  depthKm: number | null;
+  magnitude: number;
+  faultType?: FaultType;
+}
+
+export interface CatalogEvent {
+  id: string;
+  lat: number;
+  lon: number;
+  depthKm: number | null;
+  magnitude: number;
+  /** ms epoch of origin time, or ISO date string. */
+  occurredAt: number | string;
+  place?: string;
+  faultType?: FaultType;
+  /** Largest aftershock magnitude observed in the analog's sequence,
+   *  if known. Surfaced so the caller can answer "what came next?". */
+  subsequentLargestAftershock?: number;
+  /** Whether the analog produced an observed (not just warning)
+   *  tsunami. */
+  subsequentTsunamiObserved?: boolean;
+  notes?: string;
+}
+
+export interface MatchWeights {
+  location: number;
+  magnitude: number;
+  depth: number;
+  focal: number;
+}
+
+export interface MatchSearchBox {
+  /** Maximum great-circle distance (km) for a candidate to be in scope.
+   *  Default 50. */
+  maxRadiusKm: number;
+  /** Maximum magnitude delta for in-scope candidates. Default 0.5. */
+  maxMagnitudeDelta: number;
+  /** Maximum depth delta (km). Default 30. */
+  maxDepthDeltaKm: number;
+}
+
+export interface HistoricalAnalog {
+  /** Echoes the query event id so callers can correlate UI rows. */
+  eventId: string;
+  analogEventId: string;
+  /** ISO date string for display. */
+  analogDate: string;
+  analogMagnitude: number;
+  analogDepth: number | null;
+  /** 0..1 match quality. 1 = perfect match across all components. */
+  matchScore: number;
+  /** Per-component scores so the UI can explain the match. */
+  components: {
+    location: number;
+    magnitude: number;
+    depth: number;
+    focal: number;
+  };
+  distanceKm: number;
+  subsequentLargestAftershock?: number;
+  subsequentTsunamiObserved?: boolean;
+  notes?: string;
+}
+
+// ── Defaults ───────────────────────────────────────────────────────────
+
+export const DEFAULT_MATCH_WEIGHTS: MatchWeights = {
+  location: 0.4,
+  magnitude: 0.3,
+  depth: 0.2,
+  focal: 0.1,
+};
+
+export const DEFAULT_SEARCH_BOX: MatchSearchBox = {
+  maxRadiusKm: 50,
+  maxMagnitudeDelta: 0.5,
+  maxDepthDeltaKm: 30,
+};
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+export interface FindAnalogsOptions {
+  weights?: Partial<MatchWeights>;
+  searchBox?: Partial<MatchSearchBox>;
+  limit?: number;
+}
+
+/**
+ * Score a catalog candidate against a query event. Returns null when the
+ * candidate falls outside the search box on any axis (location radius,
+ * magnitude delta, depth delta when both depths are known).
+ */
+export function scoreAnalog(
+  query: QueryEvent,
+  candidate: CatalogEvent,
+  weights: MatchWeights = DEFAULT_MATCH_WEIGHTS,
+  searchBox: MatchSearchBox = DEFAULT_SEARCH_BOX,
+): HistoricalAnalog | null {
+  if (candidate.id === query.id) return null;
+  if (!Number.isFinite(candidate.lat) || !Number.isFinite(candidate.lon)) return null;
+  if (!Number.isFinite(candidate.magnitude)) return null;
+
+  const distanceKm = haversineKm(query.lat, query.lon, candidate.lat, candidate.lon);
+  if (distanceKm > searchBox.maxRadiusKm) return null;
+
+  const magnitudeDelta = Math.abs(candidate.magnitude - query.magnitude);
+  if (magnitudeDelta > searchBox.maxMagnitudeDelta) return null;
+
+  if (
+    query.depthKm !== null
+    && candidate.depthKm !== null
+    && Math.abs((candidate.depthKm ?? 0) - (query.depthKm ?? 0)) > searchBox.maxDepthDeltaKm
+  ) {
+    return null;
+  }
+
+  const locationScore = clamp01(1 - distanceKm / searchBox.maxRadiusKm);
+  const magnitudeScore = clamp01(1 - magnitudeDelta / searchBox.maxMagnitudeDelta);
+
+  const depthScore =
+    query.depthKm === null || candidate.depthKm === null
+      ? 0.5
+      : clamp01(1 - Math.abs(candidate.depthKm - query.depthKm) / searchBox.maxDepthDeltaKm);
+
+  const focalScore = scoreFocalMatch(query.faultType, candidate.faultType);
+
+  const totalWeight =
+    weights.location + weights.magnitude + weights.depth + weights.focal;
+  const matchScore =
+    totalWeight === 0
+      ? 0
+      : (locationScore * weights.location
+        + magnitudeScore * weights.magnitude
+        + depthScore * weights.depth
+        + focalScore * weights.focal)
+        / totalWeight;
+
+  return {
+    eventId: query.id,
+    analogEventId: candidate.id,
+    analogDate: toIsoDate(candidate.occurredAt),
+    analogMagnitude: candidate.magnitude,
+    analogDepth: candidate.depthKm,
+    matchScore: clamp01(matchScore),
+    components: {
+      location: locationScore,
+      magnitude: magnitudeScore,
+      depth: depthScore,
+      focal: focalScore,
+    },
+    distanceKm,
+    subsequentLargestAftershock: candidate.subsequentLargestAftershock,
+    subsequentTsunamiObserved: candidate.subsequentTsunamiObserved,
+    notes: candidate.notes,
+  };
+}
+
+/**
+ * Return the top-K analogs for `query` from `catalog`, ranked by
+ * `matchScore` descending. Default K is 5, default search box is the
+ * plan's 50 km / ±0.5 M / ±30 km box.
+ */
+export function findHistoricalAnalogs(
+  query: QueryEvent,
+  catalog: readonly CatalogEvent[],
+  options: FindAnalogsOptions = {},
+): HistoricalAnalog[] {
+  const weights = { ...DEFAULT_MATCH_WEIGHTS, ...options.weights };
+  const searchBox = { ...DEFAULT_SEARCH_BOX, ...options.searchBox };
+  const limit = options.limit ?? 5;
+
+  const scored: HistoricalAnalog[] = [];
+  for (const candidate of catalog) {
+    const result = scoreAnalog(query, candidate, weights, searchBox);
+    if (result) scored.push(result);
+  }
+  scored.sort((a, b) => {
+    if (b.matchScore !== a.matchScore) return b.matchScore - a.matchScore;
+    // Stable secondary key: smaller distance wins on ties so the ranking
+    // is deterministic regardless of input order.
+    return a.distanceKm - b.distanceKm;
+  });
+  return scored.slice(0, Math.max(0, limit));
+}
+
+/**
+ * Parse a USGS FDSN GeoJSON FeatureCollection (the response from the
+ * historical-analogs sidecar passthrough) into `CatalogEvent[]`. Drops
+ * features that lack location or magnitude.
+ */
+export function parseUsgsCatalog(payload: unknown): CatalogEvent[] {
+  if (!payload || typeof payload !== 'object') return [];
+  const features = (payload as { features?: unknown }).features;
+  if (!Array.isArray(features)) return [];
+
+  const out: CatalogEvent[] = [];
+  for (const f of features) {
+    const event = parseCatalogFeature(f);
+    if (event) out.push(event);
+  }
+  return out;
+}
+
+function parseCatalogFeature(f: unknown): CatalogEvent | null {
+  if (!f || typeof f !== 'object') return null;
+  const obj = f as Record<string, unknown>;
+  const id = obj.id;
+  if (typeof id !== 'string') return null;
+
+  const props = obj.properties;
+  if (!props || typeof props !== 'object') return null;
+  const geom = obj.geometry;
+  if (!geom || typeof geom !== 'object') return null;
+
+  const coords = (geom as Record<string, unknown>).coordinates;
+  if (!Array.isArray(coords) || coords.length < 2) return null;
+
+  const lon = Number(coords[0]);
+  const lat = Number(coords[1]);
+  const mag = Number((props as Record<string, unknown>).mag);
+  if (!Number.isFinite(lat) || !Number.isFinite(lon) || !Number.isFinite(mag)) return null;
+
+  const depthRaw = coords.length >= 3 ? Number(coords[2]) : null;
+  const place = (props as Record<string, unknown>).place;
+
+  return {
+    id,
+    lat,
+    lon,
+    depthKm: depthRaw !== null && Number.isFinite(depthRaw) ? depthRaw : null,
+    magnitude: mag,
+    occurredAt: parseOccurredAt((props as Record<string, unknown>).time),
+    place: typeof place === 'string' ? place : undefined,
+  };
+}
+
+function parseOccurredAt(time: unknown): string {
+  if (typeof time === 'number' && Number.isFinite(time)) {
+    return new Date(time).toISOString();
+  }
+  if (typeof time === 'string') return time;
+  return '';
+}
+
+// ── Internal helpers ───────────────────────────────────────────────────
+
+function scoreFocalMatch(a?: FaultType, b?: FaultType): number {
+  // Both unknown → neutral (don't penalise thin metadata).
+  if (!a && !b) return 1;
+  // One unknown → mildly neutral; we don't know enough to credit or fault.
+  if (!a || !b) return 0.5;
+  if (a === b) return 1;
+  // Different known mechanisms is a real disagreement.
+  return 0;
+}
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 0;
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}
+
+function toIsoDate(time: number | string): string {
+  if (typeof time === 'number' && Number.isFinite(time)) {
+    return new Date(time).toISOString();
+  }
+  if (typeof time === 'string' && time) return time;
+  return '';
+}
+
+const EARTH_RADIUS_KM = 6371;
+function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const phi1 = (lat1 * Math.PI) / 180;
+  const phi2 = (lat2 * Math.PI) / 180;
+  const dPhi = ((lat2 - lat1) * Math.PI) / 180;
+  const dLambda = ((lon2 - lon1) * Math.PI) / 180;
+  const a =
+    Math.sin(dPhi / 2) ** 2
+    + Math.cos(phi1) * Math.cos(phi2) * Math.sin(dLambda / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return EARTH_RADIUS_KM * c;
+}


### PR DESCRIPTION
## Summary
Pure-deterministic Layer-5 service that ranks historical earthquakes as analogs for a new event. Default search box is the plan's 50 km / ±0.5 M / ±30 km depth window; weights default to 40/30/20/10 across location/magnitude/depth/focal-mechanism similarity.

## Why
After a M≥6.0 event, "what came next last time?" is the highest-leverage signal a user can get in the first hour. Surfaces the top 5 analogs with subsequent largest aftershock and tsunami flags so the UI can answer that.

## Stacking
This PR is stacked on top of #261 (focal mechanism). It imports `FaultType` from `focal-classifier.ts`. When #261 lands first, GitHub's auto-rebase here will fast-forward.

## Changes
- `src/services/seismic/sequence-matcher.ts` — `scoreAnalog`, `findHistoricalAnalogs`, `parseUsgsCatalog`, exported defaults.
- `src/services/seismic/__tests__/sequence-matcher.test.mts` — 22 tests covering search-box gating, scoring rules, ranking determinism, custom weights, parser shape variants, and JSON-serializability.
- `src-tauri/sidecar/local-api-server.mjs` — `/api/historical-analogs` passthrough with strict bounds (`-90≤lat≤90`, `0≤mag≤10`, `0<radiusKm≤500`, `0<magDelta≤2`), 24 h cache, FDSN window excludes the last 365 days.
- `package.json` — `test:seismic` runs all 5 files (95 tests).

## Tests
`npm run test:seismic` → 95 pass / 0 fail.
`npm run typecheck:all` → clean.

## Out of scope
- Auto-curated analog notes (subsequentLargestAftershock / subsequentTsunamiObserved come from upstream metadata when present; we don't manually annotate the catalog).
- UI surface — service-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)