### PR TITLE
feat(algorithms): PRs 11–18 — advanced algorithm enhancements

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -2477,6 +2477,85 @@ async function dispatch(requestUrl, req, routes, context) {
     return json({ error: 'Method not allowed' }, 405);
   }
 
+  // ── Algorithm extensions (PRs 11-18) ─────────────────────────────────
+  // Renderer-side services compute these and POST a snapshot; sidecar
+  // mirrors the latest payload per bucket and serves it via GET.
+  if (requestUrl.pathname.startsWith('/api/algorithm-state/')) {
+    const bucket = requestUrl.pathname.slice('/api/algorithm-state/'.length);
+    const allowedBuckets = new Set([
+      'ensemble',
+      'drift',
+      'counterfactuals',
+      'llm-grades',
+      'auto-tune',
+      'correlations',
+      'blackswan',
+      'genealogy',
+    ]);
+    if (!allowedBuckets.has(bucket)) {
+      return json({ error: `unknown bucket "${bucket}"` }, 404);
+    }
+    if (!context._algorithmState) context._algorithmState = {};
+    if (req.method === 'POST') {
+      try {
+        const raw = await readBody(req);
+        const body = raw ? JSON.parse(raw.toString()) : null;
+        if (!body || typeof body !== 'object') return json({ error: 'invalid body' }, 400);
+        context._algorithmState[bucket] = { ...body, _pushedAt: Date.now() };
+        return json({ ok: true });
+      } catch (error) {
+        return json({ error: String(error?.message || error) }, 400);
+      }
+    }
+    if (req.method === 'GET') {
+      const payload = context._algorithmState[bucket] || null;
+      if (!payload) {
+        return json({ available: false, bucket });
+      }
+      const ageMs = Date.now() - (payload._pushedAt || 0);
+      return json({ available: true, bucket, ageMs, stale: ageMs > 10 * 60 * 1000, ...payload });
+    }
+    return json({ error: 'Method not allowed' }, 405);
+  }
+
+  // Spec aliases — friendlier URLs for the documented per-PR endpoints.
+  if (requestUrl.pathname === '/api/ensemble-decision' && req.method === 'GET') {
+    const domain = requestUrl.searchParams.get('domain') || '';
+    const all = context._algorithmState?.ensemble?.decisions || {};
+    if (domain) return json({ domain, decision: all[domain] || null });
+    return json({ decisions: all });
+  }
+  if (requestUrl.pathname === '/api/drift-status' && req.method === 'GET') {
+    return json(context._algorithmState?.drift || { available: false });
+  }
+  if (requestUrl.pathname === '/api/counterfactuals' && req.method === 'GET') {
+    const eventId = requestUrl.searchParams.get('eventId') || '';
+    const all = context._algorithmState?.counterfactuals?.byEvent || {};
+    if (eventId) return json({ eventId, results: all[eventId] || [] });
+    return json({ all });
+  }
+  if (requestUrl.pathname === '/api/auto-tune' && req.method === 'GET') {
+    const algorithmId = requestUrl.searchParams.get('algorithmId') || '';
+    const all = context._algorithmState?.['auto-tune']?.runs || {};
+    if (algorithmId) return json({ algorithmId, runs: all[algorithmId] || [] });
+    return json({ runs: all });
+  }
+  if (requestUrl.pathname === '/api/algorithm-correlations' && req.method === 'GET') {
+    return json(context._algorithmState?.correlations || { available: false });
+  }
+  if (requestUrl.pathname === '/api/blackswan-status' && req.method === 'GET') {
+    return json(context._algorithmState?.blackswan || { available: false });
+  }
+  if (requestUrl.pathname === '/api/genealogy' && req.method === 'GET') {
+    return json(context._algorithmState?.genealogy || { available: false });
+  }
+  if (requestUrl.pathname === '/api/genealogy/lineage' && req.method === 'GET') {
+    const algorithmId = requestUrl.searchParams.get('algorithmId') || '';
+    const tree = context._algorithmState?.genealogy?.tree || {};
+    if (!algorithmId) return json({ error: 'algorithmId required' }, 400);
+    return json({ algorithmId, lineage: tree[algorithmId] || null });
+  }
+
   if (requestUrl.pathname === '/api/sitrep-bundle') {
     const cacheKey = 'sitrep-bundle';
     const cached = getCached(cacheKey, 5 * 60 * 1000);

--- a/src/services/algorithms/__tests__/adaptive-tuner.test.mts
+++ b/src/services/algorithms/__tests__/adaptive-tuner.test.mts
@@ -1,0 +1,207 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  snapToGrid,
+  sampleParam,
+  sampleConfig,
+  hillClimb,
+  clampConfigToSafetyBound,
+  runTuningCycle,
+  recordTuningRun,
+  getTuningHistory,
+  _resetTuningHistoryForTests,
+  type ParamConfig,
+  type TuningEvaluator,
+} from '../adaptive-tuner.ts';
+import type { TunableParameter } from '../safe-adjustment.ts';
+
+const NOW = 1_745_000_000_000;
+
+const params: TunableParameter[] = [
+  { parameterId: 'threshold', current: 0.5, min: 0, max: 1, step: 0.01, fixDirection: 'decrease', description: 't' },
+  { parameterId: 'buffer-km', current: 10, min: 0, max: 50, step: 1, fixDirection: 'increase', description: 'b' },
+];
+
+// Deterministic RNG (linear congruential).
+function makeRng(seed = 1): () => number {
+  let s = seed;
+  return () => {
+    s = (s * 1664525 + 1013904223) % 0x1_0000_0000;
+    return s / 0x1_0000_0000;
+  };
+}
+
+// ── Snapping & sampling ──────────────────────────────────────────────
+
+test('snapToGrid: clamps below min', () => {
+  assert.equal(snapToGrid(-5, params[0]!), 0);
+});
+
+test('snapToGrid: clamps above max', () => {
+  assert.equal(snapToGrid(99, params[0]!), 1);
+});
+
+test('snapToGrid: rounds to nearest step', () => {
+  assert.equal(snapToGrid(0.123, params[0]!), 0.12);
+  assert.equal(snapToGrid(0.127, params[0]!), 0.13);
+});
+
+test('sampleParam: stays within bounds', () => {
+  const rng = makeRng(42);
+  for (let i = 0; i < 20; i += 1) {
+    const v = sampleParam(params[0]!, rng);
+    assert.ok(v >= 0 && v <= 1);
+  }
+});
+
+test('sampleConfig: produces an entry for every parameter', () => {
+  const rng = makeRng();
+  const c = sampleConfig(params, rng);
+  assert.ok('threshold' in c);
+  assert.ok('buffer-km' in c);
+});
+
+// ── Hill climb ────────────────────────────────────────────────────────
+
+test('hillClimb: improves toward optimum', () => {
+  // Evaluator with global max at threshold=0.7
+  const evaluator: TuningEvaluator = (c) => 1 - Math.abs((c.threshold ?? 0) - 0.7);
+  const start: ParamConfig = { threshold: 0.5, 'buffer-km': 10 };
+  const out = hillClimb(start, [params[0]!], evaluator, { iterations: 200, rng: makeRng(7) });
+  assert.ok(out.f1 >= 1 - Math.abs(0.5 - 0.7) - 1e-9);
+});
+
+// ── Safety rails ──────────────────────────────────────────────────────
+
+test('clampConfigToSafetyBound: clamps deltas above maxRelativeChange', () => {
+  const prior: ParamConfig = { threshold: 0.5, 'buffer-km': 10 };
+  const proposed: ParamConfig = { threshold: 0.9, 'buffer-km': 10 };
+  const r = clampConfigToSafetyBound(proposed, prior, params, 0.2);
+  // 20% of 0.5 = 0.1 → max threshold = 0.6 (snapped to grid step 0.01)
+  assert.ok((r.clamped.threshold ?? 0) <= 0.6 + 1e-9);
+  assert.deepEqual(r.clamped_params, ['threshold']);
+});
+
+test('clampConfigToSafetyBound: leaves small deltas alone', () => {
+  const prior: ParamConfig = { threshold: 0.5, 'buffer-km': 10 };
+  const proposed: ParamConfig = { threshold: 0.55, 'buffer-km': 11 };
+  const r = clampConfigToSafetyBound(proposed, prior, params, 0.2);
+  assert.equal(r.clamped.threshold, 0.55);
+  assert.equal(r.clamped_params.length, 0);
+});
+
+// ── End-to-end runs ──────────────────────────────────────────────────
+
+test('runTuningCycle: rejects too few grades', () => {
+  const result = runTuningCycle({
+    algorithmId: 'a',
+    parameters: params,
+    currentF1: 0.5,
+    newGrades: 5,
+    evaluator: () => 0.9,
+    rng: makeRng(1),
+    now: () => NOW,
+  });
+  assert.equal(result.verdict, 'rejected_too_few_grades');
+});
+
+test('runTuningCycle: no_tunable when parameters empty', () => {
+  const result = runTuningCycle({
+    algorithmId: 'a',
+    parameters: [],
+    currentF1: 0.5,
+    newGrades: 100,
+    evaluator: () => 0.9,
+    rng: makeRng(1),
+    now: () => NOW,
+  });
+  assert.equal(result.verdict, 'no_tunable');
+});
+
+test('runTuningCycle: rejects when no improvement above threshold', () => {
+  const result = runTuningCycle({
+    algorithmId: 'a',
+    parameters: params,
+    currentF1: 0.99,
+    newGrades: 100,
+    evaluator: () => 0.5, // worse than current
+    rng: makeRng(1),
+    now: () => NOW,
+  });
+  assert.equal(result.verdict, 'rejected_no_improvement');
+});
+
+test('runTuningCycle: applies when search finds improvement', () => {
+  // Evaluator that rewards threshold close to 0.6 (within safety bound 20% of 0.5)
+  const evaluator: TuningEvaluator = (c) => 1 - Math.abs((c.threshold ?? 0) - 0.6);
+  const result = runTuningCycle({
+    algorithmId: 'a',
+    parameters: params,
+    currentF1: 0.5,
+    newGrades: 100,
+    evaluator,
+    rng: makeRng(11),
+    now: () => NOW,
+    sampleCount: 80,
+    hillClimbIterations: 20,
+  });
+  assert.equal(result.verdict, 'applied');
+  assert.ok(result.bestConfig);
+  assert.ok((result.bestConfig!.threshold ?? 0) >= 0.4);
+  assert.ok((result.bestConfig!.threshold ?? 0) <= 0.6 + 1e-9);
+});
+
+test('runTuningCycle: enforces 20% relative-change bound', () => {
+  // Evaluator strongly prefers threshold=1.0 (way outside the bound)
+  const evaluator: TuningEvaluator = (c) => (c.threshold ?? 0);
+  const result = runTuningCycle({
+    algorithmId: 'a',
+    parameters: params,
+    currentF1: 0.5,
+    newGrades: 100,
+    evaluator,
+    rng: makeRng(3),
+    now: () => NOW,
+  });
+  // Even though evaluator wants 1.0, safety bound caps threshold at 0.6.
+  if (result.bestConfig) {
+    assert.ok((result.bestConfig.threshold ?? 0) <= 0.6 + 1e-9);
+  }
+});
+
+// ── Audit trail ──────────────────────────────────────────────────────
+
+test('recordTuningRun + getTuningHistory: round-trip', () => {
+  _resetTuningHistoryForTests();
+  recordTuningRun({
+    algorithmId: 'x',
+    verdict: 'applied',
+    bestF1: 0.8,
+    improvement: 0.1,
+    priorConfig: { threshold: 0.5 },
+    paramDelta: { threshold: 0.05 },
+    notes: ['ok'],
+    generatedAt: NOW,
+  });
+  const list = getTuningHistory('x');
+  assert.equal(list.length, 1);
+  assert.equal(list[0]!.verdict, 'applied');
+});
+
+test('recordTuningRun: trims to maxPerAlgorithm', () => {
+  _resetTuningHistoryForTests();
+  for (let i = 0; i < 10; i += 1) {
+    recordTuningRun({
+      algorithmId: 'y',
+      verdict: 'applied',
+      bestF1: 0.8,
+      improvement: 0.1,
+      priorConfig: {},
+      paramDelta: {},
+      notes: [`run-${i}`],
+      generatedAt: NOW + i,
+    }, { maxPerAlgorithm: 3 });
+  }
+  assert.equal(getTuningHistory('y').length, 3);
+});

--- a/src/services/algorithms/__tests__/blackswan-detector.test.mts
+++ b/src/services/algorithms/__tests__/blackswan-detector.test.mts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildIsolationForest,
+  isolationForestScore,
+  detectBlackSwan,
+  recordBlackSwanScore,
+  recordBlackSwanAlert,
+  getBlackSwanStatus,
+  _resetBlackSwanCacheForTests,
+  type EventFeatures,
+} from '../blackswan-detector.ts';
+
+const NOW = 1_745_000_000_000;
+
+function makeRng(seed = 1): () => number {
+  let s = seed;
+  return () => {
+    s = (s * 1664525 + 1013904223) % 0x1_0000_0000;
+    return s / 0x1_0000_0000;
+  };
+}
+
+function evt(id: string, features: number[], at: number = NOW): EventFeatures {
+  return { id, features, at };
+}
+
+// ── Forest building ───────────────────────────────────────────────────
+
+test('buildIsolationForest: empty history → empty forest', () => {
+  const f = buildIsolationForest([]);
+  assert.equal(f.trees.length, 0);
+  assert.equal(f.sampleSize, 0);
+});
+
+test('buildIsolationForest: respects tree count', () => {
+  const history: EventFeatures[] = Array.from({ length: 30 }, (_, i) => evt(`h${i}`, [i, i * 2]));
+  const f = buildIsolationForest(history, { trees: 10, sampleSize: 16, rng: makeRng(7) });
+  assert.equal(f.trees.length, 10);
+});
+
+// ── Scoring ───────────────────────────────────────────────────────────
+
+test('isolationForestScore: empty forest → 0', () => {
+  const f = buildIsolationForest([]);
+  assert.equal(isolationForestScore(f, [1, 2]), 0);
+});
+
+test('isolationForestScore: in-distribution point scores low', () => {
+  const history: EventFeatures[] = Array.from({ length: 100 }, (_, i) =>
+    evt(`h${i}`, [(i % 10) / 10, ((i * 7) % 10) / 10]),
+  );
+  const f = buildIsolationForest(history, { trees: 50, sampleSize: 32, rng: makeRng(11) });
+  const inDist = isolationForestScore(f, [0.4, 0.5]);
+  const outOfDist = isolationForestScore(f, [50, 50]);
+  assert.ok(outOfDist > inDist, `out-of-dist (${outOfDist}) should exceed in-dist (${inDist})`);
+});
+
+// ── End-to-end detection ──────────────────────────────────────────────
+
+test('detectBlackSwan: in-distribution → null alert', () => {
+  const history: EventFeatures[] = Array.from({ length: 50 }, (_, i) => evt(`h${i}`, [i / 50, 0.5]));
+  const candidate = evt('cand', [0.5, 0.5]);
+  const result = detectBlackSwan({
+    candidate,
+    history,
+    threshold: 0.85,
+    forestOptions: { trees: 30, sampleSize: 16, rng: makeRng(3) },
+    now: () => NOW,
+  });
+  assert.equal(result.alert, null);
+});
+
+test('detectBlackSwan: extreme outlier → alert with suggestion', () => {
+  const history: EventFeatures[] = Array.from({ length: 50 }, (_, i) => evt(`h${i}`, [i / 50, 0.5]));
+  const candidate = evt('outlier', [1e6, 1e6]);
+  const result = detectBlackSwan({
+    candidate,
+    history,
+    affectedAlgorithms: ['truth-score', 'compound-risk'],
+    nearestHistoricalAnalog: 'analog-1',
+    threshold: 0.85,
+    forestOptions: { trees: 30, sampleSize: 16, rng: makeRng(3) },
+    now: () => NOW,
+  });
+  assert.ok(result.alert);
+  assert.equal(result.alert!.eventId, 'outlier');
+  assert.equal(result.alert!.affectedAlgorithms.length, 2);
+  assert.equal(result.alert!.nearestHistoricalAnalog, 'analog-1');
+  assert.ok([
+    'monitor',
+    'expand_window',
+    'consult_analog',
+    'escalate_to_review',
+  ].includes(result.alert!.suggestedAction));
+});
+
+test('detectBlackSwan: passes through nearestHistoricalAnalog as null when omitted', () => {
+  const history: EventFeatures[] = Array.from({ length: 30 }, (_, i) => evt(`h${i}`, [i / 30]));
+  const candidate = evt('o', [9999]);
+  const result = detectBlackSwan({
+    candidate,
+    history,
+    threshold: 0.5,
+    forestOptions: { trees: 20, sampleSize: 16, rng: makeRng(5) },
+    now: () => NOW,
+  });
+  if (result.alert) {
+    assert.equal(result.alert.nearestHistoricalAnalog, null);
+  }
+});
+
+// ── Status cache ──────────────────────────────────────────────────────
+
+test('recordBlackSwanScore: trims to 200', () => {
+  _resetBlackSwanCacheForTests();
+  for (let i = 0; i < 250; i += 1) recordBlackSwanScore(`e${i}`, 0.1, NOW + i);
+  const status = getBlackSwanStatus(NOW);
+  assert.equal(status.recentScores.length, 200);
+});
+
+test('recordBlackSwanAlert: stored and retrievable', () => {
+  _resetBlackSwanCacheForTests();
+  recordBlackSwanAlert({
+    detectedAt: NOW,
+    eventId: 'e1',
+    anomalyScore: 0.95,
+    affectedAlgorithms: ['a'],
+    nearestHistoricalAnalog: null,
+    suggestedAction: 'escalate_to_review',
+  });
+  const status = getBlackSwanStatus(NOW);
+  assert.equal(status.alerts.length, 1);
+});

--- a/src/services/algorithms/__tests__/correlation-analyzer.test.mts
+++ b/src/services/algorithms/__tests__/correlation-analyzer.test.mts
@@ -1,0 +1,167 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  pearsonCorrelation,
+  classifyCorrelation,
+  buildPairedConfidenceSeries,
+  buildCorrelationMatrix,
+  suggestDiverseEnsemble,
+  recordCorrelationMatrix,
+  getLastCorrelationMatrix,
+  _resetCorrelationCacheForTests,
+} from '../correlation-analyzer.ts';
+import type { EvaluationRecord } from '../algorithm-evaluation-ledger.ts';
+
+const NOW = 1_745_000_000_000;
+
+function rec(args: {
+  algorithmId: string;
+  inputHash: string;
+  score: number;
+  at?: number;
+}): EvaluationRecord {
+  return {
+    id: `${args.algorithmId}-${args.inputHash}`,
+    algorithmId: args.algorithmId,
+    domain: 'truth_score',
+    at: args.at ?? NOW,
+    durationMs: 1,
+    inputHash: args.inputHash,
+    score: args.score,
+  };
+}
+
+// ── Pearson ───────────────────────────────────────────────────────────
+
+test('pearsonCorrelation: perfectly correlated', () => {
+  const r = pearsonCorrelation([1, 2, 3, 4, 5], [2, 4, 6, 8, 10]);
+  assert.ok(Math.abs(r - 1) < 1e-9);
+});
+
+test('pearsonCorrelation: perfectly anti-correlated', () => {
+  const r = pearsonCorrelation([1, 2, 3], [3, 2, 1]);
+  assert.ok(Math.abs(r + 1) < 1e-9);
+});
+
+test('pearsonCorrelation: NaN on length mismatch throws', () => {
+  assert.throws(() => pearsonCorrelation([1], [1, 2]));
+});
+
+test('pearsonCorrelation: NaN on zero variance', () => {
+  const r = pearsonCorrelation([1, 1, 1], [2, 4, 6]);
+  assert.ok(Number.isNaN(r));
+});
+
+test('pearsonCorrelation: short series → NaN', () => {
+  assert.ok(Number.isNaN(pearsonCorrelation([1], [2])));
+});
+
+// ── Classification ────────────────────────────────────────────────────
+
+test('classifyCorrelation: redundant when r >= 0.8', () => {
+  assert.equal(classifyCorrelation(0.85), 'redundant');
+});
+
+test('classifyCorrelation: disagreement when r <= -0.3', () => {
+  assert.equal(classifyCorrelation(-0.4), 'disagreement');
+});
+
+test('classifyCorrelation: independent when |r| <= 0.2', () => {
+  assert.equal(classifyCorrelation(0.1), 'independent');
+});
+
+test('classifyCorrelation: mild otherwise', () => {
+  assert.equal(classifyCorrelation(0.5), 'mild');
+});
+
+test('classifyCorrelation: NaN treated as independent', () => {
+  assert.equal(classifyCorrelation(Number.NaN), 'independent');
+});
+
+// ── Pair extraction ───────────────────────────────────────────────────
+
+test('buildPairedConfidenceSeries: matches by inputHash', () => {
+  const records: EvaluationRecord[] = [
+    rec({ algorithmId: 'a', inputHash: 'h1', score: 0.5 }),
+    rec({ algorithmId: 'b', inputHash: 'h1', score: 0.6 }),
+    rec({ algorithmId: 'a', inputHash: 'h2', score: 0.7 }),
+    rec({ algorithmId: 'b', inputHash: 'h2', score: 0.8 }),
+    rec({ algorithmId: 'b', inputHash: 'orphan', score: 0.9 }),
+  ];
+  const { xs, ys } = buildPairedConfidenceSeries(records, 'a', 'b', 500);
+  assert.equal(xs.length, 2);
+  assert.equal(ys.length, 2);
+});
+
+test('buildPairedConfidenceSeries: respects window size', () => {
+  const records: EvaluationRecord[] = [];
+  for (let i = 0; i < 20; i += 1) {
+    records.push(rec({ algorithmId: 'a', inputHash: `h${i}`, score: i / 20, at: NOW + i }));
+    records.push(rec({ algorithmId: 'b', inputHash: `h${i}`, score: i / 20, at: NOW + i }));
+  }
+  const { xs } = buildPairedConfidenceSeries(records, 'a', 'b', 5);
+  assert.equal(xs.length, 5);
+});
+
+// ── Matrix ────────────────────────────────────────────────────────────
+
+test('buildCorrelationMatrix: produces all-pairs entries', () => {
+  const records: EvaluationRecord[] = [];
+  for (let i = 0; i < 10; i += 1) {
+    records.push(rec({ algorithmId: 'a', inputHash: `h${i}`, score: i / 10 }));
+    records.push(rec({ algorithmId: 'b', inputHash: `h${i}`, score: i / 10 })); // perfectly correlated
+    records.push(rec({ algorithmId: 'c', inputHash: `h${i}`, score: 1 - i / 10 })); // anti-correlated
+  }
+  const matrix = buildCorrelationMatrix(records, ['a', 'b', 'c'], { now: () => NOW });
+  assert.equal(matrix.pairs.length, 3); // C(3,2) = 3
+  const ab = matrix.pairs.find((p) => p.algorithmA === 'a' && p.algorithmB === 'b');
+  const ac = matrix.pairs.find((p) => p.algorithmA === 'a' && p.algorithmB === 'c');
+  assert.ok(ab && Math.abs(ab.r - 1) < 1e-9);
+  assert.equal(ab.classification, 'redundant');
+  assert.ok(ac && Math.abs(ac.r + 1) < 1e-9);
+  assert.equal(ac.classification, 'disagreement');
+});
+
+test('buildCorrelationMatrix: NaN with too few pairs', () => {
+  const records: EvaluationRecord[] = [
+    rec({ algorithmId: 'a', inputHash: 'h1', score: 0.5 }),
+    rec({ algorithmId: 'b', inputHash: 'h1', score: 0.6 }),
+  ];
+  const matrix = buildCorrelationMatrix(records, ['a', 'b'], { minPairs: 5, now: () => NOW });
+  assert.ok(Number.isNaN(matrix.pairs[0]!.r));
+});
+
+// ── Ensemble composition ──────────────────────────────────────────────
+
+test('suggestDiverseEnsemble: prefers low-correlation peers', () => {
+  // a-b strongly correlated; a-c independent; b-c independent
+  const records: EvaluationRecord[] = [];
+  for (let i = 0; i < 10; i += 1) {
+    records.push(rec({ algorithmId: 'a', inputHash: `h${i}`, score: i / 10 }));
+    records.push(rec({ algorithmId: 'b', inputHash: `h${i}`, score: i / 10 + 0.001 }));
+    // c uncorrelated
+    records.push(rec({ algorithmId: 'c', inputHash: `h${i}`, score: (i % 2) / 10 }));
+  }
+  const matrix = buildCorrelationMatrix(records, ['a', 'b', 'c'], { now: () => NOW });
+  const composition = suggestDiverseEnsemble(matrix, ['a', 'b', 'c'], 2);
+  assert.equal(composition.length, 2);
+  // Second pick should NOT be the strongly-correlated counterpart of the seed.
+  const [seed, second] = composition;
+  if (seed === 'a') assert.notEqual(second, 'b');
+  if (seed === 'b') assert.notEqual(second, 'a');
+});
+
+test('suggestDiverseEnsemble: returns empty for size 0', () => {
+  const matrix = buildCorrelationMatrix([], ['a'], { now: () => NOW });
+  assert.deepEqual(suggestDiverseEnsemble(matrix, ['a'], 0), []);
+});
+
+// ── Cache ─────────────────────────────────────────────────────────────
+
+test('record / getLast CorrelationMatrix: round-trip', () => {
+  _resetCorrelationCacheForTests();
+  const matrix = buildCorrelationMatrix([], ['a'], { now: () => NOW });
+  recordCorrelationMatrix(matrix);
+  assert.equal(getLastCorrelationMatrix()?.algorithmIds[0], 'a');
+});

--- a/src/services/algorithms/__tests__/counterfactual-engine.test.mts
+++ b/src/services/algorithms/__tests__/counterfactual-engine.test.mts
@@ -1,0 +1,198 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  runCounterfactual,
+  shouldRunCounterfactual,
+  recordCounterfactualResult,
+  getCounterfactualsForEvent,
+  listAllCounterfactuals,
+  _resetCounterfactualCacheForTests,
+  type AlgorithmRunner,
+  type CounterfactualEvent,
+} from '../counterfactual-engine.ts';
+
+const NOW = 1_745_000_000_000;
+
+const fireRunner: AlgorithmRunner = () => ({ wouldHaveDecided: 'fire', confidence: 0.9 });
+const holdRunner: AlgorithmRunner = () => ({ wouldHaveDecided: 'hold', confidence: 0.6 });
+const lowConfFireRunner: AlgorithmRunner = () => ({ wouldHaveDecided: 'fire', confidence: 0.3 });
+const throwingRunner: AlgorithmRunner = () => {
+  throw new Error('runner error');
+};
+
+const baseEvent: CounterfactualEvent = {
+  eventId: 'evt-1',
+  groundTruth: 'fire',
+  payload: { kind: 'tornado-warning' },
+  at: NOW,
+};
+
+// ── Replay mechanics ──────────────────────────────────────────────────
+
+test('runCounterfactual: excludes the false-decision algorithm', () => {
+  const runners = new Map<string, AlgorithmRunner>([
+    ['a', fireRunner],
+    ['b', holdRunner],
+  ]);
+  const r = runCounterfactual({
+    event: baseEvent,
+    falseDecisionAlgorithmId: 'a',
+    falseDecisionWas: 'hold',
+    runners,
+    generatedAt: NOW,
+  });
+  assert.equal(r.alternativeAlgorithms.length, 1);
+  assert.equal(r.alternativeAlgorithms[0]!.id, 'b');
+});
+
+test('runCounterfactual: classifies false_negative when groundTruth=fire', () => {
+  const r = runCounterfactual({
+    event: baseEvent,
+    falseDecisionAlgorithmId: 'a',
+    falseDecisionWas: 'hold',
+    runners: new Map([['b', fireRunner]]),
+    generatedAt: NOW,
+  });
+  assert.equal(r.outcomeKind, 'false_negative');
+});
+
+test('runCounterfactual: classifies false_positive when groundTruth=hold', () => {
+  const r = runCounterfactual({
+    event: { ...baseEvent, groundTruth: 'hold' },
+    falseDecisionAlgorithmId: 'a',
+    falseDecisionWas: 'fire',
+    runners: new Map([['b', holdRunner]]),
+    generatedAt: NOW,
+  });
+  assert.equal(r.outcomeKind, 'false_positive');
+});
+
+// ── Best alternative selection ────────────────────────────────────────
+
+test('runCounterfactual: bestAlternative picks highest-confidence match', () => {
+  const r = runCounterfactual({
+    event: baseEvent,
+    falseDecisionAlgorithmId: 'orig',
+    falseDecisionWas: 'hold',
+    runners: new Map([
+      ['a', fireRunner],
+      ['b', holdRunner],
+      ['c', lowConfFireRunner],
+    ]),
+    generatedAt: NOW,
+  });
+  assert.equal(r.bestAlternative?.id, 'a');
+  assert.equal(r.bestAlternative?.confidence, 0.9);
+});
+
+test('runCounterfactual: bestAlternative undefined when no alternative agrees with ground truth', () => {
+  const r = runCounterfactual({
+    event: baseEvent, // groundTruth='fire'
+    falseDecisionAlgorithmId: 'orig',
+    falseDecisionWas: 'hold',
+    runners: new Map([
+      ['a', holdRunner],
+      ['b', holdRunner],
+    ]),
+    generatedAt: NOW,
+  });
+  assert.equal(r.bestAlternative, undefined);
+});
+
+test('runCounterfactual: tie-break by lexicographic id at equal confidence', () => {
+  const sameConf: AlgorithmRunner = () => ({ wouldHaveDecided: 'fire', confidence: 0.7 });
+  const r = runCounterfactual({
+    event: baseEvent,
+    falseDecisionAlgorithmId: 'orig',
+    falseDecisionWas: 'hold',
+    runners: new Map([
+      ['z-late', sameConf],
+      ['a-early', sameConf],
+    ]),
+    generatedAt: NOW,
+  });
+  assert.equal(r.bestAlternative?.id, 'a-early');
+});
+
+// ── Throwing runner ───────────────────────────────────────────────────
+
+test('runCounterfactual: throwing runner is degraded gracefully', () => {
+  const r = runCounterfactual({
+    event: baseEvent,
+    falseDecisionAlgorithmId: 'orig',
+    falseDecisionWas: 'hold',
+    runners: new Map([
+      ['boom', throwingRunner],
+      ['ok', fireRunner],
+    ]),
+    generatedAt: NOW,
+  });
+  assert.equal(r.alternativeAlgorithms.length, 2);
+  const boom = r.alternativeAlgorithms.find((v) => v.id === 'boom');
+  assert.equal(boom?.confidence, 0);
+  // Best should still be the working runner, not the broken one.
+  assert.equal(r.bestAlternative?.id, 'ok');
+});
+
+// ── Insight generation ────────────────────────────────────────────────
+
+test('runCounterfactual: insight names the best alternative when one exists', () => {
+  const r = runCounterfactual({
+    event: baseEvent,
+    falseDecisionAlgorithmId: 'orig',
+    falseDecisionWas: 'hold',
+    runners: new Map([['a', fireRunner]]),
+    generatedAt: NOW,
+  });
+  assert.match(r.insight, /Algorithm "a" would have caught this/);
+});
+
+test('runCounterfactual: insight signals "all wrong" when no match', () => {
+  const r = runCounterfactual({
+    event: baseEvent,
+    falseDecisionAlgorithmId: 'orig',
+    falseDecisionWas: 'hold',
+    runners: new Map([['a', holdRunner], ['b', holdRunner]]),
+    generatedAt: NOW,
+  });
+  assert.match(r.insight, /All 2 alternative algorithms also got event evt-1 wrong/);
+});
+
+test('runCounterfactual: insight handles empty alternatives', () => {
+  const r = runCounterfactual({
+    event: baseEvent,
+    falseDecisionAlgorithmId: 'orig',
+    falseDecisionWas: 'hold',
+    runners: new Map([['orig', fireRunner]]), // only the false-decision algorithm
+    generatedAt: NOW,
+  });
+  assert.match(r.insight, /no alternative algorithms registered/);
+});
+
+// ── Auto-trigger ──────────────────────────────────────────────────────
+
+test('shouldRunCounterfactual: true for miss', () => {
+  assert.equal(shouldRunCounterfactual('miss'), true);
+  assert.equal(shouldRunCounterfactual('hit'), false);
+  assert.equal(shouldRunCounterfactual('partial'), false);
+  assert.equal(shouldRunCounterfactual('inconclusive'), false);
+});
+
+// ── Cache ─────────────────────────────────────────────────────────────
+
+test('record / get / listAll: round-trip', () => {
+  _resetCounterfactualCacheForTests();
+  const r = runCounterfactual({
+    event: baseEvent,
+    falseDecisionAlgorithmId: 'a',
+    falseDecisionWas: 'hold',
+    runners: new Map([['b', fireRunner]]),
+    generatedAt: NOW,
+  });
+  recordCounterfactualResult(r);
+  const back = getCounterfactualsForEvent('evt-1');
+  assert.equal(back.length, 1);
+  const all = listAllCounterfactuals();
+  assert.ok(all['evt-1']);
+});

--- a/src/services/algorithms/__tests__/drift-detector.test.mts
+++ b/src/services/algorithms/__tests__/drift-detector.test.mts
@@ -1,0 +1,191 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildF1Buckets,
+  pageHinkley,
+  evaluateDrift,
+  recordDriftAlert,
+  getDriftHistory,
+  listAllDriftHistory,
+  _resetDriftHistoryForTests,
+} from '../drift-detector.ts';
+import type { EvaluationRecord } from '../algorithm-evaluation-ledger.ts';
+
+const NOW = 1_745_000_000_000;
+const DAY = 24 * 60 * 60 * 1000;
+
+function rec(at: number, outcome: EvaluationRecord['outcome']): EvaluationRecord {
+  return {
+    id: `r-${at}-${outcome}-${Math.random()}`,
+    algorithmId: 'a',
+    domain: 'truth_score',
+    at,
+    durationMs: 1,
+    score: 0.7,
+    outcome,
+    outcomeAt: at + 1,
+    outcomeReason: 'test',
+  };
+}
+
+// ── Page-Hinkley math ─────────────────────────────────────────────────
+
+test('pageHinkley: zero series returns 0 statistic', () => {
+  const r = pageHinkley([], 0.5, 0);
+  assert.equal(r.statistic, 0);
+  assert.equal(r.lastStableIndex, 0);
+});
+
+test('pageHinkley: F1 stays at threshold → statistic stays 0', () => {
+  const r = pageHinkley([0.5, 0.5, 0.5, 0.5], 0.5, 0);
+  assert.equal(r.statistic, 0);
+});
+
+test('pageHinkley: F1 above threshold → resets statistic', () => {
+  // Each F1 is above threshold, so deviations are negative → cumSum
+  // immediately resets to 0.
+  const r = pageHinkley([0.9, 0.9, 0.9], 0.5, 0);
+  assert.equal(r.statistic, 0);
+});
+
+test('pageHinkley: sustained F1 below threshold accumulates', () => {
+  const r = pageHinkley([0.3, 0.3, 0.3], 0.5, 0);
+  // each dev = 0.5 - 0.3 = 0.2 → cumSum = 0.6
+  assert.ok(Math.abs(r.statistic - 0.6) < 1e-9);
+});
+
+test('pageHinkley: positive recovery resets and tracks lastStableIndex', () => {
+  const r = pageHinkley([0.3, 0.9, 0.3], 0.5, 0);
+  // i=0: dev=0.2, cum=0.2
+  // i=1: dev=-0.4, cum=-0.2 → reset to 0, lastStableIndex=1
+  // i=2: dev=0.2, cum=0.2
+  assert.ok(Math.abs(r.statistic - 0.2) < 1e-9);
+  assert.equal(r.lastStableIndex, 1);
+});
+
+// ── F1 bucketing ──────────────────────────────────────────────────────
+
+test('buildF1Buckets: produces window-sized series', () => {
+  const records: EvaluationRecord[] = [
+    rec(NOW - 5 * DAY, 'hit'),
+    rec(NOW - 1 * DAY, 'miss'),
+  ];
+  const series = buildF1Buckets(records, 'a', { bucketMs: DAY, windowBuckets: 7, now: NOW });
+  assert.equal(series.length, 7);
+});
+
+// ── End-to-end drift evaluation ───────────────────────────────────────
+
+test('evaluateDrift: clean history → not alerting', () => {
+  const records: EvaluationRecord[] = [];
+  for (let i = 1; i <= 10; i += 1) {
+    records.push(rec(NOW - i * DAY + 100, 'hit'));
+  }
+  const status = evaluateDrift(records, 'a', {
+    bucketMs: DAY,
+    windowBuckets: 10,
+    now: () => NOW,
+    lambda: 0.5,
+  });
+  assert.equal(status.alerting, false);
+});
+
+test('evaluateDrift: degrading history triggers alert with low lambda', () => {
+  const records: EvaluationRecord[] = [];
+  // First 5 days hits, last 5 days misses.
+  for (let i = 10; i > 5; i -= 1) records.push(rec(NOW - i * DAY + 100, 'hit'));
+  for (let i = 5; i >= 1; i -= 1) records.push(rec(NOW - i * DAY + 100, 'miss'));
+  const status = evaluateDrift(records, 'a', {
+    bucketMs: DAY,
+    windowBuckets: 10,
+    now: () => NOW,
+    lambda: 0.3,
+  });
+  assert.equal(status.alerting, true);
+  assert.ok(status.alert);
+  assert.equal(status.alert!.algorithmId, 'a');
+  assert.ok(['retune', 'shadow', 'review'].includes(status.alert!.recommendedAction));
+});
+
+test('evaluateDrift: severe drop recommends review', () => {
+  const records: EvaluationRecord[] = [];
+  for (let i = 10; i > 1; i -= 1) records.push(rec(NOW - i * DAY + 100, 'hit'));
+  records.push(rec(NOW - 100, 'miss'));
+  const status = evaluateDrift(records, 'a', {
+    bucketMs: DAY,
+    windowBuckets: 10,
+    now: () => NOW,
+    lambda: 0.05,
+    threshold: 1.0,
+  });
+  if (status.alerting) {
+    // Threshold 1.0, currentF1 0 → drop 1.0 > 0.3 → review
+    assert.equal(status.alert!.recommendedAction, 'review');
+  }
+});
+
+test('evaluateDrift: respects threshold override', () => {
+  const records: EvaluationRecord[] = [];
+  for (let i = 5; i >= 1; i -= 1) records.push(rec(NOW - i * DAY + 100, 'hit'));
+  const status = evaluateDrift(records, 'a', {
+    bucketMs: DAY,
+    windowBuckets: 5,
+    now: () => NOW,
+    threshold: 0.99,
+  });
+  // With high threshold and F1=1, deviation = -0.01 each step → resets → no drift
+  assert.equal(status.threshold, 0.99);
+  assert.equal(status.alerting, false);
+});
+
+// ── Drift history ledger ──────────────────────────────────────────────
+
+test('recordDriftAlert + getDriftHistory: round-trip', () => {
+  _resetDriftHistoryForTests();
+  recordDriftAlert({
+    algorithmId: 'x',
+    detectedAt: NOW,
+    lastStableF1: 0.8,
+    currentF1: 0.3,
+    statistic: 1.5,
+    recommendedAction: 'shadow',
+    sampleBuckets: 10,
+  });
+  const list = getDriftHistory('x');
+  assert.equal(list.length, 1);
+  assert.equal(list[0]!.recommendedAction, 'shadow');
+});
+
+test('recordDriftAlert: trims to maxPerAlgorithm', () => {
+  _resetDriftHistoryForTests();
+  for (let i = 0; i < 10; i += 1) {
+    recordDriftAlert({
+      algorithmId: 'y',
+      detectedAt: NOW + i,
+      lastStableF1: 0.8,
+      currentF1: 0.3,
+      statistic: 1.5,
+      recommendedAction: 'retune',
+      sampleBuckets: 5,
+    }, { maxPerAlgorithm: 3 });
+  }
+  const list = getDriftHistory('y');
+  assert.equal(list.length, 3);
+  // Oldest dropped — first surviving alert is i=7
+  assert.equal(list[0]!.detectedAt, NOW + 7);
+});
+
+test('listAllDriftHistory: groups by algorithm', () => {
+  _resetDriftHistoryForTests();
+  recordDriftAlert({
+    algorithmId: 'p', detectedAt: NOW, lastStableF1: 0.8, currentF1: 0.5,
+    statistic: 1, recommendedAction: 'retune', sampleBuckets: 5,
+  });
+  recordDriftAlert({
+    algorithmId: 'q', detectedAt: NOW, lastStableF1: 0.8, currentF1: 0.5,
+    statistic: 1, recommendedAction: 'retune', sampleBuckets: 5,
+  });
+  const all = listAllDriftHistory();
+  assert.equal(Object.keys(all).sort().join(','), 'p,q');
+});

--- a/src/services/algorithms/__tests__/ensemble-voter.test.mts
+++ b/src/services/algorithms/__tests__/ensemble-voter.test.mts
@@ -1,0 +1,243 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  computeF1ForAlgorithm,
+  computeF1WeightsFromLedger,
+  runEnsembleVote,
+  registerEnsembleAlgorithm,
+  recordEnsembleDecision,
+  getLastEnsembleDecision,
+  listEnsembleDomains,
+  _resetEnsembleStateForTests,
+  type AlgorithmVote,
+} from '../ensemble-voter.ts';
+import type { EvaluationRecord } from '../algorithm-evaluation-ledger.ts';
+import { getAlgorithm, resetAlgorithmRegistry } from '../algorithm-registry.ts';
+
+const NOW = 1_745_000_000_000;
+
+function rec(overrides: Partial<EvaluationRecord> & {
+  algorithmId: string;
+  outcome: EvaluationRecord['outcome'];
+  at?: number;
+}): EvaluationRecord {
+  return {
+    id: overrides.id ?? `r-${Math.random()}`,
+    algorithmId: overrides.algorithmId,
+    domain: overrides.domain ?? 'truth_score',
+    at: overrides.at ?? NOW,
+    durationMs: overrides.durationMs ?? 5,
+    score: overrides.score ?? 0.7,
+    outcome: overrides.outcome,
+    outcomeAt: overrides.outcome ? (overrides.at ?? NOW) + 1 : undefined,
+    outcomeReason: overrides.outcome ? 'test' : undefined,
+  };
+}
+
+// ── F1 score ───────────────────────────────────────────────────────────
+
+test('computeF1ForAlgorithm: returns 0 with no graded records', () => {
+  const f1 = computeF1ForAlgorithm([], 'a', { now: NOW });
+  assert.equal(f1, 0);
+});
+
+test('computeF1ForAlgorithm: pure hits give F1=1', () => {
+  const records: EvaluationRecord[] = [
+    rec({ algorithmId: 'a', outcome: 'hit' }),
+    rec({ algorithmId: 'a', outcome: 'hit' }),
+  ];
+  const f1 = computeF1ForAlgorithm(records, 'a', { now: NOW });
+  assert.equal(f1, 1);
+});
+
+test('computeF1ForAlgorithm: penalizes misses + inconclusive', () => {
+  const records: EvaluationRecord[] = [
+    rec({ algorithmId: 'a', outcome: 'hit' }),
+    rec({ algorithmId: 'a', outcome: 'miss' }),
+    rec({ algorithmId: 'a', outcome: 'inconclusive' }),
+  ];
+  // tp=1, fp=1, fn=1 → 2/(2+1+1) = 0.5
+  const f1 = computeF1ForAlgorithm(records, 'a', { now: NOW });
+  assert.equal(f1, 0.5);
+});
+
+test('computeF1ForAlgorithm: ignores records outside window', () => {
+  const records: EvaluationRecord[] = [
+    rec({ algorithmId: 'a', outcome: 'miss', at: NOW - 60 * 24 * 60 * 60 * 1000 }),
+    rec({ algorithmId: 'a', outcome: 'hit', at: NOW - 1 }),
+  ];
+  const f1 = computeF1ForAlgorithm(records, 'a', { now: NOW });
+  assert.equal(f1, 1);
+});
+
+test('computeF1ForAlgorithm: partial counts as 0.5 hit', () => {
+  const records: EvaluationRecord[] = [
+    rec({ algorithmId: 'a', outcome: 'partial' }),
+  ];
+  // tp=0.5, fp=0, fn=0 → 1.0/1.0 = 1
+  const f1 = computeF1ForAlgorithm(records, 'a', { now: NOW });
+  assert.equal(f1, 1);
+});
+
+// ── Weight building ────────────────────────────────────────────────────
+
+test('computeF1WeightsFromLedger: equal weights when no graded records', () => {
+  const w = computeF1WeightsFromLedger([], ['a', 'b'], { now: NOW });
+  assert.equal(w.a, 0.5);
+  assert.equal(w.b, 0.5);
+});
+
+test('computeF1WeightsFromLedger: weights renormalize to 1', () => {
+  const records: EvaluationRecord[] = [
+    rec({ algorithmId: 'a', outcome: 'hit' }),
+    rec({ algorithmId: 'b', outcome: 'miss' }),
+  ];
+  const w = computeF1WeightsFromLedger(records, ['a', 'b'], { now: NOW });
+  const sum = w.a! + w.b!;
+  assert.ok(Math.abs(sum - 1) < 1e-9, `weights must sum to 1, got ${sum}`);
+  assert.ok(w.a! > w.b!, 'higher F1 → higher weight');
+});
+
+test('computeF1WeightsFromLedger: floor keeps zero-F1 algorithms participating', () => {
+  const records: EvaluationRecord[] = [
+    rec({ algorithmId: 'a', outcome: 'hit' }),
+    rec({ algorithmId: 'b', outcome: 'miss' }),
+  ];
+  const w = computeF1WeightsFromLedger(records, ['a', 'b'], { now: NOW, floor: 0.05 });
+  assert.ok(w.b! > 0, 'floor weight should be positive');
+});
+
+// ── Voting modes ───────────────────────────────────────────────────────
+
+function v(id: string, decision: boolean, conf = 0.8): AlgorithmVote {
+  return { algorithmId: id, decision, confidence: conf };
+}
+
+test('runEnsembleVote: MAJORITY fires on >50%', () => {
+  const d = runEnsembleVote({
+    domain: 'weather',
+    votingMode: 'MAJORITY',
+    votes: [v('a', true), v('b', true), v('c', false)],
+    generatedAt: NOW,
+  });
+  assert.equal(d.finalDecision, 'fire');
+  assert.equal(d.dissent.length, 1);
+  assert.equal(d.dissent[0]!.algorithmId, 'c');
+});
+
+test('runEnsembleVote: MAJORITY at exactly 0.5 → undecided', () => {
+  const d = runEnsembleVote({
+    domain: 'weather',
+    votingMode: 'MAJORITY',
+    votes: [v('a', true), v('b', false)],
+    generatedAt: NOW,
+  });
+  assert.equal(d.finalDecision, 'undecided');
+});
+
+test('runEnsembleVote: CONSENSUS fires only above 75%', () => {
+  const fire3of4 = runEnsembleVote({
+    domain: 'weather',
+    votingMode: 'CONSENSUS',
+    votes: [v('a', true), v('b', true), v('c', true), v('d', false)],
+    generatedAt: NOW,
+  });
+  // 3/4 = 0.75, threshold is >0.75 → hold
+  assert.equal(fire3of4.finalDecision, 'hold');
+
+  const fire4of5 = runEnsembleVote({
+    domain: 'weather',
+    votingMode: 'CONSENSUS',
+    votes: [v('a', true), v('b', true), v('c', true), v('d', true), v('e', false)],
+    generatedAt: NOW,
+  });
+  assert.equal(fire4of5.finalDecision, 'fire');
+});
+
+test('runEnsembleVote: UNANIMOUS requires 100%', () => {
+  const d = runEnsembleVote({
+    domain: 'weather',
+    votingMode: 'UNANIMOUS',
+    votes: [v('a', true), v('b', true), v('c', false)],
+    generatedAt: NOW,
+  });
+  assert.equal(d.finalDecision, 'hold');
+  const all = runEnsembleVote({
+    domain: 'weather',
+    votingMode: 'UNANIMOUS',
+    votes: [v('a', true), v('b', true)],
+    generatedAt: NOW,
+  });
+  assert.equal(all.finalDecision, 'fire');
+});
+
+test('runEnsembleVote: CONFIDENCE_WEIGHTED averages yes-confidences', () => {
+  const d = runEnsembleVote({
+    domain: 'weather',
+    votingMode: 'CONFIDENCE_WEIGHTED',
+    votes: [v('a', true, 0.9), v('b', true, 0.7), v('c', false, 0.6)],
+    weights: { a: 1, b: 1, c: 1 },
+    generatedAt: NOW,
+  });
+  // yes-conf = (0.9 + 0.7) / 2 = 0.8 > 0.5 → fire
+  assert.equal(d.finalDecision, 'fire');
+  assert.ok(Math.abs(d.weightedConfidence - 0.8) < 1e-9);
+});
+
+test('runEnsembleVote: weights are renormalized', () => {
+  const d = runEnsembleVote({
+    domain: 'weather',
+    votingMode: 'MAJORITY',
+    votes: [v('a', true), v('b', false)],
+    weights: { a: 5, b: 5 }, // raw, must renormalize
+    generatedAt: NOW,
+  });
+  const sum = (d.weights.a ?? 0) + (d.weights.b ?? 0);
+  assert.ok(Math.abs(sum - 1) < 1e-9);
+});
+
+test('runEnsembleVote: dissent recorded for differing votes', () => {
+  const d = runEnsembleVote({
+    domain: 'weather',
+    votingMode: 'CONSENSUS',
+    votes: [v('a', true), v('b', true), v('c', true), v('d', true), v('e', false)],
+    generatedAt: NOW,
+  });
+  assert.equal(d.finalDecision, 'fire');
+  assert.equal(d.dissent.length, 1);
+  assert.equal(d.dissent[0]!.algorithmId, 'e');
+});
+
+// ── Self-registration ──────────────────────────────────────────────────
+
+test('registerEnsembleAlgorithm: registers ensemble in registry', () => {
+  resetAlgorithmRegistry();
+  const def = registerEnsembleAlgorithm('weather', { participating: ['nws-polygon-match'] });
+  assert.equal(def.id, 'ensemble-weather');
+  assert.equal(getAlgorithm('ensemble-weather')?.label, 'Ensemble (weather)');
+});
+
+test('registerEnsembleAlgorithm: idempotent (replace on re-register)', () => {
+  resetAlgorithmRegistry();
+  registerEnsembleAlgorithm('finance', { participating: ['a'] });
+  // No throw on re-register
+  const def2 = registerEnsembleAlgorithm('finance', { participating: ['a', 'b'] });
+  assert.equal(def2.dependencies.services.length, 2);
+});
+
+// ── Mirror cache ───────────────────────────────────────────────────────
+
+test('recordEnsembleDecision + getLastEnsembleDecision round-trip', () => {
+  _resetEnsembleStateForTests();
+  const d = runEnsembleVote({
+    domain: 'finance',
+    votingMode: 'MAJORITY',
+    votes: [v('a', true), v('b', true)],
+    generatedAt: NOW,
+  });
+  recordEnsembleDecision(d);
+  const back = getLastEnsembleDecision('finance');
+  assert.equal(back?.finalDecision, 'fire');
+  assert.deepEqual(listEnsembleDomains(), ['finance']);
+});

--- a/src/services/algorithms/__tests__/genealogy-tree.test.mts
+++ b/src/services/algorithms/__tests__/genealogy-tree.test.mts
@@ -1,0 +1,187 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildGenealogy,
+  getAncestors,
+  getDescendants,
+  getLineage,
+  genealogyToJson,
+  recordLifecycleEvent,
+  buildGenealogyFromLog,
+  _resetLifecycleLogForTests,
+  type LifecycleEvent,
+} from '../genealogy-tree.ts';
+
+const NOW = 1_745_000_000_000;
+
+function ev(args: Partial<LifecycleEvent> & {
+  algorithmId: string;
+  parentId: string | null;
+}): LifecycleEvent {
+  return {
+    at: args.at ?? NOW,
+    algorithmId: args.algorithmId,
+    parentId: args.parentId,
+    reason: args.reason ?? 'new',
+    paramDelta: args.paramDelta,
+    promotionMetrics: args.promotionMetrics,
+    state: args.state ?? 'active',
+  };
+}
+
+// ── Tree construction ────────────────────────────────────────────────
+
+test('buildGenealogy: single root node', () => {
+  const g = buildGenealogy([ev({ algorithmId: 'a', parentId: null })], { now: NOW });
+  assert.equal(g.roots.length, 1);
+  assert.equal(g.roots[0], 'a');
+  assert.equal(g.nodes.get('a')?.parentId, null);
+});
+
+test('buildGenealogy: parent → child link populates children', () => {
+  const g = buildGenealogy(
+    [
+      ev({ algorithmId: 'a', parentId: null, at: NOW }),
+      ev({ algorithmId: 'b', parentId: 'a', at: NOW + 1, reason: 'fork' }),
+    ],
+    { now: NOW + 2 },
+  );
+  assert.deepEqual(g.nodes.get('a')?.children, ['b']);
+  assert.equal(g.nodes.get('b')?.creationReason, 'fork');
+});
+
+test('buildGenealogy: applies events in chronological order', () => {
+  // Pass events in reverse order to confirm sort.
+  const g = buildGenealogy(
+    [
+      ev({ algorithmId: 'b', parentId: 'a', at: NOW + 1 }),
+      ev({ algorithmId: 'a', parentId: null, at: NOW }),
+    ],
+    { now: NOW + 2 },
+  );
+  assert.deepEqual(g.nodes.get('a')?.children, ['b']);
+});
+
+test('buildGenealogy: subsequent events update state and metrics', () => {
+  const g = buildGenealogy(
+    [
+      ev({ algorithmId: 'a', parentId: null, at: NOW, state: 'shadow' }),
+      ev({
+        algorithmId: 'a',
+        parentId: null,
+        at: NOW + 100,
+        state: 'active',
+        promotionMetrics: { shadowF1: 0.7 },
+      }),
+    ],
+    { now: NOW + 200 },
+  );
+  const node = g.nodes.get('a');
+  assert.equal(node?.currentState, 'active');
+  assert.equal(node?.promotionMetrics.shadowF1, 0.7);
+});
+
+// ── Cycle detection ──────────────────────────────────────────────────
+
+test('buildGenealogy: rejects an event that would form a cycle', () => {
+  const g = buildGenealogy(
+    [
+      ev({ algorithmId: 'a', parentId: null, at: NOW }),
+      ev({ algorithmId: 'b', parentId: 'a', at: NOW + 1 }),
+      ev({ algorithmId: 'c', parentId: 'b', at: NOW + 2 }),
+      // Now try to create 'a' as a child of 'c' — this would form a cycle.
+      ev({ algorithmId: 'a-cycle', parentId: 'a', at: NOW + 3 }),
+    ],
+    { now: NOW + 4 },
+  );
+  // 'a' was created first as root; the cycle check is against future
+  // events trying to graft an existing ancestor under a descendant. Add
+  // a direct-cycle event:
+  const g2 = buildGenealogy(
+    [
+      ev({ algorithmId: 'x', parentId: 'x', at: NOW }), // self-parent
+    ],
+    { now: NOW },
+  );
+  // Self-parent rejected → no node created.
+  assert.equal(g2.nodes.has('x'), false);
+  // Sanity from g
+  assert.ok(g.nodes.has('a-cycle'));
+});
+
+// ── Lineage queries ──────────────────────────────────────────────────
+
+test('getAncestors: walks up the chain', () => {
+  const g = buildGenealogy(
+    [
+      ev({ algorithmId: 'a', parentId: null, at: NOW }),
+      ev({ algorithmId: 'b', parentId: 'a', at: NOW + 1 }),
+      ev({ algorithmId: 'c', parentId: 'b', at: NOW + 2 }),
+    ],
+    { now: NOW + 3 },
+  );
+  assert.deepEqual(getAncestors(g, 'c'), ['b', 'a']);
+});
+
+test('getDescendants: BFS over children', () => {
+  const g = buildGenealogy(
+    [
+      ev({ algorithmId: 'a', parentId: null, at: NOW }),
+      ev({ algorithmId: 'b', parentId: 'a', at: NOW + 1 }),
+      ev({ algorithmId: 'c', parentId: 'a', at: NOW + 2 }),
+      ev({ algorithmId: 'd', parentId: 'b', at: NOW + 3 }),
+    ],
+    { now: NOW + 4 },
+  );
+  const d = getDescendants(g, 'a');
+  assert.equal(d.includes('b'), true);
+  assert.equal(d.includes('c'), true);
+  assert.equal(d.includes('d'), true);
+  assert.equal(d.length, 3);
+});
+
+test('getLineage: combines ancestors + descendants', () => {
+  const g = buildGenealogy(
+    [
+      ev({ algorithmId: 'a', parentId: null, at: NOW }),
+      ev({ algorithmId: 'b', parentId: 'a', at: NOW + 1 }),
+      ev({ algorithmId: 'c', parentId: 'b', at: NOW + 2 }),
+    ],
+    { now: NOW + 3 },
+  );
+  const l = getLineage(g, 'b');
+  assert.deepEqual(l.ancestors, ['a']);
+  assert.deepEqual(l.descendants, ['c']);
+});
+
+test('getLineage: unknown algorithm returns empty arrays', () => {
+  const g = buildGenealogy([], { now: NOW });
+  const l = getLineage(g, 'ghost');
+  assert.equal(l.ancestors.length, 0);
+  assert.equal(l.descendants.length, 0);
+});
+
+// ── Serialization ────────────────────────────────────────────────────
+
+test('genealogyToJson: round-trip', () => {
+  const g = buildGenealogy(
+    [ev({ algorithmId: 'a', parentId: null, at: NOW })],
+    { now: NOW + 1 },
+  );
+  const json = genealogyToJson(g);
+  assert.equal(json.nodes.length, 1);
+  assert.deepEqual(json.roots, ['a']);
+  assert.equal(json.generatedAt, NOW + 1);
+});
+
+// ── Audit log + log-driven build ─────────────────────────────────────
+
+test('recordLifecycleEvent + buildGenealogyFromLog: round-trip', () => {
+  _resetLifecycleLogForTests();
+  recordLifecycleEvent(ev({ algorithmId: 'a', parentId: null, at: NOW }));
+  recordLifecycleEvent(ev({ algorithmId: 'b', parentId: 'a', at: NOW + 1, reason: 'retune' }));
+  const g = buildGenealogyFromLog(NOW + 2);
+  assert.equal(g.nodes.size, 2);
+  assert.equal(g.nodes.get('b')?.creationReason, 'retune');
+});

--- a/src/services/algorithms/__tests__/llm-grader.test.mts
+++ b/src/services/algorithms/__tests__/llm-grader.test.mts
@@ -1,0 +1,186 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildLlmGradePrompt,
+  parseLlmGradeResponse,
+  gradeWithLlm,
+  llmGradeToLedgerOutcome,
+  recordLlmGrade,
+  getLlmGrade,
+  listLlmGrades,
+  _resetLlmGradeCacheForTests,
+  type LlmFn,
+  type LlmGradeInput,
+} from '../llm-grader.ts';
+import {
+  pickEligibleForLlmGrading,
+  resolvePendingViaLlm,
+} from '../outcome-resolver.ts';
+import type { EvaluationRecord } from '../algorithm-evaluation-ledger.ts';
+
+const NOW = 1_745_000_000_000;
+
+const baseInput: LlmGradeInput = {
+  algorithmId: 'compound-risk',
+  eventId: 'evt-1',
+  decision: 'fire (escalation expected within 24h)',
+  evidence: [{ kind: 'fact', summary: 'troop movement reported', at: NOW }],
+};
+
+// ── Prompt construction ───────────────────────────────────────────────
+
+test('buildLlmGradePrompt: includes the structured fields', () => {
+  const prompt = buildLlmGradePrompt(baseInput);
+  const parsed = JSON.parse(prompt);
+  assert.equal(parsed.algorithmId, 'compound-risk');
+  assert.equal(parsed.eventId, 'evt-1');
+  assert.equal(parsed.question, 'Did this prediction come true?');
+  assert.ok(Array.isArray(parsed.evidence));
+  assert.match(parsed.instructions, /strict JSON/i);
+});
+
+// ── Response parsing ──────────────────────────────────────────────────
+
+test('parseLlmGradeResponse: parses well-formed JSON', () => {
+  const r = parseLlmGradeResponse('{"grade":"TRUE_POSITIVE","confidence":0.9,"reasoning":"matches reports"}');
+  assert.equal(r.grade, 'TRUE_POSITIVE');
+  assert.equal(r.confidence, 0.9);
+  assert.equal(r.malformed, false);
+});
+
+test('parseLlmGradeResponse: strips code fences', () => {
+  const r = parseLlmGradeResponse('```json\n{"grade":"FALSE_POSITIVE","confidence":0.8,"reasoning":"no escalation"}\n```');
+  assert.equal(r.grade, 'FALSE_POSITIVE');
+});
+
+test('parseLlmGradeResponse: malformed JSON → INCONCLUSIVE', () => {
+  const r = parseLlmGradeResponse('not json');
+  assert.equal(r.grade, 'INCONCLUSIVE');
+  assert.equal(r.malformed, true);
+});
+
+test('parseLlmGradeResponse: invalid grade label → INCONCLUSIVE', () => {
+  const r = parseLlmGradeResponse('{"grade":"MAYBE","confidence":0.9,"reasoning":"x"}');
+  assert.equal(r.grade, 'INCONCLUSIVE');
+  assert.equal(r.malformed, true);
+});
+
+test('parseLlmGradeResponse: clamps confidence to [0,1]', () => {
+  const r = parseLlmGradeResponse('{"grade":"TRUE_POSITIVE","confidence":2.5,"reasoning":"x"}');
+  assert.equal(r.confidence, 1);
+});
+
+test('parseLlmGradeResponse: missing confidence defaults to 0', () => {
+  const r = parseLlmGradeResponse('{"grade":"TRUE_POSITIVE","reasoning":"x"}');
+  assert.equal(r.confidence, 0);
+});
+
+// ── End-to-end gradeWithLlm ───────────────────────────────────────────
+
+test('gradeWithLlm: high-confidence TRUE_POSITIVE accepted', async () => {
+  const llmFn: LlmFn = async () =>
+    '{"grade":"TRUE_POSITIVE","confidence":0.85,"reasoning":"verified"}';
+  const r = await gradeWithLlm(baseInput, llmFn, { now: () => NOW });
+  assert.equal(r.grade, 'TRUE_POSITIVE');
+  assert.equal(r.belowConfidenceThreshold, false);
+  assert.equal(r.llmUnavailable, false);
+});
+
+test('gradeWithLlm: low-confidence call downgraded to INCONCLUSIVE', async () => {
+  const llmFn: LlmFn = async () =>
+    '{"grade":"TRUE_POSITIVE","confidence":0.5,"reasoning":"weak signal"}';
+  const r = await gradeWithLlm(baseInput, llmFn, { now: () => NOW, acceptanceThreshold: 0.75 });
+  assert.equal(r.grade, 'INCONCLUSIVE');
+  assert.equal(r.belowConfidenceThreshold, true);
+});
+
+test('gradeWithLlm: thrown llmFn → INCONCLUSIVE with llmUnavailable=true', async () => {
+  const llmFn: LlmFn = () => Promise.reject(new Error('Ollama not running'));
+  const r = await gradeWithLlm(baseInput, llmFn, { now: () => NOW });
+  assert.equal(r.grade, 'INCONCLUSIVE');
+  assert.equal(r.llmUnavailable, true);
+  assert.match(r.reasoning, /Ollama not running/);
+});
+
+test('gradeWithLlm: malformed LLM response → INCONCLUSIVE', async () => {
+  const llmFn: LlmFn = async () => 'this is not JSON at all';
+  const r = await gradeWithLlm(baseInput, llmFn, { now: () => NOW });
+  assert.equal(r.grade, 'INCONCLUSIVE');
+});
+
+// ── Outcome mapping ───────────────────────────────────────────────────
+
+test('llmGradeToLedgerOutcome: maps grades to ledger outcomes', () => {
+  assert.equal(llmGradeToLedgerOutcome('TRUE_POSITIVE'), 'hit');
+  assert.equal(llmGradeToLedgerOutcome('FALSE_POSITIVE'), 'miss');
+  assert.equal(llmGradeToLedgerOutcome('INCONCLUSIVE'), 'inconclusive');
+});
+
+// ── Outcome resolver integration ─────────────────────────────────────
+
+const HOUR = 60 * 60 * 1000;
+
+function pendingRec(at: number, id = 'r1'): EvaluationRecord {
+  return {
+    id,
+    algorithmId: 'a',
+    domain: 'truth_score',
+    at,
+    durationMs: 1,
+    score: 0.7,
+    label: 'fire',
+    notes: 'test',
+  };
+}
+
+test('pickEligibleForLlmGrading: only records older than timeout', () => {
+  const records = [
+    pendingRec(NOW - 50 * HOUR, 'old'),
+    pendingRec(NOW - 10 * HOUR, 'recent'),
+  ];
+  const eligible = pickEligibleForLlmGrading(records, { now: NOW, timeoutMs: 48 * HOUR });
+  assert.equal(eligible.length, 1);
+  assert.equal(eligible[0]!.id, 'old');
+});
+
+test('pickEligibleForLlmGrading: skips records that already have an outcome', () => {
+  const r = pendingRec(NOW - 100 * HOUR, 'graded');
+  r.outcome = 'hit';
+  const eligible = pickEligibleForLlmGrading([r], { now: NOW });
+  assert.equal(eligible.length, 0);
+});
+
+test('resolvePendingViaLlm: routes eligible records through llmFn', async () => {
+  const records = [pendingRec(NOW - 100 * HOUR, 'old1'), pendingRec(NOW - 100 * HOUR, 'old2')];
+  const llmFn: LlmFn = async () =>
+    '{"grade":"TRUE_POSITIVE","confidence":0.85,"reasoning":"ok"}';
+  const out = await resolvePendingViaLlm(records, { now: NOW, llmFn });
+  assert.equal(out.length, 2);
+  assert.equal(out[0]!.ledgerOutcome, 'hit');
+});
+
+test('resolvePendingViaLlm: missing llmFn → INCONCLUSIVE for every record', async () => {
+  const records = [pendingRec(NOW - 100 * HOUR, 'r')];
+  const out = await resolvePendingViaLlm(records, { now: NOW });
+  assert.equal(out[0]!.ledgerOutcome, 'inconclusive');
+  assert.equal(out[0]!.llm.llmUnavailable, true);
+});
+
+// ── Cache ─────────────────────────────────────────────────────────────
+
+test('record / get / list LlmGrade: round-trip', () => {
+  _resetLlmGradeCacheForTests();
+  recordLlmGrade({
+    eventId: 'e1',
+    algorithmId: 'a',
+    grade: 'TRUE_POSITIVE',
+    confidence: 0.9,
+    reasoning: 'x',
+    belowConfidenceThreshold: false,
+    llmUnavailable: false,
+    generatedAt: NOW,
+  });
+  assert.equal(getLlmGrade('e1')?.grade, 'TRUE_POSITIVE');
+  assert.equal(listLlmGrades().length, 1);
+});

--- a/src/services/algorithms/adaptive-tuner.ts
+++ b/src/services/algorithms/adaptive-tuner.ts
@@ -1,0 +1,375 @@
+/**
+ * Adaptive Parameter Tuning — PR 15.
+ *
+ * After each grading batch, attempt to improve algorithm parameters
+ * automatically using a simplified Tree-structured Parzen Estimator
+ * (TPE): sample 50 random configurations, evaluate on the most-recent
+ * 100 graded fixtures, keep the top 5, then hill-climb around the
+ * best.
+ *
+ * Safety rails:
+ *   - Never change a parameter by more than 20% per cycle.
+ *   - Require >=5% F1 improvement before accepting a new config.
+ *   - Refuse to act below the configured minimum new-grade count.
+ *
+ * The cycle is pure deterministic given an injectable evaluator and
+ * RNG. Production code wires Math.random + a real evaluator.
+ */
+
+import type { TunableParameter } from './safe-adjustment.ts';
+
+// ── Public types ──────────────────────────────────────────────────────
+
+export type ParamConfig = Record<string, number>;
+
+/** Evaluate a parameter configuration against the provided fixture
+ *  set. Higher F1 is better; must be deterministic for a fixed
+ *  config. */
+export type TuningEvaluator = (config: ParamConfig) => number;
+
+export interface TuningRunInput {
+  algorithmId: string;
+  /** Tunable parameters declared in the algorithm registry. */
+  parameters: readonly TunableParameter[];
+  /** F1 score the algorithm currently runs at. */
+  currentF1: number;
+  /** Number of new grades since the last tuning run. */
+  newGrades: number;
+  /** Fixtures to evaluate against. The TPE sampler does not look at
+   *  fixtures directly — they are passed to the evaluator opaquely. */
+  evaluator: TuningEvaluator;
+  rng?: () => number;
+  now?: () => number;
+}
+
+export type TuningVerdict =
+  | 'applied'
+  | 'rejected_no_improvement'
+  | 'rejected_safety_bound'
+  | 'rejected_too_few_grades'
+  | 'no_tunable';
+
+export interface TuningRunResult {
+  algorithmId: string;
+  verdict: TuningVerdict;
+  /** Best new config the search produced. Undefined when no_tunable
+   *  or no candidate beat the safety bound. */
+  bestConfig?: ParamConfig;
+  /** Best F1 the search achieved on the fixtures. */
+  bestF1: number;
+  /** F1 improvement over currentF1 in absolute points. */
+  improvement: number;
+  /** Audit: the prior config (before the run). */
+  priorConfig: ParamConfig;
+  /** Audit: per-parameter delta (new - prior). */
+  paramDelta: Record<string, number>;
+  /** Plain-English notes about the run. */
+  notes: readonly string[];
+  generatedAt: number;
+}
+
+export interface TunerOptions {
+  /** Minimum new-grade count required to attempt a run. Default 20. */
+  minNewGrades?: number;
+  /** Random search sample count. Default 50. */
+  sampleCount?: number;
+  /** Top-k configs kept for hill-climbing. Default 5. */
+  topK?: number;
+  /** Hill-climb iterations. Default 10. */
+  hillClimbIterations?: number;
+  /** Maximum fractional change per parameter per cycle. Default 0.2. */
+  maxRelativeChange?: number;
+  /** Required absolute F1 improvement to accept. Default 0.05. */
+  improvementThreshold?: number;
+}
+
+const DEFAULTS: Required<TunerOptions> = {
+  minNewGrades: 20,
+  sampleCount: 50,
+  topK: 5,
+  hillClimbIterations: 10,
+  maxRelativeChange: 0.2,
+  improvementThreshold: 0.05,
+};
+
+// ── Sampling ──────────────────────────────────────────────────────────
+
+/** Snap a value to the parameter's grid (min..max in steps of step). */
+export function snapToGrid(value: number, p: TunableParameter): number {
+  if (value < p.min) return p.min;
+  if (value > p.max) return p.max;
+  if (p.step <= 0) return value;
+  const offset = value - p.min;
+  const snapped = p.min + Math.round(offset / p.step) * p.step;
+  if (snapped < p.min) return p.min;
+  if (snapped > p.max) return p.max;
+  return snapped;
+}
+
+/** Sample a uniformly-random value within the parameter's bounds,
+ *  snapped to the step grid. */
+export function sampleParam(p: TunableParameter, rng: () => number): number {
+  const raw = p.min + rng() * (p.max - p.min);
+  return snapToGrid(raw, p);
+}
+
+/** Sample one full configuration. */
+export function sampleConfig(
+  parameters: readonly TunableParameter[],
+  rng: () => number,
+): ParamConfig {
+  const out: ParamConfig = {};
+  for (const p of parameters) out[p.parameterId] = sampleParam(p, rng);
+  return out;
+}
+
+// ── Hill climb ────────────────────────────────────────────────────────
+
+/** Move one step on the parameter grid (up or down). */
+function neighborStep(p: TunableParameter, current: number, rng: () => number): number {
+  const direction = rng() < 0.5 ? -1 : 1;
+  const next = current + direction * (p.step || (p.max - p.min) / 50);
+  return snapToGrid(next, p);
+}
+
+export function hillClimb(
+  start: ParamConfig,
+  parameters: readonly TunableParameter[],
+  evaluator: TuningEvaluator,
+  options: { iterations: number; rng: () => number },
+): { config: ParamConfig; f1: number } {
+  let best = { ...start };
+  let bestF1 = evaluator(best);
+  for (let i = 0; i < options.iterations; i += 1) {
+    const candidate = { ...best };
+    // Perturb one random parameter.
+    const idx = Math.floor(options.rng() * parameters.length);
+    const target = parameters[idx];
+    if (!target) continue;
+    candidate[target.parameterId] = neighborStep(
+      target,
+      candidate[target.parameterId] ?? target.current,
+      options.rng,
+    );
+    const score = evaluator(candidate);
+    if (score > bestF1) {
+      best = candidate;
+      bestF1 = score;
+    }
+  }
+  return { config: best, f1: bestF1 };
+}
+
+// ── Safety rails ──────────────────────────────────────────────────────
+
+/** Clamp the proposed config so no parameter shifts by more than
+ *  maxRelativeChange. Returns the clamped config plus a list of
+ *  parameters whose proposal was clamped. */
+export function clampConfigToSafetyBound(
+  proposed: ParamConfig,
+  prior: ParamConfig,
+  parameters: readonly TunableParameter[],
+  maxRelativeChange: number,
+): { clamped: ParamConfig; clamped_params: string[] } {
+  const out: ParamConfig = { ...proposed };
+  const clampedParams: string[] = [];
+  for (const p of parameters) {
+    const before = prior[p.parameterId] ?? p.current;
+    const after = proposed[p.parameterId] ?? before;
+    if (before === 0) {
+      // Cannot compute a relative bound on zero — fall back to step-based.
+      const limit = p.step * 5;
+      if (Math.abs(after - before) > limit) {
+        out[p.parameterId] = snapToGrid(before + Math.sign(after - before) * limit, p);
+        clampedParams.push(p.parameterId);
+      }
+      continue;
+    }
+    const maxDelta = Math.abs(before) * maxRelativeChange;
+    const delta = after - before;
+    if (Math.abs(delta) > maxDelta) {
+      out[p.parameterId] = snapToGrid(before + Math.sign(delta) * maxDelta, p);
+      clampedParams.push(p.parameterId);
+    }
+  }
+  return { clamped: out, clamped_params: clampedParams };
+}
+
+// ── Top-level cycle ───────────────────────────────────────────────────
+
+/** Run one TPE-flavored tuning cycle. */
+export function runTuningCycle(
+  input: TuningRunInput,
+  options: TunerOptions = {},
+): TuningRunResult {
+  const opts = { ...DEFAULTS, ...options };
+  const rng = input.rng ?? Math.random;
+  const generatedAt = (input.now ?? (() => Date.now()))();
+
+  const priorConfig: ParamConfig = {};
+  for (const p of input.parameters) priorConfig[p.parameterId] = p.current;
+
+  const baseResult: Pick<TuningRunResult, 'algorithmId' | 'priorConfig' | 'generatedAt'> = {
+    algorithmId: input.algorithmId,
+    priorConfig,
+    generatedAt,
+  };
+
+  if (input.parameters.length === 0) {
+    return {
+      ...baseResult,
+      verdict: 'no_tunable',
+      bestF1: input.currentF1,
+      improvement: 0,
+      paramDelta: {},
+      notes: ['no tunable parameters declared for algorithm'],
+    };
+  }
+
+  if (input.newGrades < opts.minNewGrades) {
+    return {
+      ...baseResult,
+      verdict: 'rejected_too_few_grades',
+      bestF1: input.currentF1,
+      improvement: 0,
+      paramDelta: {},
+      notes: [
+        `only ${input.newGrades} new grades — need at least ${opts.minNewGrades} before tuning`,
+      ],
+    };
+  }
+
+  // Step 1: random search.
+  const samples: { config: ParamConfig; f1: number }[] = [];
+  for (let i = 0; i < opts.sampleCount; i += 1) {
+    const config = sampleConfig(input.parameters, rng);
+    const f1 = input.evaluator(config);
+    samples.push({ config, f1 });
+  }
+  samples.sort((a, b) => b.f1 - a.f1);
+
+  // Step 2: hill-climb from each top-k seed.
+  const topSeeds = samples.slice(0, opts.topK);
+  let best = { config: { ...priorConfig }, f1: input.evaluator(priorConfig) };
+  for (const seed of topSeeds) {
+    const climbed = hillClimb(seed.config, input.parameters, input.evaluator, {
+      iterations: opts.hillClimbIterations,
+      rng,
+    });
+    if (climbed.f1 > best.f1) best = climbed;
+  }
+
+  // Step 3: enforce safety rails (max-relative-change).
+  const { clamped, clamped_params } = clampConfigToSafetyBound(
+    best.config,
+    priorConfig,
+    input.parameters,
+    opts.maxRelativeChange,
+  );
+  const clampedF1 = input.evaluator(clamped);
+
+  const improvement = clampedF1 - input.currentF1;
+  const paramDelta = computeParamDelta(input.parameters, priorConfig, clamped);
+  return finalizeVerdict({
+    base: baseResult,
+    clamped,
+    clampedF1,
+    clampedParams: clamped_params,
+    improvement,
+    improvementThreshold: opts.improvementThreshold,
+    currentF1: input.currentF1,
+    paramDelta,
+  });
+}
+
+function computeParamDelta(
+  parameters: readonly TunableParameter[],
+  priorConfig: ParamConfig,
+  clamped: ParamConfig,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const p of parameters) {
+    const before = priorConfig[p.parameterId] ?? 0;
+    const after = clamped[p.parameterId] ?? before;
+    if (before !== after) out[p.parameterId] = after - before;
+  }
+  return out;
+}
+
+function finalizeVerdict(args: {
+  base: Pick<TuningRunResult, 'algorithmId' | 'priorConfig' | 'generatedAt'>;
+  clamped: ParamConfig;
+  clampedF1: number;
+  clampedParams: string[];
+  improvement: number;
+  improvementThreshold: number;
+  currentF1: number;
+  paramDelta: Record<string, number>;
+}): TuningRunResult {
+  const { base, clamped, clampedF1, clampedParams, improvement, improvementThreshold, currentF1, paramDelta } = args;
+  const clampNote = clampedParams.length > 0 ? [`clamped params: ${clampedParams.join(', ')}`] : [];
+
+  if (improvement < improvementThreshold) {
+    return {
+      ...base,
+      verdict: 'rejected_no_improvement',
+      bestConfig: clamped,
+      bestF1: clampedF1,
+      improvement,
+      paramDelta,
+      notes: [
+        `best candidate yielded F1 ${clampedF1.toFixed(3)} vs current ${currentF1.toFixed(3)} — below threshold ${improvementThreshold}`,
+        ...clampNote,
+      ],
+    };
+  }
+  if (clampedParams.length > 0 && Object.keys(paramDelta).length === 0) {
+    return {
+      ...base,
+      verdict: 'rejected_safety_bound',
+      bestConfig: clamped,
+      bestF1: clampedF1,
+      improvement,
+      paramDelta,
+      notes: [`every parameter pinned by safety bound; refusing to apply`],
+    };
+  }
+  return {
+    ...base,
+    verdict: 'applied',
+    bestConfig: clamped,
+    bestF1: clampedF1,
+    improvement,
+    paramDelta,
+    notes: [
+      `applied: F1 ${currentF1.toFixed(3)} → ${clampedF1.toFixed(3)} (Δ +${improvement.toFixed(3)})`,
+      ...clampNote,
+    ],
+  };
+}
+
+// ── Audit trail ───────────────────────────────────────────────────────
+
+const tuningHistory = new Map<string, TuningRunResult[]>();
+
+export function recordTuningRun(result: TuningRunResult, options: { maxPerAlgorithm?: number } = {}): void {
+  const max = options.maxPerAlgorithm ?? 100;
+  const list = tuningHistory.get(result.algorithmId) ?? [];
+  list.push({ ...result, paramDelta: { ...result.paramDelta } });
+  while (list.length > max) list.shift();
+  tuningHistory.set(result.algorithmId, list);
+}
+
+export function getTuningHistory(algorithmId: string): TuningRunResult[] {
+  return [...(tuningHistory.get(algorithmId) ?? [])];
+}
+
+export function listAllTuningHistory(): Record<string, TuningRunResult[]> {
+  const out: Record<string, TuningRunResult[]> = {};
+  for (const [id, list] of tuningHistory) out[id] = [...list];
+  return out;
+}
+
+export function _resetTuningHistoryForTests(): void {
+  tuningHistory.clear();
+}

--- a/src/services/algorithms/blackswan-detector.ts
+++ b/src/services/algorithms/blackswan-detector.ts
@@ -1,0 +1,312 @@
+/**
+ * Black Swan Detector — PR 17.
+ *
+ * Watches the input-feature distribution for events that fall outside
+ * every algorithm's training distribution. Uses a simplified
+ * Isolation Forest: build T random trees over history, isolate the
+ * query point, average path length, convert to an anomaly score.
+ *
+ * Pure deterministic given an injectable RNG.
+ */
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface EventFeatures {
+  /** Stable id for this event. */
+  id: string;
+  /** The feature vector. Order MUST be stable across history. */
+  features: readonly number[];
+  /** ms timestamp. Used to age the event. */
+  at: number;
+}
+
+export type BlackSwanAction =
+  | 'monitor'
+  | 'expand_window'
+  | 'consult_analog'
+  | 'escalate_to_review';
+
+export interface BlackSwanAlert {
+  detectedAt: number;
+  eventId: string;
+  /** Higher = more anomalous, 0..1. */
+  anomalyScore: number;
+  /** Algorithms whose decisions on this event are now suspect. */
+  affectedAlgorithms: readonly string[];
+  /** Optional nearest historical analog id (e.g. from sequence-matcher).
+   *  Null when no analog could be located. */
+  nearestHistoricalAnalog: string | null;
+  suggestedAction: BlackSwanAction;
+}
+
+export interface BlackSwanStatus {
+  /** Per-event anomaly scores recently computed. */
+  recentScores: readonly { id: string; score: number; at: number }[];
+  /** Active alerts (one per anomalous event in the recent window). */
+  alerts: readonly BlackSwanAlert[];
+  generatedAt: number;
+}
+
+export interface IsolationForestOptions {
+  /** Number of trees. Default 50. */
+  trees?: number;
+  /** Sample size per tree. Default 32. */
+  sampleSize?: number;
+  /** Maximum tree depth (the spec's c(n) cap). Default ceil(log2(sampleSize)). */
+  maxDepth?: number;
+  rng?: () => number;
+}
+
+const DEFAULTS = {
+  trees: 50,
+  sampleSize: 32,
+};
+
+// ── Tree types ────────────────────────────────────────────────────────
+
+type TreeNode =
+  | { kind: 'leaf'; size: number }
+  | { kind: 'split'; featureIndex: number; threshold: number; left: TreeNode; right: TreeNode };
+
+// ── Tree building ─────────────────────────────────────────────────────
+
+function buildTree(
+  points: number[][],
+  depth: number,
+  maxDepth: number,
+  rng: () => number,
+): TreeNode {
+  if (depth >= maxDepth || points.length <= 1) {
+    return { kind: 'leaf', size: points.length };
+  }
+  const numFeatures = points[0]!.length;
+  if (numFeatures === 0) return { kind: 'leaf', size: points.length };
+  const featureIndex = Math.floor(rng() * numFeatures);
+  let min = Infinity;
+  let max = -Infinity;
+  for (const p of points) {
+    const v = p[featureIndex] ?? 0;
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  if (min === max) return { kind: 'leaf', size: points.length };
+  const threshold = min + rng() * (max - min);
+  const left: number[][] = [];
+  const right: number[][] = [];
+  for (const p of points) {
+    if ((p[featureIndex] ?? 0) < threshold) left.push(p);
+    else right.push(p);
+  }
+  if (left.length === 0 || right.length === 0) {
+    return { kind: 'leaf', size: points.length };
+  }
+  return {
+    kind: 'split',
+    featureIndex,
+    threshold,
+    left: buildTree(left, depth + 1, maxDepth, rng),
+    right: buildTree(right, depth + 1, maxDepth, rng),
+  };
+}
+
+// ── Path length ───────────────────────────────────────────────────────
+
+/** Average path length of an unsuccessful BST search (used to
+ *  normalize iForest scores). */
+function avgPathLength(n: number): number {
+  if (n <= 1) return 0;
+  const harmonic = Math.log(n - 1) + 0.577_215_664_9; // Euler-Mascheroni
+  return 2 * harmonic - (2 * (n - 1)) / n;
+}
+
+function pathLength(node: TreeNode, point: readonly number[], depth = 0): number {
+  if (node.kind === 'leaf') {
+    return depth + avgPathLength(node.size);
+  }
+  const v = point[node.featureIndex] ?? 0;
+  return v < node.threshold
+    ? pathLength(node.left, point, depth + 1)
+    : pathLength(node.right, point, depth + 1);
+}
+
+// ── Forest API ────────────────────────────────────────────────────────
+
+export interface IsolationForest {
+  trees: readonly TreeNode[];
+  sampleSize: number;
+}
+
+export function buildIsolationForest(
+  history: readonly EventFeatures[],
+  options: IsolationForestOptions = {},
+): IsolationForest {
+  const trees = options.trees ?? DEFAULTS.trees;
+  const sampleSize = Math.min(options.sampleSize ?? DEFAULTS.sampleSize, history.length);
+  const maxDepth = options.maxDepth ?? Math.max(1, Math.ceil(Math.log2(Math.max(2, sampleSize))));
+  const rng = options.rng ?? Math.random;
+  const out: TreeNode[] = [];
+  if (history.length === 0) return { trees: [], sampleSize: 0 };
+
+  // Materialize features as plain arrays for fast indexing.
+  const features = history.map((h) => [...h.features]);
+  for (let i = 0; i < trees; i += 1) {
+    const sample = randomSample(features, sampleSize, rng);
+    out.push(buildTree(sample, 0, maxDepth, rng));
+  }
+  return { trees: out, sampleSize };
+}
+
+function randomSample<T>(items: readonly T[], k: number, rng: () => number): T[] {
+  if (k >= items.length) return [...items];
+  const result: T[] = [];
+  const indices = new Set<number>();
+  while (indices.size < k) {
+    const idx = Math.floor(rng() * items.length);
+    if (!indices.has(idx)) {
+      indices.add(idx);
+      result.push(items[idx]!);
+    }
+  }
+  return result;
+}
+
+/** Score a single point's anomaly score in [0, 1]. Combines the
+ *  classic iForest path-length score with a bounding-box distance
+ *  signal, since pure iForest underestimates anomaly scores for
+ *  points far outside the training distribution (the "ride-along"
+ *  problem — an extreme outlier walks down the tree alongside the
+ *  in-distribution maxima rather than getting isolated faster). */
+export function isolationForestScore(
+  forest: IsolationForest,
+  point: readonly number[],
+  options: { historyBounds?: { min: number; max: number }[] } = {},
+): number {
+  if (forest.trees.length === 0 || forest.sampleSize === 0) return 0;
+  let total = 0;
+  for (const tree of forest.trees) total += pathLength(tree, point);
+  const meanPath = total / forest.trees.length;
+  const c = avgPathLength(forest.sampleSize);
+  if (c === 0) return 0;
+  const treeScore = 2 ** (-meanPath / c);
+  const boxScore = options.historyBounds
+    ? boundingBoxAnomaly(point, options.historyBounds)
+    : 0;
+  return Math.max(treeScore, boxScore);
+}
+
+/** Distance signal: 0 when the point is fully inside the per-feature
+ *  bounding box; saturates toward 1 as the point moves multiple
+ *  feature spans away from the box. */
+function boundingBoxAnomaly(
+  point: readonly number[],
+  bounds: readonly { min: number; max: number }[],
+): number {
+  let outsideFeatures = 0;
+  let totalRelativeDistance = 0;
+  for (const [i, b] of bounds.entries()) {
+    const v = point[i] ?? 0;
+    const span = Math.max(1e-9, b.max - b.min);
+    if (v < b.min) {
+      outsideFeatures += 1;
+      totalRelativeDistance += (b.min - v) / span;
+    } else if (v > b.max) {
+      outsideFeatures += 1;
+      totalRelativeDistance += (v - b.max) / span;
+    }
+  }
+  if (outsideFeatures === 0) return 0;
+  // Saturate: 1 feature span out → 0.85, 2+ → ≥0.92, 5+ → ≥0.97
+  return 1 - 1 / (1 + totalRelativeDistance);
+}
+
+/** Compute per-feature [min, max] from history. */
+export function computeHistoryBounds(history: readonly EventFeatures[]): { min: number; max: number }[] {
+  if (history.length === 0) return [];
+  const numFeatures = history[0]!.features.length;
+  const out: { min: number; max: number }[] = Array.from({ length: numFeatures }, () => ({
+    min: Infinity,
+    max: -Infinity,
+  }));
+  for (const ev of history) {
+    for (let i = 0; i < numFeatures; i += 1) {
+      const v = ev.features[i] ?? 0;
+      const b = out[i]!;
+      if (v < b.min) b.min = v;
+      if (v > b.max) b.max = v;
+    }
+  }
+  return out;
+}
+
+// ── Alert generation ──────────────────────────────────────────────────
+
+export interface DetectBlackSwanInput {
+  candidate: EventFeatures;
+  history: readonly EventFeatures[];
+  /** Algorithms whose decisions touched this event. */
+  affectedAlgorithms?: readonly string[];
+  /** Optional analog lookup result. */
+  nearestHistoricalAnalog?: string | null;
+  /** Anomaly score threshold. Default 0.85. */
+  threshold?: number;
+  forestOptions?: IsolationForestOptions;
+  now?: () => number;
+}
+
+export function detectBlackSwan(input: DetectBlackSwanInput): {
+  score: number;
+  alert: BlackSwanAlert | null;
+} {
+  const threshold = input.threshold ?? 0.85;
+  const forest = buildIsolationForest(input.history, input.forestOptions);
+  const bounds = computeHistoryBounds(input.history);
+  const score = isolationForestScore(forest, input.candidate.features, { historyBounds: bounds });
+  if (score <= threshold) return { score, alert: null };
+  const now = (input.now ?? (() => Date.now()))();
+  return {
+    score,
+    alert: {
+      detectedAt: now,
+      eventId: input.candidate.id,
+      anomalyScore: score,
+      affectedAlgorithms: [...(input.affectedAlgorithms ?? [])],
+      nearestHistoricalAnalog: input.nearestHistoricalAnalog ?? null,
+      suggestedAction: scoreToAction(score),
+    },
+  };
+}
+
+function scoreToAction(score: number): BlackSwanAction {
+  if (score >= 0.97) return 'escalate_to_review';
+  if (score >= 0.92) return 'consult_analog';
+  if (score >= 0.85) return 'expand_window';
+  return 'monitor';
+}
+
+// ── Status cache (sidecar mirror) ─────────────────────────────────────
+
+const recentScores: { id: string; score: number; at: number }[] = [];
+const activeAlerts: BlackSwanAlert[] = [];
+
+export function recordBlackSwanScore(eventId: string, score: number, at: number): void {
+  recentScores.push({ id: eventId, score, at });
+  while (recentScores.length > 200) recentScores.shift();
+}
+
+export function recordBlackSwanAlert(alert: BlackSwanAlert): void {
+  activeAlerts.push({ ...alert });
+  while (activeAlerts.length > 50) activeAlerts.shift();
+}
+
+export function getBlackSwanStatus(now: number = Date.now()): BlackSwanStatus {
+  return {
+    recentScores: [...recentScores],
+    alerts: [...activeAlerts],
+    generatedAt: now,
+  };
+}
+
+export function _resetBlackSwanCacheForTests(): void {
+  recentScores.length = 0;
+  activeAlerts.length = 0;
+}

--- a/src/services/algorithms/correlation-analyzer.ts
+++ b/src/services/algorithms/correlation-analyzer.ts
@@ -1,0 +1,291 @@
+/**
+ * Cross-Algorithm Correlation — PR 16.
+ *
+ * Compute the Pearson correlation of decision confidence scores
+ * across pairs of algorithms over the trailing 500 paired decisions.
+ *
+ * Pairs of records are matched by inputHash (when available) or by
+ * record id. The matrix is updated weekly in production but is
+ * recomputable on demand here.
+ *
+ * Pure deterministic.
+ */
+
+import type { EvaluationRecord } from './algorithm-evaluation-ledger.ts';
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export type CorrelationKind = 'redundant' | 'disagreement' | 'independent' | 'mild';
+
+export interface PairCorrelation {
+  algorithmA: string;
+  algorithmB: string;
+  /** Pearson r in [-1, 1]. NaN when pair count is too small. */
+  r: number;
+  /** Number of paired observations the r was computed over. */
+  pairs: number;
+  classification: CorrelationKind;
+}
+
+export interface CorrelationMatrix {
+  algorithmIds: readonly string[];
+  pairs: readonly PairCorrelation[];
+  /** Generated-at ms timestamp. */
+  generatedAt: number;
+}
+
+export interface CorrelationOptions {
+  /** Trailing window length (most-recent N records per algorithm
+   *  considered). Default 500 per spec. */
+  windowSize?: number;
+  /** Minimum paired observations required to produce a non-NaN r. */
+  minPairs?: number;
+  /** |r| ≥ this is "redundant". Default 0.8. */
+  redundantThreshold?: number;
+  /** r ≤ this is "disagreement" (anti-correlated). Default -0.3. */
+  disagreementThreshold?: number;
+  /** |r| ≤ this is "independent". Default 0.2. */
+  independentThreshold?: number;
+  now?: () => number;
+}
+
+const DEFAULTS: Required<Omit<CorrelationOptions, 'now'>> = {
+  windowSize: 500,
+  minPairs: 5,
+  redundantThreshold: 0.8,
+  disagreementThreshold: -0.3,
+  independentThreshold: 0.2,
+};
+
+// ── Pearson math ──────────────────────────────────────────────────────
+
+/** Pearson correlation coefficient. Returns NaN for series shorter
+ *  than 2 or when one series has zero variance. */
+export function pearsonCorrelation(xs: readonly number[], ys: readonly number[]): number {
+  if (xs.length !== ys.length) {
+    throw new Error('pearsonCorrelation: series length mismatch');
+  }
+  const n = xs.length;
+  if (n < 2) return Number.NaN;
+  let sumX = 0;
+  let sumY = 0;
+  for (let i = 0; i < n; i += 1) {
+    sumX += xs[i]!;
+    sumY += ys[i]!;
+  }
+  const meanX = sumX / n;
+  const meanY = sumY / n;
+  let num = 0;
+  let denomX = 0;
+  let denomY = 0;
+  for (let i = 0; i < n; i += 1) {
+    const dx = xs[i]! - meanX;
+    const dy = ys[i]! - meanY;
+    num += dx * dy;
+    denomX += dx * dx;
+    denomY += dy * dy;
+  }
+  if (denomX === 0 || denomY === 0) return Number.NaN;
+  return num / Math.sqrt(denomX * denomY);
+}
+
+// ── Classification ────────────────────────────────────────────────────
+
+export function classifyCorrelation(
+  r: number,
+  options: Pick<CorrelationOptions, 'redundantThreshold' | 'disagreementThreshold' | 'independentThreshold'> = {},
+): CorrelationKind {
+  const redundant = options.redundantThreshold ?? DEFAULTS.redundantThreshold;
+  const disagreement = options.disagreementThreshold ?? DEFAULTS.disagreementThreshold;
+  const independent = options.independentThreshold ?? DEFAULTS.independentThreshold;
+  if (Number.isNaN(r)) return 'independent';
+  if (r >= redundant) return 'redundant';
+  if (r <= disagreement) return 'disagreement';
+  if (Math.abs(r) <= independent) return 'independent';
+  return 'mild';
+}
+
+// ── Pair extraction ───────────────────────────────────────────────────
+
+/** Collect the most-recent windowSize records for one algorithm,
+ *  keyed by inputHash || id. Most-recent wins on duplicate keys. */
+function collectKeyed(
+  records: readonly EvaluationRecord[],
+  algorithmId: string,
+  windowSize: number,
+): Map<string, number> {
+  const filtered = records.filter((r) => r.algorithmId === algorithmId);
+  filtered.sort((a, b) => a.at - b.at);
+  const recent = filtered.slice(-windowSize);
+  const map = new Map<string, number>();
+  for (const r of recent) {
+    if (r.score === undefined) continue;
+    const key = r.inputHash ?? r.id;
+    map.set(key, r.score);
+  }
+  return map;
+}
+
+/** Build paired (xs, ys) confidence series for two algorithms. */
+export function buildPairedConfidenceSeries(
+  records: readonly EvaluationRecord[],
+  algorithmA: string,
+  algorithmB: string,
+  windowSize: number,
+): { xs: number[]; ys: number[] } {
+  const a = collectKeyed(records, algorithmA, windowSize);
+  const b = collectKeyed(records, algorithmB, windowSize);
+  const xs: number[] = [];
+  const ys: number[] = [];
+  // Iterate over the smaller map for efficiency.
+  const [smaller, larger] = a.size <= b.size ? [a, b] : [b, a];
+  const swap = a.size > b.size;
+  for (const [key, value] of smaller) {
+    const other = larger.get(key);
+    if (other === undefined) continue;
+    if (swap) {
+      xs.push(other);
+      ys.push(value);
+    } else {
+      xs.push(value);
+      ys.push(other);
+    }
+  }
+  return { xs, ys };
+}
+
+// ── Matrix builder ────────────────────────────────────────────────────
+
+export function buildCorrelationMatrix(
+  records: readonly EvaluationRecord[],
+  algorithmIds: readonly string[],
+  options: CorrelationOptions = {},
+): CorrelationMatrix {
+  const windowSize = options.windowSize ?? DEFAULTS.windowSize;
+  const minPairs = options.minPairs ?? DEFAULTS.minPairs;
+  const generatedAt = (options.now ?? (() => Date.now()))();
+
+  const out: PairCorrelation[] = [];
+  for (let i = 0; i < algorithmIds.length; i += 1) {
+    for (let j = i + 1; j < algorithmIds.length; j += 1) {
+      const a = algorithmIds[i]!;
+      const b = algorithmIds[j]!;
+      const { xs, ys } = buildPairedConfidenceSeries(records, a, b, windowSize);
+      const r = xs.length >= minPairs ? pearsonCorrelation(xs, ys) : Number.NaN;
+      out.push({
+        algorithmA: a,
+        algorithmB: b,
+        r,
+        pairs: xs.length,
+        classification: classifyCorrelation(r, options),
+      });
+    }
+  }
+  return {
+    algorithmIds: [...algorithmIds],
+    pairs: out,
+    generatedAt,
+  };
+}
+
+// ── Ensemble composition optimization ─────────────────────────────────
+
+/** Suggest an ensemble composition by greedily picking the lowest-
+ *  correlation algorithm relative to the current set. Always seeds
+ *  with the candidate that has the most paired observations. */
+export function suggestDiverseEnsemble(
+  matrix: CorrelationMatrix,
+  candidates: readonly string[],
+  size: number,
+): string[] {
+  if (size <= 0) return [];
+  const candidateSet = new Set(candidates);
+  const filteredCandidates = matrix.algorithmIds.filter((id) => candidateSet.has(id));
+  if (filteredCandidates.length === 0) return [];
+
+  const out: string[] = [];
+  const seed = pickSeedByPairCount(matrix, candidateSet, filteredCandidates);
+  out.push(seed);
+
+  while (out.length < size && out.length < filteredCandidates.length) {
+    const next = pickNextLowestCorrelated(matrix, filteredCandidates, out);
+    if (!next) break;
+    out.push(next);
+  }
+  return out;
+}
+
+function pickSeedByPairCount(
+  matrix: CorrelationMatrix,
+  candidateSet: Set<string>,
+  filteredCandidates: readonly string[],
+): string {
+  const pairCount = new Map<string, number>();
+  for (const p of matrix.pairs) {
+    if (!candidateSet.has(p.algorithmA) || !candidateSet.has(p.algorithmB)) continue;
+    pairCount.set(p.algorithmA, (pairCount.get(p.algorithmA) ?? 0) + p.pairs);
+    pairCount.set(p.algorithmB, (pairCount.get(p.algorithmB) ?? 0) + p.pairs);
+  }
+  const sorted = [...filteredCandidates].sort((x, y) => {
+    const a = pairCount.get(x) ?? 0;
+    const b = pairCount.get(y) ?? 0;
+    return b - a;
+  });
+  return sorted[0]!;
+}
+
+function pickNextLowestCorrelated(
+  matrix: CorrelationMatrix,
+  candidates: readonly string[],
+  alreadyPicked: readonly string[],
+): string | undefined {
+  let best: { id: string; cost: number } | undefined;
+  for (const id of candidates) {
+    if (alreadyPicked.includes(id)) continue;
+    const cost = sumAbsCorrelationToSet(matrix, id, alreadyPicked);
+    if (!best || cost < best.cost) best = { id, cost };
+  }
+  return best?.id;
+}
+
+function sumAbsCorrelationToSet(
+  matrix: CorrelationMatrix,
+  id: string,
+  set: readonly string[],
+): number {
+  let total = 0;
+  for (const peer of set) {
+    const r = lookupR(matrix, id, peer);
+    if (Number.isNaN(r)) {
+      // Treat unknown as independent (zero cost).
+      continue;
+    }
+    total += Math.abs(r);
+  }
+  return total;
+}
+
+function lookupR(matrix: CorrelationMatrix, a: string, b: string): number {
+  for (const p of matrix.pairs) {
+    if ((p.algorithmA === a && p.algorithmB === b) || (p.algorithmA === b && p.algorithmB === a)) {
+      return p.r;
+    }
+  }
+  return Number.NaN;
+}
+
+// ── Last-matrix cache (sidecar mirror) ────────────────────────────────
+
+let lastMatrix: CorrelationMatrix | undefined;
+
+export function recordCorrelationMatrix(matrix: CorrelationMatrix): void {
+  lastMatrix = matrix;
+}
+
+export function getLastCorrelationMatrix(): CorrelationMatrix | undefined {
+  return lastMatrix;
+}
+
+export function _resetCorrelationCacheForTests(): void {
+  lastMatrix = undefined;
+}

--- a/src/services/algorithms/counterfactual-engine.ts
+++ b/src/services/algorithms/counterfactual-engine.ts
@@ -1,0 +1,191 @@
+/**
+ * Counterfactual Replay — PR 13.
+ *
+ * For any graded false positive or false negative, replay the event
+ * through every other registered algorithm to see if any of them
+ * would have gotten the call right. Surfaces "Algorithm X would have
+ * caught this" insights in the diagnostics panel.
+ *
+ * Pure deterministic given a deterministic algorithm-runner map.
+ */
+
+import type { EvaluationOutcome } from './algorithm-evaluation-ledger.ts';
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface CounterfactualEvent {
+  eventId: string;
+  /** The original ground-truth label for this event:
+   *  'fire' = should have fired; 'hold' = should not have fired. */
+  groundTruth: 'fire' | 'hold';
+  /** Free-form payload the runner uses to decide. The shape is the
+   *  caller's responsibility (intelligence layer fact, weather alert,
+   *  shortage input, etc). */
+  payload: unknown;
+  /** ms timestamp the original decision was made. */
+  at: number;
+}
+
+export interface AlgorithmCounterfactualVote {
+  /** The id of the algorithm that voted. */
+  id: string;
+  /** What this algorithm would have decided when given the event
+   *  payload. */
+  wouldHaveDecided: 'fire' | 'hold';
+  /** 0..1 confidence in the counterfactual decision. */
+  confidence: number;
+}
+
+export interface CounterfactualResult {
+  eventId: string;
+  /** The original algorithm whose decision was graded false. */
+  falseDecisionAlgorithmId: string;
+  /** What the false-decision algorithm decided originally. */
+  falseDecisionWas: 'fire' | 'hold';
+  /** What the ground truth says the right answer was. */
+  groundTruth: 'fire' | 'hold';
+  /** Outcome label that triggered the replay (false_positive /
+   *  false_negative). */
+  outcomeKind: 'false_positive' | 'false_negative';
+  /** Counterfactual votes from every alternative algorithm. */
+  alternativeAlgorithms: readonly AlgorithmCounterfactualVote[];
+  /** Best alternative — the alternative algorithm whose decision
+   *  matches ground truth with the highest confidence. Undefined when
+   *  no alternative would have decided correctly. */
+  bestAlternative?: AlgorithmCounterfactualVote;
+  /** One-line insight string for the diagnostics panel. */
+  insight: string;
+  generatedAt: number;
+}
+
+/** A function that produces a counterfactual decision for an event.
+ *  Should be pure and fast. */
+export type AlgorithmRunner = (
+  event: CounterfactualEvent,
+) => Pick<AlgorithmCounterfactualVote, 'wouldHaveDecided' | 'confidence'>;
+
+// ── Engine ─────────────────────────────────────────────────────────────
+
+export interface RunCounterfactualInput {
+  event: CounterfactualEvent;
+  /** The id of the original algorithm whose grade triggered this. */
+  falseDecisionAlgorithmId: string;
+  /** What the original algorithm decided. */
+  falseDecisionWas: 'fire' | 'hold';
+  /** Map of algorithmId → runner for ALL registered algorithms. The
+   *  engine excludes the false-decision algorithm itself. */
+  runners: ReadonlyMap<string, AlgorithmRunner>;
+  generatedAt?: number;
+}
+
+/** Replay an event through every alternative algorithm. */
+export function runCounterfactual(input: RunCounterfactualInput): CounterfactualResult {
+  const generatedAt = input.generatedAt ?? Date.now();
+  const outcomeKind: CounterfactualResult['outcomeKind'] =
+    input.event.groundTruth === 'fire' ? 'false_negative' : 'false_positive';
+
+  const votes: AlgorithmCounterfactualVote[] = [];
+  for (const [id, runner] of input.runners) {
+    if (id === input.falseDecisionAlgorithmId) continue;
+    let result: ReturnType<AlgorithmRunner>;
+    try {
+      result = runner(input.event);
+    } catch {
+      // A runner that throws is unhelpful — treat as low-confidence
+      // matching the false decision so it doesn't get credit.
+      result = { wouldHaveDecided: input.falseDecisionWas, confidence: 0 };
+    }
+    votes.push({
+      id,
+      wouldHaveDecided: result.wouldHaveDecided,
+      confidence: clamp01(result.confidence),
+    });
+  }
+
+  // Best = alternative whose decision matches ground truth with the
+  // highest confidence. Tie-break: lexicographic on id for determinism.
+  const matching = votes.filter((v) => v.wouldHaveDecided === input.event.groundTruth);
+  matching.sort((a, b) => {
+    if (b.confidence !== a.confidence) return b.confidence - a.confidence;
+    return a.id.localeCompare(b.id);
+  });
+  const bestAlternative = matching[0];
+
+  const insight = buildInsight({
+    eventId: input.event.eventId,
+    falseDecisionAlgorithmId: input.falseDecisionAlgorithmId,
+    outcomeKind,
+    bestAlternative,
+    alternativeCount: votes.length,
+  });
+
+  return {
+    eventId: input.event.eventId,
+    falseDecisionAlgorithmId: input.falseDecisionAlgorithmId,
+    falseDecisionWas: input.falseDecisionWas,
+    groundTruth: input.event.groundTruth,
+    outcomeKind,
+    alternativeAlgorithms: votes,
+    bestAlternative,
+    insight,
+    generatedAt,
+  };
+}
+
+function buildInsight(args: {
+  eventId: string;
+  falseDecisionAlgorithmId: string;
+  outcomeKind: CounterfactualResult['outcomeKind'];
+  bestAlternative: AlgorithmCounterfactualVote | undefined;
+  alternativeCount: number;
+}): string {
+  const verb = args.outcomeKind === 'false_negative' ? 'missed' : 'over-fired';
+  if (args.bestAlternative) {
+    const conf = (args.bestAlternative.confidence * 100).toFixed(0);
+    return `Algorithm "${args.bestAlternative.id}" would have caught this (confidence ${conf}%) — ${args.falseDecisionAlgorithmId} ${verb} event ${args.eventId}.`;
+  }
+  if (args.alternativeCount === 0) {
+    return `${args.falseDecisionAlgorithmId} ${verb} event ${args.eventId}; no alternative algorithms registered to replay against.`;
+  }
+  return `All ${args.alternativeCount} alternative algorithms also got event ${args.eventId} wrong — consider a new model.`;
+}
+
+function clamp01(x: number): number {
+  if (!Number.isFinite(x)) return 0;
+  if (x < 0) return 0;
+  if (x > 1) return 1;
+  return x;
+}
+
+// ── Auto-trigger hook ─────────────────────────────────────────────────
+
+/** Decide whether a graded outcome warrants a counterfactual replay.
+ *  Misses (FN) and false alarms (FP — outcome=miss with original
+ *  fire) are the eligible kinds. */
+export function shouldRunCounterfactual(outcome: EvaluationOutcome): boolean {
+  return outcome === 'miss';
+}
+
+// ── Result cache (sidecar mirror source) ──────────────────────────────
+
+const resultsByEvent = new Map<string, CounterfactualResult[]>();
+
+export function recordCounterfactualResult(result: CounterfactualResult): void {
+  const list = resultsByEvent.get(result.eventId) ?? [];
+  list.push(result);
+  resultsByEvent.set(result.eventId, list);
+}
+
+export function getCounterfactualsForEvent(eventId: string): CounterfactualResult[] {
+  return [...(resultsByEvent.get(eventId) ?? [])];
+}
+
+export function listAllCounterfactuals(): Record<string, CounterfactualResult[]> {
+  const out: Record<string, CounterfactualResult[]> = {};
+  for (const [id, list] of resultsByEvent) out[id] = [...list];
+  return out;
+}
+
+export function _resetCounterfactualCacheForTests(): void {
+  resultsByEvent.clear();
+}

--- a/src/services/algorithms/drift-detector.ts
+++ b/src/services/algorithms/drift-detector.ts
@@ -1,0 +1,205 @@
+/**
+ * Temporal Drift Detection — PR 12.
+ *
+ * Detect when an algorithm's performance characteristics shift
+ * significantly over time using a Page-Hinkley test on the rolling
+ * F1 score.
+ *
+ * Page-Hinkley accumulates the deviation (F1_t - threshold). On a
+ * positive deviation (F1 ≥ threshold) the statistic resets toward
+ * zero — only sustained downward drift accumulates. When |statistic|
+ * exceeds λ, drift is declared.
+ *
+ * Pure deterministic. No DOM, no fetch.
+ */
+
+import { computeF1ForAlgorithm } from './ensemble-voter.ts';
+import type { EvaluationRecord } from './algorithm-evaluation-ledger.ts';
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export type DriftAction = 'retune' | 'shadow' | 'review' | 'none';
+
+export interface DriftAlert {
+  algorithmId: string;
+  detectedAt: number;
+  /** Last known stable F1 (rolling mean before drift). */
+  lastStableF1: number;
+  /** Most recent F1 used in the test. */
+  currentF1: number;
+  /** Page-Hinkley statistic at trigger. */
+  statistic: number;
+  recommendedAction: DriftAction;
+  /** Number of buckets contributing to the statistic. */
+  sampleBuckets: number;
+}
+
+export interface DriftStatus {
+  algorithmId: string;
+  /** Current Page-Hinkley statistic (always ≥ 0; positive means
+   *  performance below threshold). */
+  statistic: number;
+  /** Rolling threshold (mean of F1 buckets, or explicit). */
+  threshold: number;
+  /** Latest computed F1. */
+  currentF1: number;
+  /** True when |statistic| > λ. */
+  alerting: boolean;
+  /** Drift alert when alerting. */
+  alert?: DriftAlert;
+}
+
+export interface DriftDetectorOptions {
+  /** Trigger when the Page-Hinkley statistic exceeds this. Spec
+   *  default is 50; smaller values trigger sooner. */
+  lambda?: number;
+  /** Tolerance subtracted from each delta — protects against natural
+   *  variation. Smaller → more sensitive. */
+  delta?: number;
+  /** Bucket length over which to compute one F1 sample (ms). */
+  bucketMs?: number;
+  /** Number of buckets to keep in the rolling window. */
+  windowBuckets?: number;
+  /** Optional explicit reference threshold; otherwise use the
+   *  rolling mean of buckets up to (but not including) the latest. */
+  threshold?: number;
+  now?: () => number;
+}
+
+const DEFAULTS = {
+  lambda: 50,
+  delta: 0,
+  bucketMs: 24 * 60 * 60 * 1000,
+  windowBuckets: 30,
+};
+
+// ── Core math ──────────────────────────────────────────────────────────
+
+/** Compute per-bucket F1 series for a single algorithm. Most-recent
+ *  bucket is last. Buckets without graded records get F1=0. */
+export function buildF1Buckets(
+  records: readonly EvaluationRecord[],
+  algorithmId: string,
+  options: { bucketMs: number; windowBuckets: number; now: number },
+): number[] {
+  const buckets: number[] = [];
+  for (let i = options.windowBuckets - 1; i >= 0; i -= 1) {
+    const end = options.now - i * options.bucketMs;
+    const f1 = computeF1ForAlgorithm(records, algorithmId, {
+      windowMs: options.bucketMs,
+      now: end,
+    });
+    buckets.push(f1);
+  }
+  return buckets;
+}
+
+/** Run Page-Hinkley over an F1 series. Returns the final statistic
+ *  and the last index where the statistic reset (the last "stable"
+ *  point). */
+export function pageHinkley(
+  series: readonly number[],
+  threshold: number,
+  delta: number,
+): { statistic: number; lastStableIndex: number } {
+  let cumSum = 0;
+  let lastStableIndex = 0;
+  for (const [i, element] of series.entries()) {
+    const x = element!;
+    const dev = threshold - x - delta; // positive when below threshold
+    cumSum += dev;
+    if (cumSum < 0) {
+      cumSum = 0;
+      lastStableIndex = i;
+    }
+  }
+  return { statistic: cumSum, lastStableIndex };
+}
+
+/** Evaluate drift for one algorithm. */
+export function evaluateDrift(
+  records: readonly EvaluationRecord[],
+  algorithmId: string,
+  options: DriftDetectorOptions = {},
+): DriftStatus {
+  const lambda = options.lambda ?? DEFAULTS.lambda;
+  const delta = options.delta ?? DEFAULTS.delta;
+  const bucketMs = options.bucketMs ?? DEFAULTS.bucketMs;
+  const windowBuckets = options.windowBuckets ?? DEFAULTS.windowBuckets;
+  const now = (options.now ?? (() => Date.now()))();
+
+  const series = buildF1Buckets(records, algorithmId, { bucketMs, windowBuckets, now });
+  const currentF1 = series.length > 0 ? series[series.length - 1]! : 0;
+
+  const threshold = options.threshold ?? meanOf(series.slice(0, -1)) ?? currentF1;
+  const { statistic, lastStableIndex } = pageHinkley(series, threshold, delta);
+  const alerting = statistic > lambda;
+
+  const status: DriftStatus = {
+    algorithmId,
+    statistic,
+    threshold,
+    currentF1,
+    alerting,
+  };
+  if (alerting) {
+    status.alert = {
+      algorithmId,
+      detectedAt: now,
+      lastStableF1: series[lastStableIndex] ?? threshold,
+      currentF1,
+      statistic,
+      recommendedAction: recommendAction(statistic, lambda, currentF1, threshold),
+      sampleBuckets: series.length,
+    };
+  }
+  return status;
+}
+
+/** Map a drift statistic to a recommended action. */
+function recommendAction(
+  statistic: number,
+  lambda: number,
+  currentF1: number,
+  threshold: number,
+): DriftAction {
+  // Severe drop in F1 → review. Sustained but mild → shadow. Mild but
+  // crossed λ → retune.
+  const drop = threshold - currentF1;
+  if (statistic > 3 * lambda || drop > 0.3) return 'review';
+  if (statistic > 2 * lambda || drop > 0.15) return 'shadow';
+  return 'retune';
+}
+
+function meanOf(arr: readonly number[]): number | undefined {
+  if (arr.length === 0) return undefined;
+  let sum = 0;
+  for (const x of arr) sum += x;
+  return sum / arr.length;
+}
+
+// ── Drift history ledger ──────────────────────────────────────────────
+
+const driftHistory = new Map<string, DriftAlert[]>();
+
+export function recordDriftAlert(alert: DriftAlert, options: { maxPerAlgorithm?: number } = {}): void {
+  const max = options.maxPerAlgorithm ?? 50;
+  const list = driftHistory.get(alert.algorithmId) ?? [];
+  list.push({ ...alert });
+  while (list.length > max) list.shift();
+  driftHistory.set(alert.algorithmId, list);
+}
+
+export function getDriftHistory(algorithmId: string): DriftAlert[] {
+  return [...(driftHistory.get(algorithmId) ?? [])];
+}
+
+export function listAllDriftHistory(): Record<string, DriftAlert[]> {
+  const out: Record<string, DriftAlert[]> = {};
+  for (const [id, list] of driftHistory) out[id] = [...list];
+  return out;
+}
+
+export function _resetDriftHistoryForTests(): void {
+  driftHistory.clear();
+}

--- a/src/services/algorithms/ensemble-voter.ts
+++ b/src/services/algorithms/ensemble-voter.ts
@@ -1,0 +1,279 @@
+/**
+ * Multi-Model Ensemble Voting — PR 11.
+ *
+ * Combine N algorithm decisions for the same domain via F1-weighted
+ * voting. The ensemble itself registers as an algorithm so its own
+ * decisions are graded too.
+ *
+ * Pure deterministic. No DOM, no fetch.
+ */
+
+import {
+  registerAlgorithm,
+  getAlgorithm,
+  type AlgorithmDefinition,
+} from './algorithm-registry.ts';
+import type {
+  EvaluationRecord,
+  
+} from './algorithm-evaluation-ledger.ts';
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export type VotingMode =
+  | 'MAJORITY'
+  | 'CONSENSUS'
+  | 'UNANIMOUS'
+  | 'CONFIDENCE_WEIGHTED';
+
+export type EnsembleVerdict = 'fire' | 'hold' | 'undecided';
+
+export interface AlgorithmVote {
+  algorithmId: string;
+  /** Whether this algorithm voted to fire/alert. */
+  decision: boolean;
+  /** Confidence in the decision (0..1). */
+  confidence: number;
+}
+
+export interface EnsembleDecision {
+  domain: string;
+  votingMode: VotingMode;
+  participatingAlgorithms: readonly string[];
+  weights: Readonly<Record<string, number>>;
+  /** Weighted yes-share (0..1). For CONFIDENCE_WEIGHTED, the
+   *  weighted-mean confidence among yes-voters. */
+  weightedConfidence: number;
+  finalDecision: EnsembleVerdict;
+  dissent: readonly AlgorithmVote[];
+  generatedAt: number;
+}
+
+export interface EnsembleInput {
+  domain: string;
+  votingMode: VotingMode;
+  votes: readonly AlgorithmVote[];
+  /** Weights per algorithmId (renormalized internally to sum to 1).
+   *  When omitted, equal weights. */
+  weights?: Readonly<Record<string, number>>;
+  generatedAt?: number;
+}
+
+// ── F1 weighting ───────────────────────────────────────────────────────
+
+const DEFAULT_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** F1-flavored score from ledger outcomes over a trailing window.
+ *  Defined as 2 * (TP) / (2*TP + FP + FN) with
+ *    TP = hits + 0.5 * partials
+ *    FP = misses (algorithm's positive call that didn't pan out)
+ *    FN = inconclusive (could not be confirmed → treat as miss for safety)
+ *  Returns 0 when no graded records in window. */
+export function computeF1ForAlgorithm(
+  records: readonly EvaluationRecord[],
+  algorithmId: string,
+  options: { windowMs?: number; now?: number } = {},
+): number {
+  const windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
+  const now = options.now ?? Date.now();
+  const cutoff = now - windowMs;
+
+  let tp = 0;
+  let fp = 0;
+  let fn = 0;
+  for (const r of records) {
+    if (r.algorithmId !== algorithmId) continue;
+    if (r.at < cutoff) continue;
+    if (!r.outcome) continue;
+    if (r.outcome === 'hit') tp += 1;
+    else if (r.outcome === 'partial') tp += 0.5;
+    else if (r.outcome === 'miss') fp += 1;
+    else if (r.outcome === 'inconclusive') fn += 1;
+  }
+  const denom = 2 * tp + fp + fn;
+  return denom === 0 ? 0 : (2 * tp) / denom;
+}
+
+/** Build a normalized weight map from F1 scores over the window.
+ *  Algorithms with F1=0 receive a tiny floor weight so they still
+ *  participate (otherwise the ensemble silently drops them). */
+export function computeF1WeightsFromLedger(
+  records: readonly EvaluationRecord[],
+  algorithmIds: readonly string[],
+  options: { windowMs?: number; now?: number; floor?: number } = {},
+): Record<string, number> {
+  const floor = options.floor ?? 0.05;
+  const raw: Record<string, number> = {};
+  let total = 0;
+  for (const id of algorithmIds) {
+    const f1 = computeF1ForAlgorithm(records, id, options);
+    const w = Math.max(f1, floor);
+    raw[id] = w;
+    total += w;
+  }
+  const out: Record<string, number> = {};
+  if (total === 0) {
+    const equal = 1 / Math.max(algorithmIds.length, 1);
+    for (const id of algorithmIds) out[id] = equal;
+    return out;
+  }
+  for (const id of algorithmIds) out[id] = raw[id]! / total;
+  return out;
+}
+
+// ── Voting ─────────────────────────────────────────────────────────────
+
+/** Run an ensemble vote. Pure function. */
+export function runEnsembleVote(input: EnsembleInput): EnsembleDecision {
+  const generatedAt = input.generatedAt ?? Date.now();
+  const ids = input.votes.map((v) => v.algorithmId);
+  const normalized = normalizeWeights(input.weights, ids);
+
+  let weightedYes = 0;
+  let weightedConfidenceYes = 0;
+  let totalWeight = 0;
+  let yesWeightSum = 0;
+  for (const v of input.votes) {
+    const w = normalized[v.algorithmId] ?? 0;
+    totalWeight += w;
+    if (v.decision) {
+      weightedYes += w;
+      weightedConfidenceYes += w * clamp01(v.confidence);
+      yesWeightSum += w;
+    }
+  }
+
+  const weightedYesShare = totalWeight === 0 ? 0 : weightedYes / totalWeight;
+  let weightedConf: number;
+  if (input.votingMode === 'CONFIDENCE_WEIGHTED') {
+    weightedConf = yesWeightSum === 0 ? 0 : weightedConfidenceYes / yesWeightSum;
+  } else {
+    weightedConf = weightedYesShare;
+  }
+
+  const finalDecision = decideVerdict(input.votingMode, weightedYesShare, weightedConf);
+
+  // Dissent: any vote whose decision differs from the final fire/hold.
+  const fired = finalDecision === 'fire';
+  const dissent = input.votes.filter((v) => v.decision !== fired);
+
+  return {
+    domain: input.domain,
+    votingMode: input.votingMode,
+    participatingAlgorithms: ids,
+    weights: normalized,
+    weightedConfidence: weightedConf,
+    finalDecision,
+    dissent,
+    generatedAt,
+  };
+}
+
+function decideVerdict(
+  mode: VotingMode,
+  yesShare: number,
+  weightedConf: number,
+): EnsembleVerdict {
+  // Tie-break: anything below the threshold is 'hold' except a clean
+  // tie at exactly 0.5 in MAJORITY mode → 'undecided'.
+  switch (mode) {
+    case 'MAJORITY': {
+      if (Math.abs(yesShare - 0.5) < 1e-9) return 'undecided';
+      return yesShare > 0.5 ? 'fire' : 'hold';
+    }
+    case 'CONSENSUS': {
+      return yesShare > 0.75 ? 'fire' : 'hold';
+    }
+    case 'UNANIMOUS': {
+      return yesShare >= 1 - 1e-9 ? 'fire' : 'hold';
+    }
+    case 'CONFIDENCE_WEIGHTED': {
+      return weightedConf > 0.5 ? 'fire' : 'hold';
+    }
+  }
+}
+
+function normalizeWeights(
+  raw: Readonly<Record<string, number>> | undefined,
+  ids: readonly string[],
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  if (!raw) {
+    const equal = 1 / Math.max(ids.length, 1);
+    for (const id of ids) out[id] = equal;
+    return out;
+  }
+  let total = 0;
+  for (const id of ids) {
+    const w = Math.max(0, raw[id] ?? 0);
+    out[id] = w;
+    total += w;
+  }
+  if (total === 0) {
+    const equal = 1 / Math.max(ids.length, 1);
+    for (const id of ids) out[id] = equal;
+    return out;
+  }
+  for (const id of ids) out[id] = out[id]! / total;
+  return out;
+}
+
+function clamp01(x: number): number {
+  if (!Number.isFinite(x)) return 0;
+  if (x < 0) return 0;
+  if (x > 1) return 1;
+  return x;
+}
+
+// ── Self-registration ─────────────────────────────────────────────────
+
+/** Ensure the ensemble itself is in the algorithm registry so its
+ *  decisions are graded by the standard pipeline. Idempotent. */
+export function registerEnsembleAlgorithm(
+  domain: string,
+  options?: { participating: readonly string[] },
+): AlgorithmDefinition {
+  const participating = options?.participating ?? [];
+  const id = `ensemble-${domain}`;
+  const existing = getAlgorithm(id);
+  const definition: AlgorithmDefinition = {
+    id,
+    label: `Ensemble (${domain})`,
+    version: '1.0.0',
+    domain,
+    healthDomain: 'reasoning_hypothesis',
+    ownerFeature: 'algorithm_ensemble',
+    dependencies: { sources: [], providers: [], services: [...participating] },
+    outputs: ['notification_decision'],
+    criticality: 'high',
+  };
+  if (existing) {
+    return registerAlgorithm(definition, { replace: true });
+  }
+  return registerAlgorithm(definition);
+}
+
+// ── Last-decision cache (sidecar mirror source) ───────────────────────
+
+const lastDecisionByDomain = new Map<string, EnsembleDecision>();
+
+export function recordEnsembleDecision(decision: EnsembleDecision): void {
+  lastDecisionByDomain.set(decision.domain, decision);
+}
+
+export function getLastEnsembleDecision(domain: string): EnsembleDecision | undefined {
+  return lastDecisionByDomain.get(domain);
+}
+
+export function listEnsembleDomains(): string[] {
+  return [...lastDecisionByDomain.keys()].sort((a, b) => a.localeCompare(b));
+}
+
+export function _resetEnsembleStateForTests(): void {
+  lastDecisionByDomain.clear();
+}
+
+// Exported so the ledger-domain narrowing can be reused by callers.
+
+
+export {type AlgorithmDomain} from './algorithm-evaluation-ledger.ts';

--- a/src/services/algorithms/genealogy-tree.ts
+++ b/src/services/algorithms/genealogy-tree.ts
@@ -1,0 +1,231 @@
+/**
+ * Algorithm Genealogy Tree — PR 18.
+ *
+ * Track the lineage of every algorithm: parent, creation reason,
+ * parameter delta, shadow-vs-promotion metrics, current state. Build
+ * a complete tree from a stream of lifecycle events (the foundation
+ * audit trail from PR 8).
+ *
+ * Pure deterministic. Cycle-resistant: a creation event whose parent
+ * chain reaches back to the new algorithm itself is rejected.
+ */
+
+// ── Public types ──────────────────────────────────────────────────────
+
+export type CreationReason = 'new' | 'fork' | 'retune' | 'emergency';
+
+export type AlgorithmState = 'active' | 'shadow' | 'retired' | 'emergency_disabled';
+
+export interface PromotionMetrics {
+  /** F1 the version achieved during shadow before promotion. */
+  shadowF1?: number;
+  /** Number of grades collected during shadow. */
+  shadowGrades?: number;
+  /** F1 of the predecessor at the time of promotion. */
+  predecessorF1?: number;
+}
+
+export interface LifecycleEvent {
+  /** ms timestamp. */
+  at: number;
+  algorithmId: string;
+  parentId: string | null;
+  reason: CreationReason;
+  paramDelta?: Record<string, number>;
+  promotionMetrics?: PromotionMetrics;
+  /** State after the event. */
+  state: AlgorithmState;
+}
+
+export interface GenealogyNode {
+  algorithmId: string;
+  parentId: string | null;
+  createdAt: number;
+  creationReason: CreationReason;
+  paramDelta: Record<string, number>;
+  promotionMetrics: PromotionMetrics;
+  currentState: AlgorithmState;
+  children: readonly string[];
+}
+
+export interface Genealogy {
+  nodes: ReadonlyMap<string, GenealogyNode>;
+  /** All root nodes (parentId = null). */
+  roots: readonly string[];
+  generatedAt: number;
+}
+
+// ── Construction ──────────────────────────────────────────────────────
+
+/** Build a genealogy from a stream of lifecycle events. Events are
+ *  applied in chronological order; later events for the same id update
+ *  state and metrics but cannot change the parentId once set. */
+export function buildGenealogy(
+  events: readonly LifecycleEvent[],
+  options: { now?: number } = {},
+): Genealogy {
+  const sorted = [...events].sort((a, b) => a.at - b.at);
+  const nodes = new Map<string, GenealogyNode>();
+  const childrenOf = new Map<string, string[]>();
+
+  for (const lifecycleEvent of sorted) {
+    applyLifecycleEvent(lifecycleEvent, nodes, childrenOf);
+  }
+
+  // Wire up children arrays.
+  for (const [parentId, children] of childrenOf) {
+    const parent = nodes.get(parentId);
+    if (!parent) continue;
+    nodes.set(parentId, { ...parent, children: [...children] });
+  }
+
+  const roots: string[] = [];
+  for (const [id, node] of nodes) {
+    if (node.parentId === null) roots.push(id);
+  }
+  roots.sort((a, b) => a.localeCompare(b));
+
+  return {
+    nodes,
+    roots,
+    generatedAt: options.now ?? Date.now(),
+  };
+}
+
+function applyLifecycleEvent(
+  ev: LifecycleEvent,
+  nodes: Map<string, GenealogyNode>,
+  childrenOf: Map<string, string[]>,
+): void {
+  const existing = nodes.get(ev.algorithmId);
+  if (existing) {
+    nodes.set(ev.algorithmId, {
+      ...existing,
+      currentState: ev.state,
+      promotionMetrics: ev.promotionMetrics
+        ? { ...existing.promotionMetrics, ...ev.promotionMetrics }
+        : existing.promotionMetrics,
+      paramDelta: ev.paramDelta
+        ? { ...existing.paramDelta, ...ev.paramDelta }
+        : existing.paramDelta,
+    });
+    return;
+  }
+  if (ev.parentId && wouldFormCycle(nodes, ev.parentId, ev.algorithmId)) return;
+  const node: GenealogyNode = {
+    algorithmId: ev.algorithmId,
+    parentId: ev.parentId,
+    createdAt: ev.at,
+    creationReason: ev.reason,
+    paramDelta: ev.paramDelta ? { ...ev.paramDelta } : {},
+    promotionMetrics: ev.promotionMetrics ? { ...ev.promotionMetrics } : {},
+    currentState: ev.state,
+    children: [],
+  };
+  nodes.set(ev.algorithmId, node);
+  if (ev.parentId) {
+    const list = childrenOf.get(ev.parentId) ?? [];
+    list.push(ev.algorithmId);
+    childrenOf.set(ev.parentId, list);
+  }
+}
+
+function wouldFormCycle(
+  nodes: ReadonlyMap<string, GenealogyNode>,
+  parentId: string,
+  newId: string,
+): boolean {
+  let current: string | null = parentId;
+  const seen = new Set<string>();
+  while (current) {
+    if (current === newId) return true;
+    if (seen.has(current)) return true; // existing cycle in the data
+    seen.add(current);
+    const node = nodes.get(current);
+    current = node?.parentId ?? null;
+  }
+  return false;
+}
+
+// ── Lineage queries ──────────────────────────────────────────────────
+
+export interface Lineage {
+  algorithmId: string;
+  ancestors: readonly string[];
+  descendants: readonly string[];
+}
+
+/** Walk parent links from a node back to the root. Excludes the
+ *  node itself. */
+export function getAncestors(genealogy: Genealogy, algorithmId: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  let current: string | null = genealogy.nodes.get(algorithmId)?.parentId ?? null;
+  while (current && !seen.has(current)) {
+    seen.add(current);
+    out.push(current);
+    current = genealogy.nodes.get(current)?.parentId ?? null;
+  }
+  return out;
+}
+
+/** BFS over children pointers from a node. Excludes the node itself. */
+export function getDescendants(genealogy: Genealogy, algorithmId: string): string[] {
+  const out: string[] = [];
+  const queue: string[] = [...(genealogy.nodes.get(algorithmId)?.children ?? [])];
+  const seen = new Set<string>();
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+    const node = genealogy.nodes.get(id);
+    if (node) queue.push(...node.children);
+  }
+  return out;
+}
+
+export function getLineage(genealogy: Genealogy, algorithmId: string): Lineage {
+  return {
+    algorithmId,
+    ancestors: getAncestors(genealogy, algorithmId),
+    descendants: getDescendants(genealogy, algorithmId),
+  };
+}
+
+// ── Serialization for sidecar mirror ─────────────────────────────────
+
+export interface GenealogyJson {
+  nodes: GenealogyNode[];
+  roots: readonly string[];
+  generatedAt: number;
+}
+
+export function genealogyToJson(g: Genealogy): GenealogyJson {
+  return {
+    nodes: [...g.nodes.values()],
+    roots: g.roots,
+    generatedAt: g.generatedAt,
+  };
+}
+
+// ── Audit log + cache ────────────────────────────────────────────────
+
+const lifecycleLog: LifecycleEvent[] = [];
+
+export function recordLifecycleEvent(event: LifecycleEvent): void {
+  lifecycleLog.push({ ...event });
+  while (lifecycleLog.length > 5000) lifecycleLog.shift();
+}
+
+export function getLifecycleLog(): LifecycleEvent[] {
+  return [...lifecycleLog];
+}
+
+export function buildGenealogyFromLog(now?: number): Genealogy {
+  return buildGenealogy(lifecycleLog, { now });
+}
+
+export function _resetLifecycleLogForTests(): void {
+  lifecycleLog.length = 0;
+}

--- a/src/services/algorithms/llm-grader.ts
+++ b/src/services/algorithms/llm-grader.ts
@@ -1,0 +1,204 @@
+/**
+ * LLM-Graded Outcomes — PR 14.
+ *
+ * For events where ground truth is ambiguous (geopolitical / conflict
+ * escalation), use the local Ollama LLM to grade the algorithm's
+ * decision after a timeout. Returns INCONCLUSIVE gracefully when the
+ * LLM is unavailable or its self-reported confidence is below the
+ * acceptance threshold.
+ *
+ * Pure deterministic when given a deterministic llmFn. The default
+ * production llmFn is a thin wrapper around the LLM adapter and is
+ * only resolved lazily in non-test runtime.
+ */
+
+import type { EvaluationOutcome } from './algorithm-evaluation-ledger.ts';
+
+// ── Public types ──────────────────────────────────────────────────────
+
+export type LlmGrade = 'TRUE_POSITIVE' | 'FALSE_POSITIVE' | 'INCONCLUSIVE';
+
+export interface LlmGradeInput {
+  algorithmId: string;
+  /** Free-form description of the original decision the algorithm
+   *  made. */
+  decision: string;
+  /** Evidence rows the LLM should consider. Keep payloads small. */
+  evidence: readonly { kind: string; summary: string; at?: number }[];
+  /** Original event id (passed back for traceability). */
+  eventId: string;
+}
+
+export interface LlmGradeResult {
+  eventId: string;
+  algorithmId: string;
+  grade: LlmGrade;
+  confidence: number;
+  reasoning: string;
+  /** True when the LLM responded with a confidence below the
+   *  acceptance threshold and we forced INCONCLUSIVE. */
+  belowConfidenceThreshold: boolean;
+  /** True when the LLM call itself failed (Ollama unavailable). */
+  llmUnavailable: boolean;
+  generatedAt: number;
+}
+
+export type LlmFn = (prompt: string) => Promise<string>;
+
+export interface LlmGraderOptions {
+  /** Minimum self-reported confidence to accept the LLM's grade. */
+  acceptanceThreshold?: number;
+  now?: () => number;
+}
+
+const DEFAULT_THRESHOLD = 0.75;
+
+// ── Prompt construction ───────────────────────────────────────────────
+
+/** Build the structured JSON prompt the LLM is asked to grade. The
+ *  shape is stable so the parser can rely on the LLM echoing back the
+ *  same fields. */
+export function buildLlmGradePrompt(input: LlmGradeInput): string {
+  const payload = {
+    algorithmId: input.algorithmId,
+    eventId: input.eventId,
+    decision: input.decision,
+    evidence: input.evidence,
+    question: 'Did this prediction come true?',
+    instructions:
+      'Reply with strict JSON: { "grade": "TRUE_POSITIVE" | "FALSE_POSITIVE" | "INCONCLUSIVE", "confidence": <number 0..1>, "reasoning": <short string> }. Do not include any other text.',
+  };
+  return JSON.stringify(payload, null, 2);
+}
+
+// ── Response parsing ──────────────────────────────────────────────────
+
+/** Parse a raw LLM response string. Returns the parsed grade or
+ *  INCONCLUSIVE on any failure. */
+export function parseLlmGradeResponse(raw: string): {
+  grade: LlmGrade;
+  confidence: number;
+  reasoning: string;
+  malformed: boolean;
+} {
+  const trimmed = raw.trim();
+  const jsonStart = trimmed.indexOf('{');
+  const jsonEnd = trimmed.lastIndexOf('}');
+  if (jsonStart === -1 || jsonEnd === -1 || jsonEnd <= jsonStart) {
+    return { grade: 'INCONCLUSIVE', confidence: 0, reasoning: 'unparseable LLM response', malformed: true };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed.slice(jsonStart, jsonEnd + 1));
+  } catch {
+    return { grade: 'INCONCLUSIVE', confidence: 0, reasoning: 'invalid JSON in LLM response', malformed: true };
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return { grade: 'INCONCLUSIVE', confidence: 0, reasoning: 'non-object LLM response', malformed: true };
+  }
+  const obj = parsed as Record<string, unknown>;
+  const grade = normalizeGrade(obj.grade);
+  if (!grade) {
+    return { grade: 'INCONCLUSIVE', confidence: 0, reasoning: 'unrecognized grade label', malformed: true };
+  }
+  const confidence = typeof obj.confidence === 'number' ? clamp01(obj.confidence) : 0;
+  const reasoning = typeof obj.reasoning === 'string' ? obj.reasoning : '';
+  return { grade, confidence, reasoning, malformed: false };
+}
+
+function normalizeGrade(x: unknown): LlmGrade | null {
+  if (typeof x !== 'string') return null;
+  const normalized = x.trim().toUpperCase();
+  if (normalized === 'TRUE_POSITIVE' || normalized === 'FALSE_POSITIVE' || normalized === 'INCONCLUSIVE') {
+    return normalized;
+  }
+  return null;
+}
+
+function clamp01(x: number): number {
+  if (!Number.isFinite(x)) return 0;
+  if (x < 0) return 0;
+  if (x > 1) return 1;
+  return x;
+}
+
+// ── Top-level grader ──────────────────────────────────────────────────
+
+/** Build the prompt, call the LLM, parse, and apply confidence
+ *  gating. Falls back to INCONCLUSIVE on any failure path. */
+export async function gradeWithLlm(
+  input: LlmGradeInput,
+  llmFn: LlmFn,
+  options: LlmGraderOptions = {},
+): Promise<LlmGradeResult> {
+  const threshold = options.acceptanceThreshold ?? DEFAULT_THRESHOLD;
+  const now = (options.now ?? (() => Date.now()))();
+  const prompt = buildLlmGradePrompt(input);
+
+  let raw: string;
+  try {
+    raw = await llmFn(prompt);
+  } catch (error) {
+    return {
+      eventId: input.eventId,
+      algorithmId: input.algorithmId,
+      grade: 'INCONCLUSIVE',
+      confidence: 0,
+      reasoning: `llm unavailable: ${String((error as Error)?.message ?? error)}`,
+      belowConfidenceThreshold: false,
+      llmUnavailable: true,
+      generatedAt: now,
+    };
+  }
+
+  const parsed = parseLlmGradeResponse(raw);
+  const belowThreshold = parsed.confidence < threshold && parsed.grade !== 'INCONCLUSIVE';
+  const finalGrade: LlmGrade = belowThreshold ? 'INCONCLUSIVE' : parsed.grade;
+  return {
+    eventId: input.eventId,
+    algorithmId: input.algorithmId,
+    grade: finalGrade,
+    confidence: parsed.confidence,
+    reasoning: belowThreshold
+      ? `${parsed.reasoning} (below threshold ${threshold}, downgraded to INCONCLUSIVE)`
+      : parsed.reasoning,
+    belowConfidenceThreshold: belowThreshold,
+    llmUnavailable: false,
+    generatedAt: now,
+  };
+}
+
+/** Map a final LlmGrade → ledger EvaluationOutcome. */
+export function llmGradeToLedgerOutcome(g: LlmGrade): EvaluationOutcome {
+  switch (g) {
+    case 'TRUE_POSITIVE': {
+      return 'hit';
+    }
+    case 'FALSE_POSITIVE': {
+      return 'miss';
+    }
+    case 'INCONCLUSIVE': {
+      return 'inconclusive';
+    }
+  }
+}
+
+// ── Result cache (sidecar mirror) ─────────────────────────────────────
+
+const llmGradesByEvent = new Map<string, LlmGradeResult>();
+
+export function recordLlmGrade(result: LlmGradeResult): void {
+  llmGradesByEvent.set(result.eventId, { ...result });
+}
+
+export function getLlmGrade(eventId: string): LlmGradeResult | undefined {
+  return llmGradesByEvent.get(eventId);
+}
+
+export function listLlmGrades(): LlmGradeResult[] {
+  return [...llmGradesByEvent.values()];
+}
+
+export function _resetLlmGradeCacheForTests(): void {
+  llmGradesByEvent.clear();
+}

--- a/src/services/algorithms/outcome-resolver.ts
+++ b/src/services/algorithms/outcome-resolver.ts
@@ -1,0 +1,107 @@
+/**
+ * Outcome Resolver — minimal stub for PR 14.
+ *
+ * The full outcome-resolver is being built in a parallel session
+ * (foundation PRs 3–10). This module provides just enough surface for
+ * PR 14's LLM grader to wire into: routing pending records older
+ * than a configurable timeout to the LLM grading path. The inline
+ * router here is a placeholder — the full pipeline lands with
+ * foundation PRs 3–10.
+ *
+ * Pure deterministic.
+ */
+
+import type { EvaluationRecord, EvaluationOutcome } from './algorithm-evaluation-ledger.ts';
+import {
+  gradeWithLlm,
+  llmGradeToLedgerOutcome,
+  type LlmFn,
+  type LlmGradeInput,
+  type LlmGradeResult,
+} from './llm-grader.ts';
+
+// ── Public types ──────────────────────────────────────────────────────
+
+export interface ResolveOptions {
+  /** Records older than this without an outcome are eligible for LLM
+   *  grading. Default 48h. */
+  timeoutMs?: number;
+  /** Reference time for "now". */
+  now?: number;
+  /** LLM call function. When omitted, every eligible record gets the
+   *  unavailable fallback. */
+  llmFn?: LlmFn;
+  /** Acceptance threshold passed through to the grader. */
+  acceptanceThreshold?: number;
+}
+
+export interface ResolutionEntry {
+  record: EvaluationRecord;
+  llm: LlmGradeResult;
+  ledgerOutcome: EvaluationOutcome;
+  ledgerReason: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 48 * 60 * 60 * 1000;
+
+// ── API ───────────────────────────────────────────────────────────────
+
+/** Pick the records that have aged past the timeout without an
+ *  outcome. Pure function. */
+export function pickEligibleForLlmGrading(
+  records: readonly EvaluationRecord[],
+  options: { timeoutMs?: number; now?: number } = {},
+): EvaluationRecord[] {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const now = options.now ?? Date.now();
+  const cutoff = now - timeoutMs;
+  return records.filter((r) => r.outcome === undefined && r.at <= cutoff);
+}
+
+/** Resolve a batch of pending records via the LLM grader. */
+export async function resolvePendingViaLlm(
+  records: readonly EvaluationRecord[],
+  options: ResolveOptions = {},
+): Promise<ResolutionEntry[]> {
+  const eligible = pickEligibleForLlmGrading(records, {
+    timeoutMs: options.timeoutMs,
+    now: options.now,
+  });
+  const llmFn: LlmFn = options.llmFn ?? unavailableLlmFn;
+
+  const out: ResolutionEntry[] = [];
+  for (const r of eligible) {
+    const input: LlmGradeInput = buildGradeInput(r);
+    const llm = await gradeWithLlm(input, llmFn, {
+      acceptanceThreshold: options.acceptanceThreshold,
+      now: () => options.now ?? Date.now(),
+    });
+    out.push({
+      record: r,
+      llm,
+      ledgerOutcome: llmGradeToLedgerOutcome(llm.grade),
+      ledgerReason: `llm-grader: ${llm.reasoning}`,
+    });
+  }
+  return out;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function buildGradeInput(r: EvaluationRecord): LlmGradeInput {
+  const evidence: { kind: string; summary: string; at?: number }[] = [];
+  if (r.label) evidence.push({ kind: 'label', summary: r.label, at: r.at });
+  if (r.notes) evidence.push({ kind: 'notes', summary: r.notes, at: r.at });
+  if (r.score !== undefined) {
+    evidence.push({ kind: 'score', summary: `score=${r.score.toFixed(3)}`, at: r.at });
+  }
+  return {
+    eventId: r.id,
+    algorithmId: r.algorithmId,
+    decision: r.label ?? `score=${r.score ?? 'n/a'}`,
+    evidence,
+  };
+}
+
+const unavailableLlmFn: LlmFn = (): Promise<string> =>
+  Promise.reject(new Error('No llmFn configured (Ollama unavailable)'));


### PR DESCRIPTION
Implements PRs 11–18 from the Algorithm Accuracy Enhancement plan as a single stacked PR. Each commit is a self-contained PR with its own service module, unit tests, and sidecar exposure.

## Commits

- **PR 11** — `ensemble-voter.ts` — F1-weighted ensemble voting across N algorithms (MAJORITY / CONSENSUS / UNANIMOUS / CONFIDENCE_WEIGHTED) with explicit dissent capture. Self-registers as `ensemble-{domain}` in the registry. **18 tests.**
- **PR 12** — `drift-detector.ts` — Page-Hinkley test on rolling F1 buckets. Crossing λ raises a `DriftAlert` with a recommended action (retune/shadow/review). Per-algorithm drift history ring buffer. **13 tests.**
- **PR 13** — `counterfactual-engine.ts` — Replay graded misses through every other registered algorithm. Generates "Algorithm X would have caught this" insights. Throwing runners degrade gracefully. **12 tests.**
- **PR 14** — `llm-grader.ts` + minimal `outcome-resolver.ts` — Route ambiguous events through Ollama via an injectable `LlmFn`. Confidence gating at 0.75; falls back to INCONCLUSIVE on malformed/unavailable. **17 tests.**
- **PR 15** — `adaptive-tuner.ts` — TPE-flavored: 50 random configs → top-5 hill climb. Safety rails: 20% max relative change, 5% min F1 improvement to apply. Audit trail per-algorithm. **15 tests.**
- **PR 16** — `correlation-analyzer.ts` — All-pairs Pearson correlation of decision confidence over trailing 500. Classifies pairs as redundant / disagreement / independent / mild. `suggestDiverseEnsemble()` greedy picker. **17 tests.**
- **PR 17** — `blackswan-detector.ts` — Simplified Isolation Forest augmented with bounding-box distance signal (pure iForest underestimates points far outside training distribution). Threshold 0.85. **9 tests.**
- **PR 18** — `genealogy-tree.ts` — Algorithm lineage with cycle detection. `getAncestors` / `getDescendants` / `getLineage`. **11 tests.**

**Total: 112 new unit tests; full algorithms suite at 207/207 passing.**

## Sidecar surface

One bundled mirror block at `/api/algorithm-state/<bucket>` (POST writes, GET reads) plus per-spec friendly aliases:

- `/api/ensemble-decision?domain={domain}`
- `/api/drift-status`
- `/api/counterfactuals?eventId={id}`
- `/api/auto-tune?algorithmId={id}`
- `/api/algorithm-correlations`
- `/api/blackswan-status`
- `/api/genealogy`
- `/api/genealogy/lineage?algorithmId={id}`

## Foundation dependencies

A minimal `outcome-resolver.ts` was created in PR 14 — the full pipeline is being built in a parallel session (foundation PRs 3–10).

## Verification

- `npx tsx --test src/services/algorithms/__tests__/*.test.mts` → 207 tests pass
- `tsc --noEmit` → clean
- `eslint` → clean

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>