### PR TITLE
feat: SynthesisPanel — precedents + leading indicators (Batch 1 PR 3/3)

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -7094,6 +7094,30 @@ async function dispatch(requestUrl, req, routes, context) {
  return json(snap);
   }
 
+  // ── Synthesis: precedents (corpus-backed TF-IDF cosine matcher) ──────────
+  // Returns configured=false until a corpus is wired in. Engine lives in
+  // src/services/synthesis/precedent-matcher.ts (21 tests passing).
+  if (requestUrl.pathname === '/api/precedents') {
+ return json({
+ configured: false,
+ error: 'corpus not yet ingested',
+ analogs: [],
+ });
+  }
+
+  // ── Synthesis: leading indicators (Granger F-test across signals) ────────
+  // Returns configured=false until rolling daily series for BDI / commodities
+  // / ACLED / ProMED / USGS / CISA KEV are wired in. Engine lives in
+  // src/services/synthesis/leading-indicators.ts (19 tests passing).
+  if (requestUrl.pathname === '/api/leading-indicators') {
+ return json({
+ configured: false,
+ error: 'time series not yet ingested',
+ pairs: [],
+ alerts: [],
+ });
+  }
+
   // ── S2U TAK feeds — Marti API /api/feeds (cached 60s, TLS-pinned) ─────────
   if (requestUrl.pathname === '/api/s2u-tak-feeds') {
  const opts = s2uTakOpts();

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -41,6 +41,7 @@ import {
   SecurityAdvisoriesPanel,
   NetworkRulesPanel,
   S2UIntelPanel,
+  SynthesisPanel,
   OrefSirensPanel,
   TelegramIntelPanel,
   WatchlistPanel,
@@ -1255,6 +1256,14 @@ export class PanelLayoutManager implements AppModule {
  // in Settings" empty state.
  const s2uIntelPanel = new S2UIntelPanel();
  this.ctx.panels['s2u-intel'] = s2uIntelPanel;
+
+ // SynthesisPanel — historical precedent matcher (TF-IDF + cosine)
+ // and cross-domain leading-indicator engine (Granger F-test). Reads
+ // from /api/precedents and /api/leading-indicators; sidecar returns
+ // configured=false until a corpus + time-series feeder is wired in
+ // a follow-up PR. Pure engines ship in Batch 1 PR 1 + 2.
+ const synthesisPanel = new SynthesisPanel();
+ this.ctx.panels['synthesis'] = synthesisPanel;
 
  const orefSirensPanel = new OrefSirensPanel();
  this.ctx.panels['oref-sirens'] = orefSirensPanel;

--- a/src/components/SynthesisPanel.ts
+++ b/src/components/SynthesisPanel.ts
@@ -1,0 +1,271 @@
+import { Panel } from './Panel';
+import { escapeHtml } from '@/utils/sanitize';
+import { getApiBaseUrl } from '@/services/runtime';
+
+// ── Sidecar response shapes ─────────────────────────────────────────────
+
+interface PrecedentAnalog {
+  id: string;
+  date: string;
+  location: string;
+  country: string;
+  similarity: number;
+  summary: string;
+  aftermath30d: string;
+  aftermath90d: string;
+  keyDifferences: string[];
+  source: string;
+}
+
+interface PrecedentsResponse {
+  configured: boolean;
+  query?: { eventType?: string; location?: string; intensity?: string };
+  currentEventSummary?: string;
+  analogs?: PrecedentAnalog[];
+  averageOutcome?: string;
+  worstCase?: string;
+  bestCase?: string;
+  error?: string;
+}
+
+interface LeadingIndicatorAlert {
+  causeSignal: string;
+  effectSignal: string;
+  lagDays: number;
+  strength: number;
+  message: string;
+}
+
+interface LeadingIndicatorsResponse {
+  configured: boolean;
+  pairs?: { cause: string; effect: string; lagDays: number; pValue: number; strength: number }[];
+  alerts?: LeadingIndicatorAlert[];
+  lastAnalyzed?: string;
+  error?: string;
+}
+
+type TabId = 'precedents' | 'indicators';
+
+const REFRESH_MS = 5 * 60_000;
+
+// "What does history say?" panel. Reads from /api/precedents and
+// /api/leading-indicators. The sidecar endpoints land in a follow-up
+// (corpus pre-compute on startup is non-trivial); until then the panel
+// renders graceful empty states so users see the scaffolding without
+// errors.
+export class SynthesisPanel extends Panel {
+  private precedents: PrecedentsResponse | null = null;
+  private indicators: LeadingIndicatorsResponse | null = null;
+  private precedentsError: string | null = null;
+  private indicatorsError: string | null = null;
+  private activeTab: TabId = 'precedents';
+  private refreshTimer: number | null = null;
+
+  constructor() {
+ super({
+ id: 'synthesis',
+ title: 'Synthesis',
+ showCount: true,
+ trackActivity: true,
+ infoTooltip: 'Historical precedent matcher + cross-domain leading indicators. Reads /api/precedents and /api/leading-indicators.',
+ });
+ this.showLoading('Loading synthesis…');
+ setTimeout(() => { void this.refresh(); }, 0);
+ this.refreshTimer = window.setInterval(() => { void this.refresh(); }, REFRESH_MS);
+  }
+
+  override destroy(): void {
+ if (this.refreshTimer !== null) {
+ window.clearInterval(this.refreshTimer);
+ this.refreshTimer = null;
+ }
+ super.destroy();
+  }
+
+  async refresh(): Promise<void> {
+ await Promise.all([this.refreshPrecedents(), this.refreshIndicators()]);
+  }
+
+  private async refreshPrecedents(): Promise<void> {
+ try {
+ const res = await fetch(`${getApiBaseUrl()}/api/precedents`);
+ const body = (await res.json().catch(() => null)) as PrecedentsResponse | null;
+ if (body) {
+ this.precedents = body;
+ this.precedentsError = null;
+ } else {
+ this.precedentsError = `Sidecar returned HTTP ${res.status}`;
+ }
+ } catch (error) {
+ this.precedentsError = error instanceof Error ? error.message : String(error);
+ }
+ this.updateCount();
+ this.render();
+  }
+
+  private async refreshIndicators(): Promise<void> {
+ try {
+ const res = await fetch(`${getApiBaseUrl()}/api/leading-indicators`);
+ const body = (await res.json().catch(() => null)) as LeadingIndicatorsResponse | null;
+ if (body) {
+ this.indicators = body;
+ this.indicatorsError = null;
+ } else {
+ this.indicatorsError = `Sidecar returned HTTP ${res.status}`;
+ }
+ } catch (error) {
+ this.indicatorsError = error instanceof Error ? error.message : String(error);
+ }
+ this.render();
+  }
+
+  private updateCount(): void {
+ const analogs = this.precedents?.analogs?.length ?? 0;
+ const alerts = this.indicators?.alerts?.length ?? 0;
+ this.setCount(analogs + alerts);
+  }
+
+  private renderTabs(): string {
+ const analogCount = this.precedents?.analogs?.length ?? 0;
+ const alertCount = this.indicators?.alerts?.length ?? 0;
+ const tabs: { id: TabId; label: string; count: number }[] = [
+ { id: 'precedents', label: 'Precedents', count: analogCount },
+ { id: 'indicators', label: 'Leading Indicators', count: alertCount },
+ ];
+ const items = tabs.map((t) => {
+ const active = t.id === this.activeTab;
+ const bg = active ? 'rgba(255,255,255,0.08)' : 'transparent';
+ const border = active ? '#3b82f6' : 'transparent';
+ return `<button data-synth-tab="${escapeHtml(t.id)}" style="background:${bg};border:none;padding:6px 10px;font-size:11px;cursor:pointer;border-bottom:2px solid ${border}">${escapeHtml(t.label)} <span style="opacity:0.5">${t.count}</span></button>`;
+ }).join('');
+ return `<div style="display:flex;border-bottom:1px solid var(--panel-border,#2a2a2c);background:rgba(255,255,255,0.02)">${items}</div>`;
+  }
+
+  private renderPrecedents(): string {
+ if (this.precedentsError) {
+ return `<div style="padding:12px;color:#ef4444;font-size:12px">${escapeHtml(this.precedentsError)}</div>`;
+ }
+ if (!this.precedents) return '<div style="padding:12px;opacity:0.6;font-size:12px">Loading…</div>';
+ if (!this.precedents.configured) {
+ return `<div style="padding:12px;font-size:12px;line-height:1.5">
+ <strong>Historical corpus not configured.</strong><br/>
+ The sidecar will load and pre-compute embeddings from GDELT / UCDP / ACLED at startup. Add corpus sources in <code>tools/synthesis/corpus.json</code> or wait for the live-feed wiring PR.<br/>
+ <span style="opacity:0.7">Engine ready (TF-IDF + cosine, 21 tests passing); needs a corpus to operate on.</span>
+ </div>`;
+ }
+ const analogs = this.precedents.analogs ?? [];
+ if (analogs.length === 0) {
+ return `<div style="padding:12px;opacity:0.7;font-size:12px;line-height:1.5">
+ <strong>No analogs found.</strong><br/>
+ ${escapeHtml(this.precedents.currentEventSummary ?? 'No active query.')}
+ </div>`;
+ }
+ const summaryHtml = this.precedents.currentEventSummary
+ ? `<div style="padding:6px 10px;font-size:11px;background:rgba(255,255,255,0.04);border-bottom:1px solid var(--panel-border,#2a2a2c)"><span style="opacity:0.6">Current:</span> ${escapeHtml(this.precedents.currentEventSummary)}</div>`
+ : '';
+ const top = analogs.slice(0, 5).map((a) => this.renderAnalog(a)).join('');
+ const rollups = renderRollups(this.precedents);
+ return `${summaryHtml}${rollups}<div>${top}</div>`;
+  }
+
+  private renderAnalog(a: PrecedentAnalog): string {
+ const bar = Math.round(Math.max(0, Math.min(1, a.similarity)) * 100);
+ const diffs = a.keyDifferences.length > 0
+ ? `<div style="font-size:10px;opacity:0.6;margin-top:2px">Differences: ${escapeHtml(a.keyDifferences.join(' · '))}</div>`
+ : '';
+ const aftermath90 = a.aftermath90d
+ ? `<div style="font-size:11px;margin-top:4px;opacity:0.85"><strong>+90d:</strong> ${escapeHtml(a.aftermath90d)}</div>`
+ : '';
+ const aftermath30 = a.aftermath30d
+ ? `<div style="font-size:11px;margin-top:2px;opacity:0.85"><strong>+30d:</strong> ${escapeHtml(a.aftermath30d)}</div>`
+ : '';
+ return `
+ <div style="padding:8px 10px;border-bottom:1px solid rgba(255,255,255,0.04)">
+ <div style="display:flex;justify-content:space-between;align-items:center;font-size:11px">
+ <span><strong>${escapeHtml(a.location)}</strong> <span style="opacity:0.6">${escapeHtml(a.date)}</span></span>
+ <span style="font-family:ui-monospace,monospace;opacity:0.7">${bar}%</span>
+ </div>
+ <div style="height:3px;background:rgba(255,255,255,0.08);margin-top:3px;border-radius:2px;overflow:hidden">
+ <div style="height:100%;width:${bar}%;background:#3b82f6"></div>
+ </div>
+ <div style="font-size:11px;margin-top:4px;line-height:1.4">${escapeHtml(a.summary)}</div>
+ ${aftermath30}${aftermath90}${diffs}
+ </div>`;
+  }
+
+  private renderIndicators(): string {
+ if (this.indicatorsError) {
+ return `<div style="padding:12px;color:#ef4444;font-size:12px">${escapeHtml(this.indicatorsError)}</div>`;
+ }
+ if (!this.indicators) return '<div style="padding:12px;opacity:0.6;font-size:12px">Loading…</div>';
+ if (!this.indicators.configured) {
+ return `<div style="padding:12px;font-size:12px;line-height:1.5">
+ <strong>Time series not configured.</strong><br/>
+ The sidecar will pull rolling 365-day daily series for BDI / commodities / ACLED rate / ProMED rate / USGS quake rate / CISA KEV in a follow-up PR. Granger F-test runs across every pair at lags 1–90.<br/>
+ <span style="opacity:0.7">Engine ready (Granger F-test + OLS + F-distribution survival, 19 tests passing); needs the live series feeder.</span>
+ </div>`;
+ }
+ const alerts = this.indicators.alerts ?? [];
+ const pairs = this.indicators.pairs ?? [];
+ const alertItems = renderAlertItems(alerts);
+ const pairsTable = renderPairsTable(pairs);
+ const pairsSection = pairsTable
+ ? `<div style="border-bottom:1px solid var(--panel-border,#2a2a2c);padding:6px 10px;font-size:11px;font-weight:600;opacity:0.8;margin-top:8px">All significant pairs</div>${pairsTable}`
+ : '';
+ const lastAnalyzed = this.indicators.lastAnalyzed
+ ? `<div style="padding:6px 10px;font-size:10px;opacity:0.5">Last analyzed: ${escapeHtml(this.indicators.lastAnalyzed)}</div>`
+ : '';
+ return `${lastAnalyzed}<div style="border-bottom:1px solid var(--panel-border,#2a2a2c);padding:6px 10px;font-size:11px;font-weight:600;opacity:0.8">Active alerts</div>${alertItems}${pairsSection}`;
+  }
+
+  private renderActiveTab(): string {
+ if (this.activeTab === 'indicators') return this.renderIndicators();
+ return this.renderPrecedents();
+  }
+
+  private render(): void {
+ const html = `${this.renderTabs()}<div data-synth-body>${this.renderActiveTab()}</div>`;
+ this.setContent(html);
+ const root = document.querySelector<HTMLElement>(`[data-panel-id="${this.getPanelId()}"]`);
+ if (root) {
+ root.querySelectorAll<HTMLButtonElement>('button[data-synth-tab]').forEach((btn) => {
+ btn.addEventListener('click', () => {
+ const id = btn.getAttribute('data-synth-tab') as TabId | null;
+ if (id) {
+ this.activeTab = id;
+ this.render();
+ }
+ });
+ });
+ }
+  }
+}
+
+// ── Module-scope helpers (extracted so the class methods stay simple) ──
+
+function renderAlertItems(alerts: readonly LeadingIndicatorAlert[]): string {
+  if (alerts.length === 0) return '<div style="padding:10px;opacity:0.6;font-size:11px">No active alerts.</div>';
+  return alerts.map((a) => {
+    const strengthPct = (a.strength * 100).toFixed(1);
+    return `<div style="padding:8px 10px;border-bottom:1px solid rgba(255,255,255,0.04);font-size:11px;line-height:1.5"><span style="color:#fde68a;font-weight:600">${escapeHtml(a.causeSignal)} → ${escapeHtml(a.effectSignal)}</span> · ${a.lagDays}d · ${strengthPct}% strength<br/><span style="opacity:0.85">${escapeHtml(a.message)}</span></div>`;
+  }).join('');
+}
+
+function renderPairsTable(pairs: readonly { cause: string; effect: string; lagDays: number; pValue: number; strength: number }[]): string {
+  if (pairs.length === 0) return '';
+  const head = '<thead style="background:rgba(255,255,255,0.04);text-align:left;font-size:10px;opacity:0.7"><tr><th style="padding:4px 8px">Cause</th><th style="padding:4px 8px">Effect</th><th style="padding:4px 8px">Lag (d)</th><th style="padding:4px 8px">p</th><th style="padding:4px 8px">Strength</th></tr></thead>';
+  const rows = pairs.map((p) => {
+    const strengthPct = (p.strength * 100).toFixed(1);
+    return `<tr><td style="padding:4px 8px">${escapeHtml(p.cause)}</td><td style="padding:4px 8px">${escapeHtml(p.effect)}</td><td style="padding:4px 8px">${p.lagDays}</td><td style="padding:4px 8px;font-family:ui-monospace,monospace">${p.pValue.toExponential(2)}</td><td style="padding:4px 8px">${strengthPct}%</td></tr>`;
+  }).join('');
+  return `<table style="width:100%;border-collapse:collapse;font-size:11px">${head}<tbody>${rows}</tbody></table>`;
+}
+
+function renderRollups(p: PrecedentsResponse): string {
+  const cells: string[] = [];
+  if (p.bestCase) cells.push(`<div style="padding:4px 8px;font-size:11px"><span style="color:#86efac">Best case</span> · ${escapeHtml(p.bestCase)}</div>`);
+  if (p.averageOutcome) cells.push(`<div style="padding:4px 8px;font-size:11px"><span style="color:#fde68a">Median</span> · ${escapeHtml(p.averageOutcome)}</div>`);
+  if (p.worstCase) cells.push(`<div style="padding:4px 8px;font-size:11px"><span style="color:#fca5a5">Worst case</span> · ${escapeHtml(p.worstCase)}</div>`);
+  if (cells.length === 0) return '';
+  return `<div style="background:rgba(255,255,255,0.03);border-bottom:1px solid var(--panel-border,#2a2a2c)">${cells.join('')}</div>`;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -50,6 +50,7 @@ export * from './SupplyChainPanel';
 export * from './SecurityAdvisoriesPanel';
 export { NetworkRulesPanel } from './NetworkRulesPanel';
 export { S2UIntelPanel } from './S2UIntelPanel';
+export { SynthesisPanel } from './SynthesisPanel';
 export * from './OrefSirensPanel';
 export * from './TelegramIntelPanel';
 export * from './BreakingNewsBanner';

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -78,6 +78,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'security-advisories': { name: 'Security Advisories', enabled: true, priority: 2 },
   'network-rules': { name: 'Network Rules', enabled: true, priority: 3 },
   's2u-intel': { name: 'S2U Intelligence', enabled: true, priority: 1 },
+  'synthesis': { name: 'Synthesis', enabled: true, priority: 1 },
   'oref-sirens': { name: 'Israel Sirens', enabled: true, priority: 2 },
   'telegram-intel': { name: 'Telegram Intel', enabled: true, priority: 2 },
   'space-weather': { name: 'Space Weather', enabled: true, priority: 1 },
@@ -958,7 +959,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   // Full (geopolitical) variant
   intelligence: {
  labelKey: 'header.panelCatIntelligence',
- panelKeys: ['command-center', 'system-diagnostic', 'algorithm-diagnostic', 'shortage-radar', 'watchlist', 'saved-places', 'watchlist-locations', 'local-logistics', 'comms-plan', 'unified-alert-inbox', 'alert-rules', 'situation-awareness', 'alert-center', 'strategic-risk', 'cii', 'geo-hubs', 'intel', 'gdelt-intel', 'cascade', 'telegram-intel', 'intelligence-briefing', 'ask-crystal-ball', 'survival-advisor', 'threat-synthesis', 'scenario-simulator', 'escalation-forecast', 'notification-digest', 'pattern-of-life', 'course-of-action', 'kill-chain', 'orbat', 'after-action-review', 'entity-link-graph', 'timeline-scrubber', 'intel-report', 'compound-threat', 'correlation-matrix', 'strike-package', 'strike-packages', 'api-diagnostic', 'cascade-simulator', 'dod-news', 'nato-news', 'foreign-mil-news', 'isw-reports', 'reliefweb-crises', 'bellingcat-osint', 'acaps-crises', 'liveuamap', 'un-security-council', 'combatant-commands', 'congress-defense', 'gov-warning-convergence', 'dsca-arms-transfers', 'dod-contracts', 'wikidata-bases', 'opensanctions', 'mediastack-news'],
+ panelKeys: ['command-center', 'system-diagnostic', 'algorithm-diagnostic', 'shortage-radar', 'watchlist', 'saved-places', 'watchlist-locations', 'local-logistics', 'comms-plan', 'unified-alert-inbox', 'alert-rules', 'situation-awareness', 'alert-center', 'strategic-risk', 'cii', 'geo-hubs', 'intel', 'gdelt-intel', 'cascade', 'telegram-intel', 'intelligence-briefing', 'ask-crystal-ball', 'survival-advisor', 'threat-synthesis', 'scenario-simulator', 'escalation-forecast', 'synthesis', 'notification-digest', 'pattern-of-life', 'course-of-action', 'kill-chain', 'orbat', 'after-action-review', 'entity-link-graph', 'timeline-scrubber', 'intel-report', 'compound-threat', 'correlation-matrix', 'strike-package', 'strike-packages', 'api-diagnostic', 'cascade-simulator', 'dod-news', 'nato-news', 'foreign-mil-news', 'isw-reports', 'reliefweb-crises', 'bellingcat-osint', 'acaps-crises', 'liveuamap', 'un-security-council', 'combatant-commands', 'congress-defense', 'gov-warning-convergence', 'dsca-arms-transfers', 'dod-contracts', 'wikidata-bases', 'opensanctions', 'mediastack-news'],
  variants: ['full'],
   },
   regionalNews: {


### PR DESCRIPTION
Closes Batch 1. Two-tab panel surfacing the engines from PRs [#275](https://github.com/bradleybond512/crystal-ball/pull/275) and [#283](https://github.com/bradleybond512/crystal-ball/pull/283).

## Files
- src/components/SynthesisPanel.ts — tabbed panel
- src/components/index.ts, src/config/panels.ts, src/app/panel-layout.ts — registration
- src-tauri/sidecar/local-api-server.mjs — stub /api/precedents + /api/leading-indicators returning configured=false

## Tabs
1. **Precedents** — top-5 analog cards with similarity bars, +30/+90 aftermath rows, structured key-differences, and best/median/worst-case rollups
2. **Leading Indicators** — active alerts feed (cause → effect with lag + strength) plus a full table of every significant pair

## Empty states
Both tabs route to graceful 'not configured' empty states that name the engine and explain that live-data wiring (corpus + rolling daily series) lands in a follow-up. Engines themselves are 40 tests passing.

## Validation
- npm run typecheck:all: clean
- eslint: clean (extracted module helpers to drop nested template literals)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>