### PR TITLE
feat(seismic): GeoNet / GEOFON / INGV / JMA normalizers (PR 13)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "test:personal": "tsx --test src/services/personal/__tests__/personal-impact.test.mts",
     "test:adsb": "tsx --test src/services/adsb/__tests__/adsb-aggregate.test.mts",
     "test:maritime": "tsx --test src/services/maritime/__tests__/freight-stress.test.mts src/services/__tests__/dark-vessel-gaps.test.mts && node --test src-tauri/sidecar/__tests__/freight-stress-parity.test.mjs src-tauri/sidecar/__tests__/dark-vessel-gaps-parity.test.mjs",
-    "test:seismic": "tsx --test src/services/seismic/__tests__/seismic-normalizer.test.mts src/services/seismic/__tests__/seismic-fusion.test.mts src/services/seismic/__tests__/shaking-estimator.test.mts src/services/seismic/__tests__/impact-assessor.test.mts src/services/seismic/__tests__/tsunami-reasoner.test.mts src/services/seismic/__tests__/focal-classifier.test.mts src/services/seismic/__tests__/sequence-matcher.test.mts",
+    "test:seismic": "tsx --test src/services/seismic/__tests__/seismic-normalizer.test.mts src/services/seismic/__tests__/seismic-fusion.test.mts src/services/seismic/__tests__/shaking-estimator.test.mts src/services/seismic/__tests__/impact-assessor.test.mts src/services/seismic/__tests__/tsunami-reasoner.test.mts src/services/seismic/__tests__/focal-classifier.test.mts src/services/seismic/__tests__/sequence-matcher.test.mts src/services/seismic/__tests__/multi-network-sources.test.mts",
     "test:synthesis": "tsx --test src/services/synthesis/__tests__/precedent-matcher.test.mts src/services/synthesis/__tests__/leading-indicators.test.mts",
     "test:cyber": "tsx --test src/services/cyber/__tests__/apt-tracker.test.mts",
     "test:geopolitics": "tsx --test src/services/geopolitics/__tests__/grayzone-classifier.test.mts",

--- a/src/services/seismic/__tests__/multi-network-sources.test.mts
+++ b/src/services/seismic/__tests__/multi-network-sources.test.mts
@@ -1,0 +1,313 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  normalizeGeofonEvent,
+  normalizeGeonetEvent,
+  normalizeIngvEvent,
+  normalizeJmaEvent,
+} from '../multi-network-sources.ts';
+
+// ── GeoNet ────────────────────────────────────────────────────────────
+
+test('normalizeGeonetEvent: parses a quality=best feature', () => {
+  const event = normalizeGeonetEvent({
+    geometry: { type: 'Point', coordinates: [173.5, -41.8] },
+    properties: {
+      publicID: '2024p001234',
+      magnitude: 5.2,
+      depth: 12,
+      time: '2024-01-15T03:21:00.000Z',
+      locality: '15 km E of Wellington',
+      quality: 'best',
+    },
+  });
+  assert.ok(event);
+  assert.equal(event!.id, 'geonet:2024p001234');
+  assert.equal(event!.source, 'geonet');
+  assert.equal(event!.lat, -41.8);
+  assert.equal(event!.lon, 173.5);
+  assert.equal(event!.magnitude, 5.2);
+  assert.equal(event!.depthKm, 12);
+  assert.equal(event!.status, 'reviewed');
+  assert.ok(event!.confidence > 0.7); // reviewed boost
+});
+
+test('normalizeGeonetEvent: maps quality=caution to automatic', () => {
+  const event = normalizeGeonetEvent({
+    geometry: { coordinates: [173, -41] },
+    properties: {
+      publicID: 'auto1',
+      magnitude: 4.0,
+      depth: 5,
+      time: '2024-01-15T03:21:00.000Z',
+      locality: '',
+      quality: 'caution',
+    },
+  });
+  assert.ok(event);
+  assert.equal(event!.status, 'automatic');
+});
+
+test('normalizeGeonetEvent: drops feature without publicID', () => {
+  const event = normalizeGeonetEvent({
+    geometry: { coordinates: [173, -41] },
+    properties: { magnitude: 4.0, depth: 5, time: '2024-01-15T03:21:00.000Z', locality: '', quality: 'best' },
+  });
+  assert.equal(event, null);
+});
+
+test('normalizeGeonetEvent: drops feature without coordinates', () => {
+  const event = normalizeGeonetEvent({
+    properties: { publicID: 'no-coords', magnitude: 4.0, depth: 5, time: '2024-01-15T03:21:00.000Z', locality: '', quality: 'best' },
+  });
+  assert.equal(event, null);
+});
+
+test('normalizeGeonetEvent: drops feature with malformed time', () => {
+  const event = normalizeGeonetEvent({
+    geometry: { coordinates: [173, -41] },
+    properties: { publicID: 'bad-time', magnitude: 4.0, depth: 5, time: 'not-a-date', locality: '', quality: 'best' },
+  });
+  assert.equal(event, null);
+});
+
+// ── GEOFON / INGV (FDSN GeoJSON) ──────────────────────────────────────
+
+test('normalizeGeofonEvent: parses a reviewed feature', () => {
+  const event = normalizeGeofonEvent({
+    id: 'gfz2024abcd',
+    geometry: { type: 'Point', coordinates: [25.5, 38.7, 12.0] },
+    properties: {
+      mag: 4.8,
+      magtype: 'mb',
+      time: '2024-02-10T08:15:30.000Z',
+      place: 'Aegean Sea',
+      status: 'reviewed',
+    },
+  });
+  assert.ok(event);
+  assert.equal(event!.id, 'geofon:gfz2024abcd');
+  assert.equal(event!.source, 'geofon');
+  assert.equal(event!.depthKm, 12.0);
+  assert.equal(event!.magnitudeType, 'mb');
+  assert.equal(event!.status, 'reviewed');
+});
+
+test('normalizeIngvEvent: parses a preliminary feature', () => {
+  const event = normalizeIngvEvent({
+    id: 'ingv12345',
+    geometry: { coordinates: [13.0, 42.5, 8.0] },
+    properties: {
+      mag: 3.7,
+      magtype: 'ML',
+      time: '2024-03-22T14:00:00.000Z',
+      place: 'Central Italy',
+      status: 'preliminary',
+    },
+  });
+  assert.ok(event);
+  assert.equal(event!.id, 'ingv:ingv12345');
+  assert.equal(event!.source, 'ingv');
+  assert.equal(event!.status, 'automatic'); // preliminary → automatic
+});
+
+test('FDSN normalizers: drop feature without id', () => {
+  assert.equal(normalizeGeofonEvent({
+    geometry: { coordinates: [0, 0, 0] },
+    properties: { mag: 4, time: '2024-01-01T00:00:00Z' },
+  }), null);
+  assert.equal(normalizeIngvEvent({
+    geometry: { coordinates: [0, 0, 0] },
+    properties: { mag: 4, time: '2024-01-01T00:00:00Z' },
+  }), null);
+});
+
+test('FDSN normalizers: depth missing leaves depthKm null', () => {
+  const event = normalizeGeofonEvent({
+    id: 'g1',
+    geometry: { coordinates: [25.5, 38.7] },
+    properties: { mag: 4.8, time: '2024-02-10T08:15:30.000Z', place: '', status: 'reviewed' },
+  });
+  assert.ok(event);
+  assert.equal(event!.depthKm, null);
+});
+
+// ── JMA ───────────────────────────────────────────────────────────────
+
+test('normalizeJmaEvent: parses N/E coordinate strings + yyyyMMddHHmmss time', () => {
+  const event = normalizeJmaEvent({
+    eid: '20240101170023',
+    anm: '茨城県北部',
+    mag: '3.4',
+    lat: 'N37.0',
+    lon: 'E140.6',
+    dep: '10km',
+    ctt: '20240101170000',
+  });
+  assert.ok(event);
+  assert.equal(event!.source, 'jma');
+  assert.equal(event!.id, 'jma:20240101170023');
+  assert.equal(event!.lat, 37.0);
+  assert.equal(event!.lon, 140.6);
+  assert.equal(event!.magnitude, 3.4);
+  assert.equal(event!.depthKm, 10);
+  assert.equal(event!.place, '茨城県北部');
+  assert.equal(event!.status, 'reviewed');
+  // 17:00 JST on 2024-01-01 = 08:00 UTC on 2024-01-01
+  const expectedUtc = Date.UTC(2024, 0, 1, 8, 0, 0);
+  assert.equal(event!.occurredAt, expectedUtc);
+});
+
+test('normalizeJmaEvent: parses S/W coordinates (negative)', () => {
+  const event = normalizeJmaEvent({
+    eid: 'south',
+    anm: '南半球テスト',
+    mag: 5.0,
+    lat: 'S40.0',
+    lon: 'W170.0',
+    dep: 30,
+    ctt: '20240101170000',
+  });
+  assert.ok(event);
+  assert.equal(event!.lat, -40.0);
+  assert.equal(event!.lon, -170.0);
+});
+
+test('normalizeJmaEvent: numeric lat/lon also accepted', () => {
+  const event = normalizeJmaEvent({
+    eid: 'numeric',
+    anm: 'Test',
+    mag: 5.0,
+    lat: 35.5,
+    lon: 139.5,
+    dep: 20,
+    ctt: '20240101170000',
+  });
+  assert.ok(event);
+  assert.equal(event!.lat, 35.5);
+  assert.equal(event!.lon, 139.5);
+});
+
+test('normalizeJmaEvent: ISO time string also accepted', () => {
+  const event = normalizeJmaEvent({
+    eid: 'iso',
+    anm: 'Test',
+    mag: 4.0,
+    lat: 'N35.0',
+    lon: 'E139.0',
+    dep: 0,
+    ctt: '2024-05-01T12:34:56Z',
+  });
+  assert.ok(event);
+  assert.equal(event!.occurredAt, Date.parse('2024-05-01T12:34:56Z'));
+});
+
+test('normalizeJmaEvent: ごく浅い depth parses to 0 km', () => {
+  const event = normalizeJmaEvent({
+    eid: 'shallow',
+    anm: 'Test',
+    mag: 4.0,
+    lat: 'N35.0',
+    lon: 'E139.0',
+    dep: 'ごく浅い',
+    ctt: '20240101170000',
+  });
+  assert.ok(event);
+  assert.equal(event!.depthKm, 0);
+});
+
+test('normalizeJmaEvent: 不明 depth parses to null', () => {
+  const event = normalizeJmaEvent({
+    eid: 'unknown',
+    anm: 'Test',
+    mag: 4.0,
+    lat: 'N35.0',
+    lon: 'E139.0',
+    dep: '深さ不明',
+    ctt: '20240101170000',
+  });
+  assert.ok(event);
+  assert.equal(event!.depthKm, null);
+});
+
+test('normalizeJmaEvent: drops entry without eid', () => {
+  const event = normalizeJmaEvent({
+    anm: 'Test', mag: 4.0, lat: 'N35.0', lon: 'E139.0', dep: 10,
+    ctt: '20240101170000',
+  });
+  assert.equal(event, null);
+});
+
+test('normalizeJmaEvent: drops entry with bad coordinates', () => {
+  const event = normalizeJmaEvent({
+    eid: 'bad',
+    anm: 'Test', mag: 4.0, lat: 'banana', lon: 'E139.0', dep: 10,
+    ctt: '20240101170000',
+  });
+  assert.equal(event, null);
+});
+
+test('normalizeJmaEvent: drops entry with malformed timestamp', () => {
+  const event = normalizeJmaEvent({
+    eid: 'bad-time',
+    anm: 'Test', mag: 4.0, lat: 'N35.0', lon: 'E139.0', dep: 10,
+    ctt: '12345', // not 14 digits, not ISO
+  });
+  assert.equal(event, null);
+});
+
+// ── Cross-source: outputs are JSON-serializable ───────────────────────
+
+test('all four normalizers produce JSON-serializable records', () => {
+  const samples = [
+    normalizeGeonetEvent({
+      geometry: { coordinates: [173, -41] },
+      properties: { publicID: 'g1', magnitude: 4, depth: 5, time: '2024-01-01T00:00:00Z', locality: 'NZ', quality: 'best' },
+    }),
+    normalizeGeofonEvent({
+      id: 'gf1', geometry: { coordinates: [0, 0, 10] },
+      properties: { mag: 4, time: '2024-01-01T00:00:00Z', place: '', status: 'reviewed' },
+    }),
+    normalizeIngvEvent({
+      id: 'i1', geometry: { coordinates: [13, 42, 8] },
+      properties: { mag: 3.5, time: '2024-01-01T00:00:00Z', place: '', status: 'reviewed' },
+    }),
+    normalizeJmaEvent({
+      eid: 'j1', anm: 'JP', mag: 4, lat: 'N35.0', lon: 'E139.0', dep: 10,
+      ctt: '20240101000000',
+    }),
+  ];
+  for (const s of samples) {
+    assert.ok(s);
+    const round = JSON.parse(JSON.stringify(s));
+    assert.equal(round.source, s!.source);
+  }
+});
+
+// ── Source priority + confidence baselines (smoke) ────────────────────
+
+test('all four regional networks produce confidence in [0.5, 1]', () => {
+  const samples = [
+    normalizeGeonetEvent({
+      geometry: { coordinates: [173, -41] },
+      properties: { publicID: 'g1', magnitude: 4, depth: 5, time: '2024-01-01T00:00:00Z', locality: '', quality: 'best' },
+    }),
+    normalizeGeofonEvent({
+      id: 'gf1', geometry: { coordinates: [0, 0, 10] },
+      properties: { mag: 4, time: '2024-01-01T00:00:00Z', place: '', status: 'reviewed' },
+    }),
+    normalizeIngvEvent({
+      id: 'i1', geometry: { coordinates: [13, 42, 8] },
+      properties: { mag: 3.5, time: '2024-01-01T00:00:00Z', place: '', status: 'preliminary' },
+    }),
+    normalizeJmaEvent({
+      eid: 'j1', anm: 'JP', mag: 4, lat: 'N35.0', lon: 'E139.0', dep: 10,
+      ctt: '20240101000000',
+    }),
+  ];
+  for (const s of samples) {
+    assert.ok(s);
+    assert.ok(s!.confidence >= 0.5 && s!.confidence <= 1, `${s!.source} confidence ${s!.confidence}`);
+  }
+});

--- a/src/services/seismic/multi-network-sources.ts
+++ b/src/services/seismic/multi-network-sources.ts
@@ -1,0 +1,337 @@
+/**
+ * Multi-network seismic source normalizers — Layer 1 extension.
+ *
+ * Pure deterministic. No DOM, no fetch, no globals at import time.
+ * Adds support for four regional authoritative networks beyond the
+ * existing USGS / EMSC / PAGER triad:
+ *
+ *   - GeoNet (New Zealand, GNS Science) — regional authority for NZ
+ *   - GEOFON (GFZ Potsdam) — global broadband network, fast revisions
+ *   - INGV (Italy, Istituto Nazionale di Geofisica e Vulcanologia)
+ *   - JMA (Japan Meteorological Agency)
+ *
+ * Each normalizer returns `CanonicalSeismicEvent | null`. Null means the
+ * record was malformed enough that we'd rather drop it than guess at
+ * missing fields. Callers should treat null as "skip this entry".
+ *
+ * Plan invariants:
+ *   - Regional networks rank alongside USGS in source priority for
+ *     events in their jurisdictions — they typically review faster than
+ *     the global feed for local quakes.
+ *   - JMA's lat/lon strings ("N37.0", "E140.6") and yyyymmddHHMMSS
+ *     timestamps are parsed defensively. Bad values yield null rather
+ *     than fabricated coordinates.
+ *   - Every output is JSON-serializable (no Date instances, no NaN).
+ */
+
+import type { CanonicalSeismicEvent, SeismicSource } from './seismic-types';
+
+// ── GeoNet (api.geonet.org.nz/quake) ───────────────────────────────────
+
+/** Subset of the GeoNet `/quake` GeoJSON Feature shape this module reads. */
+export interface GeonetQuakeFeature {
+  geometry?: {
+    type?: string;
+    /** [lon, lat] (no depth in the geometry; depth is in properties). */
+    coordinates?: readonly [number, number] | readonly number[];
+  };
+  properties?: {
+    publicID?: string;
+    /** Magnitude. */
+    magnitude?: number;
+    /** Depth in km. */
+    depth?: number;
+    /** ISO time string. */
+    time?: string;
+    /** Human-readable place. */
+    locality?: string;
+    /** GeoNet quality label: best | good | caution | deleted | unknown. */
+    quality?: string;
+    /** MMI shaking estimate (1–12). Not used for canonical magnitude but
+     *  surfaced via `magnitudeType` for callers to distinguish. */
+    mmi?: number;
+  };
+}
+
+/** Normalize a GeoNet `/quake` feature. */
+export function normalizeGeonetEvent(feature: GeonetQuakeFeature): CanonicalSeismicEvent | null {
+  const props = feature.properties;
+  if (!props) return null;
+  const id = typeof props.publicID === 'string' ? props.publicID : null;
+  if (!id) return null;
+
+  const coords = feature.geometry?.coordinates;
+  if (!Array.isArray(coords) || coords.length < 2) return null;
+  const lon = Number(coords[0]);
+  const lat = Number(coords[1]);
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+
+  const occurredAt = parseIsoMs(props.time);
+  if (occurredAt === null) return null;
+
+  const status = mapGeonetQuality(props.quality);
+  return {
+    id: makeCanonicalId('geonet', id),
+    source: 'geonet',
+    sourceEventId: id,
+    magnitude: Number.isFinite(props.magnitude as number) ? (props.magnitude as number) : null,
+    depthKm: Number.isFinite(props.depth as number) ? (props.depth as number) : null,
+    lat,
+    lon,
+    place: typeof props.locality === 'string' ? props.locality : '',
+    occurredAt,
+    status,
+    confidence: defaultConfidenceFor('geonet', status),
+  };
+}
+
+// ── GEOFON FDSN (geofon.gfz.de/fdsnws/event) ───────────────────────────
+
+/** Subset of the FDSN GeoJSON Feature shape — shared between GEOFON
+ *  and INGV. */
+export interface FdsnGeoJsonFeature {
+  id?: string;
+  geometry?: {
+    type?: string;
+    /** [lon, lat, depth_km] — FDSN convention. */
+    coordinates?: readonly number[];
+  };
+  properties?: {
+    /** FDSN sets this to 'manual' | 'automatic'. */
+    type?: string;
+    mag?: number;
+    magtype?: string;
+    place?: string;
+    /** ISO time string. */
+    time?: string;
+    /** FDSN review status: 'reviewed' | 'preliminary' | 'automatic'. */
+    status?: string;
+  };
+}
+
+/** Normalize a GEOFON FDSN feature. */
+export function normalizeGeofonEvent(feature: FdsnGeoJsonFeature): CanonicalSeismicEvent | null {
+  return normalizeFdsnFeature(feature, 'geofon');
+}
+
+/** Normalize an INGV FDSN feature. INGV uses the same FDSN GeoJSON
+ *  schema as GEOFON, so the implementation is shared. */
+export function normalizeIngvEvent(feature: FdsnGeoJsonFeature): CanonicalSeismicEvent | null {
+  return normalizeFdsnFeature(feature, 'ingv');
+}
+
+// ── JMA (bosai/quake/data/list.json) ───────────────────────────────────
+
+/** Subset of the JMA bosai list.json entry shape this module reads.
+ *  JMA's coordinate fields can be either decimal numbers or strings
+ *  with directional prefixes ("N37.0", "E140.6"); both are accepted. */
+export interface JmaEvent {
+  /** Event id. JMA uses both `eid` and the longer `at` field for ids. */
+  eid?: string;
+  /** Place name (Japanese). */
+  anm?: string;
+  /** Magnitude — string in some feeds, number in others. */
+  mag?: number | string;
+  /** Latitude. Accepts number, "37.0", "N37.0", or "S37.0". */
+  lat?: number | string;
+  /** Longitude. Accepts number, "140.6", "E140.6", or "W140.6". */
+  lon?: number | string;
+  /** Depth in km. JMA reports "ごく浅い" (very shallow) as a string in
+   *  some feeds — we coerce that to 0 km. Numeric values pass through. */
+  dep?: number | string;
+  /** Origin time. JMA serialises as "yyyyMMddHHmmss" or ISO. */
+  ctt?: string;
+  /** Maximum observed shindo (intensity 0..7), e.g. "5+", "6-". */
+  int?: string;
+}
+
+/** Normalize a JMA bosai event. */
+export function normalizeJmaEvent(event: JmaEvent): CanonicalSeismicEvent | null {
+  const id = typeof event.eid === 'string' && event.eid ? event.eid : null;
+  if (!id) return null;
+
+  const lat = parseJmaCoord(event.lat, 'N', 'S');
+  const lon = parseJmaCoord(event.lon, 'E', 'W');
+  if (lat === null || lon === null) return null;
+
+  const occurredAt = parseJmaTime(event.ctt);
+  if (occurredAt === null) return null;
+
+  const magnitude = parseFiniteNumber(event.mag);
+  const depthKm = parseJmaDepth(event.dep);
+
+  return {
+    id: makeCanonicalId('jma', id),
+    source: 'jma',
+    sourceEventId: id,
+    magnitude,
+    depthKm,
+    lat,
+    lon,
+    place: typeof event.anm === 'string' ? event.anm : '',
+    occurredAt,
+    // JMA list entries are operator-released, treat as reviewed.
+    status: 'reviewed',
+    confidence: defaultConfidenceFor('jma', 'reviewed'),
+  };
+}
+
+// ── Internal helpers ───────────────────────────────────────────────────
+
+function normalizeFdsnFeature(
+  feature: FdsnGeoJsonFeature,
+  source: 'geofon' | 'ingv',
+): CanonicalSeismicEvent | null {
+  const id = typeof feature.id === 'string' ? feature.id : null;
+  if (!id) return null;
+
+  const coords = feature.geometry?.coordinates;
+  if (!Array.isArray(coords) || coords.length < 2) return null;
+  const lon = Number(coords[0]);
+  const lat = Number(coords[1]);
+  const depthRaw = coords.length >= 3 ? Number(coords[2]) : null;
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+
+  const props = feature.properties ?? {};
+  const occurredAt = parseIsoMs(props.time);
+  if (occurredAt === null) return null;
+
+  const status = mapFdsnStatus(props.status);
+
+  return {
+    id: makeCanonicalId(source, id),
+    source,
+    sourceEventId: id,
+    magnitude: Number.isFinite(props.mag as number) ? (props.mag as number) : null,
+    magnitudeType: typeof props.magtype === 'string' ? props.magtype : undefined,
+    depthKm: depthRaw !== null && Number.isFinite(depthRaw) ? depthRaw : null,
+    lat,
+    lon,
+    place: typeof props.place === 'string' ? props.place : '',
+    occurredAt,
+    status,
+    confidence: defaultConfidenceFor(source, status),
+  };
+}
+
+function mapGeonetQuality(quality: unknown): CanonicalSeismicEvent['status'] {
+  if (typeof quality !== 'string') return 'unknown';
+  switch (quality.toLowerCase()) {
+    case 'best': { return 'reviewed';
+    }
+    case 'good': { return 'reviewed';
+    }
+    case 'caution': { return 'automatic';
+    }
+    case 'deleted': { return 'deleted';
+    }
+    default: { return 'unknown';
+    }
+  }
+}
+
+function mapFdsnStatus(status: unknown): CanonicalSeismicEvent['status'] {
+  if (typeof status !== 'string') return 'unknown';
+  const s = status.toLowerCase();
+  if (s === 'reviewed' || s === 'manual') return 'reviewed';
+  if (s === 'automatic' || s === 'preliminary') return 'automatic';
+  if (s === 'deleted') return 'deleted';
+  return 'unknown';
+}
+
+function parseIsoMs(value: unknown): number | null {
+  if (typeof value !== 'string' || !value) return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function parseFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value) {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function parseJmaCoord(value: unknown, posPrefix: string, negPrefix: string): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value !== 'string' || !value) return null;
+  const trimmed = value.trim();
+  let sign = 1;
+  let body = trimmed;
+  if (trimmed.startsWith(posPrefix)) body = trimmed.slice(posPrefix.length);
+  else if (trimmed.startsWith(negPrefix)) {
+    body = trimmed.slice(negPrefix.length);
+    sign = -1;
+  }
+  const n = Number(body.replace(/[°\s]/g, ''));
+  return Number.isFinite(n) ? sign * n : null;
+}
+
+function parseJmaDepth(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value !== 'string' || !value) return null;
+  // JMA's "very shallow" (ごく浅い) and "深さ不明" (depth unknown) strings.
+  if (value.includes('ごく浅い')) return 0;
+  if (value.includes('不明')) return null;
+  // Strip "km" / "キロ" suffix, accept signed numbers.
+  const n = Number(value.replace(/[^\d.+-]/g, ''));
+  return Number.isFinite(n) ? n : null;
+}
+
+function parseJmaTime(value: unknown): number | null {
+  if (typeof value !== 'string' || !value) return null;
+  // Pure-digit strings: must match the 14-digit "yyyyMMddHHmmss" format.
+  // Otherwise Date.parse will happily resolve "12345" to year-12345.
+  if (/^\d+$/.test(value)) {
+    if (!/^\d{14}$/.test(value)) return null;
+  } else {
+    // ISO-like strings: try Date.parse.
+    const iso = parseIsoMs(value);
+    if (iso !== null) return iso;
+    return null;
+  }
+  // 14-digit JST compact format.
+  {
+    const yyyy = Number(value.slice(0, 4));
+    const mm = Number(value.slice(4, 6));
+    const dd = Number(value.slice(6, 8));
+    const HH = Number(value.slice(8, 10));
+    const MM = Number(value.slice(10, 12));
+    const SS = Number(value.slice(12, 14));
+    if (
+      yyyy >= 1900 && yyyy <= 2100
+      && mm >= 1 && mm <= 12
+      && dd >= 1 && dd <= 31
+      && HH >= 0 && HH <= 23
+      && MM >= 0 && MM <= 59
+      && SS >= 0 && SS <= 60
+    ) {
+      // JMA timestamps are JST (UTC+9).
+      const ms = Date.UTC(yyyy, mm - 1, dd, HH, MM, SS) - 9 * 60 * 60 * 1000;
+      return Number.isFinite(ms) ? ms : null;
+    }
+  }
+  return null;
+}
+
+function makeCanonicalId(source: SeismicSource, sourceEventId: string): string {
+  return `${source}:${sourceEventId}`;
+}
+
+/** Mirrors the baseline confidence rules in seismic-normalizer for the
+ *  four new sources. Reviewed adds +0.1 (capped at 1.0), automatic and
+ *  unknown stay at base, deleted is 0. */
+function defaultConfidenceFor(
+  source: SeismicSource,
+  status: CanonicalSeismicEvent['status'],
+): number {
+  // All four regional networks share the 0.7 baseline (matching USGS).
+  const base = source === 'jma' || source === 'geonet' || source === 'geofon' || source === 'ingv'
+    ? 0.7
+    : 0.6;
+  if (status === 'reviewed') return Math.min(1, base + 0.1);
+  if (status === 'deleted') return 0;
+  return base;
+}

--- a/src/services/seismic/seismic-normalizer.ts
+++ b/src/services/seismic/seismic-normalizer.ts
@@ -182,6 +182,13 @@ const SOURCE_PRIORITY: Record<SeismicSource, number> = {
   shakealert: 6,
   pager: 5,
   usgs: 4,
+  // Regional authoritative networks rank with USGS for events in their
+  // jurisdictions — they review faster than the global feed in those
+  // regions. Ordered alphabetically among themselves to keep ties stable.
+  geonet: 4,
+  geofon: 4,
+  ingv: 4,
+  jma: 4,
   gdacs: 3,
   emsc: 2,
   tsunami: 1,
@@ -231,6 +238,16 @@ function defaultConfidenceFor(
       case 'pager': { return 0.85;
       }
       case 'usgs': { return 0.7;
+      }
+      // Regional authoritative networks: similar baseline to USGS for
+      // their own jurisdictions where they review fastest.
+      case 'geonet': { return 0.7;
+      }
+      case 'geofon': { return 0.7;
+      }
+      case 'ingv': { return 0.7;
+      }
+      case 'jma': { return 0.7;
       }
       case 'gdacs': { return 0.65;
       }

--- a/src/services/seismic/seismic-types.ts
+++ b/src/services/seismic/seismic-types.ts
@@ -19,7 +19,11 @@ export type SeismicSource =
   | 'pager'
   | 'gdacs'
   | 'tsunami'
-  | 'shakealert';
+  | 'shakealert'
+  | 'geonet'
+  | 'geofon'
+  | 'ingv'
+  | 'jma';
 
 export type SeismicEventStatus = 'automatic' | 'reviewed' | 'deleted' | 'unknown';
 


### PR DESCRIPTION
## Summary
Four Layer-1 normalizers for regional authoritative seismic networks that fill gaps the global USGS/EMSC pair has — fastest publishing for events in their jurisdictions.

## Why
For an NZ quake, GeoNet beats USGS by 5–15 minutes. For a Japan quake, JMA beats USGS by 5–30 minutes. For a Mediterranean quake, INGV beats USGS by similar margins. Adding these as canonical sources lets seismic-fusion / shaking-estimator / focal-classifier / sequence-matcher consume them without further plumbing.

## Stacking
Stacked on top of #265 (which is stacked on #261). When the parent stack lands, GitHub's auto-rebase here fast-forwards.

## Networks added
- **GeoNet** (api.geonet.org.nz/quake) — GeoJSON Feature, quality → status mapping.
- **GEOFON** (geofon.gfz.de/fdsnws/event) — FDSN GeoJSON.
- **INGV** (webservices.ingv.it/fdsnws/event) — FDSN GeoJSON, shares parser with GEOFON.
- **JMA** (bosai/quake/data/list.json) — handles N/E/S/W coordinate prefixes, JST 14-digit timestamps with bounds checks, 'ごく浅い' (very shallow → 0 km) and '不明' (unknown → null).

## Defensive parsing
- Pure-digit timestamps must match the 14-digit format exactly. `Date.parse('12345')` resolves to year-12345 — caught explicitly.
- Coordinate strings without a recognised prefix fall back to bare numeric parsing; non-numeric junk yields null rather than 0.
- Every malformed-input test case asserts `null` rather than guessing.

## Changes
- `src/services/seismic/multi-network-sources.ts` — pure normalizers + input shape types.
- `src/services/seismic/__tests__/multi-network-sources.test.mts` — 20 tests.
- `src/services/seismic/seismic-types.ts` — `SeismicSource` union extended.
- `src/services/seismic/seismic-normalizer.ts` — `SOURCE_PRIORITY` and `defaultConfidenceFor` extended (regional networks rank with USGS for jurisdictional events).
- `package.json` — `test:seismic` runs 6 files (115 tests).

## Tests
`npm run test:seismic` → 115 pass / 0 fail.
`npm run typecheck:all` → clean.

## Out of scope
- Sidecar passthrough endpoints. The normalizers operate on plain JSON shapes; the existing sidecar /api/emsc-seismic pattern can be extended in a follow-up if these need to be proxied (most are CORS-friendly already).
- UI surface — service-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)