### PR TITLE
feat: maritime dark-vessel gap detection (PR C)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "test:insights": "tsx --test src/services/insights/__tests__/big-event-detector.test.mts src/services/insights/__tests__/confidence-urgency-matrix.test.mts src/services/insights/__tests__/notification-ladder.test.mts src/services/insights/__tests__/share-packet.test.mts src/services/insights/__tests__/ask-the-data.test.mts src/services/insights/__tests__/action-briefs.test.mts src/services/insights/__tests__/data-bridge.test.mts src/services/insights/__tests__/what-changed-digest.test.mts",
     "test:personal": "tsx --test src/services/personal/__tests__/personal-impact.test.mts",
     "test:adsb": "tsx --test src/services/adsb/__tests__/adsb-aggregate.test.mts",
-    "test:maritime": "tsx --test src/services/maritime/__tests__/freight-stress.test.mts && node --test src-tauri/sidecar/__tests__/freight-stress-parity.test.mjs",
+    "test:maritime": "tsx --test src/services/maritime/__tests__/freight-stress.test.mts src/services/__tests__/dark-vessel-gaps.test.mts && node --test src-tauri/sidecar/__tests__/freight-stress-parity.test.mjs src-tauri/sidecar/__tests__/dark-vessel-gaps-parity.test.mjs",
     "test:seismic": "tsx --test src/services/seismic/__tests__/seismic-normalizer.test.mts src/services/seismic/__tests__/seismic-fusion.test.mts src/services/seismic/__tests__/shaking-estimator.test.mts src/services/seismic/__tests__/impact-assessor.test.mts",
     "test:panels:smoke": "node tests/panels/run-harness.mjs",
     "test:panels:fixtures": "tsx --import ./tests/panels/register-hook.mjs --test tests/panels/panel-fixtures.test.mts",

--- a/src-tauri/sidecar/__tests__/dark-vessel-gaps-parity.test.mjs
+++ b/src-tauri/sidecar/__tests__/dark-vessel-gaps-parity.test.mjs
@@ -1,0 +1,113 @@
+/**
+ * Parity test: the sidecar's inline JS port of dark-vessel gap detection
+ * must produce results matching the canonical TS module in
+ * src/services/dark-vessel.ts.
+ *
+ * If you change one, change the other and update this test.
+ */
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+import {
+  computeGapRiskScoreSidecar,
+  detectAisGapEventsSidecar,
+} from '../local-api-server.mjs';
+
+const NOW = 1_745_000_000_000;
+const HOUR_MS = 60 * 60 * 1000;
+
+function obs(mmsi, lat, lon, hoursAgo, name) {
+  return { mmsi, lat, lon, observedAt: NOW - hoursAgo * HOUR_MS, name };
+}
+
+test('computeGapRiskScoreSidecar: 6h gap at chokepoint center → 60', () => {
+  assert.equal(computeGapRiskScoreSidecar(6, 0), 60);
+});
+
+test('computeGapRiskScoreSidecar: 48h gap close → 100', () => {
+  assert.equal(computeGapRiskScoreSidecar(48, 25), 100);
+});
+
+test('computeGapRiskScoreSidecar: clamped 0..100', () => {
+  for (const g of [0, 6, 24, 48, 72]) {
+    for (const d of [0, 100, 200, 500]) {
+      const s = computeGapRiskScoreSidecar(g, d);
+      assert.ok(s >= 0 && s <= 100);
+    }
+  }
+});
+
+test('detectAisGapEventsSidecar: 7h gap at Hormuz → event', () => {
+  const events = detectAisGapEventsSidecar(
+    [obs('111', 26.5, 56.3, 7, 'TANKER A')],
+    { now: NOW },
+  );
+  assert.equal(events.length, 1);
+  assert.equal(events[0].mmsi, '111');
+  assert.equal(events[0].nearestChokepoint, 'Strait of Hormuz');
+});
+
+test('detectAisGapEventsSidecar: <6h gap → no event', () => {
+  const events = detectAisGapEventsSidecar(
+    [obs('111', 26.5, 56.3, 3, 'A')],
+    { now: NOW },
+  );
+  assert.equal(events.length, 0);
+});
+
+test('detectAisGapEventsSidecar: middle of Atlantic → no event (not near zone)', () => {
+  const events = detectAisGapEventsSidecar(
+    [obs('111', 30, -40, 24, 'A')],
+    { now: NOW },
+  );
+  assert.equal(events.length, 0);
+});
+
+test('detectAisGapEventsSidecar: latest observation per mmsi wins', () => {
+  const events = detectAisGapEventsSidecar(
+    [
+      obs('111', 26.5, 56.3, 24, 'A'),
+      obs('111', 27, 56.5, 8, 'A'),
+    ],
+    { now: NOW },
+  );
+  assert.equal(events.length, 1);
+  assert.equal(events[0].lastKnownLat, 27);
+});
+
+test('detectAisGapEventsSidecar: sorted by risk score desc', () => {
+  const events = detectAisGapEventsSidecar(
+    [
+      obs('low', 26.5, 57.85, 7, 'L'),
+      obs('high', 12.5, 43.5, 50, 'H'),
+      obs('mid', 2, 103.1, 14, 'M'),
+    ],
+    { now: NOW },
+  );
+  assert.equal(events.length, 3);
+  assert.equal(events[0].mmsi, 'high');
+  assert.equal(events[1].mmsi, 'mid');
+  assert.equal(events[2].mmsi, 'low');
+});
+
+test('detectAisGapEventsSidecar: Panama and Bosphorus in zone list', () => {
+  const panama = detectAisGapEventsSidecar(
+    [obs('p', 9.1, -79.7, 12, 'P')], { now: NOW },
+  );
+  const bos = detectAisGapEventsSidecar(
+    [obs('b', 41.1, 29, 12, 'B')], { now: NOW },
+  );
+  assert.equal(panama[0].nearestChokepoint, 'Panama Canal');
+  assert.equal(bos[0].nearestChokepoint, 'Bosphorus Strait');
+});
+
+test('detectAisGapEventsSidecar: drops bad coordinates', () => {
+  const events = detectAisGapEventsSidecar(
+    [
+      obs('good', 26.5, 56.3, 12, 'G'),
+      { mmsi: 'bad', lat: Number.NaN, lon: 56.3, observedAt: NOW - 12 * HOUR_MS },
+    ],
+    { now: NOW },
+  );
+  assert.equal(events.length, 1);
+  assert.equal(events[0].mmsi, 'good');
+});

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -173,6 +173,9 @@ const aisState = {
   socket: null,
   vessels: new Map(),
   candidateReports: new Map(),
+  // 24h-retention log of last position per mmsi — outlives the 30-min vessels
+  // TTL so /api/dark-vessels can find vessels that have been silent 6-24h.
+  darkHistory: new Map(),
   reconnectTimer: null,
   messageCount: 0,
   sequence: 0,
@@ -180,6 +183,8 @@ const aisState = {
   lastSnapshotJson: null,
   activeKey: null,
 };
+
+const AIS_DARK_HISTORY_TTL_MS = 24 * 60 * 60 * 1000;
 
 function aisBuildSnapshot() {
   const now = Date.now();
@@ -252,6 +257,9 @@ function aisProcessMessage(raw) {
   aisState.vessels.set(mmsi, {
  mmsi, name: meta.ShipName || '', lat, lon, timestamp: now,
  shipType: meta.ShipType, heading: pos.TrueHeading, speed: pos.Sog, course: pos.Cog,
+  });
+  aisState.darkHistory.set(mmsi, {
+    mmsi, name: meta.ShipName || '', lat, lon, observedAt: now, shipType: meta.ShipType,
   });
   aisState.messageCount++;
   aisState.lastSnapshotJson = null; // invalidate cache
@@ -1131,6 +1139,85 @@ function makeCorsHeaders(req) {
  'Access-Control-Max-Age': '86400',
  'Vary': 'Origin',
   };
+}
+
+// ── Dark-vessel gap helpers (mirror src/services/dark-vessel.ts) ────────────
+const DARK_VESSEL_RISK_ZONES = [
+  { name: 'Strait of Hormuz', lat: 26.5, lon: 56.3, radiusKm: 200 },
+  { name: 'Bab el-Mandeb', lat: 12.5, lon: 43.5, radiusKm: 150 },
+  { name: 'Red Sea', lat: 20, lon: 38, radiusKm: 400 },
+  { name: 'Suez Canal', lat: 30.5, lon: 32.3, radiusKm: 100 },
+  { name: 'Malacca Strait', lat: 2, lon: 102, radiusKm: 200 },
+  { name: 'Taiwan Strait', lat: 24.5, lon: 119, radiusKm: 200 },
+  { name: 'South China Sea', lat: 12, lon: 115, radiusKm: 500 },
+  { name: 'Black Sea', lat: 43, lon: 34, radiusKm: 400 },
+  { name: 'Baltic Sea', lat: 57, lon: 20, radiusKm: 300 },
+  { name: 'Persian Gulf', lat: 27, lon: 51, radiusKm: 300 },
+  { name: 'Gulf of Guinea', lat: 3, lon: 3, radiusKm: 400 },
+  { name: 'Somalia Coast', lat: 5, lon: 47, radiusKm: 300 },
+  { name: 'Panama Canal', lat: 9.1, lon: -79.7, radiusKm: 150 },
+  { name: 'Bosphorus Strait', lat: 41.1, lon: 29.0, radiusKm: 100 },
+];
+
+function darkVesselHaversineKm(lat1, lon1, lat2, lon2) {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLon = ((lon2 - lon1) * Math.PI) / 180;
+  const a = Math.sin(dLat / 2) ** 2
+    + Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180) * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+export function computeGapRiskScoreSidecar(gapHours, distanceKm) {
+  let score = 0;
+  if (gapHours >= 48) score += 50;
+  else if (gapHours >= 24) score += 35;
+  else if (gapHours >= 12) score += 20;
+  else if (gapHours >= 6) score += 10;
+  if (distanceKm <= 50) score += 50;
+  else if (distanceKm <= 100) score += 35;
+  else if (distanceKm <= 150) score += 20;
+  else if (distanceKm <= 200) score += 10;
+  return Math.min(100, score);
+}
+
+export function detectAisGapEventsSidecar(observations, options = {}) {
+  const now = options.now ?? Date.now();
+  const thresholdHours = options.thresholdHours ?? 6;
+  const radiusKm = options.riskZoneRadiusKm ?? 200;
+  const thresholdMs = thresholdHours * 60 * 60 * 1000;
+  const latest = new Map();
+  for (const obs of observations) {
+    if (!Number.isFinite(obs.lat) || !Number.isFinite(obs.lon)) continue;
+    if (!Number.isFinite(obs.observedAt)) continue;
+    const cur = latest.get(obs.mmsi);
+    if (!cur || obs.observedAt > cur.observedAt) latest.set(obs.mmsi, obs);
+  }
+  const events = [];
+  for (const obs of latest.values()) {
+    const gapMs = now - obs.observedAt;
+    if (gapMs < thresholdMs) continue;
+    let nearest = null;
+    for (const zone of DARK_VESSEL_RISK_ZONES) {
+      const d = darkVesselHaversineKm(obs.lat, obs.lon, zone.lat, zone.lon);
+      if (!nearest || d < nearest.distanceKm) nearest = { name: zone.name, distanceKm: d };
+    }
+    if (!nearest || nearest.distanceKm > radiusKm) continue;
+    const gapHours = gapMs / (60 * 60 * 1000);
+    events.push({
+      mmsi: obs.mmsi,
+      vesselName: obs.name,
+      lastKnownLat: obs.lat,
+      lastKnownLon: obs.lon,
+      lastSeenAt: obs.observedAt,
+      gapDurationHours: Math.round(gapHours * 10) / 10,
+      nearestChokepoint: nearest.name,
+      nearestChokepointKm: Math.round(nearest.distanceKm),
+      riskScore: computeGapRiskScoreSidecar(gapHours, nearest.distanceKm),
+    });
+  }
+  events.sort((a, b) => b.riskScore - a.riskScore || b.gapDurationHours - a.gapDurationHours);
+  return events;
 }
 
 // ── Freight-stress helpers (mirror src/services/maritime/freight-stress.ts) ──
@@ -2908,6 +2995,28 @@ async function dispatch(requestUrl, req, routes, context) {
     }
     const overallLevel = overallScore >= 75 ? 'critical' : overallScore >= 50 ? 'high' : overallScore >= 25 ? 'medium' : 'low';
     return json({ components, overallScore, overallLevel, asOf });
+  }
+
+  // ── Dark vessel gap events (driven by aisState.darkHistory) ─────────────
+  // Lists vessels whose last AIS observation is older than the gap threshold
+  // AND whose last known position is within range of a chokepoint.
+  if (requestUrl.pathname === '/api/dark-vessels') {
+    const now = Date.now();
+    const cutoff = now - AIS_DARK_HISTORY_TTL_MS;
+    for (const [mmsi, obs] of aisState.darkHistory) {
+      if (obs.observedAt < cutoff) aisState.darkHistory.delete(mmsi);
+    }
+    const thresholdHours = Math.max(1, Math.min(24, Number(requestUrl.searchParams.get('thresholdHours') || '6')));
+    const radiusKm = Math.max(10, Math.min(500, Number(requestUrl.searchParams.get('radiusKm') || '200')));
+    const observations = [...aisState.darkHistory.values()];
+    const events = detectAisGapEventsSidecar(observations, { now, thresholdHours, riskZoneRadiusKm: radiusKm });
+    return json({
+      events,
+      sampleSize: observations.length,
+      thresholdHours,
+      radiusKm,
+      asOf: new Date(now).toISOString(),
+    });
   }
 
   // ── ThreatFox IOC feed ───────────────────────────────────────────────────

--- a/src/services/__tests__/dark-vessel-gaps.test.mts
+++ b/src/services/__tests__/dark-vessel-gaps.test.mts
@@ -1,0 +1,194 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  computeGapRiskScore,
+  detectAisGapEvents,
+  DEFAULT_GAP_THRESHOLD_HOURS,
+} from '../dark-vessel.ts';
+import type { VesselSnapshotObservation } from '../dark-vessel.ts';
+
+const NOW = 1_745_000_000_000;
+const HOUR_MS = 60 * 60 * 1000;
+
+function obs(
+  mmsi: string,
+  lat: number,
+  lon: number,
+  hoursAgo: number,
+  name?: string,
+): VesselSnapshotObservation {
+  return { mmsi, lat, lon, observedAt: NOW - hoursAgo * HOUR_MS, name };
+}
+
+// ── computeGapRiskScore ──────────────────────────────────────────────────────
+
+test('risk score: 6h gap right at chokepoint → 60 (10 + 50)', () => {
+  assert.equal(computeGapRiskScore(6, 0), 60);
+});
+
+test('risk score: 48h gap + within 50km → max 100', () => {
+  assert.equal(computeGapRiskScore(48, 25), 100);
+});
+
+test('risk score: short gap + far from chokepoint → 0', () => {
+  assert.equal(computeGapRiskScore(2, 250), 0);
+});
+
+test('risk score: monotonic in gap duration (fixed distance)', () => {
+  const distance = 80;
+  const scores = [0, 6, 12, 24, 48].map((h) => computeGapRiskScore(h, distance));
+  for (let i = 1; i < scores.length; i++) {
+    assert.ok(scores[i]! >= scores[i - 1]!,
+      `not monotonic: ${scores}`);
+  }
+});
+
+test('risk score: monotonic decreasing with distance (fixed gap)', () => {
+  const gap = 12;
+  const scores = [0, 50, 100, 150, 200, 300].map((d) => computeGapRiskScore(gap, d));
+  for (let i = 1; i < scores.length; i++) {
+    assert.ok(scores[i]! <= scores[i - 1]!,
+      `not monotonic: ${scores}`);
+  }
+});
+
+test('risk score is clamped to 0..100', () => {
+  for (const g of [0, 1, 6, 24, 48, 72, 168]) {
+    for (const d of [0, 50, 100, 200, 500]) {
+      const s = computeGapRiskScore(g, d);
+      assert.ok(s >= 0 && s <= 100, `${g}h ${d}km → ${s}`);
+    }
+  }
+});
+
+// ── detectAisGapEvents ───────────────────────────────────────────────────────
+
+test('vessel last seen 7h ago in Hormuz → gap event with chokepoint name', () => {
+  const events = detectAisGapEvents(
+    [obs('111', 26.5, 56.3, 7, 'TANKER A')],
+    { now: NOW },
+  );
+  assert.equal(events.length, 1);
+  assert.equal(events[0]!.mmsi, '111');
+  assert.equal(events[0]!.vesselName, 'TANKER A');
+  assert.equal(events[0]!.nearestChokepoint, 'Strait of Hormuz');
+  assert.ok(events[0]!.gapDurationHours >= 6.9 && events[0]!.gapDurationHours <= 7.1);
+});
+
+test('vessel last seen <6h ago → no gap event', () => {
+  const events = detectAisGapEvents(
+    [obs('111', 26.5, 56.3, 3, 'A')],
+    { now: NOW },
+  );
+  assert.equal(events.length, 0);
+});
+
+test('vessel in middle of Atlantic with old timestamp → no event (not near risk zone)', () => {
+  const events = detectAisGapEvents(
+    [obs('111', 30, -40, 24, 'A')],
+    { now: NOW },
+  );
+  assert.equal(events.length, 0);
+});
+
+test('multiple observations per mmsi → uses latest position', () => {
+  const events = detectAisGapEvents(
+    [
+      obs('111', 26.5, 56.3, 24, 'TANKER A'),
+      obs('111', 27.0, 56.5, 8, 'TANKER A'),
+    ],
+    { now: NOW },
+  );
+  assert.equal(events.length, 1);
+  assert.equal(events[0]!.lastKnownLat, 27.0);
+  assert.ok(events[0]!.gapDurationHours >= 7.9 && events[0]!.gapDurationHours <= 8.1);
+});
+
+test('events sorted by risk score descending', () => {
+  const events = detectAisGapEvents(
+    [
+      // 7h gap + ~150km from Hormuz center → 10 + 20 = 30
+      obs('low', 26.5, 57.85, 7, 'L'),
+      // 50h gap right at Bab el-Mandeb → 50 + 50 = 100
+      obs('high', 12.5, 43.5, 50, 'H'),
+      // 14h gap + ~120km from Malacca center → 20 + 20 = 40
+      obs('mid', 2.0, 103.1, 14, 'M'),
+    ],
+    { now: NOW },
+  );
+  assert.equal(events.length, 3);
+  assert.equal(events[0]!.mmsi, 'high');
+  assert.equal(events[1]!.mmsi, 'mid');
+  assert.equal(events[2]!.mmsi, 'low');
+});
+
+test('threshold override: 12h threshold filters out 8h gaps', () => {
+  const events = detectAisGapEvents(
+    [obs('111', 26.5, 56.3, 8, 'A')],
+    { now: NOW, thresholdHours: 12 },
+  );
+  assert.equal(events.length, 0);
+});
+
+test('riskZoneRadiusKm override: tighter radius excludes vessels just outside', () => {
+  const eventsWide = detectAisGapEvents(
+    [obs('111', 28, 58, 12, 'A')], // ~218km from Hormuz center
+    { now: NOW, riskZoneRadiusKm: 250 },
+  );
+  const eventsNarrow = detectAisGapEvents(
+    [obs('111', 28, 58, 12, 'A')],
+    { now: NOW, riskZoneRadiusKm: 100 },
+  );
+  assert.equal(eventsWide.length, 1);
+  assert.equal(eventsNarrow.length, 0);
+});
+
+test('Panama Canal is a recognized chokepoint', () => {
+  const events = detectAisGapEvents(
+    [obs('111', 9.1, -79.7, 12, 'A')],
+    { now: NOW },
+  );
+  assert.equal(events.length, 1);
+  assert.equal(events[0]!.nearestChokepoint, 'Panama Canal');
+});
+
+test('Bosphorus Strait is a recognized chokepoint', () => {
+  const events = detectAisGapEvents(
+    [obs('111', 41.1, 29.0, 12, 'A')],
+    { now: NOW },
+  );
+  assert.equal(events.length, 1);
+  assert.equal(events[0]!.nearestChokepoint, 'Bosphorus Strait');
+});
+
+test('drops observations with non-finite coordinates', () => {
+  const events = detectAisGapEvents(
+    [
+      { mmsi: 'good', lat: 26.5, lon: 56.3, observedAt: NOW - 12 * HOUR_MS },
+      { mmsi: 'bad-lat', lat: Number.NaN, lon: 56.3, observedAt: NOW - 12 * HOUR_MS },
+      { mmsi: 'bad-lon', lat: 26.5, lon: Number.NaN, observedAt: NOW - 12 * HOUR_MS },
+      { mmsi: 'bad-time', lat: 26.5, lon: 56.3, observedAt: Number.NaN },
+    ],
+    { now: NOW },
+  );
+  assert.equal(events.length, 1);
+  assert.equal(events[0]!.mmsi, 'good');
+});
+
+test('default threshold is 6 hours', () => {
+  assert.equal(DEFAULT_GAP_THRESHOLD_HOURS, 6);
+});
+
+test('empty input → empty output', () => {
+  assert.deepEqual(detectAisGapEvents([], { now: NOW }), []);
+});
+
+test('reports gap duration to one decimal place', () => {
+  const events = detectAisGapEvents(
+    [obs('111', 26.5, 56.3, 7.567, 'A')],
+    { now: NOW },
+  );
+  // 7.567h rounded to 1 dp
+  assert.equal(events[0]!.gapDurationHours, 7.6);
+});

--- a/src/services/dark-vessel.ts
+++ b/src/services/dark-vessel.ts
@@ -92,6 +92,8 @@ const RISK_ZONES: RiskZone[] = [
   { name: 'Persian Gulf', lat: 27, lon: 51, radiusKm: 300 },
   { name: 'Gulf of Guinea', lat: 3, lon: 3, radiusKm: 400 },
   { name: 'Somalia Coast', lat: 5, lon: 47, radiusKm: 300 },
+  { name: 'Panama Canal', lat: 9.1, lon: -79.7, radiusKm: 150 },
+  { name: 'Bosphorus Strait', lat: 41.1, lon: 29.0, radiusKm: 100 },
 ];
 
 function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
@@ -304,4 +306,131 @@ export function getDarkVesselCount(): number {
  }
   }
   return count;
+}
+
+// ── Snapshot-based gap detection (pure-deterministic) ────────────────────────
+
+/**
+ * Lightweight observation shape — typically derived from /api/ais-snapshot
+ * candidate reports. Caller passes accumulated observations across recent
+ * polls; the detector finds vessels whose latest observation is older than
+ * the gap threshold AND was within range of a chokepoint / risk zone.
+ */
+export interface VesselSnapshotObservation {
+  mmsi: string;
+  lat: number;
+  lon: number;
+  observedAt: number;
+  name?: string;
+  shipType?: number;
+}
+
+export interface DarkVesselGapEvent {
+  mmsi: string;
+  vesselName?: string;
+  lastKnownLat: number;
+  lastKnownLon: number;
+  lastSeenAt: number;
+  gapDurationHours: number;
+  nearestChokepoint: string | null;
+  nearestChokepointKm: number | null;
+  riskScore: number;
+}
+
+export interface GapDetectorOptions {
+  thresholdHours?: number;
+  /** Defaults to Date.now() */
+  now?: number;
+  /** Only emit events for vessels whose last position is within this many km
+   * of a chokepoint / risk zone. Default 200 km. */
+  riskZoneRadiusKm?: number;
+}
+
+export const DEFAULT_GAP_THRESHOLD_HOURS = 6;
+
+/** Find the closest risk zone to a position. Returns null if none defined. */
+function nearestRiskZone(lat: number, lon: number): { name: string; distanceKm: number } | null {
+  let best: { name: string; distanceKm: number } | null = null;
+  for (const zone of RISK_ZONES) {
+    const d = haversineKm(lat, lon, zone.lat, zone.lon);
+    if (!best || d < best.distanceKm) {
+      best = { name: zone.name, distanceKm: d };
+    }
+  }
+  return best;
+}
+
+/**
+ * Score gap risk 0..100. Longer gap + closer to chokepoint = higher risk.
+ * Sanctions / military dimensions are tracked separately by the stateful
+ * `detectDarkVessels` path; this function focuses on pure spatiotemporal
+ * gap evidence.
+ */
+export function computeGapRiskScore(gapHours: number, distanceKm: number): number {
+  let score = 0;
+  if (gapHours >= 48) score += 50;
+  else if (gapHours >= 24) score += 35;
+  else if (gapHours >= 12) score += 20;
+  else if (gapHours >= 6) score += 10;
+
+  if (distanceKm <= 50) score += 50;
+  else if (distanceKm <= 100) score += 35;
+  else if (distanceKm <= 150) score += 20;
+  else if (distanceKm <= 200) score += 10;
+
+  return Math.min(100, score);
+}
+
+/**
+ * Pure detector. Given a flat list of vessel observations from the recent
+ * past (callers typically accumulate from poll-to-poll), return the gap
+ * events for vessels that haven't been seen for >= thresholdHours AND
+ * whose last known position was within riskZoneRadiusKm of a chokepoint.
+ *
+ * No state, no side effects.
+ */
+export function detectAisGapEvents(
+  observations: readonly VesselSnapshotObservation[],
+  options: GapDetectorOptions = {},
+): DarkVesselGapEvent[] {
+  const now = options.now ?? Date.now();
+  const thresholdHours = options.thresholdHours ?? DEFAULT_GAP_THRESHOLD_HOURS;
+  const radiusKm = options.riskZoneRadiusKm ?? 200;
+  const thresholdMs = thresholdHours * 60 * 60 * 1000;
+
+  // Group by mmsi, find latest observation per vessel
+  const latest = new Map<string, VesselSnapshotObservation>();
+  for (const obs of observations) {
+    if (!Number.isFinite(obs.lat) || !Number.isFinite(obs.lon)) continue;
+    if (!Number.isFinite(obs.observedAt)) continue;
+    const cur = latest.get(obs.mmsi);
+    if (!cur || obs.observedAt > cur.observedAt) {
+      latest.set(obs.mmsi, obs);
+    }
+  }
+
+  const events: DarkVesselGapEvent[] = [];
+  for (const obs of latest.values()) {
+    const gapMs = now - obs.observedAt;
+    if (gapMs < thresholdMs) continue;
+
+    const nearest = nearestRiskZone(obs.lat, obs.lon);
+    if (!nearest || nearest.distanceKm > radiusKm) continue;
+
+    const gapHours = gapMs / (60 * 60 * 1000);
+    events.push({
+      mmsi: obs.mmsi,
+      vesselName: obs.name,
+      lastKnownLat: obs.lat,
+      lastKnownLon: obs.lon,
+      lastSeenAt: obs.observedAt,
+      gapDurationHours: Math.round(gapHours * 10) / 10,
+      nearestChokepoint: nearest.name,
+      nearestChokepointKm: Math.round(nearest.distanceKm),
+      riskScore: computeGapRiskScore(gapHours, nearest.distanceKm),
+    });
+  }
+
+  events.sort((a, b) => b.riskScore - a.riskScore || b.gapDurationHours - a.gapDurationHours);
+  return events;
 }


### PR DESCRIPTION
**PR C of 4** in the maritime chokepoint intelligence stack.

Pure-deterministic gap-event detection: vessels whose last AIS observation is older than 6h AND whose last known position was within range of a chokepoint / risk zone. Captures the operational signal of a vessel "going dark" — sanctions evasion, smuggling, military ops.

## Files
- \`src/services/dark-vessel.ts\` — \`detectAisGapEvents\`, \`computeGapRiskScore\`, \`DarkVesselGapEvent\` type. Adds **Panama Canal** + **Bosphorus Strait** to risk zones (previously missing).
- \`src-tauri/sidecar/local-api-server.mjs\` — \`aisState.darkHistory\` 24h rolling log + \`/api/dark-vessels\` endpoint.
- 19 tsx unit tests + 10 sidecar parity tests.

## Risk score (0..100)
gap duration band + proximity-to-chokepoint band:
| gap | adds | distance | adds |
|---|---|---|---|
| ≥48h | 50 | ≤50km | 50 |
| ≥24h | 35 | ≤100km | 35 |
| ≥12h | 20 | ≤150km | 20 |
| ≥6h | 10 | ≤200km | 10 |

## Why this shape
The renderer's existing \`detectDarkVessels()\` is state-based and sanctions-aware. The new \`detectAisGapEvents\` is stateless and snapshot-driven — they complement each other. The sidecar's \`darkHistory\` outlives the 30-min \`vessels\` TTL so vessels going dark for 6-24h are still visible.

## Verification
- \`npm run test:maritime\` — 59 tests pass
- \`npm run typecheck:all\` — clean