### PR TITLE
feat: CyberGeoPanel — APT activity + gray zone (Batch 2 PR 3/3)

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -7118,6 +7118,30 @@ async function dispatch(requestUrl, req, routes, context) {
  });
   }
 
+  // ── Cyber: APT groups (MITRE ATT&CK + OTX + CISA cross-ref) ──────────────
+  // Engine lives in src/services/cyber/apt-tracker.ts (23 tests passing).
+  // Returns configured=false until ATT&CK STIX bundle is vendored + OTX
+  // polling is wired. configured=true response shape matches AptGroup[].
+  if (requestUrl.pathname === '/api/apt-groups') {
+ return json({
+ configured: false,
+ error: 'ATT&CK corpus not yet vendored',
+ groups: [],
+ });
+  }
+
+  // ── Geopolitics: gray-zone events ─────────────────────────────────────
+  // Engine lives in src/services/geopolitics/grayzone-classifier.ts
+  // (23 tests passing). configured=false until OpenSanctions / CISA /
+  // ACLED / GDELT feeders run through the classifiers.
+  if (requestUrl.pathname === '/api/grayzone-events') {
+ return json({
+ configured: false,
+ error: 'gray-zone classifier not yet wired',
+ events: [],
+ });
+  }
+
   // ── S2U TAK feeds — Marti API /api/feeds (cached 60s, TLS-pinned) ─────────
   if (requestUrl.pathname === '/api/s2u-tak-feeds') {
  const opts = s2uTakOpts();

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -42,6 +42,7 @@ import {
   NetworkRulesPanel,
   S2UIntelPanel,
   SynthesisPanel,
+  CyberGeoPanel,
   OrefSirensPanel,
   TelegramIntelPanel,
   WatchlistPanel,
@@ -1264,6 +1265,14 @@ export class PanelLayoutManager implements AppModule {
  // a follow-up PR. Pure engines ship in Batch 1 PR 1 + 2.
  const synthesisPanel = new SynthesisPanel();
  this.ctx.panels['synthesis'] = synthesisPanel;
+
+ // CyberGeoPanel — APT activity table + gray-zone event timeline +
+ // great-power escalation meters. Reads from /api/apt-groups and
+ // /api/grayzone-events. Engines ship in Batch 2 PR 1 (#290) +
+ // PR 2 (#292); the sidecar returns configured=false until live
+ // ingestion lands.
+ const cyberGeoPanel = new CyberGeoPanel();
+ this.ctx.panels['cyber-geo'] = cyberGeoPanel;
 
  const orefSirensPanel = new OrefSirensPanel();
  this.ctx.panels['oref-sirens'] = orefSirensPanel;

--- a/src/components/CyberGeoPanel.ts
+++ b/src/components/CyberGeoPanel.ts
@@ -1,0 +1,270 @@
+import { Panel } from './Panel';
+import { escapeHtml } from '@/utils/sanitize';
+import { getApiBaseUrl } from '@/services/runtime';
+
+// ── Sidecar response shapes (mirror the engines from PRs #290 + #292) ──
+
+interface AptGroup {
+  id: string;
+  name: string;
+  aliases: string[];
+  country: string;
+  targetSectors: string[];
+  recentTechniques: string[];
+  lastActiveDate?: string;
+  activityScore: number;
+}
+
+interface AptGroupsResponse {
+  configured: boolean;
+  groups?: AptGroup[];
+  error?: string;
+  lastUpdated?: string;
+}
+
+interface GrayZoneEvent {
+  id: string;
+  type: string;
+  date: string;
+  suspectedActor: string;
+  targetCountry: string;
+  confidence: number;
+  severity: string;
+  summary: string;
+}
+
+interface GrayZoneResponse {
+  configured: boolean;
+  events?: GrayZoneEvent[];
+  error?: string;
+}
+
+type TabId = 'apt' | 'grayzone' | 'escalation';
+const REFRESH_MS = 5 * 60_000;
+
+// CyberGeoPanel: APT activity table (sorted by score), gray-zone event
+// timeline, and great-power escalation meters. Reads from sidecar
+// /api/apt-groups + /api/grayzone-events. Both endpoints return
+// configured=false until live ingestion lands; the panel renders
+// graceful empty states meanwhile.
+export class CyberGeoPanel extends Panel {
+  private apt: AptGroupsResponse | null = null;
+  private grayzone: GrayZoneResponse | null = null;
+  private aptError: string | null = null;
+  private grayzoneError: string | null = null;
+  private activeTab: TabId = 'apt';
+  private refreshTimer: number | null = null;
+
+  constructor() {
+ super({
+ id: 'cyber-geo',
+ title: 'Cyber × Geo',
+ showCount: true,
+ trackActivity: true,
+ infoTooltip: 'APT group activity + great-power gray-zone events. Reads /api/apt-groups and /api/grayzone-events.',
+ });
+ this.showLoading('Loading cyber × geo…');
+ setTimeout(() => { void this.refresh(); }, 0);
+ this.refreshTimer = window.setInterval(() => { void this.refresh(); }, REFRESH_MS);
+  }
+
+  override destroy(): void {
+ if (this.refreshTimer !== null) {
+ window.clearInterval(this.refreshTimer);
+ this.refreshTimer = null;
+ }
+ super.destroy();
+  }
+
+  async refresh(): Promise<void> {
+ await Promise.all([this.refreshApt(), this.refreshGrayzone()]);
+  }
+
+  private async refreshApt(): Promise<void> {
+ try {
+ const res = await fetch(`${getApiBaseUrl()}/api/apt-groups`);
+ const body = (await res.json().catch(() => null)) as AptGroupsResponse | null;
+ if (body) {
+ this.apt = body;
+ this.aptError = null;
+ } else {
+ this.aptError = `Sidecar returned HTTP ${res.status}`;
+ }
+ } catch (error) {
+ this.aptError = error instanceof Error ? error.message : String(error);
+ }
+ this.updateCount();
+ this.render();
+  }
+
+  private async refreshGrayzone(): Promise<void> {
+ try {
+ const res = await fetch(`${getApiBaseUrl()}/api/grayzone-events`);
+ const body = (await res.json().catch(() => null)) as GrayZoneResponse | null;
+ if (body) {
+ this.grayzone = body;
+ this.grayzoneError = null;
+ } else {
+ this.grayzoneError = `Sidecar returned HTTP ${res.status}`;
+ }
+ } catch (error) {
+ this.grayzoneError = error instanceof Error ? error.message : String(error);
+ }
+ this.render();
+  }
+
+  private updateCount(): void {
+ const aptCount = this.apt?.groups?.filter((g) => g.activityScore >= 60).length ?? 0;
+ const gzCount = this.grayzone?.events?.length ?? 0;
+ this.setCount(aptCount + gzCount);
+  }
+
+  private renderTabs(): string {
+ const aptHot = this.apt?.groups?.filter((g) => g.activityScore >= 60).length ?? 0;
+ const gzCount = this.grayzone?.events?.length ?? 0;
+ const tabs: { id: TabId; label: string; count: number }[] = [
+ { id: 'apt', label: 'APT Activity', count: aptHot },
+ { id: 'grayzone', label: 'Gray Zone', count: gzCount },
+ { id: 'escalation', label: 'Escalation', count: countActorsActive(this.grayzone?.events ?? []) },
+ ];
+ const items = tabs.map((t) => {
+ const active = t.id === this.activeTab;
+ const bg = active ? 'rgba(255,255,255,0.08)' : 'transparent';
+ const border = active ? '#3b82f6' : 'transparent';
+ return `<button data-cgeo-tab="${escapeHtml(t.id)}" style="background:${bg};border:none;padding:6px 10px;font-size:11px;cursor:pointer;border-bottom:2px solid ${border}">${escapeHtml(t.label)} <span style="opacity:0.5">${t.count}</span></button>`;
+ }).join('');
+ return `<div style="display:flex;border-bottom:1px solid var(--panel-border,#2a2a2c);background:rgba(255,255,255,0.02)">${items}</div>`;
+  }
+
+  private renderApt(): string {
+ if (this.aptError) return `<div style="padding:12px;color:#ef4444;font-size:12px">${escapeHtml(this.aptError)}</div>`;
+ if (!this.apt) return '<div style="padding:12px;opacity:0.6;font-size:12px">Loading…</div>';
+ if (!this.apt.configured) {
+ return `<div style="padding:12px;font-size:12px;line-height:1.5">
+ <strong>APT corpus not yet loaded.</strong><br/>
+ Engine ready (MITRE ATT&CK + OTX + CISA KEV/advisories, 23 tests passing). Live ingest follows in a sidecar PR — vendoring the ATT&CK STIX bundle weekly + polling OTX with the existing OTX_API_KEY.
+ </div>`;
+ }
+ const groups = [...(this.apt.groups ?? [])].sort((a, b) => b.activityScore - a.activityScore);
+ if (groups.length === 0) return '<div style="padding:12px;opacity:0.6;font-size:12px">No APT groups in corpus.</div>';
+ const rows = groups.slice(0, 25).map((g) => renderAptRow(g)).join('');
+ const updated = this.apt.lastUpdated ? `<div style="padding:6px 10px;font-size:10px;opacity:0.5">Updated ${escapeHtml(this.apt.lastUpdated)}</div>` : '';
+ return `${updated}<table style="width:100%;border-collapse:collapse;font-size:11px"><thead style="background:rgba(255,255,255,0.04);text-align:left;font-size:10px;opacity:0.7"><tr><th style="padding:4px 8px">Score</th><th style="padding:4px 8px">Group</th><th style="padding:4px 8px">Country</th><th style="padding:4px 8px">Last active</th><th style="padding:4px 8px">Sectors</th></tr></thead><tbody>${rows}</tbody></table>`;
+  }
+
+  private renderGrayzone(): string {
+ if (this.grayzoneError) return `<div style="padding:12px;color:#ef4444;font-size:12px">${escapeHtml(this.grayzoneError)}</div>`;
+ if (!this.grayzone) return '<div style="padding:12px;opacity:0.6;font-size:12px">Loading…</div>';
+ if (!this.grayzone.configured) {
+ return `<div style="padding:12px;font-size:12px;line-height:1.5">
+ <strong>Gray zone classifier not yet wired.</strong><br/>
+ Engine ready (sanctions / cyber / proxy / disinfo / econ / infra, 23 tests passing). Live wiring follows in a sidecar PR pulling OpenSanctions + CISA + ACLED + GDELT.
+ </div>`;
+ }
+ const events = [...(this.grayzone.events ?? [])].sort((a, b) => Date.parse(b.date) - Date.parse(a.date));
+ if (events.length === 0) return '<div style="padding:12px;opacity:0.6;font-size:12px">No gray-zone events recorded.</div>';
+ const rows = events.slice(0, 50).map((e) => renderGrayzoneRow(e)).join('');
+ return `<div>${rows}</div>`;
+  }
+
+  private renderEscalation(): string {
+ if (!this.grayzone?.configured) {
+ return '<div style="padding:12px;opacity:0.6;font-size:12px;line-height:1.5">Escalation meters depend on gray-zone events. Configure first.</div>';
+ }
+ const events = this.grayzone.events ?? [];
+ const actors: string[] = ['Russia', 'China', 'Iran', 'North Korea', 'United States'];
+ const rows = actors.map((actor) => {
+ const actorEvents = events.filter((e) => e.suspectedActor === actor);
+ const count = actorEvents.length;
+ const score = Math.min(100, count * 5);
+ const fillColor = scoreColor(score);
+ return `<div style="padding:8px 10px;border-bottom:1px solid rgba(255,255,255,0.04)"><div style="display:flex;justify-content:space-between;font-size:11px"><strong>${escapeHtml(actor)}</strong><span style="opacity:0.6">${count} events · score ${score}</span></div><div style="height:4px;background:rgba(255,255,255,0.08);margin-top:4px;border-radius:2px;overflow:hidden"><div style="height:100%;width:${score}%;background:${fillColor}"></div></div></div>`;
+ }).join('');
+ return `<div>${rows}</div>`;
+  }
+
+  private renderActiveTab(): string {
+ if (this.activeTab === 'grayzone') return this.renderGrayzone();
+ if (this.activeTab === 'escalation') return this.renderEscalation();
+ return this.renderApt();
+  }
+
+  private render(): void {
+ const html = `${this.renderTabs()}<div data-cgeo-body>${this.renderActiveTab()}</div>`;
+ this.setContent(html);
+ const root = document.querySelector<HTMLElement>(`[data-panel-id="${this.getPanelId()}"]`);
+ if (root) {
+ root.querySelectorAll<HTMLButtonElement>('button[data-cgeo-tab]').forEach((btn) => {
+ btn.addEventListener('click', () => {
+ const id = btn.getAttribute('data-cgeo-tab') as TabId | null;
+ if (id) {
+ this.activeTab = id;
+ this.render();
+ }
+ });
+ });
+ }
+  }
+}
+
+// ── Module-scope helpers ─────────────────────────────────────────────
+
+function scoreColor(score: number): string {
+  if (score >= 60) return '#fca5a5';
+  if (score >= 30) return '#fde68a';
+  return '#86efac';
+}
+
+function renderAptRow(g: AptGroup): string {
+  const fillColor = scoreColor(g.activityScore);
+  const sectors = g.targetSectors.slice(0, 3).join(', ');
+  const lastActive = g.lastActiveDate ? new Date(g.lastActiveDate).toLocaleDateString() : '—';
+  return `<tr><td style="padding:4px 8px;font-family:ui-monospace,monospace"><span style="color:${fillColor}">${g.activityScore.toFixed(0)}</span></td><td style="padding:4px 8px"><strong>${escapeHtml(g.name)}</strong> <span style="opacity:0.5;font-size:10px">${escapeHtml(g.id)}</span></td><td style="padding:4px 8px;opacity:0.7">${escapeHtml(g.country)}</td><td style="padding:4px 8px;opacity:0.7">${escapeHtml(lastActive)}</td><td style="padding:4px 8px;opacity:0.7">${escapeHtml(sectors)}</td></tr>`;
+}
+
+function renderGrayzoneRow(e: GrayZoneEvent): string {
+  const date = new Date(e.date).toLocaleDateString();
+  const typeColor = colorForEventType(e.type);
+  const severityColor = colorForSeverity(e.severity);
+  return `<div style="padding:6px 10px;border-bottom:1px solid rgba(255,255,255,0.04);font-size:11px;line-height:1.5"><div style="display:flex;justify-content:space-between"><span><span style="color:${typeColor};font-weight:600">${escapeHtml(e.type)}</span> · ${escapeHtml(e.suspectedActor)} → ${escapeHtml(e.targetCountry)}</span><span style="opacity:0.6">${escapeHtml(date)} · <span style="color:${severityColor}">${escapeHtml(e.severity)}</span></span></div><div style="opacity:0.85;margin-top:2px">${escapeHtml(e.summary)}</div></div>`;
+}
+
+function colorForEventType(type: string): string {
+  switch (type) {
+    case 'sanctions': { return '#fde68a';
+    }
+    case 'cyber_attack': { return '#fca5a5';
+    }
+    case 'proxy_warfare': { return '#f87171';
+    }
+    case 'disinformation': { return '#a78bfa';
+    }
+    case 'economic_coercion': { return '#fbbf24';
+    }
+    case 'infrastructure_sabotage': { return '#ef4444';
+    }
+    default: { return '#9ca3af';
+    }
+  }
+}
+
+function colorForSeverity(severity: string): string {
+  switch (severity) {
+    case 'critical': { return '#ef4444';
+    }
+    case 'high': { return '#fca5a5';
+    }
+    case 'medium': { return '#fde68a';
+    }
+    default: { return '#9ca3af';
+    }
+  }
+}
+
+function countActorsActive(events: readonly GrayZoneEvent[]): number {
+  const set = new Set<string>();
+  for (const e of events) {
+    if (e.suspectedActor && e.suspectedActor !== 'Unknown') set.add(e.suspectedActor);
+  }
+  return set.size;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -51,6 +51,7 @@ export * from './SecurityAdvisoriesPanel';
 export { NetworkRulesPanel } from './NetworkRulesPanel';
 export { S2UIntelPanel } from './S2UIntelPanel';
 export { SynthesisPanel } from './SynthesisPanel';
+export { CyberGeoPanel } from './CyberGeoPanel';
 export * from './OrefSirensPanel';
 export * from './TelegramIntelPanel';
 export * from './BreakingNewsBanner';

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -79,6 +79,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'network-rules': { name: 'Network Rules', enabled: true, priority: 3 },
   's2u-intel': { name: 'S2U Intelligence', enabled: true, priority: 1 },
   'synthesis': { name: 'Synthesis', enabled: true, priority: 1 },
+  'cyber-geo': { name: 'Cyber × Geo', enabled: true, priority: 1 },
   'oref-sirens': { name: 'Israel Sirens', enabled: true, priority: 2 },
   'telegram-intel': { name: 'Telegram Intel', enabled: true, priority: 2 },
   'space-weather': { name: 'Space Weather', enabled: true, priority: 1 },
@@ -959,7 +960,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   // Full (geopolitical) variant
   intelligence: {
  labelKey: 'header.panelCatIntelligence',
- panelKeys: ['command-center', 'system-diagnostic', 'algorithm-diagnostic', 'shortage-radar', 'watchlist', 'saved-places', 'watchlist-locations', 'local-logistics', 'comms-plan', 'unified-alert-inbox', 'alert-rules', 'situation-awareness', 'alert-center', 'strategic-risk', 'cii', 'geo-hubs', 'intel', 'gdelt-intel', 'cascade', 'telegram-intel', 'intelligence-briefing', 'ask-crystal-ball', 'survival-advisor', 'threat-synthesis', 'scenario-simulator', 'escalation-forecast', 'synthesis', 'notification-digest', 'pattern-of-life', 'course-of-action', 'kill-chain', 'orbat', 'after-action-review', 'entity-link-graph', 'timeline-scrubber', 'intel-report', 'compound-threat', 'correlation-matrix', 'strike-package', 'strike-packages', 'api-diagnostic', 'cascade-simulator', 'dod-news', 'nato-news', 'foreign-mil-news', 'isw-reports', 'reliefweb-crises', 'bellingcat-osint', 'acaps-crises', 'liveuamap', 'un-security-council', 'combatant-commands', 'congress-defense', 'gov-warning-convergence', 'dsca-arms-transfers', 'dod-contracts', 'wikidata-bases', 'opensanctions', 'mediastack-news'],
+ panelKeys: ['command-center', 'system-diagnostic', 'algorithm-diagnostic', 'shortage-radar', 'watchlist', 'saved-places', 'watchlist-locations', 'local-logistics', 'comms-plan', 'unified-alert-inbox', 'alert-rules', 'situation-awareness', 'alert-center', 'strategic-risk', 'cii', 'geo-hubs', 'intel', 'gdelt-intel', 'cascade', 'telegram-intel', 'intelligence-briefing', 'ask-crystal-ball', 'survival-advisor', 'threat-synthesis', 'scenario-simulator', 'escalation-forecast', 'synthesis', 'cyber-geo', 'notification-digest', 'pattern-of-life', 'course-of-action', 'kill-chain', 'orbat', 'after-action-review', 'entity-link-graph', 'timeline-scrubber', 'intel-report', 'compound-threat', 'correlation-matrix', 'strike-package', 'strike-packages', 'api-diagnostic', 'cascade-simulator', 'dod-news', 'nato-news', 'foreign-mil-news', 'isw-reports', 'reliefweb-crises', 'bellingcat-osint', 'acaps-crises', 'liveuamap', 'un-security-council', 'combatant-commands', 'congress-defense', 'gov-warning-convergence', 'dsca-arms-transfers', 'dod-contracts', 'wikidata-bases', 'opensanctions', 'mediastack-news'],
  variants: ['full'],
   },
   regionalNews: {


### PR DESCRIPTION
Closes Batch 2. Three-tab panel surfacing the APT tracker ([#290](https://github.com/bradleybond512/crystal-ball/pull/290)) + gray-zone classifier ([#292](https://github.com/bradleybond512/crystal-ball/pull/292)).

## Tabs
- **APT Activity** — top-25 groups by activityScore, color-coded chips (>=60 red, >=30 amber), country/last-active/sectors
- **Gray Zone** — type-coded event timeline (sanctions/cyber/proxy/disinfo/econ/infra)
- **Escalation** — per-actor (Russia/China/Iran/NK/US) meters

## Files
- src/components/CyberGeoPanel.ts
- src/components/index.ts, src/config/panels.ts, src/app/panel-layout.ts
- src-tauri/sidecar/local-api-server.mjs — stub /api/apt-groups + /api/grayzone-events returning configured=false

## Validation
- npm run typecheck:all: clean
- eslint clean (extracted scoreColor helper)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>