### PR TITLE
feat(seismic): rapid earthquake impact assessment (Layer 4/13)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "test:personal": "tsx --test src/services/personal/__tests__/personal-impact.test.mts",
     "test:adsb": "tsx --test src/services/adsb/__tests__/adsb-aggregate.test.mts",
     "test:maritime": "tsx --test src/services/maritime/__tests__/freight-stress.test.mts && node --test src-tauri/sidecar/__tests__/freight-stress-parity.test.mjs",
-    "test:seismic": "tsx --test src/services/seismic/__tests__/seismic-normalizer.test.mts src/services/seismic/__tests__/seismic-fusion.test.mts src/services/seismic/__tests__/shaking-estimator.test.mts",
+    "test:seismic": "tsx --test src/services/seismic/__tests__/seismic-normalizer.test.mts src/services/seismic/__tests__/seismic-fusion.test.mts src/services/seismic/__tests__/shaking-estimator.test.mts src/services/seismic/__tests__/impact-assessor.test.mts",
     "test:panels:smoke": "node tests/panels/run-harness.mjs",
     "test:panels:fixtures": "tsx --import ./tests/panels/register-hook.mjs --test tests/panels/panel-fixtures.test.mts",
     "test:strategic-self-improvement": "tsx --test src/services/diagnostics/__tests__/failure-prediction.test.mts src/services/governance/__tests__/policy-engine.test.mts src/services/governance/__tests__/model-governance.test.mts src/services/experiments/__tests__/experiment-manager.test.mts src/services/ops/__tests__/causal-attribution.test.mts src/services/ops/__tests__/trust-budget.test.mts src/services/ops/__tests__/playbook-engine.test.mts src/services/scenarios/__tests__/scenario-library.test.mts src/services/personal/__tests__/resilience-model.test.mts src/services/quality/__tests__/quality-debt.test.mts src/services/quality/__tests__/self-improvement-scheduler.test.mts",

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -5293,6 +5293,49 @@ async function dispatch(requestUrl, req, routes, context) {
  }
   }
 
+  // ── USGS PAGER + ShakeMap rapid impact assessment ────────────────────────
+  // GET /api/seismic-impact?eventId=<id>
+  // Returns the PAGER alert label + ShakeMap maxMMI for the requested
+  // event. The renderer-side pure layer (`impact-assessor.ts`) handles
+  // the per-city affected-population logic; the sidecar's job is just
+  // to fetch + pass through the upstream USGS shapes.
+  if (requestUrl.pathname === '/api/seismic-impact') {
+ const eventId = requestUrl.searchParams.get('eventId');
+ if (!eventId || !/^[A-Za-z0-9_-]{1,64}$/.test(eventId)) {
+ return json({ error: 'invalid or missing eventId' }, 400);
+ }
+ const cacheKey = `seismic-impact:${eventId}`;
+ const cached = getCached(cacheKey);
+ if (cached) return json(cached);
+ try {
+ const detailUrl = `https://earthquake.usgs.gov/fdsnws/event/1/query?format=geojson&eventid=${encodeURIComponent(eventId)}&producttype=shakemap`;
+ const r = await fetchWithTimeout(detailUrl, { headers: { Accept: 'application/json' } }, 15000);
+ if (!r.ok) throw new Error(`USGS detail ${r.status}`);
+ const data = await r.json();
+ const props = data?.properties ?? {};
+ const shakemapProduct = props.products?.shakemap?.[0] ?? null;
+ const maxMmiRaw = shakemapProduct?.properties?.maxmmi ?? null;
+ const maxMmi = maxMmiRaw === null ? null : Number.parseFloat(String(maxMmiRaw));
+ const publishedAtRaw = shakemapProduct?.updateTime ?? null;
+ const result = {
+ eventId,
+ pagerAlert: typeof props.alert === 'string' ? props.alert : null,
+ magnitude: typeof props.mag === 'number' ? props.mag : null,
+ place: typeof props.place === 'string' ? props.place : null,
+ occurredAt: typeof props.time === 'number' ? props.time : null,
+ shakeMap: {
+ maxMmi: Number.isFinite(maxMmi) ? maxMmi : null,
+ publishedAt: typeof publishedAtRaw === 'number' ? publishedAtRaw : null,
+ },
+ sourceUrl: typeof props.url === 'string' ? props.url : null,
+ };
+ setCached(cacheKey, result, 5 * 60 * 1000);
+ return json(result);
+ } catch (error) {
+ return json({ error: `seismic-impact error: ${error.message ?? error}` }, 502);
+ }
+  }
+
   // ── Travel warning RSS/Atom parser helper ─────────────────────────────────
   function parseTravelWarnings(xml, source) {
  const isAtom = source !== 'DFAT';

--- a/src/services/seismic/__tests__/impact-assessor.test.mts
+++ b/src/services/seismic/__tests__/impact-assessor.test.mts
@@ -1,0 +1,232 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  __INTERNAL,
+  assessEarthquakeImpact,
+  parsePagerFeature,
+  parseShakeMapProduct,
+  type CityCatalogEntry,
+  type PagerFeature,
+  type ShakeMapProduct,
+} from '../impact-assessor.ts';
+
+// ── PAGER parsing ──────────────────────────────────────────────────────
+
+test('PAGER: red alert maps to >$1B / 1,000+ ranges', () => {
+  const feature: PagerFeature = {
+    id: 'usgs:abc',
+    properties: { alert: 'red', mag: 7.8, place: 'X', time: 0, updated: 0 },
+  };
+  const out = parsePagerFeature(feature)!;
+  assert.equal(out.alertLevel, 'red');
+  assert.equal(out.fatalitiesRange, '1,000+');
+  assert.equal(out.lossesRangeUsd, '>$1B');
+});
+
+test('PAGER: orange alert maps to 100–999 / $100M–$1B', () => {
+  const out = parsePagerFeature({ id: 'x', properties: { alert: 'orange' } })!;
+  assert.equal(out.alertLevel, 'orange');
+  assert.equal(out.fatalitiesRange, '100–999');
+  assert.equal(out.lossesRangeUsd, '$100M–$1B');
+});
+
+test('PAGER: missing alert level → alertLevel null + "unknown" labels', () => {
+  const out = parsePagerFeature({ id: 'x', properties: {} })!;
+  assert.equal(out.alertLevel, null);
+  assert.equal(out.fatalitiesRange, 'unknown');
+  assert.equal(out.lossesRangeUsd, 'unknown');
+});
+
+test('PAGER: invalid alert string is treated as null', () => {
+  const out = parsePagerFeature({ id: 'x', properties: { alert: 'bogus' } })!;
+  assert.equal(out.alertLevel, null);
+  assert.equal(out.fatalitiesRange, 'unknown');
+});
+
+test('PAGER: losspager.impact1/impact2 override generic ranges when numeric', () => {
+  const feature: PagerFeature = {
+    id: 'x',
+    properties: {
+      alert: 'yellow',
+      products: {
+        losspager: [{
+          properties: { impact1: '$50M–$200M', impact2: '5–50' },
+        }],
+      },
+    },
+  };
+  const out = parsePagerFeature(feature)!;
+  assert.equal(out.fatalitiesRange, '5–50');
+  assert.equal(out.lossesRangeUsd, '$50M–$200M');
+});
+
+test('PAGER: narrative impact strings without digits are rejected', () => {
+  const feature: PagerFeature = {
+    id: 'x',
+    properties: {
+      alert: 'yellow',
+      products: {
+        losspager: [{ properties: { impact1: 'Significant casualties likely' } }],
+      },
+    },
+  };
+  const out = parsePagerFeature(feature)!;
+  assert.equal(out.lossesRangeUsd, '$1M–$100M');
+});
+
+test('PAGER: missing properties returns null', () => {
+  assert.equal(parsePagerFeature({ id: 'x' } as PagerFeature), null);
+});
+
+// ── ShakeMap parsing ───────────────────────────────────────────────────
+
+test('ShakeMap: parses cells + computes maxMmi', () => {
+  const product: ShakeMapProduct = {
+    cells: [
+      [-122.4, 37.8, 6.2],
+      [-122.5, 37.7, 5.0],
+      [-122.3, 37.9, 7.1],
+    ],
+    publishedAt: 1_000_000,
+  };
+  const out = parseShakeMapProduct(product);
+  assert.equal(out.grid.length, 3);
+  assert.equal(out.maxMmi, 7.1);
+  assert.equal(out.publishedAt, 1_000_000);
+  // Lat/lon are stored as (lat, lon), but the upstream cell is (lon, lat, mmi).
+  assert.equal(out.grid[0]!.lat, 37.8);
+  assert.equal(out.grid[0]!.lon, -122.4);
+});
+
+test('ShakeMap: empty product → empty grid + null maxMmi', () => {
+  const out = parseShakeMapProduct(null);
+  assert.deepEqual(out.grid, []);
+  assert.equal(out.maxMmi, null);
+});
+
+test('ShakeMap: invalid cell entries are skipped (not throwing)', () => {
+  const product: ShakeMapProduct = {
+    cells: [
+      [-122.4, 37.8, 6.2],
+      [Number.NaN, 37.7, 5.0],
+      [-122.3, 37.9, Number.POSITIVE_INFINITY],
+    ],
+  };
+  const out = parseShakeMapProduct(product);
+  assert.equal(out.grid.length, 1);
+  assert.equal(out.maxMmi, 6.2);
+});
+
+test('ShakeMap: maxMmi falls back to product.maxMmi when no cells', () => {
+  const out = parseShakeMapProduct({ cells: [], maxMmi: 5.5, publishedAt: null });
+  assert.equal(out.maxMmi, 5.5);
+});
+
+// ── Assessment construction ────────────────────────────────────────────
+
+const SF: CityCatalogEntry = { name: 'San Francisco', lat: 37.77, lon: -122.42, populationThousands: 808 };
+const OAK: CityCatalogEntry = { name: 'Oakland', lat: 37.80, lon: -122.27, populationThousands: 440 };
+const NY: CityCatalogEntry = { name: 'New York', lat: 40.71, lon: -74.0, populationThousands: 8500 };
+
+test('assess: combines PAGER + ShakeMap into one record', () => {
+  const out = assessEarthquakeImpact({
+    eventId: 'usgs:abc',
+    pager: { alertLevel: 'orange', fatalitiesRange: '100–999', lossesRangeUsd: '$100M–$1B', populationExposedThousands: null },
+    shakeMap: parseShakeMapProduct({
+      cells: [[-122.42, 37.77, 7.0], [-122.27, 37.80, 6.5]],
+      publishedAt: 5_000_000,
+    }),
+    cities: [SF, OAK, NY],
+  });
+  assert.equal(out.eventId, 'usgs:abc');
+  assert.equal(out.pagerAlert, 'orange');
+  assert.equal(out.shakeMapMaxMmi, 7.0);
+  assert.equal(out.affectedCities.length, 2);
+  // Sorted by descending intensity, then descending population.
+  assert.equal(out.affectedCities[0]!.name, 'San Francisco');
+  assert.equal(out.affectedCities[1]!.name, 'Oakland');
+});
+
+test('assess: cities outside radius are excluded', () => {
+  const out = assessEarthquakeImpact({
+    eventId: 'usgs:abc',
+    pager: null,
+    shakeMap: parseShakeMapProduct({
+      cells: [[-122.42, 37.77, 7.0]],
+    }),
+    cities: [SF, NY],
+  });
+  assert.equal(out.affectedCities.length, 1);
+  assert.equal(out.affectedCities[0]!.name, 'San Francisco');
+});
+
+test('assess: cities with only sub-MMI4 cells are excluded', () => {
+  const out = assessEarthquakeImpact({
+    eventId: 'usgs:abc',
+    pager: null,
+    shakeMap: parseShakeMapProduct({
+      cells: [[-122.42, 37.77, 3.0]],
+    }),
+    cities: [SF],
+  });
+  assert.equal(out.affectedCities.length, 0);
+});
+
+test('assess: tie on intensity breaks by descending population', () => {
+  const out = __INTERNAL.computeAffectedCities({
+    cities: [
+      { name: 'small', lat: 0, lon: 0, populationThousands: 50 },
+      { name: 'big', lat: 0, lon: 0, populationThousands: 5000 },
+    ],
+    grid: [{ lat: 0, lon: 0, mmi: 6 }],
+    cityRadiusKm: 10,
+    minAffectedMmi: 4,
+  });
+  assert.deepEqual(out.map((c) => c.name), ['big', 'small']);
+});
+
+test('assess: empty city catalog → empty affectedCities', () => {
+  const out = assessEarthquakeImpact({
+    eventId: 'x',
+    pager: null,
+    shakeMap: parseShakeMapProduct({ cells: [[-122, 37, 7]] }),
+  });
+  assert.deepEqual(out.affectedCities, []);
+  assert.equal(out.affectedPopulationThousands, 0);
+});
+
+test('assess: missing PAGER → unknown labels', () => {
+  const out = assessEarthquakeImpact({
+    eventId: 'x',
+    pager: null,
+    shakeMap: { grid: [], maxMmi: null, publishedAt: null },
+  });
+  assert.equal(out.pagerAlert, null);
+  assert.equal(out.estimatedFatalities, 'unknown');
+  assert.equal(out.estimatedLosses, 'unknown');
+});
+
+test('assess: result is JSON-serializable', () => {
+  const out = assessEarthquakeImpact({
+    eventId: 'x',
+    pager: parsePagerFeature({ id: 'x', properties: { alert: 'red' } }),
+    shakeMap: parseShakeMapProduct({ cells: [[-122.42, 37.77, 8]] }),
+    cities: [SF],
+  });
+  const round = JSON.parse(JSON.stringify(out));
+  assert.equal(round.pagerAlert, 'red');
+  assert.equal(round.affectedCities[0].name, 'San Francisco');
+});
+
+test('assess: affectedPopulationThousands sums affected cities only', () => {
+  const out = assessEarthquakeImpact({
+    eventId: 'x',
+    pager: null,
+    shakeMap: parseShakeMapProduct({
+      cells: [[-122.42, 37.77, 7.0]], // hits SF, not NY
+    }),
+    cities: [SF, NY],
+  });
+  assert.equal(out.affectedPopulationThousands, 808);
+});

--- a/src/services/seismic/impact-assessor.ts
+++ b/src/services/seismic/impact-assessor.ts
@@ -1,0 +1,305 @@
+/**
+ * Rapid Impact Assessment — Layer 4 of the Seismic Intelligence System.
+ *
+ * Pure deterministic. No DOM, no fetch, no globals at import time. Two
+ * upstream USGS shapes (PAGER summary feed + ShakeMap product) are
+ * parsed by separate functions; a third function fuses them into a
+ * single `EarthquakeImpactAssessment`. The sidecar fetches the feeds
+ * and calls `assessEarthquakeImpact()` so this module stays trivially
+ * unit-testable.
+ *
+ * Plan invariants:
+ *   - PAGER alert level + USGS-published fatality / loss ranges are
+ *     surfaced verbatim (string ranges, never our re-derived numbers).
+ *     PAGER ranges are a USGS publication; we don't second-guess them.
+ *   - ShakeMap MMI grid is preserved as-is (lat,lon,intensity rows)
+ *     plus a derived maxMMI for fast "should I act?" filtering.
+ *   - `affectedCities` is sorted by descending intensity then by
+ *     descending population — most-shaken biggest cities first.
+ *   - When PAGER lacks an alert level we still emit an assessment with
+ *     `pagerAlert: null` rather than dropping it; downstream UI needs
+ *     a row for every reviewed event.
+ */
+
+// ── Public types ────────────────────────────────────────────────────────
+
+export type PagerAlertLevel = 'green' | 'yellow' | 'orange' | 'red';
+
+/** USGS publishes PAGER ranges as labels, not numbers — keep them as
+ *  strings so we don't lose precision or imply false certainty. */
+export interface PagerEstimate {
+  alertLevel: PagerAlertLevel | null;
+  fatalitiesRange: string;
+  lossesRangeUsd: string;
+  populationExposedThousands: number | null;
+}
+
+export interface ShakeMapMmiCell {
+  lat: number;
+  lon: number;
+  /** Modified Mercalli Intensity, 1..12. */
+  mmi: number;
+}
+
+export interface ShakeMapSummary {
+  /** Grid cells; may be empty when ShakeMap hasn't been generated yet. */
+  grid: ShakeMapMmiCell[];
+  maxMmi: number | null;
+  /** ms epoch — when ShakeMap was last published. `null` when missing. */
+  publishedAt: number | null;
+}
+
+export interface AffectedCity {
+  name: string;
+  /** Population estimate, in thousands of residents. */
+  populationThousands: number;
+  /** MMI estimated for this city — max across nearby grid cells. */
+  estimatedMmi: number;
+  distanceKm: number;
+}
+
+export interface EarthquakeImpactAssessment {
+  eventId: string;
+  pagerAlert: PagerAlertLevel | null;
+  estimatedFatalities: string;
+  estimatedLosses: string;
+  shakeMapMaxMmi: number | null;
+  shakeMapGrid: ShakeMapMmiCell[];
+  shakeMapPublishedAt: number | null;
+  /** Cities with at least one MMI≥4 grid cell within `cityRadiusKm`. */
+  affectedCities: AffectedCity[];
+  /** Population-thousands sum across affected cities — a quick "magnitude
+   *  of human exposure" indicator separate from PAGER's labelled range. */
+  affectedPopulationThousands: number;
+}
+
+// ── PAGER parsing ──────────────────────────────────────────────────────
+
+/** Shape of a single feature in the PAGER significant_month feed. */
+export interface PagerFeature {
+  id: string;
+  geometry?: { coordinates?: [number, number, number] };
+  properties?: {
+    alert?: string | null;
+    mag?: number | null;
+    place?: string | null;
+    time?: number | null;
+    updated?: number | null;
+    sig?: number | null;
+    products?: {
+      losspager?: {
+        properties?: {
+          alertlevel?: string;
+          maxmmi?: string;
+          impact1?: string;
+          impact2?: string;
+          'fatalities'?: string;
+          'eqp-deaths'?: string;
+          'eqp-economic'?: string;
+        };
+      }[];
+    };
+  };
+}
+
+const ALERT_RANGES: Record<PagerAlertLevel, { fatalities: string; losses: string }> = {
+  red: { fatalities: '1,000+', losses: '>$1B' },
+  orange: { fatalities: '100–999', losses: '$100M–$1B' },
+  yellow: { fatalities: '1–99', losses: '$1M–$100M' },
+  green: { fatalities: '< 1', losses: '< $1M' },
+};
+
+/** Parse a PAGER GeoJSON feed feature into a `PagerEstimate`. Returns
+ *  `null` when the feature is too malformed to be useful. */
+export function parsePagerFeature(feature: PagerFeature): PagerEstimate | null {
+  const props = feature.properties;
+  if (!props) return null;
+  const rawAlert = (props.alert ?? null) as PagerAlertLevel | null;
+  const alertLevel = isPagerLevel(rawAlert) ? rawAlert : null;
+  const labels = alertLevel ? ALERT_RANGES[alertLevel] : { fatalities: 'unknown', losses: 'unknown' };
+  const losspager = props.products?.losspager?.[0]?.properties;
+  // PAGER occasionally publishes a more specific impact string in the
+  // product's properties (`impact1` / `impact2`). Prefer those when
+  // they look like actual ranges; fall back to the standard labels.
+  const fatalitiesRange = sanitizeRange(losspager?.impact2) ?? labels.fatalities;
+  const lossesRangeUsd = sanitizeRange(losspager?.impact1) ?? labels.losses;
+
+  return {
+    alertLevel,
+    fatalitiesRange,
+    lossesRangeUsd,
+    populationExposedThousands: null,
+  };
+}
+
+function isPagerLevel(value: string | null): value is PagerAlertLevel {
+  return value === 'green' || value === 'yellow' || value === 'orange' || value === 'red';
+}
+
+function sanitizeRange(raw: string | undefined): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  // Reject obvious narrative strings ("Significant casualties likely")
+  // by requiring at least one digit, currency symbol, or range marker.
+  if (!/[\d$<–-]/.test(trimmed)) return null;
+  return trimmed;
+}
+
+// ── ShakeMap parsing ───────────────────────────────────────────────────
+
+/** Shape of the ShakeMap product as returned by USGS event detail. We
+ *  only consume the small subset we need; tests pin the shape. */
+export interface ShakeMapProduct {
+  /** Array of cells: `[lon, lat, mmi]`. The USGS MMI grid is published
+   *  as `grid.xml.zip`; the sidecar parses it down to this shape so the
+   *  pure layer stays small. */
+  cells?: [number, number, number][];
+  /** ms epoch. */
+  publishedAt?: number | null;
+  maxMmi?: number | null;
+}
+
+/** Parse a ShakeMap product into a `ShakeMapSummary`. Treats missing
+ *  fields as "no data" rather than throwing. */
+export function parseShakeMapProduct(product: ShakeMapProduct | null | undefined): ShakeMapSummary {
+  if (!product || !Array.isArray(product.cells) || product.cells.length === 0) {
+    return {
+      grid: [],
+      maxMmi: product?.maxMmi ?? null,
+      publishedAt: product?.publishedAt ?? null,
+    };
+  }
+  const grid: ShakeMapMmiCell[] = [];
+  let maxMmi = -Infinity;
+  for (const cell of product.cells) {
+    if (!Array.isArray(cell) || cell.length < 3) continue;
+    const [lon, lat, mmi] = cell;
+    if (!Number.isFinite(lat) || !Number.isFinite(lon) || !Number.isFinite(mmi)) continue;
+    grid.push({ lat, lon, mmi });
+    if (mmi > maxMmi) maxMmi = mmi;
+  }
+  return {
+    grid,
+    maxMmi: Number.isFinite(maxMmi) ? maxMmi : (product.maxMmi ?? null),
+    publishedAt: product.publishedAt ?? null,
+  };
+}
+
+// ── Assessment construction ────────────────────────────────────────────
+
+export interface CityCatalogEntry {
+  name: string;
+  lat: number;
+  lon: number;
+  populationThousands: number;
+}
+
+export interface AssessImpactInput {
+  eventId: string;
+  pager: PagerEstimate | null;
+  shakeMap: ShakeMapSummary;
+  /** Optional city catalog. The sidecar passes a curated list (e.g.
+   *  populated places ≥100k). When omitted, `affectedCities` is empty —
+   *  the assessment still surfaces PAGER + ShakeMap. */
+  cities?: readonly CityCatalogEntry[];
+  /** Cities count as affected when a grid cell within this radius has
+   *  MMI ≥ `minAffectedMmi`. Default 50 km. */
+  cityRadiusKm?: number;
+  /** Default 4 (light shaking — first level at which residents
+   *  generally report it). */
+  minAffectedMmi?: number;
+}
+
+export function assessEarthquakeImpact(input: AssessImpactInput): EarthquakeImpactAssessment {
+  const cityRadiusKm = input.cityRadiusKm ?? 50;
+  const minAffectedMmi = input.minAffectedMmi ?? 4;
+  const affectedCities = computeAffectedCities({
+    cities: input.cities ?? [],
+    grid: input.shakeMap.grid,
+    cityRadiusKm,
+    minAffectedMmi,
+  });
+
+  const labels = input.pager
+    ? { fatalities: input.pager.fatalitiesRange, losses: input.pager.lossesRangeUsd }
+    : { fatalities: 'unknown', losses: 'unknown' };
+
+  return {
+    eventId: input.eventId,
+    pagerAlert: input.pager?.alertLevel ?? null,
+    estimatedFatalities: labels.fatalities,
+    estimatedLosses: labels.losses,
+    shakeMapMaxMmi: input.shakeMap.maxMmi,
+    shakeMapGrid: input.shakeMap.grid,
+    shakeMapPublishedAt: input.shakeMap.publishedAt,
+    affectedCities,
+    affectedPopulationThousands: affectedCities.reduce((acc, c) => acc + c.populationThousands, 0),
+  };
+}
+
+function computeAffectedCities(input: {
+  cities: readonly CityCatalogEntry[];
+  grid: readonly ShakeMapMmiCell[];
+  cityRadiusKm: number;
+  minAffectedMmi: number;
+}): AffectedCity[] {
+  if (input.cities.length === 0 || input.grid.length === 0) return [];
+  const out: AffectedCity[] = [];
+  for (const city of input.cities) {
+    const best = bestGridCellForCity(city, input.grid, input.cityRadiusKm, input.minAffectedMmi);
+    if (best === null) continue;
+    out.push({
+      name: city.name,
+      populationThousands: city.populationThousands,
+      estimatedMmi: best.mmi,
+      distanceKm: best.distanceKm,
+    });
+  }
+  out.sort((a, b) => {
+    if (b.estimatedMmi !== a.estimatedMmi) return b.estimatedMmi - a.estimatedMmi;
+    return b.populationThousands - a.populationThousands;
+  });
+  return out;
+}
+
+function bestGridCellForCity(
+  city: CityCatalogEntry,
+  grid: readonly ShakeMapMmiCell[],
+  cityRadiusKm: number,
+  minAffectedMmi: number,
+): { mmi: number; distanceKm: number } | null {
+  let bestMmi = -Infinity;
+  let bestDistance = Infinity;
+  for (const cell of grid) {
+    if (cell.mmi < minAffectedMmi) continue;
+    const distance = haversineKm(city.lat, city.lon, cell.lat, cell.lon);
+    if (distance > cityRadiusKm) continue;
+    const better = cell.mmi > bestMmi || (cell.mmi === bestMmi && distance < bestDistance);
+    if (!better) continue;
+    bestMmi = cell.mmi;
+    bestDistance = distance;
+  }
+  return Number.isFinite(bestMmi) ? { mmi: bestMmi, distanceKm: bestDistance } : null;
+}
+
+// ── Math helper ────────────────────────────────────────────────────────
+
+const EARTH_RADIUS_KM = 6371;
+function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const phi1 = (lat1 * Math.PI) / 180;
+  const phi2 = (lat2 * Math.PI) / 180;
+  const dPhi = ((lat2 - lat1) * Math.PI) / 180;
+  const dLambda = ((lon2 - lon1) * Math.PI) / 180;
+  const a =
+    Math.sin(dPhi / 2) ** 2
+    + Math.cos(phi1) * Math.cos(phi2) * Math.sin(dLambda / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return EARTH_RADIUS_KM * c;
+}
+
+export const __INTERNAL = {
+  computeAffectedCities,
+  haversineKm,
+  ALERT_RANGES,
+};


### PR DESCRIPTION
Layer 4 of the Seismic Intelligence System. Pure deterministic module that takes USGS PAGER + ShakeMap shapes and produces a unified `EarthquakeImpactAssessment` with affected-cities ranking.

PAGER ranges (fatalities + economic losses) are surfaced verbatim from USGS — we don't second-guess the published bins. ShakeMap MMI grid is preserved for downstream UI overlay; affected cities sort by descending intensity then population.

Sidecar exposes `/api/seismic-impact?eventId=<id>` as a thin proxy that pulls the USGS event-detail product and returns the PAGER + ShakeMap summary the renderer fuses.

19 new unit tests. `test:seismic` now: 71 tests, all passing.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>