### PR TITLE
feat: Gray Zone Classifier (Batch 2 PR 2/3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "test:seismic": "tsx --test src/services/seismic/__tests__/seismic-normalizer.test.mts src/services/seismic/__tests__/seismic-fusion.test.mts src/services/seismic/__tests__/shaking-estimator.test.mts src/services/seismic/__tests__/impact-assessor.test.mts src/services/seismic/__tests__/tsunami-reasoner.test.mts",
     "test:synthesis": "tsx --test src/services/synthesis/__tests__/precedent-matcher.test.mts src/services/synthesis/__tests__/leading-indicators.test.mts",
     "test:cyber": "tsx --test src/services/cyber/__tests__/apt-tracker.test.mts",
+    "test:geopolitics": "tsx --test src/services/geopolitics/__tests__/grayzone-classifier.test.mts",
     "test:panels:smoke": "node tests/panels/run-harness.mjs",
     "test:panels:fixtures": "tsx --import ./tests/panels/register-hook.mjs --test tests/panels/panel-fixtures.test.mts",
     "test:strategic-self-improvement": "tsx --test src/services/diagnostics/__tests__/failure-prediction.test.mts src/services/governance/__tests__/policy-engine.test.mts src/services/governance/__tests__/model-governance.test.mts src/services/experiments/__tests__/experiment-manager.test.mts src/services/ops/__tests__/causal-attribution.test.mts src/services/ops/__tests__/trust-budget.test.mts src/services/ops/__tests__/playbook-engine.test.mts src/services/scenarios/__tests__/scenario-library.test.mts src/services/personal/__tests__/resilience-model.test.mts src/services/quality/__tests__/quality-debt.test.mts src/services/quality/__tests__/self-improvement-scheduler.test.mts",

--- a/src/services/geopolitics/__tests__/grayzone-classifier.test.mts
+++ b/src/services/geopolitics/__tests__/grayzone-classifier.test.mts
@@ -1,0 +1,262 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  GREAT_POWER_INTERESTS,
+  classifyCyber,
+  classifyDisinformation,
+  classifyEconomicCoercion,
+  classifyInfrastructure,
+  classifyProxy,
+  classifySanctions,
+  detectPatterns,
+  summarizeActor,
+  type AcledLikeEvent,
+  type CyberIncident,
+  type GdeltLikeArticle,
+  type GrayZoneEvent,
+  type InfrastructureKeywordHit,
+  type SanctionsEntry,
+} from '../grayzone-classifier.ts';
+
+const NOW = '2026-04-15T00:00:00Z';
+
+// ── Static interest map ────────────────────────────────────────────────
+
+test('GREAT_POWER_INTERESTS: covers all 5 powers', () => {
+  const keys = Object.keys(GREAT_POWER_INTERESTS);
+  for (const expected of ['Russia', 'China', 'Iran', 'North Korea', 'United States']) {
+    assert.ok(keys.includes(expected), `${expected} should be present`);
+  }
+});
+
+test('GREAT_POWER_INTERESTS: Russia includes Ukraine', () => {
+  assert.ok(GREAT_POWER_INTERESTS.Russia.includes('Ukraine'));
+});
+
+// ── classifySanctions ────────────────────────────────────────────────
+
+test('classifySanctions: maps sender to actor + high confidence', () => {
+  const entry: SanctionsEntry = {
+    date: NOW, sender: 'United States', target: 'Iran', summary: 'OFAC SDN list update',
+  };
+  const event = classifySanctions(entry);
+  assert.equal(event.type, 'sanctions');
+  assert.equal(event.suspectedActor, 'United States');
+  assert.equal(event.targetCountry, 'Iran');
+  assert.equal(event.confidence, 0.95);
+});
+
+// ── classifyCyber ────────────────────────────────────────────────────
+
+test('classifyCyber: named attribution gets 0.75 confidence', () => {
+  const incident: CyberIncident = {
+    date: NOW, attribution: 'Russia', target: 'Ukraine', summary: 'GRU cyber op', severity: 'high',
+  };
+  const event = classifyCyber(incident);
+  assert.equal(event.suspectedActor, 'Russia');
+  assert.equal(event.confidence, 0.75);
+});
+
+test('classifyCyber: missing attribution → Unknown + 0.4 confidence', () => {
+  const incident: CyberIncident = {
+    date: NOW, target: 'Energy sector', summary: 'unattributed', severity: 'medium',
+  };
+  const event = classifyCyber(incident);
+  assert.equal(event.suspectedActor, 'Unknown');
+  assert.equal(event.confidence, 0.4);
+});
+
+// ── classifyProxy ────────────────────────────────────────────────────
+
+test('classifyProxy: ACLED non-state event in Yemen routes to Iran', () => {
+  const event: AcledLikeEvent = {
+    date: NOW, country: 'Yemen', actor1: 'Houthis', hasNonStateActor: true, summary: 'attack on shipping',
+  };
+  const out = classifyProxy(event);
+  assert.ok(out);
+  assert.equal(out!.suspectedActor, 'Iran');
+  assert.equal(out!.type, 'proxy_warfare');
+});
+
+test('classifyProxy: state-only event returns null', () => {
+  const event: AcledLikeEvent = {
+    date: NOW, country: 'Yemen', actor1: 'Saudi Arabia', hasNonStateActor: false, summary: 'airstrike',
+  };
+  assert.equal(classifyProxy(event), null);
+});
+
+test('classifyProxy: country with no great-power interest returns null', () => {
+  const event: AcledLikeEvent = {
+    date: NOW, country: 'Iceland', actor1: 'rebels', hasNonStateActor: true, summary: 'no interest map entry',
+  };
+  assert.equal(classifyProxy(event), null);
+});
+
+// ── classifyDisinformation ───────────────────────────────────────────
+
+test('classifyDisinformation: 2σ spike on CAMEO 17x triggers an event', () => {
+  const article: GdeltLikeArticle = {
+    date: NOW, cameoCode: '172', country: 'Ukraine',
+    baselineVolumePerDay: 25, observedVolumePerDay: 60, // 60 >> 25 + 2*sqrt(25)=35
+    title: 'Sanctions threat coverage spikes',
+  };
+  const event = classifyDisinformation(article);
+  assert.ok(event);
+  assert.equal(event!.type, 'disinformation');
+});
+
+test('classifyDisinformation: below threshold returns null', () => {
+  const article: GdeltLikeArticle = {
+    date: NOW, cameoCode: '172', country: 'Ukraine',
+    baselineVolumePerDay: 25, observedVolumePerDay: 30,
+    title: 'normal coverage',
+  };
+  assert.equal(classifyDisinformation(article), null);
+});
+
+test('classifyDisinformation: tiny baselines (<4) return null', () => {
+  const article: GdeltLikeArticle = {
+    date: NOW, cameoCode: '172',
+    baselineVolumePerDay: 2, observedVolumePerDay: 10,
+    title: 'noise',
+  };
+  assert.equal(classifyDisinformation(article), null);
+});
+
+test('classifyDisinformation: non-17x CAMEO returns null', () => {
+  const article: GdeltLikeArticle = {
+    date: NOW, cameoCode: '04', baselineVolumePerDay: 100, observedVolumePerDay: 500,
+    title: 'unrelated category',
+  };
+  assert.equal(classifyDisinformation(article), null);
+});
+
+// ── classifyEconomicCoercion ─────────────────────────────────────────
+
+test('classifyEconomicCoercion: detects "export ban" keyword', () => {
+  const article: GdeltLikeArticle = {
+    date: NOW, country: 'Japan', title: 'China imposes rare earth export ban',
+  };
+  const event = classifyEconomicCoercion(article);
+  assert.ok(event);
+  assert.equal(event!.type, 'economic_coercion');
+});
+
+test('classifyEconomicCoercion: no match returns null', () => {
+  const article: GdeltLikeArticle = { date: NOW, country: 'JP', title: 'Tokyo summit announced' };
+  assert.equal(classifyEconomicCoercion(article), null);
+});
+
+// ── classifyInfrastructure ───────────────────────────────────────────
+
+test('classifyInfrastructure: writes high severity + named attribution', () => {
+  const hit: InfrastructureKeywordHit = {
+    date: NOW, country: 'Finland', keyword: 'cable',
+    title: 'Undersea cable cut in Baltic; Russian shadow fleet vessel suspected',
+    attribution: 'Russia',
+  };
+  const event = classifyInfrastructure(hit);
+  assert.equal(event.severity, 'high');
+  assert.equal(event.suspectedActor, 'Russia');
+});
+
+test('classifyInfrastructure: no attribution → Unknown + lower confidence', () => {
+  const hit: InfrastructureKeywordHit = {
+    date: NOW, country: 'Germany', keyword: 'pipeline',
+    title: 'Pipeline pressure drop investigation',
+  };
+  const event = classifyInfrastructure(hit);
+  assert.equal(event.suspectedActor, 'Unknown');
+  assert.ok(event.confidence < 0.5);
+});
+
+// ── detectPatterns ───────────────────────────────────────────────────
+
+function ev(overrides: Partial<GrayZoneEvent> & { id: string; date: string }): GrayZoneEvent {
+  return {
+    id: overrides.id,
+    type: overrides.type ?? 'cyber_attack',
+    date: overrides.date,
+    suspectedActor: overrides.suspectedActor ?? 'Russia',
+    targetCountry: overrides.targetCountry ?? 'Ukraine',
+    confidence: overrides.confidence ?? 0.7,
+    evidence: overrides.evidence ?? [],
+    severity: overrides.severity ?? 'medium',
+    summary: overrides.summary ?? '',
+  };
+}
+
+test('detectPatterns: 3 same-actor events in 30 days emits a pattern', () => {
+  const events: GrayZoneEvent[] = [
+    ev({ id: 'a', date: '2026-04-01T00:00:00Z', type: 'cyber_attack' }),
+    ev({ id: 'b', date: '2026-04-10T00:00:00Z', type: 'disinformation' }),
+    ev({ id: 'c', date: '2026-04-20T00:00:00Z', type: 'sanctions' }),
+  ];
+  const patterns = detectPatterns(events);
+  assert.equal(patterns.length, 1);
+  assert.deepEqual(patterns[0]!.actors, ['Russia']);
+  assert.equal(patterns[0]!.eventSequence.length, 3);
+});
+
+test('detectPatterns: events spread > 30 days do not pattern-link', () => {
+  const events: GrayZoneEvent[] = [
+    ev({ id: 'a', date: '2026-01-01T00:00:00Z' }),
+    ev({ id: 'b', date: '2026-03-01T00:00:00Z' }),
+    ev({ id: 'c', date: '2026-05-01T00:00:00Z' }),
+  ];
+  const patterns = detectPatterns(events);
+  assert.equal(patterns.length, 0);
+});
+
+test('detectPatterns: cyber + disinformation surfaces hybrid interpretation', () => {
+  const events: GrayZoneEvent[] = [
+    ev({ id: 'a', date: '2026-04-01T00:00:00Z', type: 'cyber_attack' }),
+    ev({ id: 'b', date: '2026-04-05T00:00:00Z', type: 'disinformation' }),
+    ev({ id: 'c', date: '2026-04-09T00:00:00Z', type: 'cyber_attack' }),
+  ];
+  const patterns = detectPatterns(events);
+  assert.equal(patterns.length, 1);
+  assert.match(patterns[0]!.interpretation, /hybrid/i);
+});
+
+test('detectPatterns: ignores Unknown actor', () => {
+  const events: GrayZoneEvent[] = [
+    ev({ id: 'a', date: '2026-04-01T00:00:00Z', suspectedActor: 'Unknown' }),
+    ev({ id: 'b', date: '2026-04-02T00:00:00Z', suspectedActor: 'Unknown' }),
+    ev({ id: 'c', date: '2026-04-03T00:00:00Z', suspectedActor: 'Unknown' }),
+  ];
+  assert.equal(detectPatterns(events).length, 0);
+});
+
+// ── summarizeActor ───────────────────────────────────────────────────
+
+test('summarizeActor: rolls up counts by type + top targets', () => {
+  const events: GrayZoneEvent[] = [
+    ev({ id: 'a', date: '2026-04-01T00:00:00Z', type: 'cyber_attack', targetCountry: 'Ukraine' }),
+    ev({ id: 'b', date: '2026-04-10T00:00:00Z', type: 'disinformation', targetCountry: 'Ukraine' }),
+    ev({ id: 'c', date: '2026-04-15T00:00:00Z', type: 'cyber_attack', targetCountry: 'Poland' }),
+  ];
+  const summary = summarizeActor('Russia', events);
+  assert.equal(summary.eventCount, 3);
+  assert.equal(summary.byType.cyber_attack, 2);
+  assert.equal(summary.byType.disinformation, 1);
+  assert.equal(summary.topTargets[0], 'Ukraine');
+  assert.equal(summary.earliestDate, '2026-04-01T00:00:00.000Z');
+  assert.equal(summary.latestDate, '2026-04-15T00:00:00.000Z');
+});
+
+test('summarizeActor: empty events → zeros', () => {
+  const summary = summarizeActor('Russia', []);
+  assert.equal(summary.eventCount, 0);
+  assert.equal(summary.earliestDate, null);
+  assert.equal(summary.latestDate, null);
+});
+
+// ── JSON serializability ─────────────────────────────────────────────
+
+test('events + patterns are JSON-serializable', () => {
+  const e = classifySanctions({ date: NOW, sender: 'United States', target: 'Iran', summary: 'x' });
+  const round = structuredClone(e);
+  assert.equal(round.id, e.id);
+});

--- a/src/services/geopolitics/grayzone-classifier.ts
+++ b/src/services/geopolitics/grayzone-classifier.ts
@@ -1,0 +1,409 @@
+/**
+ * Gray Zone Classifier — per Batch 2 of the cyber/geo plan.
+ *
+ * Classifies sub-kinetic great-power conflict from existing data
+ * streams: sanctions, cyber attacks, proxy warfare, disinformation,
+ * economic coercion, infrastructure sabotage. No new data ingestion —
+ * the engine accepts pre-normalised inputs from existing handlers
+ * (OpenSanctions, CISA, ACLED, GDELT) and emits typed events.
+ *
+ * Pure deterministic. No DOM, no fetch, no globals. Static great-power
+ * "interest map" for proxy-warfare attribution. JSON-serializable
+ * outputs. Pattern detection groups same-actor sequences within a
+ * 30-day window into GrayZonePatterns.
+ */
+
+// ── Public types ───────────────────────────────────────────────────────
+
+export type GrayZoneEventType =
+  | 'sanctions'
+  | 'cyber_attack'
+  | 'proxy_warfare'
+  | 'disinformation'
+  | 'economic_coercion'
+  | 'infrastructure_sabotage';
+
+export type GreatPowerActor = 'Russia' | 'China' | 'Iran' | 'North Korea' | 'United States' | 'Unknown';
+
+export type GrayZoneSeverity = 'info' | 'low' | 'medium' | 'high' | 'critical';
+
+export interface GrayZoneEvent {
+  /** Stable id — the engine generates `gz-<hash>` from the inputs. */
+  id: string;
+  type: GrayZoneEventType;
+  /** ISO 8601. */
+  date: string;
+  suspectedActor: GreatPowerActor;
+  /** ISO country / region label of the affected target. */
+  targetCountry: string;
+  /** [0, 1]; combines source-confidence with attribution-strength. */
+  confidence: number;
+  /** Free-text evidence references the analyst can verify. */
+  evidence: readonly string[];
+  severity: GrayZoneSeverity;
+  /** Free-text summary for the timeline cell. */
+  summary: string;
+}
+
+export interface GrayZonePattern {
+  /** Stable id derived from the participant set. */
+  id: string;
+  actors: readonly GreatPowerActor[];
+  /** Ordered (oldest first) event ids in the sequence. */
+  eventSequence: readonly string[];
+  /** Earliest event ISO date. */
+  startDate: string;
+  /** Latest event ISO date. */
+  endDate: string;
+  interpretation: string;
+}
+
+// ── Static great-power interest map ────────────────────────────────────
+
+/** Where each great power has clear current proxy/operational interests.
+ *  Used for proxy-warfare attribution: an ACLED non-state event in one
+ *  of these countries gets routed to the corresponding actor. Static
+ *  on purpose — geopolitics changes slowly enough that hardcoding the
+ *  map (and reviewing in PR) is safer than a dynamic feed that could
+ *  silently drift.
+ *
+ *  Reviewed/updated 2026-05-05; future shifts (e.g. new theatres) get
+ *  added via PR review. Multi-actor countries are listed under every
+ *  power that has skin in the game. */
+export const GREAT_POWER_INTERESTS: Readonly<Record<Exclude<GreatPowerActor, 'Unknown'>, readonly string[]>> = {
+  Russia: ['Ukraine', 'Syria', 'Mali', 'Central African Republic', 'Libya', 'Sudan', 'Belarus', 'Georgia'],
+  China: ['Taiwan', 'South China Sea', 'Philippines', 'Vietnam', 'Solomon Islands', 'Ethiopia', 'Djibouti', 'Pakistan', 'Myanmar', 'Nepal'],
+  Iran: ['Yemen', 'Lebanon', 'Iraq', 'Syria', 'Bahrain', 'Saudi Arabia', 'Israel'],
+  'North Korea': ['South Korea', 'Japan'],
+  'United States': ['Ukraine', 'Taiwan', 'Israel', 'Saudi Arabia', 'Philippines', 'Japan', 'South Korea', 'Iraq'],
+};
+
+/** Reverse map: country → set of actors with stated interest. */
+function buildCountryInterestMap(): Map<string, Set<GreatPowerActor>> {
+  const out = new Map<string, Set<GreatPowerActor>>();
+  for (const [actor, countries] of Object.entries(GREAT_POWER_INTERESTS) as [GreatPowerActor, readonly string[]][]) {
+    for (const c of countries) {
+      if (!out.has(c)) out.set(c, new Set());
+      out.get(c)!.add(actor);
+    }
+  }
+  return out;
+}
+const COUNTRY_TO_ACTORS = buildCountryInterestMap();
+
+// ── Inputs ──────────────────────────────────────────────────────────────
+
+export interface SanctionsEntry {
+  date: string;
+  /** Sanctioning party (e.g. "United States", "EU"). */
+  sender: string;
+  /** Targeted country / entity. */
+  target: string;
+  summary: string;
+}
+
+export interface CyberIncident {
+  date: string;
+  /** Suspected attribution if any (free text). */
+  attribution?: string;
+  /** Targeted country / sector. */
+  target: string;
+  summary: string;
+  severity: GrayZoneSeverity;
+}
+
+export interface AcledLikeEvent {
+  date: string;
+  country: string;
+  actor1?: string;
+  actor2?: string;
+  /** Whether either actor is a non-state entity. */
+  hasNonStateActor: boolean;
+  summary: string;
+}
+
+export interface GdeltLikeArticle {
+  date: string;
+  /** CAMEO root code as a string (e.g. "172", "045"). */
+  cameoCode?: string;
+  /** Article country (location of event, not source). */
+  country?: string;
+  /** 7-day baseline volume on the same CAMEO code, in articles/day. */
+  baselineVolumePerDay?: number;
+  /** Today's volume on the same CAMEO code. */
+  observedVolumePerDay?: number;
+  title: string;
+  url?: string;
+}
+
+export interface InfrastructureKeywordHit {
+  date: string;
+  country: string;
+  /** Keyword that triggered the match (cable, pipeline, grid, etc.). */
+  keyword: string;
+  title: string;
+  url?: string;
+  /** Suspected attribution if the article names one. */
+  attribution?: string;
+}
+
+// ── Classifiers ────────────────────────────────────────────────────────
+
+export function classifySanctions(entry: SanctionsEntry): GrayZoneEvent {
+  const actor = normalizeActor(entry.sender);
+  return {
+    id: hashId('sanctions', entry.date, entry.sender, entry.target),
+    type: 'sanctions',
+    date: entry.date,
+    suspectedActor: actor,
+    targetCountry: entry.target,
+    confidence: 0.95, // sanctions are formally announced — high confidence on the fact + actor
+    evidence: [entry.summary],
+    severity: 'medium',
+    summary: `${entry.sender} sanctioned ${entry.target}`,
+  };
+}
+
+export function classifyCyber(incident: CyberIncident): GrayZoneEvent {
+  const actor = normalizeActor(incident.attribution ?? 'Unknown');
+  // Confidence depends on whether attribution is named explicitly.
+  const confidence = actor === 'Unknown' ? 0.4 : 0.75;
+  return {
+    id: hashId('cyber', incident.date, incident.attribution ?? '', incident.target),
+    type: 'cyber_attack',
+    date: incident.date,
+    suspectedActor: actor,
+    targetCountry: incident.target,
+    confidence,
+    evidence: [incident.summary],
+    severity: incident.severity,
+    summary: actor === 'Unknown'
+      ? `Cyber incident vs ${incident.target}`
+      : `Cyber incident vs ${incident.target} (suspected ${actor})`,
+  };
+}
+
+/** Map an ACLED event with a non-state actor to a great-power proxy
+ *  attribution via the interest map. Returns null when neither the
+ *  country nor the actors point to a great-power link. */
+export function classifyProxy(event: AcledLikeEvent): GrayZoneEvent | null {
+  if (!event.hasNonStateActor) return null;
+  const actors = COUNTRY_TO_ACTORS.get(event.country);
+  if (!actors || actors.size === 0) return null;
+  // Pick the first actor — when multiple powers contest the same
+  // country, the panel can split events by also filtering on actor1
+  // text. For attribution accuracy in this engine, we surface the
+  // first match and let downstream review tighten it.
+  const [actor] = actors;
+  return {
+    id: hashId('proxy', event.date, event.country, event.actor1 ?? '', event.actor2 ?? ''),
+    type: 'proxy_warfare',
+    date: event.date,
+    suspectedActor: actor!,
+    targetCountry: event.country,
+    confidence: 0.55, // attribution by interest map is heuristic — moderate confidence
+    evidence: [event.summary],
+    severity: 'medium',
+    summary: `Proxy-warfare event in ${event.country} (non-state actor; ${actor} interest)`,
+  };
+}
+
+/** GDELT CAMEO 17x = COERCE (sanctions, threats, …) and 18x = ASSAULT.
+ *  We treat 17x volume spikes >2σ above baseline as disinformation
+ *  signals. Returns null when no spike. */
+export function classifyDisinformation(article: GdeltLikeArticle): GrayZoneEvent | null {
+  const cameoRoot = (article.cameoCode ?? '').slice(0, 2);
+  if (cameoRoot !== '17') return null;
+  const baseline = article.baselineVolumePerDay ?? 0;
+  const observed = article.observedVolumePerDay ?? 0;
+  // 2σ proxy: assume Poisson; std ≈ sqrt(baseline). Trigger when
+  // observed >= baseline + 2*sqrt(baseline) and baseline >= 4 (so the
+  // sqrt isn't dominated by sampling noise).
+  if (baseline < 4) return null;
+  if (observed < baseline + 2 * Math.sqrt(baseline)) return null;
+  return {
+    id: hashId('disinfo', article.date, article.country ?? '', article.title),
+    type: 'disinformation',
+    date: article.date,
+    suspectedActor: 'Unknown',
+    targetCountry: article.country ?? 'Unknown',
+    confidence: 0.5,
+    evidence: article.url ? [article.title, article.url] : [article.title],
+    severity: 'medium',
+    summary: `Disinfo volume spike (${observed}/${baseline} baseline): ${article.title}`,
+  };
+}
+
+/** Detect economic-coercion mentions in news. Looks for trade
+ *  restriction terms in the article title. Returns null when no terms
+ *  match. */
+export function classifyEconomicCoercion(article: GdeltLikeArticle): GrayZoneEvent | null {
+  const title = article.title.toLowerCase();
+  const terms = ['export ban', 'export curb', 'tariff', 'trade restriction', 'rare earth ban', 'commodity ban', 'embargo'];
+  if (!terms.some((t) => title.includes(t))) return null;
+  return {
+    id: hashId('econ', article.date, article.country ?? '', article.title),
+    type: 'economic_coercion',
+    date: article.date,
+    suspectedActor: 'Unknown',
+    targetCountry: article.country ?? 'Unknown',
+    confidence: 0.6,
+    evidence: article.url ? [article.title, article.url] : [article.title],
+    severity: 'medium',
+    summary: `Economic coercion signal: ${article.title}`,
+  };
+}
+
+export function classifyInfrastructure(hit: InfrastructureKeywordHit): GrayZoneEvent {
+  const actor = normalizeActor(hit.attribution ?? 'Unknown');
+  return {
+    id: hashId('infra', hit.date, hit.country, hit.keyword, hit.title),
+    type: 'infrastructure_sabotage',
+    date: hit.date,
+    suspectedActor: actor,
+    targetCountry: hit.country,
+    confidence: actor === 'Unknown' ? 0.4 : 0.65,
+    evidence: hit.url ? [hit.title, hit.url] : [hit.title],
+    severity: 'high',
+    summary: `Infrastructure event (${hit.keyword}) in ${hit.country}: ${hit.title}`,
+  };
+}
+
+// ── Pattern detection ──────────────────────────────────────────────────
+
+const PATTERN_WINDOW_DAYS = 30;
+const PATTERN_MIN_EVENTS = 3;
+
+function groupEventsByActor(events: readonly GrayZoneEvent[]): Map<GreatPowerActor, GrayZoneEvent[]> {
+  const byActor = new Map<GreatPowerActor, GrayZoneEvent[]>();
+  for (const e of events) {
+    if (e.suspectedActor === 'Unknown') continue;
+    if (!byActor.has(e.suspectedActor)) byActor.set(e.suspectedActor, []);
+    byActor.get(e.suspectedActor)!.push(e);
+  }
+  return byActor;
+}
+
+function collectWindow(list: readonly GrayZoneEvent[], i: number): GrayZoneEvent[] {
+  const start = Date.parse(list[i]!.date);
+  const window: GrayZoneEvent[] = [];
+  for (let j = i; j < list.length; j += 1) {
+    const ageDays = (Date.parse(list[j]!.date) - start) / 86_400_000;
+    if (ageDays > PATTERN_WINDOW_DAYS) break;
+    window.push(list[j]!);
+  }
+  return window;
+}
+
+function buildPattern(actor: GreatPowerActor, window: GrayZoneEvent[], anchorId: string): GrayZonePattern {
+  const types = new Set(window.map((e) => e.type));
+  const actorSlug = actor.split(' ').join('-').toLowerCase();
+  return {
+    id: `pattern-${actorSlug}-${anchorId}`,
+    actors: [actor],
+    eventSequence: window.map((e) => e.id),
+    startDate: window[0]!.date,
+    endDate: window[window.length - 1]!.date,
+    interpretation: interpretPattern(actor, [...types]),
+  };
+}
+
+/** Group same-actor events within a 30-day rolling window. Returns one
+ *  GrayZonePattern per actor when ≥3 events fit the window. */
+export function detectPatterns(events: readonly GrayZoneEvent[]): GrayZonePattern[] {
+  const byActor = groupEventsByActor(events);
+  const patterns: GrayZonePattern[] = [];
+  for (const [actor, list] of byActor) {
+    list.sort((a, b) => Date.parse(a.date) - Date.parse(b.date));
+    let i = 0;
+    while (i < list.length) {
+      const window = collectWindow(list, i);
+      if (window.length >= PATTERN_MIN_EVENTS) {
+        patterns.push(buildPattern(actor, window, list[i]!.id));
+        i += window.length; // skip ahead — no overlapping windows
+      } else {
+        i += 1;
+      }
+    }
+  }
+  return patterns;
+}
+
+function interpretPattern(actor: GreatPowerActor, types: readonly GrayZoneEventType[]): string {
+  if (types.includes('cyber_attack') && types.includes('disinformation')) {
+    return `${actor}: combined cyber + influence ops within 30 days — typical hybrid playbook.`;
+  }
+  if (types.includes('sanctions') && types.includes('economic_coercion')) {
+    return `${actor}: sanctions + economic coercion sequence — sustained pressure campaign.`;
+  }
+  if (types.includes('proxy_warfare') && types.includes('infrastructure_sabotage')) {
+    return `${actor}: proxy + infrastructure — escalating sub-kinetic posture.`;
+  }
+  return `${actor}: ${types.length} activity types in 30 days — sustained gray-zone tempo.`;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function normalizeActor(raw: string): GreatPowerActor {
+  const s = raw.trim().toLowerCase();
+  if (s.includes('russia') || s.includes('kremlin')) return 'Russia';
+  if (s.includes('china') || s.includes('prc') || s === 'pla') return 'China';
+  if (s.includes('iran') || s.includes('irgc')) return 'Iran';
+  if (s.includes('north korea') || s.includes('dprk')) return 'North Korea';
+  if (s.includes('united states') || s === 'us' || s === 'u.s.' || s === 'usa') return 'United States';
+  return 'Unknown';
+}
+
+/** Tiny deterministic id from a tuple of strings. Not cryptographic;
+ *  just enough to dedupe the same event from two ingestion paths. */
+function hashId(...parts: string[]): string {
+  let h = 0;
+  for (const p of parts) {
+    for (let i = 0; i < p.length; i += 1) {
+      h = Math.trunc(h * 31 + (p.codePointAt(i) ?? 0));
+    }
+  }
+  return `gz-${(h >>> 0).toString(36)}`;
+}
+
+// ── Top-level summary helper ────────────────────────────────────────────
+
+export interface ActorSummary {
+  actor: GreatPowerActor;
+  eventCount: number;
+  byType: Record<GrayZoneEventType, number>;
+  earliestDate: string | null;
+  latestDate: string | null;
+  topTargets: string[];
+}
+
+/** Roll up events for a specific actor for the /api/grayzone-summary
+ *  endpoint. Pure. */
+export function summarizeActor(actor: GreatPowerActor, events: readonly GrayZoneEvent[]): ActorSummary {
+  const filtered = events.filter((e) => e.suspectedActor === actor);
+  const byType: Record<GrayZoneEventType, number> = {
+    sanctions: 0, cyber_attack: 0, proxy_warfare: 0,
+    disinformation: 0, economic_coercion: 0, infrastructure_sabotage: 0,
+  };
+  const targetCounts = new Map<string, number>();
+  let earliestMs = Number.POSITIVE_INFINITY;
+  let latestMs = Number.NEGATIVE_INFINITY;
+  for (const e of filtered) {
+    byType[e.type] += 1;
+    targetCounts.set(e.targetCountry, (targetCounts.get(e.targetCountry) ?? 0) + 1);
+    const ms = Date.parse(e.date);
+    if (Number.isFinite(ms)) {
+      if (ms < earliestMs) earliestMs = ms;
+      if (ms > latestMs) latestMs = ms;
+    }
+  }
+  const topTargets = [...targetCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 5).map(([t]) => t);
+  return {
+    actor,
+    eventCount: filtered.length,
+    byType,
+    earliestDate: Number.isFinite(earliestMs) ? new Date(earliestMs).toISOString() : null,
+    latestDate: Number.isFinite(latestMs) ? new Date(latestMs).toISOString() : null,
+    topTargets,
+  };
+}


### PR DESCRIPTION
Classifies sub-kinetic great-power conflict from existing data streams. **No new data ingestion** — engine accepts pre-normalised inputs from existing feeds (OpenSanctions, CISA, ACLED, GDELT).

## Files
- src/services/geopolitics/grayzone-classifier.ts (engine)
- src/services/geopolitics/__tests__/grayzone-classifier.test.mts (23 tests)
- package.json (test:geopolitics)

## 6 event types
- sanctions / cyber_attack / proxy_warfare / disinformation / economic_coercion / infrastructure_sabotage

## Attribution heuristics
- **Static** GREAT_POWER_INTERESTS map (Russia/China/Iran/North Korea/United States). Reviewed 2026-05-05; geopolitics changes slowly enough that hardcoded + PR review > silent dynamic feed.
- normalizeActor handles aliases (Kremlin → Russia, PRC/PLA → China, IRGC → Iran, DPRK → North Korea).
- Sanctions: 0.95 (formally announced). Named cyber attribution: 0.75. Unnamed cyber: 0.4.
- Disinfo: 2σ spike on GDELT CAMEO 17x with baseline ≥ 4 to avoid noise.

## Patterns
- detectPatterns: ≥3 same-actor events in a 30-day rolling window
- Interpretations: cyber+disinfo → 'hybrid playbook', sanctions+econ → 'sustained pressure', proxy+infra → 'escalating sub-kinetic'

## Validation
- npm run test:geopolitics: 23/23
- npm run typecheck:all: clean
- eslint clean

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>