### PR TITLE
feat(seismic): tsunami & cascade reasoner (Layer 5/13)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "test:personal": "tsx --test src/services/personal/__tests__/personal-impact.test.mts",
     "test:adsb": "tsx --test src/services/adsb/__tests__/adsb-aggregate.test.mts",
     "test:maritime": "tsx --test src/services/maritime/__tests__/freight-stress.test.mts src/services/__tests__/dark-vessel-gaps.test.mts && node --test src-tauri/sidecar/__tests__/freight-stress-parity.test.mjs src-tauri/sidecar/__tests__/dark-vessel-gaps-parity.test.mjs",
-    "test:seismic": "tsx --test src/services/seismic/__tests__/seismic-normalizer.test.mts src/services/seismic/__tests__/seismic-fusion.test.mts src/services/seismic/__tests__/shaking-estimator.test.mts src/services/seismic/__tests__/impact-assessor.test.mts",
+    "test:seismic": "tsx --test src/services/seismic/__tests__/seismic-normalizer.test.mts src/services/seismic/__tests__/seismic-fusion.test.mts src/services/seismic/__tests__/shaking-estimator.test.mts src/services/seismic/__tests__/impact-assessor.test.mts src/services/seismic/__tests__/tsunami-reasoner.test.mts",
     "test:synthesis": "tsx --test src/services/synthesis/__tests__/precedent-matcher.test.mts src/services/synthesis/__tests__/leading-indicators.test.mts",
     "test:panels:smoke": "node tests/panels/run-harness.mjs",
     "test:panels:fixtures": "tsx --import ./tests/panels/register-hook.mjs --test tests/panels/panel-fixtures.test.mts",

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -5445,6 +5445,44 @@ async function dispatch(requestUrl, req, routes, context) {
  }
   }
 
+  // ── Tsunami status: PTWC Atom + 10 NDBC DART buoys ────────────────────────
+  // GET /api/tsunami-status
+  // Returns the raw PTWC Atom XML and per-buoy realtime2 .txt bodies.
+  // The renderer's `tsunami-reasoner.ts` parses both into structured
+  // bulletins + DART anomalies. 15-minute cache.
+  if (requestUrl.pathname === '/api/tsunami-status') {
+ const cacheKey = 'tsunami-status';
+ const cached = getCached(cacheKey);
+ if (cached) return json(cached);
+ const DART_BUOYS = ['46411','46412','46413','46407','51407','55023','55012','55015','32401','32412'];
+ const ptwcUrl = 'https://www.tsunami.gov/events/xml/PAAQAtom.xml';
+ try {
+ const ptwcRes = await fetchWithTimeout(ptwcUrl, { headers: { Accept: 'application/atom+xml,application/xml;q=0.9' } }, 15000);
+ const ptwcXml = ptwcRes.ok ? await ptwcRes.text() : '';
+ const dartResults = await Promise.all(
+ DART_BUOYS.map(async (id) => {
+ try {
+ const dr = await fetchWithTimeout(`https://www.ndbc.noaa.gov/data/realtime2/${id}.txt`, { headers: { Accept: 'text/plain' } }, 12000);
+ if (!dr.ok) return { buoyId: id, ok: false, body: null, status: dr.status };
+ const body = await dr.text();
+ return { buoyId: id, ok: true, body, status: dr.status };
+ } catch (error) {
+ return { buoyId: id, ok: false, body: null, error: String(error?.message ?? error) };
+ }
+ }),
+ );
+ const result = {
+ fetchedAt: Date.now(),
+ ptwc: { ok: ptwcRes.ok, status: ptwcRes.status, xml: ptwcXml },
+ dart: dartResults,
+ };
+ setCached(cacheKey, result, 15 * 60 * 1000);
+ return json(result);
+ } catch (error) {
+ return json({ error: `tsunami-status error: ${error.message ?? error}` }, 502);
+ }
+  }
+
   // ── Travel warning RSS/Atom parser helper ─────────────────────────────────
   function parseTravelWarnings(xml, source) {
  const isAtom = source !== 'DFAT';

--- a/src/services/seismic/__tests__/tsunami-reasoner.test.mts
+++ b/src/services/seismic/__tests__/tsunami-reasoner.test.mts
@@ -1,0 +1,292 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  TsunamiReasoner,
+  DARTAnomalyDetector,
+  DART_BUOY_IDS,
+  parsePTWCAtom,
+  parseDartTxt,
+  locateSubductionZone,
+  buildTsunamiStatusSnapshot,
+  SUBDUCTION_ZONES,
+} from '../tsunami-reasoner.ts';
+
+// ── TsunamiReasoner.assessThreat ──────────────────────────────────────
+
+test('threat: HIGH for M7.6 / 30 km / Sunda Trench', () => {
+  const r = TsunamiReasoner.assessThreat({ magnitude: 7.6, depthKm: 30, lat: -3, lon: 100 });
+  assert.equal(r.level, 'high');
+  assert.equal(r.isSubmarine, true);
+  assert.equal(r.subductionZone, 'sunda-trench');
+  assert.equal(r.cascadeRuleFired, true);
+  assert.ok(r.reasons.some((x) => x.includes('high tsunami potential')));
+});
+
+test('threat: HIGH cascade does NOT fire when high event is outside known zones', () => {
+  // Mid-Atlantic ridge area not in our subduction list — still HIGH from M+depth, but cascade is gated.
+  const r = TsunamiReasoner.assessThreat({ magnitude: 7.8, depthKm: 25, lat: 5, lon: -30 });
+  assert.equal(r.level, 'high');
+  assert.equal(r.isSubmarine, false);
+  assert.equal(r.cascadeRuleFired, false);
+  assert.ok(r.reasons.some((x) => x.includes('cascade auto-advisory not fired')));
+});
+
+test('threat: MODERATE for M6.6 / 40 km / inland', () => {
+  const r = TsunamiReasoner.assessThreat({ magnitude: 6.6, depthKm: 40, lat: 35, lon: -100 });
+  assert.equal(r.level, 'moderate');
+  assert.equal(r.cascadeRuleFired, false);
+});
+
+test('threat: LOW for M6.0 submarine subduction', () => {
+  const r = TsunamiReasoner.assessThreat({ magnitude: 6.0, depthKm: 60, lat: -20, lon: -71 });
+  assert.equal(r.level, 'low');
+  assert.equal(r.isSubmarine, true);
+  assert.equal(r.subductionZone, 'peru-chile');
+});
+
+test('threat: NONE for shallow M5.5', () => {
+  const r = TsunamiReasoner.assessThreat({ magnitude: 5.5, depthKm: 10, lat: 35, lon: 139 });
+  assert.equal(r.level, 'none');
+});
+
+test('threat: deep M ≥ 7.5 in subduction zone falls to LOW (submarine fallback)', () => {
+  // M7.6 at 200 km depth fails HIGH (depth > 70) and MODERATE (depth > 50),
+  // but is still in a submarine subduction zone with M ≥ 6.0 → LOW.
+  const r = TsunamiReasoner.assessThreat({ magnitude: 7.6, depthKm: 200, lat: -3, lon: 100 });
+  assert.equal(r.level, 'low');
+  assert.equal(r.isSubmarine, true);
+});
+
+test('threat: NONE when M ≥ 7.5 but depth > 70 km AND outside subduction zones', () => {
+  const r = TsunamiReasoner.assessThreat({ magnitude: 7.6, depthKm: 200, lat: 5, lon: -30 });
+  assert.equal(r.level, 'none');
+});
+
+test('threat: NONE when M ≥ 6.5 but depth > 50 km (and below high threshold)', () => {
+  const r = TsunamiReasoner.assessThreat({ magnitude: 6.7, depthKm: 80, lat: 35, lon: -100 });
+  assert.equal(r.level, 'none');
+});
+
+test('threat: magnitude null falls through to NONE with reason', () => {
+  const r = TsunamiReasoner.assessThreat({ magnitude: null, depthKm: 10, lat: 0, lon: 0 });
+  assert.equal(r.level, 'none');
+  assert.ok(r.reasons.some((x) => x.includes('magnitude unknown')));
+});
+
+test('threat: depth null still meets HIGH (treated as shallow)', () => {
+  const r = TsunamiReasoner.assessThreat({ magnitude: 7.5, depthKm: null, lat: -5, lon: 105 });
+  assert.equal(r.level, 'high');
+});
+
+test('threat: result is JSON-serializable', () => {
+  const r = TsunamiReasoner.assessThreat({ magnitude: 7.0, depthKm: 30, lat: -3, lon: 100 });
+  const round = JSON.parse(JSON.stringify(r));
+  assert.deepEqual(round, r);
+});
+
+// ── locateSubductionZone (antimeridian + Hellenic + non-zones) ─────────
+
+test('subduction: Tonga-Kermadec straddles antimeridian (lon = 175 hits)', () => {
+  assert.equal(locateSubductionZone(-25, 175).zone, 'tonga-kermadec');
+});
+
+test('subduction: Tonga-Kermadec straddles antimeridian (lon = -175 hits)', () => {
+  assert.equal(locateSubductionZone(-25, -175).zone, 'tonga-kermadec');
+});
+
+test('subduction: Cascadia hit', () => {
+  assert.equal(locateSubductionZone(45, -125).zone, 'cascadia');
+});
+
+test('subduction: middle of Atlantic is NOT a subduction zone', () => {
+  assert.equal(locateSubductionZone(20, -40).hit, false);
+});
+
+test('subduction: NaN coordinates do not crash', () => {
+  assert.equal(locateSubductionZone(Number.NaN, 0).hit, false);
+});
+
+test('subduction: zone list is non-empty + all coordinates finite', () => {
+  assert.ok(SUBDUCTION_ZONES.length >= 10);
+  for (const z of SUBDUCTION_ZONES) {
+    assert.ok(Number.isFinite(z.minLat) && Number.isFinite(z.maxLat));
+    assert.ok(Number.isFinite(z.minLon) && Number.isFinite(z.maxLon));
+  }
+});
+
+// ── DARTAnomalyDetector ───────────────────────────────────────────────
+
+test('DART: stable readings → no anomaly', () => {
+  const readings = Array.from({ length: 10 }, (_, i) => ({
+    buoyId: '46411',
+    timestamp: 1_700_000_000_000 + i * 60_000,
+    seaLevelMeters: 2942.0 + (i % 2 === 0 ? 0.005 : -0.005), // ±0.5 cm
+  }));
+  const r = DARTAnomalyDetector.analyze('46411', readings);
+  assert.equal(r.anomalyDetected, false);
+  assert.equal(r.sampleCount, 10);
+});
+
+test('DART: 5 cm jump on latest reading → anomaly', () => {
+  const readings = Array.from({ length: 9 }, (_, i) => ({
+    buoyId: '46411',
+    timestamp: 1_700_000_000_000 + i * 60_000,
+    seaLevelMeters: 2942.0,
+  }));
+  readings.push({ buoyId: '46411', timestamp: 1_700_000_000_000 + 9 * 60_000, seaLevelMeters: 2942.05 });
+  const r = DARTAnomalyDetector.analyze('46411', readings);
+  assert.equal(r.anomalyDetected, true);
+  assert.ok(Math.abs(r.deviationCm - 5) < 1e-6);
+  assert.ok(r.reason.includes('exceeds'));
+});
+
+test('DART: insufficient samples reports gracefully', () => {
+  const r = DARTAnomalyDetector.analyze('46411', [
+    { buoyId: '46411', timestamp: 1, seaLevelMeters: 2942.0 },
+  ]);
+  assert.equal(r.anomalyDetected, false);
+  assert.equal(r.sampleCount, 1);
+  assert.ok(r.reason.includes('insufficient'));
+});
+
+test('DART: only the most recent WINDOW=10 samples are used', () => {
+  // 20 samples; first 10 are noisy at 2940, last 10 are stable at 2942.
+  const readings = [
+    ...Array.from({ length: 10 }, (_, i) => ({ buoyId: '46411', timestamp: i, seaLevelMeters: 2940.0 })),
+    ...Array.from({ length: 10 }, (_, i) => ({ buoyId: '46411', timestamp: 100 + i, seaLevelMeters: 2942.0 })),
+  ];
+  const r = DARTAnomalyDetector.analyze('46411', readings);
+  // Baseline = mean of last 9 of the stable batch = 2942; latest = 2942 → 0 cm deviation.
+  assert.equal(r.anomalyDetected, false);
+  assert.ok(Math.abs(r.deviationCm) < 1e-6);
+});
+
+test('DART: NaN-height readings are filtered out', () => {
+  const readings = [
+    ...Array.from({ length: 9 }, (_, i) => ({ buoyId: '46411', timestamp: i, seaLevelMeters: 2942.0 })),
+    { buoyId: '46411', timestamp: 9, seaLevelMeters: Number.NaN },
+    { buoyId: '46411', timestamp: 10, seaLevelMeters: 2942.04 }, // 4 cm
+  ];
+  const r = DARTAnomalyDetector.analyze('46411', readings);
+  assert.equal(r.anomalyDetected, true);
+  assert.equal(r.sampleCount, 10);
+});
+
+test('DART: there are exactly 10 supported buoys', () => {
+  assert.equal(DART_BUOY_IDS.length, 10);
+});
+
+// ── parseDartTxt ──────────────────────────────────────────────────────
+
+test('parseDartTxt: parses the documented header + data layout', () => {
+  const body = [
+    '#YY  MM DD hh mm ss T   HEIGHT',
+    '#yr  mo dy hr mn  s -   m',
+    '2026 05 05 17 00  0 1   2942.123',
+    '2026 05 05 17 15  0 1   2942.130',
+    '',
+    '2026 05 05 17 30  0 1   2942.127',
+  ].join('\n');
+  const r = parseDartTxt('46411', body);
+  assert.equal(r.length, 3);
+  assert.equal(r[0].seaLevelMeters, 2942.123);
+  assert.equal(r[2].seaLevelMeters, 2942.127);
+  assert.ok(r[0].timestamp < r[1].timestamp && r[1].timestamp < r[2].timestamp);
+});
+
+test('parseDartTxt: malformed rows are skipped, not thrown', () => {
+  const body = [
+    '#YY  MM DD hh mm ss T   HEIGHT',
+    'not a row',
+    '2026 05 05 17 00  0 1   2942.0',
+    '2026 zz 05 17 00  0 1   2942.0',
+  ].join('\n');
+  const r = parseDartTxt('46411', body);
+  assert.equal(r.length, 1);
+});
+
+// ── parsePTWCAtom ─────────────────────────────────────────────────────
+
+test('parsePTWCAtom: parses entries with CDATA + nested HTML', () => {
+  const xml = `<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>PTWC Atom</title>
+  <entry>
+    <id>urn:ptwc:1</id>
+    <title type="html"><![CDATA[<b>Tsunami Information Statement</b>]]></title>
+    <summary><![CDATA[NO TSUNAMI THREAT.]]></summary>
+    <updated>2026-05-05T18:00:00Z</updated>
+    <published>2026-05-05T17:55:00Z</published>
+    <link href="https://www.tsunami.gov/events/1" />
+  </entry>
+  <entry>
+    <id>urn:ptwc:2</id>
+    <title>Tsunami Warning</title>
+    <summary>Hazardous tsunami waves possible.</summary>
+    <updated>2026-05-05T18:30:00Z</updated>
+  </entry>
+</feed>`;
+  const out = parsePTWCAtom(xml);
+  assert.equal(out.length, 2);
+  assert.equal(out[0].id, 'urn:ptwc:1');
+  assert.equal(out[0].title, 'Tsunami Information Statement');
+  assert.equal(out[0].summary, 'NO TSUNAMI THREAT.');
+  assert.equal(out[0].link, 'https://www.tsunami.gov/events/1');
+  assert.ok(out[0].publishedAt && out[0].updatedAt);
+  assert.equal(out[1].link, null);
+  assert.equal(out[1].publishedAt, null);
+});
+
+test('parsePTWCAtom: empty feed returns empty array', () => {
+  assert.deepEqual(parsePTWCAtom('<feed></feed>'), []);
+});
+
+test('parsePTWCAtom: entries without an id are dropped', () => {
+  const xml = `<feed><entry><title>x</title></entry></feed>`;
+  assert.deepEqual(parsePTWCAtom(xml), []);
+});
+
+// ── buildTsunamiStatusSnapshot ────────────────────────────────────────
+
+test('snapshot: anyDartAnomaly + hasActiveBulletin reflect inputs', () => {
+  const snap = buildTsunamiStatusSnapshot({
+    fetchedAt: 1_700_000_000_000,
+    ptwcBulletins: [
+      { id: 'a', title: 't', summary: 's', publishedAt: null, updatedAt: null, link: null },
+    ],
+    dartAnomalies: [
+      {
+        buoyId: '46411',
+        anomalyDetected: false,
+        deviationCm: 0.5,
+        baselineMeters: 2942,
+        latestMeters: 2942.005,
+        sampleCount: 10,
+        reason: 'within',
+      },
+      {
+        buoyId: '46412',
+        anomalyDetected: true,
+        deviationCm: 4,
+        baselineMeters: 2942,
+        latestMeters: 2942.04,
+        sampleCount: 10,
+        reason: 'exceeds',
+      },
+    ],
+  });
+  assert.equal(snap.anyDartAnomaly, true);
+  assert.equal(snap.hasActiveBulletin, true);
+  assert.equal(snap.dartAnomalies.length, 2);
+});
+
+test('snapshot: empty inputs produce a valid snapshot', () => {
+  const snap = buildTsunamiStatusSnapshot({
+    fetchedAt: 1_700_000_000_000,
+    ptwcBulletins: [],
+    dartAnomalies: [],
+  });
+  assert.equal(snap.anyDartAnomaly, false);
+  assert.equal(snap.hasActiveBulletin, false);
+});

--- a/src/services/seismic/tsunami-reasoner.ts
+++ b/src/services/seismic/tsunami-reasoner.ts
@@ -1,0 +1,385 @@
+/**
+ * Tsunami & Cascade Reasoner — Layer 5 of the Seismic Intelligence
+ * System.
+ *
+ * Pure deterministic. No DOM, no fetch, no globals at import time.
+ * Three responsibilities:
+ *
+ *   1. `TsunamiReasoner.assessThreat(event)` — given a seismic event's
+ *      magnitude, depth, and epicenter coordinates, classify the
+ *      tsunami threat at HIGH / MODERATE / LOW / NONE using cascade
+ *      thresholds and a Ring-of-Fire + Sunda-Trench subduction-zone
+ *      bounding-box check.
+ *
+ *   2. `DARTAnomalyDetector.analyze(buoyId, readings)` — given a stream
+ *      of DART buoy sea-level readings, flag a deviation > 2 cm vs the
+ *      rolling-window baseline. Returns a structured anomaly result so
+ *      downstream UI can show "buoy moved before the bulletin
+ *      arrived".
+ *
+ *   3. `parsePTWCAtom(xml)` — strict-but-tolerant Atom parser for the
+ *      Pacific Tsunami Warning Center feed (PAAQAtom.xml). The sidecar
+ *      proxy fetches the raw bytes; this function turns them into
+ *      structured `PTWCBulletin` records the renderer can fuse.
+ *
+ * Plan invariants:
+ *   - Threat levels are reported with explicit reasons so the renderer
+ *     can show "why" alongside "what".
+ *   - DART deviation is first-class: a quake without a PTWC bulletin
+ *     but with confirmed DART deviation is still actionable.
+ *   - Magnitude unknown ⇒ threat level falls through to NONE with a
+ *     reason — never silently inferred.
+ */
+
+import type { CanonicalSeismicEvent } from './seismic-types';
+
+// ─── Subduction-zone bounding boxes ───────────────────────────────────
+
+/** Ring-of-Fire + Sunda Trench coverage. Boxes are intentionally coarse;
+ *  they exist to answer "could this be a submarine subduction-zone
+ *  quake?" not to draw exact trench geometry. Boxes that cross the
+ *  antimeridian use `minLon > maxLon`. */
+export const SUBDUCTION_ZONES: readonly {
+  readonly name: string;
+  readonly minLat: number;
+  readonly maxLat: number;
+  readonly minLon: number;
+  readonly maxLon: number;
+}[] = [
+  { name: 'aleutian-alaska', minLat: 50, maxLat: 65, minLon: 170, maxLon: -130 },
+  { name: 'cascadia', minLat: 40, maxLat: 50, minLon: -130, maxLon: -120 },
+  { name: 'central-america', minLat: 5, maxLat: 25, minLon: -110, maxLon: -80 },
+  { name: 'peru-chile', minLat: -50, maxLat: 5, minLon: -85, maxLon: -65 },
+  { name: 'kuril-japan', minLat: 25, maxLat: 50, minLon: 130, maxLon: 165 },
+  { name: 'marianas', minLat: 10, maxLat: 25, minLon: 140, maxLon: 150 },
+  { name: 'philippines', minLat: 5, maxLat: 22, minLon: 120, maxLon: 130 },
+  { name: 'sunda-trench', minLat: -12, maxLat: 7, minLon: 90, maxLon: 130 },
+  { name: 'tonga-kermadec', minLat: -45, maxLat: -10, minLon: 170, maxLon: -170 },
+  { name: 'vanuatu-solomon', minLat: -25, maxLat: -5, minLon: 150, maxLon: 175 },
+  { name: 'hellenic-arc', minLat: 33, maxLat: 38, minLon: 20, maxLon: 30 },
+];
+
+export interface SubductionHit {
+  hit: boolean;
+  zone: string | null;
+}
+
+export function locateSubductionZone(lat: number, lon: number): SubductionHit {
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return { hit: false, zone: null };
+  for (const z of SUBDUCTION_ZONES) {
+    const latIn = lat >= z.minLat && lat <= z.maxLat;
+    // Antimeridian-spanning boxes use minLon > maxLon: hit if either side is in range.
+    const lonIn = z.minLon <= z.maxLon
+      ? lon >= z.minLon && lon <= z.maxLon
+      : lon >= z.minLon || lon <= z.maxLon;
+    if (latIn && lonIn) return { hit: true, zone: z.name };
+  }
+  return { hit: false, zone: null };
+}
+
+// ─── Tsunami threat assessment ────────────────────────────────────────
+
+export type TsunamiThreatLevel = 'high' | 'moderate' | 'low' | 'none';
+
+export interface TsunamiThreatAssessment {
+  level: TsunamiThreatLevel;
+  reasons: string[];
+  isSubmarine: boolean;
+  subductionZone: string | null;
+  cascadeRuleFired: boolean;
+  magnitude: number | null;
+  depthKm: number | null;
+}
+
+export interface TsunamiAssessmentInput {
+  magnitude: number | null;
+  depthKm: number | null;
+  lat: number;
+  lon: number;
+}
+
+export const TsunamiReasoner = {
+  /**
+   * Cascade thresholds:
+   *   HIGH      — M ≥ 7.5 AND depth ≤ 70 km
+   *   MODERATE  — M ≥ 6.5 AND depth ≤ 50 km
+   *   LOW       — submarine subduction-zone hit AND M ≥ 6.0
+   *   NONE      — otherwise (or magnitude unknown)
+   *
+   * `cascadeRuleFired` is true when a HIGH-tier event additionally lies
+   * in a known submarine subduction zone — this is the "auto-advisory
+   * before PTWC bulletin lands" gate downstream consumers care about.
+   */
+  assessThreat(event: TsunamiAssessmentInput | CanonicalSeismicEvent): TsunamiThreatAssessment {
+    const reasons: string[] = [];
+    const sub = locateSubductionZone(event.lat, event.lon);
+    const isSubmarine = sub.hit;
+    if (isSubmarine) reasons.push(`submarine subduction zone: ${sub.zone}`);
+
+    const m = event.magnitude;
+    const d = event.depthKm;
+
+    if (m === null || !Number.isFinite(m)) {
+      reasons.push('magnitude unknown — threat level falls through to none');
+      return {
+        level: 'none',
+        reasons,
+        isSubmarine,
+        subductionZone: sub.zone,
+        cascadeRuleFired: false,
+        magnitude: m,
+        depthKm: d,
+      };
+    }
+
+    const depthOk70 = d === null || !Number.isFinite(d) ? true : d <= 70;
+    const depthOk50 = d === null || !Number.isFinite(d) ? true : d <= 50;
+
+    let level: TsunamiThreatLevel = 'none';
+    let cascadeRuleFired = false;
+
+    if (m >= 7.5 && depthOk70) {
+      level = 'high';
+      reasons.push(`M${m} ≥ 7.5 with depth ≤ 70 km — high tsunami potential`);
+      cascadeRuleFired = isSubmarine;
+      if (!cascadeRuleFired) reasons.push('outside known subduction zones — cascade auto-advisory not fired');
+    } else if (m >= 6.5 && depthOk50) {
+      level = 'moderate';
+      reasons.push(`M${m} ≥ 6.5 with depth ≤ 50 km — moderate tsunami potential`);
+    } else if (isSubmarine && m >= 6) {
+      level = 'low';
+      reasons.push(`M${m} submarine event — low tsunami potential`);
+    } else {
+      reasons.push('thresholds not met — no tsunami threat from earthquake parameters alone');
+    }
+
+    return {
+      level,
+      reasons,
+      isSubmarine,
+      subductionZone: sub.zone,
+      cascadeRuleFired,
+      magnitude: m,
+      depthKm: d,
+    };
+  },
+};
+
+// ─── DART buoy anomaly detection ──────────────────────────────────────
+
+/** The 10 NDBC DART buoys covering the Pacific basin + Caribbean. */
+export const DART_BUOY_IDS = [
+  '46411', // NE Pacific (off Eureka)
+  '46412', // NE Pacific (off N. California)
+  '46413', // NE Pacific (off W. Oregon)
+  '46407', // NE Pacific (off N. Oregon)
+  '51407', // Hawaii
+  '55023', // SW Pacific
+  '55012', // SW Pacific
+  '55015', // SW Pacific
+  '32401', // Eastern Pacific (off N. Chile)
+  '32412', // Eastern Pacific (off Lima, Peru)
+] as const;
+export type DARTBuoyId = typeof DART_BUOY_IDS[number];
+
+export interface DARTReading {
+  buoyId: string;
+  /** ms epoch */
+  timestamp: number;
+  /** Sea level height in meters (instantaneous height). */
+  seaLevelMeters: number;
+}
+
+export interface DARTAnomalyResult {
+  buoyId: string;
+  anomalyDetected: boolean;
+  /** Latest reading minus baseline mean, expressed in centimeters. */
+  deviationCm: number;
+  baselineMeters: number;
+  latestMeters: number;
+  sampleCount: number;
+  reason: string;
+}
+
+export class DARTAnomalyDetector {
+  /** Threshold above which a deviation is considered anomalous (cm). */
+  static readonly THRESHOLD_CM = 2;
+  /** Window size for the rolling baseline. */
+  static readonly WINDOW = 10;
+
+  /**
+   * Sort the readings ascending by timestamp, take the last WINDOW,
+   * compare the latest sample to the mean of the WINDOW-1 prior
+   * samples. Anomaly when |deviation| > THRESHOLD_CM.
+   */
+  static analyze(buoyId: string, readings: readonly DARTReading[]): DARTAnomalyResult {
+    const recent = [...readings]
+      .filter((r) => Number.isFinite(r.seaLevelMeters) && Number.isFinite(r.timestamp))
+      .sort((a, b) => a.timestamp - b.timestamp)
+      .slice(-DARTAnomalyDetector.WINDOW);
+
+    if (recent.length < 2) {
+      return {
+        buoyId,
+        anomalyDetected: false,
+        deviationCm: 0,
+        baselineMeters: Number.NaN,
+        latestMeters: Number.NaN,
+        sampleCount: recent.length,
+        reason: 'insufficient samples (need ≥2)',
+      };
+    }
+
+    const last = recent[recent.length - 1];
+    if (!last) {
+      // Unreachable: recent.length >= 2 from the guard above; satisfies noUncheckedIndexedAccess.
+      return {
+        buoyId,
+        anomalyDetected: false,
+        deviationCm: 0,
+        baselineMeters: Number.NaN,
+        latestMeters: Number.NaN,
+        sampleCount: recent.length,
+        reason: 'insufficient samples (need ≥2)',
+      };
+    }
+    const latest = last.seaLevelMeters;
+    const priorSum = recent.slice(0, -1).reduce((acc, r) => acc + r.seaLevelMeters, 0);
+    const baseline = priorSum / (recent.length - 1);
+    const deviationCm = (latest - baseline) * 100;
+    const absDevCm = Math.abs(deviationCm);
+    const anomaly = absDevCm > DARTAnomalyDetector.THRESHOLD_CM;
+
+    return {
+      buoyId,
+      anomalyDetected: anomaly,
+      deviationCm,
+      baselineMeters: baseline,
+      latestMeters: latest,
+      sampleCount: recent.length,
+      reason: anomaly
+        ? `deviation ${deviationCm.toFixed(2)} cm exceeds ${DARTAnomalyDetector.THRESHOLD_CM} cm threshold`
+        : `deviation ${deviationCm.toFixed(2)} cm within ${DARTAnomalyDetector.THRESHOLD_CM} cm threshold`,
+    };
+  }
+}
+
+/**
+ * Parse one DART buoy NDBC realtime2 .txt body. Format is:
+ *
+ *   #YY  MM DD hh mm ss T   HEIGHT
+ *   #yr  mo dy hr mn  s -   m
+ *   2026 05 05 17 00  0 1   2942.123
+ *   ...
+ *
+ * Lines starting with `#` are ignored. The 8th column is the sea-level
+ * height in meters (the column is `HEIGHT`). Returns oldest-first.
+ */
+export function parseDartTxt(buoyId: string, body: string): DARTReading[] {
+  const out: DARTReading[] = [];
+  const lines = body.split(/\r?\n/);
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const cols = line.split(/\s+/);
+    if (cols.length < 8) continue;
+    const yy = Number.parseInt(cols[0] ?? '', 10);
+    const mn = Number.parseInt(cols[1] ?? '', 10);
+    const dy = Number.parseInt(cols[2] ?? '', 10);
+    const hr = Number.parseInt(cols[3] ?? '', 10);
+    const min = Number.parseInt(cols[4] ?? '', 10);
+    const sec = Number.parseInt(cols[5] ?? '', 10);
+    const m = Number.parseFloat(cols[7] ?? '');
+    if (![yy, mn, dy, hr, min, sec].every((v) => Number.isFinite(v)) || !Number.isFinite(m)) continue;
+    const ts = Date.UTC(yy, mn - 1, dy, hr, min, sec);
+    out.push({ buoyId, timestamp: ts, seaLevelMeters: m });
+  }
+  return out.sort((a, b) => a.timestamp - b.timestamp);
+}
+
+// ─── PTWC Atom parser ─────────────────────────────────────────────────
+
+export interface PTWCBulletin {
+  id: string;
+  title: string;
+  summary: string;
+  publishedAt: number | null;
+  updatedAt: number | null;
+  link: string | null;
+}
+
+/**
+ * Parse the PTWC PAAQAtom.xml feed. Tolerates CDATA blocks, missing
+ * `<published>` (falls back to `<updated>`), and entries without a
+ * `<link>` (sets `link: null`). Returns entries in upstream order.
+ */
+export function parsePTWCAtom(xml: string): PTWCBulletin[] {
+  const out: PTWCBulletin[] = [];
+  const entries = xml.match(/<entry\b[\s\S]*?<\/entry>/g) ?? [];
+  for (const block of entries) {
+    const id = textOf(block, 'id');
+    if (!id) continue;
+    const title = textOf(block, 'title');
+    const summary = textOf(block, 'summary');
+    const updated = textOf(block, 'updated');
+    const published = textOf(block, 'published');
+    const link = (/<link\b[^>]*\bhref="([^"]+)"/.exec(block))?.[1] ?? null;
+    out.push({
+      id,
+      title,
+      summary,
+      publishedAt: published ? safeParseDate(published) : null,
+      updatedAt: updated ? safeParseDate(updated) : null,
+      link,
+    });
+  }
+  return out;
+}
+
+function textOf(block: string, tag: string): string {
+  const m = new RegExp(String.raw`<${tag}\b[^>]*>([\s\S]*?)<\/${tag}>`).exec(block);
+  if (m?.[1] === undefined) return '';
+  return stripHtml(m[1]).trim();
+}
+
+function stripHtml(s: string): string {
+  const noCdata = s.split('<![CDATA[').join('').split(']]>').join('');
+  // eslint-disable-next-line sonarjs/slow-regex -- bounded char class, single-character match — linear time.
+  return noCdata.replace(/<[^>]+>/g, '');
+}
+
+function safeParseDate(s: string): number | null {
+  const t = Date.parse(s);
+  return Number.isFinite(t) ? t : null;
+}
+
+// ─── Combined snapshot ────────────────────────────────────────────────
+
+export interface TsunamiStatusSnapshot {
+  fetchedAt: number;
+  ptwcBulletins: PTWCBulletin[];
+  dartAnomalies: DARTAnomalyResult[];
+  /** True if any DART buoy is reporting an anomaly. */
+  anyDartAnomaly: boolean;
+  /** True if any PTWC bulletin is present in the feed. */
+  hasActiveBulletin: boolean;
+}
+
+/**
+ * Pure helper that fuses the two sidecar-fetched payloads (PTWC + DART)
+ * into a single snapshot the renderer can render directly. Renderer
+ * never has to walk both lists itself.
+ */
+export function buildTsunamiStatusSnapshot(input: {
+  fetchedAt: number;
+  ptwcBulletins: PTWCBulletin[];
+  dartAnomalies: DARTAnomalyResult[];
+}): TsunamiStatusSnapshot {
+  return {
+    fetchedAt: input.fetchedAt,
+    ptwcBulletins: [...input.ptwcBulletins],
+    dartAnomalies: [...input.dartAnomalies],
+    anyDartAnomaly: input.dartAnomalies.some((d) => d.anomalyDetected),
+    hasActiveBulletin: input.ptwcBulletins.length > 0,
+  };
+}


### PR DESCRIPTION
PR 5 of the Seismic Intelligence System. Stacks on PR #268.

`TsunamiReasoner.assessThreat()` classifies tsunami threat at HIGH/MODERATE/LOW/NONE using cascade thresholds:
- HIGH: M≥7.5 AND depth≤70 km
- MODERATE: M≥6.5 AND depth≤50 km
- LOW: submarine subduction-zone hit AND M≥6.0
- NONE: otherwise

The cascade auto-advisory only fires for HIGH events that lie in a known submarine subduction zone (Ring of Fire + Sunda Trench bounding boxes), so the renderer can warn 'this could trigger a tsunami; watch DART' before PTWC publishes a bulletin.

`DARTAnomalyDetector.analyze()` takes the last 10 readings per buoy and flags >2 cm deviation vs the rolling-window baseline. `parseDartTxt()` parses the NDBC realtime2 .txt format. `parsePTWCAtom()` handles the PTWC PAAQAtom.xml feed.

Sidecar adds `/api/tsunami-status`: 15-minute cached fetch of the PTWC Atom plus per-buoy realtime2 .txt for all 10 NDBC DART buoys (46411,46412,46413,46407,51407,55023,55012,55015,32401,32412).

30 new unit tests. `test:seismic` now 101 tests, all passing.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>