### PR TITLE
feat: OFR FSI + Commodity Stress monitor (Batch 3 PR 1/3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "test:synthesis": "tsx --test src/services/synthesis/__tests__/precedent-matcher.test.mts src/services/synthesis/__tests__/leading-indicators.test.mts",
     "test:cyber": "tsx --test src/services/cyber/__tests__/apt-tracker.test.mts",
     "test:geopolitics": "tsx --test src/services/geopolitics/__tests__/grayzone-classifier.test.mts",
+    "test:finance": "tsx --test src/services/finance/__tests__/stress-monitor.test.mts",
     "test:panels:smoke": "node tests/panels/run-harness.mjs",
     "test:panels:fixtures": "tsx --import ./tests/panels/register-hook.mjs --test tests/panels/panel-fixtures.test.mts",
     "test:strategic-self-improvement": "tsx --test src/services/diagnostics/__tests__/failure-prediction.test.mts src/services/governance/__tests__/policy-engine.test.mts src/services/governance/__tests__/model-governance.test.mts src/services/experiments/__tests__/experiment-manager.test.mts src/services/ops/__tests__/causal-attribution.test.mts src/services/ops/__tests__/trust-budget.test.mts src/services/ops/__tests__/playbook-engine.test.mts src/services/scenarios/__tests__/scenario-library.test.mts src/services/personal/__tests__/resilience-model.test.mts src/services/quality/__tests__/quality-debt.test.mts src/services/quality/__tests__/self-improvement-scheduler.test.mts",

--- a/src/services/finance/__tests__/stress-monitor.test.mts
+++ b/src/services/finance/__tests__/stress-monitor.test.mts
@@ -1,0 +1,187 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  FSI_THRESHOLDS,
+  buildCommodityAlert,
+  buildFsiAlert,
+  mean,
+  rankCommodityAlerts,
+  riskTierForDeviation,
+  sigmaDeviation,
+  stdev,
+  tierForFsi,
+  trendSign,
+  type CommodityObservation,
+  type CommoditySeries,
+} from '../stress-monitor.ts';
+
+const ISO = (y: number, m: number) => new Date(Date.UTC(y, m - 1, 1)).toISOString();
+
+// ── FSI tiering ────────────────────────────────────────────────────────
+
+test('tierForFsi: bands match documented thresholds', () => {
+  assert.equal(tierForFsi(0), 'normal');
+  assert.equal(tierForFsi(FSI_THRESHOLDS.elevated), 'elevated');
+  assert.equal(tierForFsi(FSI_THRESHOLDS.severe), 'severe');
+  assert.equal(tierForFsi(-FSI_THRESHOLDS.elevated), 'low');
+  assert.equal(tierForFsi(Number.NaN), 'normal');
+});
+
+test('buildFsiAlert: writes tier + a tier-specific message', () => {
+  const a = buildFsiAlert({ date: ISO(2026, 4), index: 3.2 });
+  assert.equal(a.tier, 'severe');
+  assert.match(a.message, /severe/);
+  const b = buildFsiAlert({ date: ISO(2026, 4), index: 0.5 });
+  assert.equal(b.tier, 'normal');
+});
+
+// ── mean / stdev / sigmaDeviation ─────────────────────────────────────
+
+test('mean: ignores NaN, NaN on empty', () => {
+  assert.equal(mean([1, 2, 3]), 2);
+  assert.equal(mean([1, Number.NaN, 3]), 2);
+  assert.ok(Number.isNaN(mean([])));
+});
+
+test('stdev: known small dataset', () => {
+  // [1, 2, 3, 4, 5] → mean 3, variance 2.5, sd ≈ 1.5811
+  const sd = stdev([1, 2, 3, 4, 5]);
+  assert.ok(Math.abs(sd - 1.5811388300841898) < 1e-9);
+});
+
+test('stdev: NaN for n<2', () => {
+  assert.ok(Number.isNaN(stdev([1])));
+});
+
+test('sigmaDeviation: 2σ above mean returns ~2', () => {
+  // window = [10,12,14,16,18] mean=14 sd≈3.162; current=20 → (20-14)/3.162 ≈ 1.897
+  const sigma = sigmaDeviation(20, [10, 12, 14, 16, 18]);
+  assert.ok(Math.abs(sigma - 1.8973665961010275) < 1e-9);
+});
+
+test('sigmaDeviation: zero stdev returns 0 (no signal)', () => {
+  assert.equal(sigmaDeviation(5, [3, 3, 3]), 0);
+});
+
+// ── trendSign ─────────────────────────────────────────────────────────
+
+test('trendSign: monotonic increase → rising', () => {
+  const obs: CommodityObservation[] = [
+    { date: ISO(2026, 1), price: 100 },
+    { date: ISO(2026, 2), price: 110 },
+    { date: ISO(2026, 3), price: 125 },
+  ];
+  assert.equal(trendSign(obs), 'rising');
+});
+
+test('trendSign: monotonic decrease → falling', () => {
+  const obs: CommodityObservation[] = [
+    { date: ISO(2026, 1), price: 100 },
+    { date: ISO(2026, 2), price: 95 },
+    { date: ISO(2026, 3), price: 88 },
+  ];
+  assert.equal(trendSign(obs), 'falling');
+});
+
+test('trendSign: flat within 1% → stable', () => {
+  const obs: CommodityObservation[] = [
+    { date: ISO(2026, 1), price: 100 },
+    { date: ISO(2026, 2), price: 100.2 },
+    { date: ISO(2026, 3), price: 99.9 },
+  ];
+  assert.equal(trendSign(obs), 'stable');
+});
+
+// ── riskTierForDeviation ──────────────────────────────────────────────
+
+test('riskTierForDeviation: ladder', () => {
+  assert.equal(riskTierForDeviation(0.5, 0.5), 'low');
+  assert.equal(riskTierForDeviation(1.5, 0.5), 'medium');
+  assert.equal(riskTierForDeviation(2.5, 0.5), 'high');
+  assert.equal(riskTierForDeviation(3.5, 0.5), 'critical');
+});
+
+test('riskTierForDeviation: takes max of |d12|, |d24|', () => {
+  // d12 small, d24 huge → tier should reflect the big one.
+  assert.equal(riskTierForDeviation(0.1, -3.5), 'critical');
+});
+
+// ── buildCommodityAlert ──────────────────────────────────────────────
+
+function flatSeries(price: number, n: number): CommoditySeries {
+  return {
+    commodity: 'wheat',
+    unit: 'USD/MT',
+    observations: Array.from({ length: n }, (_, i) => ({
+      date: ISO(2024, ((i % 12) + 1)),
+      price,
+    })),
+  };
+}
+
+test('buildCommodityAlert: too few observations → null', () => {
+  const series: CommoditySeries = {
+    commodity: 'wheat', unit: 'USD/MT',
+    observations: [{ date: ISO(2026, 1), price: 200 }],
+  };
+  assert.equal(buildCommodityAlert(series), null);
+});
+
+test('buildCommodityAlert: 12 flat then a 2σ spike → high tier', () => {
+  const obs: CommodityObservation[] = Array.from({ length: 13 }, (_, i) => ({
+    date: ISO(2025, i + 1),
+    // 12 flat at 200 plus a current observation at 240 — that's the
+    // "current" in obs[12]. window12 picks obs[0..11] (mean 200, sd 0).
+    // Stdev=0 → sigmaDeviation returns 0 by design. To exercise the
+    // alert path we add some natural variation.
+    price: i < 12 ? (200 + (i % 3) * 2) : 240,
+  }));
+  const series: CommoditySeries = { commodity: 'wheat', unit: 'USD/MT', observations: obs };
+  const alert = buildCommodityAlert(series);
+  assert.ok(alert);
+  assert.equal(alert!.commodity, 'wheat');
+  assert.ok(alert!.deviation12mSigma > 2, `12m σ = ${alert!.deviation12mSigma} should be > 2`);
+  assert.ok(alert!.overallRisk === 'high' || alert!.overallRisk === 'critical');
+});
+
+test('buildCommodityAlert: 12 flat at constant → low tier (zero sigma)', () => {
+  const series = flatSeries(200, 13);
+  const alert = buildCommodityAlert(series);
+  assert.ok(alert);
+  assert.equal(alert!.deviation12mSigma, 0);
+  assert.equal(alert!.overallRisk, 'low');
+});
+
+// ── rankCommodityAlerts ──────────────────────────────────────────────
+
+test('rankCommodityAlerts: critical before high before medium before low', () => {
+  const make = (commodity: 'wheat' | 'oil' | 'gold' | 'rice', d12: number, tier: 'low' | 'medium' | 'high' | 'critical') => ({
+    commodity, unit: 'x', currentPrice: 1, deviation12mSigma: d12, deviation24mSigma: 0,
+    trend: 'stable' as const, overallRisk: tier, message: '',
+  });
+  const ranked = rankCommodityAlerts([
+    make('wheat', 0.2, 'low'),
+    make('oil', 3.5, 'critical'),
+    make('gold', 1.2, 'medium'),
+    make('rice', 2.5, 'high'),
+  ]);
+  assert.deepEqual(ranked.map((a) => a.commodity), ['oil', 'rice', 'gold', 'wheat']);
+});
+
+test('rankCommodityAlerts: same tier breaks ties by |12m σ|', () => {
+  const make = (c: 'wheat' | 'rice', d12: number) => ({
+    commodity: c, unit: 'x', currentPrice: 1, deviation12mSigma: d12, deviation24mSigma: 0,
+    trend: 'stable' as const, overallRisk: 'high' as const, message: '',
+  });
+  const ranked = rankCommodityAlerts([make('wheat', 2.1), make('rice', 2.9)]);
+  assert.equal(ranked[0]!.commodity, 'rice');
+});
+
+// ── JSON serializability ─────────────────────────────────────────────
+
+test('alerts are JSON-serializable', () => {
+  const a = buildFsiAlert({ date: ISO(2026, 4), index: 2 });
+  const round = structuredClone(a);
+  assert.equal(round.tier, a.tier);
+});

--- a/src/services/finance/stress-monitor.ts
+++ b/src/services/finance/stress-monitor.ts
@@ -1,0 +1,234 @@
+/**
+ * Financial Stress + Commodity Stress monitor — per Batch 3 of the
+ * economic-intel plan.
+ *
+ * Pure deterministic engine. Accepts pre-fetched series from OFR FSI
+ * and World Bank commodity prices, normalises into typed alerts +
+ * stress scores. Sidecar fetcher is a follow-up.
+ *
+ * Plan invariants:
+ *   - Pure functions are unit-testable on static fixtures.
+ *   - Alert thresholds are constants (FSI > 1.5 elevated, > 3.0 severe)
+ *     so the user sees consistent labels across builds.
+ *   - Commodity stress uses 12-month + 24-month standard-deviation
+ *     bands — surfaces deviation, not absolute price, so it works
+ *     across goods with very different scales.
+ */
+
+// ── Public types ───────────────────────────────────────────────────────
+
+export type FsiTier = 'low' | 'normal' | 'elevated' | 'severe';
+
+export interface FsiObservation {
+  /** ISO 8601 (date or datetime). */
+  date: string;
+  index: number;
+  /** Optional component breakdown the OFR API returns. */
+  components?: Readonly<Record<string, number>>;
+}
+
+export interface FsiAlert {
+  date: string;
+  index: number;
+  tier: FsiTier;
+  message: string;
+}
+
+export type CommodityKey =
+  | 'wheat' | 'rice' | 'oil' | 'natural_gas' | 'fertilizer'
+  | 'corn' | 'soybeans' | 'gold';
+
+export interface CommodityObservation {
+  /** ISO 8601 (typically a month boundary). */
+  date: string;
+  price: number;
+}
+
+export interface CommoditySeries {
+  commodity: CommodityKey;
+  /** Monthly observations in chronological order. */
+  observations: readonly CommodityObservation[];
+  /** Display unit ("USD/MT", "USD/bbl", …). */
+  unit: string;
+}
+
+export type CommodityRiskTier = 'low' | 'medium' | 'high' | 'critical';
+
+export interface CommodityAlert {
+  commodity: CommodityKey;
+  unit: string;
+  /** Most recent observed price. */
+  currentPrice: number;
+  /** σ-deviation against the trailing 12-month series. */
+  deviation12mSigma: number;
+  /** σ-deviation against the trailing 24-month series. */
+  deviation24mSigma: number;
+  /** "rising" / "falling" / "stable" — derived from 3-month slope sign. */
+  trend: 'rising' | 'falling' | 'stable';
+  overallRisk: CommodityRiskTier;
+  message: string;
+}
+
+// ── FSI tiering ────────────────────────────────────────────────────────
+
+export const FSI_THRESHOLDS = {
+  elevated: 1.5,
+  severe: 3,
+} as const;
+
+export function tierForFsi(index: number): FsiTier {
+  if (!Number.isFinite(index)) return 'normal';
+  if (index >= FSI_THRESHOLDS.severe) return 'severe';
+  if (index >= FSI_THRESHOLDS.elevated) return 'elevated';
+  if (index <= -FSI_THRESHOLDS.elevated) return 'low';
+  return 'normal';
+}
+
+export function buildFsiAlert(obs: FsiObservation): FsiAlert {
+  const tier = tierForFsi(obs.index);
+  return {
+    date: obs.date,
+    index: obs.index,
+    tier,
+    message: messageForFsi(obs, tier),
+  };
+}
+
+function messageForFsi(obs: FsiObservation, tier: FsiTier): string {
+  const indexStr = obs.index.toFixed(2);
+  switch (tier) {
+    case 'severe': {
+      return `OFR FSI ${indexStr} — severe systemic stress; equity / credit / FX dislocation likely.`;
+    }
+    case 'elevated': {
+      return `OFR FSI ${indexStr} — elevated stress; watch credit spreads + funding markets.`;
+    }
+    case 'low': {
+      return `OFR FSI ${indexStr} — markets unusually calm; tail-risk premia compressed.`;
+    }
+    default: {
+      return `OFR FSI ${indexStr} — normal range.`;
+    }
+  }
+}
+
+// ── Series statistics ──────────────────────────────────────────────────
+
+/** Compute mean of finite numeric values. NaN when empty. */
+export function mean(values: readonly number[]): number {
+  if (values.length === 0) return Number.NaN;
+  let sum = 0;
+  let n = 0;
+  for (const v of values) {
+    if (Number.isFinite(v)) {
+      sum += v;
+      n += 1;
+    }
+  }
+  return n === 0 ? Number.NaN : sum / n;
+}
+
+/** Sample standard deviation (N-1 denominator). NaN when n < 2. */
+export function stdev(values: readonly number[]): number {
+  if (values.length < 2) return Number.NaN;
+  const mu = mean(values);
+  if (!Number.isFinite(mu)) return Number.NaN;
+  let s = 0;
+  let n = 0;
+  for (const v of values) {
+    if (!Number.isFinite(v)) continue;
+    const d = v - mu;
+    s += d * d;
+    n += 1;
+  }
+  return n < 2 ? Number.NaN : Math.sqrt(s / (n - 1));
+}
+
+/** σ-deviation of `current` from a window of past observations. Returns
+ *  0 when stdev is degenerate. */
+export function sigmaDeviation(current: number, window: readonly number[]): number {
+  const sd = stdev(window);
+  if (!Number.isFinite(sd) || sd === 0) return 0;
+  return (current - mean(window)) / sd;
+}
+
+// ── Commodity stress ──────────────────────────────────────────────────
+
+/** Compute the trend sign over the last `n` observations: +1 rising,
+ *  -1 falling, 0 stable. Uses linear regression slope sign with a
+ *  ±1 % cutoff on relative slope to mark "stable". */
+export function trendSign(
+  observations: readonly CommodityObservation[],
+  n = 3,
+): 'rising' | 'falling' | 'stable' {
+  if (observations.length < 2) return 'stable';
+  const slice = observations.slice(-n);
+  if (slice.length < 2) return 'stable';
+  // Slope via least-squares on (i, price).
+  let xMean = 0; for (let i = 0; i < slice.length; i += 1) xMean += i;
+  xMean /= slice.length;
+  const yMean = mean(slice.map((o) => o.price));
+  let num = 0;
+  let den = 0;
+  for (const [i, element] of slice.entries()) {
+    const dx = i - xMean;
+    num += dx * (element!.price - yMean);
+    den += dx * dx;
+  }
+  if (den === 0) return 'stable';
+  const slope = num / den;
+  const rel = Math.abs(slope) / Math.max(1, Math.abs(yMean));
+  if (rel < 0.01) return 'stable';
+  return slope > 0 ? 'rising' : 'falling';
+}
+
+/** Map combined 12m/24m σ-deviations to a tier. Always rounds away
+ *  from "low" when in doubt — better to over-warn than miss. */
+export function riskTierForDeviation(d12: number, d24: number): CommodityRiskTier {
+  const mag = Math.max(Math.abs(d12), Math.abs(d24));
+  if (mag >= 3) return 'critical';
+  if (mag >= 2) return 'high';
+  if (mag >= 1) return 'medium';
+  return 'low';
+}
+
+/** Build a commodity alert given a series with enough history. Returns
+ *  null when the series is too short to evaluate (need at least 12
+ *  observations). */
+export function buildCommodityAlert(series: CommoditySeries): CommodityAlert | null {
+  const obs = series.observations;
+  if (obs.length < 12) return null;
+  const current = obs[obs.length - 1]!.price;
+  const window12 = obs.slice(-13, -1).map((o) => o.price); // 12 prior obs
+  const window24 = obs.length >= 25
+    ? obs.slice(-25, -1).map((o) => o.price)               // 24 prior obs
+    : window12;
+  const d12 = sigmaDeviation(current, window12);
+  const d24 = sigmaDeviation(current, window24);
+  const trend = trendSign(obs, 3);
+  const tier = riskTierForDeviation(d12, d24);
+  const direction = d12 >= 0 ? 'above' : 'below';
+  return {
+    commodity: series.commodity,
+    unit: series.unit,
+    currentPrice: current,
+    deviation12mSigma: d12,
+    deviation24mSigma: d24,
+    trend,
+    overallRisk: tier,
+    message: `${series.commodity}: ${current.toFixed(2)} ${series.unit} — ${Math.abs(d12).toFixed(1)}σ ${direction} 12-month mean (${trend}).`,
+  };
+}
+
+/** Roll up a list of commodity alerts into the snapshot the panel
+ *  consumes. Sorts by overallRisk descending, then by |12m σ|. */
+export function rankCommodityAlerts(alerts: readonly CommodityAlert[]): CommodityAlert[] {
+  const tierRank: Record<CommodityRiskTier, number> = {
+    low: 0, medium: 1, high: 2, critical: 3,
+  };
+  return [...alerts].sort((a, b) => {
+    const dt = tierRank[b.overallRisk] - tierRank[a.overallRisk];
+    if (dt !== 0) return dt;
+    return Math.abs(b.deviation12mSigma) - Math.abs(a.deviation12mSigma);
+  });
+}


### PR DESCRIPTION
Pure deterministic engine — OFR FSI tier ladder + commodity-price σ-deviation alerts.

## Files
- src/services/finance/stress-monitor.ts (engine)
- src/services/finance/__tests__/stress-monitor.test.mts (18 tests)
- package.json (test:finance)

## Engine surface
- tierForFsi / buildFsiAlert (elevated > 1.5, severe > 3.0)
- mean / stdev / sigmaDeviation primitives
- trendSign (linear-regression slope, ±1 % cutoff)
- buildCommodityAlert (12-month + 24-month σ windows)
- riskTierForDeviation (1σ/2σ/3σ ladder on max(|d12|, |d24|))
- rankCommodityAlerts (tier descending, |σ| tiebreak)

## Validation
- npm run test:finance: 18/18
- npm run typecheck:all: clean
- eslint clean

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>