### PR TITLE
feat: ENSO Monitor + shortage-radar adjustments (Batch 3 PR 2/3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "test:cyber": "tsx --test src/services/cyber/__tests__/apt-tracker.test.mts",
     "test:geopolitics": "tsx --test src/services/geopolitics/__tests__/grayzone-classifier.test.mts",
     "test:finance": "tsx --test src/services/finance/__tests__/stress-monitor.test.mts",
+    "test:climate": "tsx --test src/services/climate/__tests__/enso-monitor.test.mts",
     "test:panels:smoke": "node tests/panels/run-harness.mjs",
     "test:panels:fixtures": "tsx --import ./tests/panels/register-hook.mjs --test tests/panels/panel-fixtures.test.mts",
     "test:strategic-self-improvement": "tsx --test src/services/diagnostics/__tests__/failure-prediction.test.mts src/services/governance/__tests__/policy-engine.test.mts src/services/governance/__tests__/model-governance.test.mts src/services/experiments/__tests__/experiment-manager.test.mts src/services/ops/__tests__/causal-attribution.test.mts src/services/ops/__tests__/trust-budget.test.mts src/services/ops/__tests__/playbook-engine.test.mts src/services/scenarios/__tests__/scenario-library.test.mts src/services/personal/__tests__/resilience-model.test.mts src/services/quality/__tests__/quality-debt.test.mts src/services/quality/__tests__/self-improvement-scheduler.test.mts",

--- a/src/services/climate/__tests__/enso-monitor.test.mts
+++ b/src/services/climate/__tests__/enso-monitor.test.mts
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  adjustmentsFor,
+  applyAdjustment,
+  buildSnapshot,
+  currentPhaseRun,
+  outlookFor,
+  parseOniAscii,
+  type EnsoObservation,
+} from '../enso-monitor.ts';
+
+// ── parseOniAscii ────────────────────────────────────────────────────
+
+test('parseOniAscii: parses a standard NOAA fixture', () => {
+  const text = `SEAS  YR  TOTAL  ANOM
+DJF  1950  24.72  -1.54
+JFM  1950  25.16  -1.34
+FMA  1950  25.66  -1.16`;
+  const obs = parseOniAscii(text);
+  assert.equal(obs.length, 3);
+  assert.equal(obs[0]!.season, 'DJF');
+  assert.equal(obs[0]!.year, 1950);
+  assert.equal(obs[0]!.oni, -1.54);
+});
+
+test('parseOniAscii: tolerates blank + comment lines', () => {
+  const text = `# header note
+SEAS YR TOTAL ANOM
+DJF 2025 25.5 0.6
+
+JFM 2025 25.8 0.8
+`;
+  const obs = parseOniAscii(text);
+  assert.equal(obs.length, 2);
+});
+
+test('parseOniAscii: drops malformed rows', () => {
+  const text = `DJF 2025 25.5 NaN
+JFM 2025 25.5 0.6
+GARBAGE LINE
+FMA bad-year 25 0.7`;
+  const obs = parseOniAscii(text);
+  assert.equal(obs.length, 1);
+  assert.equal(obs[0]!.season, 'JFM');
+});
+
+test('parseOniAscii: empty input returns []', () => {
+  assert.deepEqual(parseOniAscii(''), []);
+});
+
+// ── currentPhaseRun ──────────────────────────────────────────────────
+
+function obs(values: number[]): EnsoObservation[] {
+  return values.map((v, i) => ({ year: 2024, season: `S${i}`, oni: v }));
+}
+
+test('currentPhaseRun: el_nino run of 5', () => {
+  const out = currentPhaseRun(obs([0, 0.3, 0.6, 0.7, 0.9, 1.0, 1.1]));
+  assert.equal(out.phase, 'el_nino');
+  assert.equal(out.runLength, 5);
+});
+
+test('currentPhaseRun: la_nina run of 3', () => {
+  const out = currentPhaseRun(obs([0.2, -0.6, -0.7, -0.8]));
+  assert.equal(out.phase, 'la_nina');
+  assert.equal(out.runLength, 3);
+});
+
+test('currentPhaseRun: latest neutral → run length 0', () => {
+  const out = currentPhaseRun(obs([0.6, 0.4]));
+  assert.equal(out.phase, 'neutral');
+  assert.equal(out.runLength, 0);
+});
+
+test('currentPhaseRun: empty input → neutral 0', () => {
+  const out = currentPhaseRun([]);
+  assert.equal(out.phase, 'neutral');
+  assert.equal(out.runLength, 0);
+});
+
+// ── outlookFor ──────────────────────────────────────────────────────
+
+test('outlookFor: warming El Niño → strengthening message', () => {
+  const text = outlookFor(obs([0.5, 0.6, 0.8, 1.0]));
+  assert.match(text, /El Niño/);
+  assert.match(text, /strengthening/);
+});
+
+test('outlookFor: neutral with strong upward drift → "trending toward El Niño"', () => {
+  const text = outlookFor(obs([-0.1, 0, 0.2, 0.4]));
+  assert.match(text, /Trending toward El Niño/);
+});
+
+test('outlookFor: neutral flat → no strong signal', () => {
+  const text = outlookFor(obs([0.05, 0.0, -0.05, 0.0]));
+  assert.match(text, /Neutral conditions persisting/);
+});
+
+test('outlookFor: insufficient history → explicit message', () => {
+  const text = outlookFor(obs([0.1]));
+  assert.match(text, /Insufficient history/);
+});
+
+// ── buildSnapshot ───────────────────────────────────────────────────
+
+test('buildSnapshot: produces a JSON-serializable record', () => {
+  const snap = buildSnapshot(obs([-0.6, -0.7, -0.8, -0.9]));
+  assert.ok(snap);
+  assert.equal(snap!.phase, 'la_nina');
+  const round = structuredClone(snap);
+  assert.equal(round.phase, 'la_nina');
+});
+
+test('buildSnapshot: empty input → null', () => {
+  assert.equal(buildSnapshot([]), null);
+});
+
+// ── adjustmentsFor ──────────────────────────────────────────────────
+
+test('adjustmentsFor: el_nino includes wheat_australia at >1 multiplier', () => {
+  const adjustments = adjustmentsFor('el_nino');
+  const wheatAU = adjustments.find((a) => a.commodity === 'wheat_australia');
+  assert.ok(wheatAU);
+  assert.ok(wheatAU!.multiplier > 1);
+});
+
+test('adjustmentsFor: la_nina includes wheat_north_america + coffee_east_africa', () => {
+  const adjustments = adjustmentsFor('la_nina');
+  assert.ok(adjustments.find((a) => a.commodity === 'wheat_north_america'));
+  assert.ok(adjustments.find((a) => a.commodity === 'coffee_east_africa'));
+});
+
+test('adjustmentsFor: neutral → empty', () => {
+  assert.deepEqual(adjustmentsFor('neutral'), []);
+});
+
+// ── applyAdjustment ─────────────────────────────────────────────────
+
+test('applyAdjustment: el_nino raises wheat_australia probability', () => {
+  const adjusted = applyAdjustment(0.4, 'wheat_australia', 'el_nino');
+  assert.ok(adjusted > 0.4);
+});
+
+test('applyAdjustment: clamps at 1', () => {
+  assert.equal(applyAdjustment(0.9, 'wheat_australia', 'el_nino'), 1);
+});
+
+test('applyAdjustment: la_nina lowers corn_north_america probability slightly', () => {
+  const adjusted = applyAdjustment(0.5, 'corn_north_america', 'la_nina');
+  assert.ok(adjusted < 0.5);
+});
+
+test('applyAdjustment: neutral phase passes through', () => {
+  assert.equal(applyAdjustment(0.42, 'wheat_australia', 'neutral'), 0.42);
+});
+
+test('applyAdjustment: commodity not in current phase passes through', () => {
+  assert.equal(applyAdjustment(0.42, 'coffee_east_africa', 'el_nino'), 0.42);
+});

--- a/src/services/climate/enso-monitor.ts
+++ b/src/services/climate/enso-monitor.ts
@@ -1,0 +1,211 @@
+/**
+ * ENSO Monitor — per Batch 3 of the climate/economic plan.
+ *
+ * NOAA ONI (Oceanic Niño Index) parser + phase classification + the
+ * ENSO→shortage impact table. Wires into the existing shortage radar
+ * by emitting per-commodity probability adjustments based on the
+ * current phase.
+ *
+ * Pure deterministic. No DOM, no fetch, no globals. The sidecar pulls
+ * the ASCII table from cpc.ncep.noaa.gov; this module turns the text
+ * into typed observations and applies the adjustment table.
+ */
+
+// ── Public types ───────────────────────────────────────────────────────
+
+export type EnsoPhase = 'el_nino' | 'la_nina' | 'neutral';
+
+export interface EnsoObservation {
+  /** Calendar year. */
+  year: number;
+  /** 3-month overlapping season label NOAA uses ("DJF", "JFM", "FMA",
+   *  …). The most recent season anchors the snapshot. */
+  season: string;
+  /** Oceanic Niño Index value (°C anomaly in ERSSTv5 Niño 3.4). */
+  oni: number;
+}
+
+export interface EnsoSnapshot {
+  /** Most recent observation. */
+  current: EnsoObservation;
+  /** Most recent run of consecutive observations meeting the
+   *  threshold. NOAA's official rule is 5 consecutive seasons of
+   *  ONI ≥ 0.5 (El Niño) / ≤ -0.5 (La Niña). */
+  phase: EnsoPhase;
+  /** Length of the current phase run, in seasons. */
+  phaseRunLength: number;
+  /** Plain-English description of the 6-month outlook, derived from
+   *  the deterministic state-machine in `outlookFor`. */
+  forecast6m: string;
+}
+
+export type EnsoCommodityKey =
+  | 'wheat_australia'
+  | 'rice_southeast_asia'
+  | 'soy_south_america'
+  | 'corn_north_america'
+  | 'wheat_north_america'
+  | 'coffee_east_africa';
+
+export interface EnsoShortageAdjustment {
+  commodity: EnsoCommodityKey;
+  /** Multiplier applied to the existing shortage probability when this
+   *  phase is active. >1 raises risk, <1 lowers it. Always > 0. */
+  multiplier: number;
+  /** Free-text rationale that goes onto the shortage card. */
+  rationale: string;
+}
+
+// ── ASCII parser ───────────────────────────────────────────────────────
+
+/**
+ * Parse the NOAA CPC `oni.ascii.txt` file. Format (whitespace-separated):
+ *
+ *   SEAS  YR  TOTAL  ANOM
+ *   DJF  1950  24.72  -1.54
+ *   ...
+ *
+ * Returns observations chronologically (oldest first). Tolerates
+ * blank lines, comment lines starting with `#`, and varying internal
+ * whitespace. Drops rows where ANOM is missing/non-numeric.
+ */
+export function parseOniAscii(text: string): EnsoObservation[] {
+  if (!text) return [];
+  const out: EnsoObservation[] = [];
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const parts = line.split(/\s+/);
+    if (parts.length < 4) continue;
+    const season = parts[0]!;
+    if (!/^[A-Z]{3}$/.test(season)) continue;            // skip header line
+    const year = Number.parseInt(parts[1]!, 10);
+    const anom = Number.parseFloat(parts[3]!);
+    if (!Number.isFinite(year) || !Number.isFinite(anom)) continue;
+    out.push({ year, season, oni: anom });
+  }
+  return out;
+}
+
+// ── Phase classification ───────────────────────────────────────────────
+
+const PHASE_THRESHOLD = 0.5;
+/** Per NOAA, the official El Niño / La Niña declaration needs 5
+ *  consecutive overlapping seasons meeting the threshold. The
+ *  `currentPhaseRun` helper reports the actual run length so callers
+ *  can decide whether to render "developing" vs "established"; this
+ *  module does not enforce a minimum. */
+
+function describeDrift(drift: number): 'strengthening' | 'weakening' | 'holding' {
+  if (drift > 0.1) return 'strengthening';
+  if (drift < -0.1) return 'weakening';
+  return 'holding';
+}
+
+function phaseOfValue(oni: number): EnsoPhase {
+  if (oni >= PHASE_THRESHOLD) return 'el_nino';
+  if (oni <= -PHASE_THRESHOLD) return 'la_nina';
+  return 'neutral';
+}
+
+/** Walk the trailing observations to find the longest run that
+ *  matches the most recent phase. Returns 0 when the latest reading
+ *  is neutral (no run). */
+export function currentPhaseRun(observations: readonly EnsoObservation[]): {
+  phase: EnsoPhase;
+  runLength: number;
+} {
+  if (observations.length === 0) return { phase: 'neutral', runLength: 0 };
+  const latest = observations[observations.length - 1]!;
+  const phase = phaseOfValue(latest.oni);
+  if (phase === 'neutral') return { phase: 'neutral', runLength: 0 };
+  let run = 0;
+  for (let i = observations.length - 1; i >= 0; i -= 1) {
+    if (phaseOfValue(observations[i]!.oni) !== phase) break;
+    run += 1;
+  }
+  return { phase, runLength: run };
+}
+
+// ── 6-month outlook ────────────────────────────────────────────────────
+
+/** Deterministic outlook derived from the most recent slope of the
+ *  3-month moving average. Not an actual forecast — anchored language
+ *  the panel can show without lying about predictive power. */
+export function outlookFor(observations: readonly EnsoObservation[]): string {
+  if (observations.length < 4) return 'Insufficient history for an outlook.';
+  const tail = observations.slice(-4).map((o) => o.oni);
+  const earlyAvg = (tail[0]! + tail[1]!) / 2;
+  const lateAvg = (tail[2]! + tail[3]!) / 2;
+  const drift = lateAvg - earlyAvg;
+  const phase = phaseOfValue(tail[3]!);
+  const direction = describeDrift(drift);
+  switch (phase) {
+    case 'el_nino': {
+      return `El Niño ${direction}; sustained warm anomaly likely through next 6 months.`;
+    }
+    case 'la_nina': {
+      return `La Niña ${direction}; cool anomaly likely through next 6 months.`;
+    }
+    default: {
+      if (drift > 0.2) return 'Trending toward El Niño territory; watch for ONI ≥ 0.5 in upcoming seasons.';
+      if (drift < -0.2) return 'Trending toward La Niña territory; watch for ONI ≤ -0.5 in upcoming seasons.';
+      return 'Neutral conditions persisting; no strong directional signal.';
+    }
+  }
+}
+
+// ── Snapshot ───────────────────────────────────────────────────────────
+
+export function buildSnapshot(observations: readonly EnsoObservation[]): EnsoSnapshot | null {
+  if (observations.length === 0) return null;
+  const { phase, runLength } = currentPhaseRun(observations);
+  return {
+    current: observations[observations.length - 1]!,
+    phase,
+    phaseRunLength: runLength,
+    forecast6m: outlookFor(observations),
+  };
+}
+
+// ── ENSO → shortage impact table ───────────────────────────────────────
+
+/** Static impact table — per the spec. Multipliers apply on top of the
+ *  shortage radar's existing per-commodity probability. Reviewed
+ *  2026-05-05; future climate-economic literature updates land via PR. */
+const EL_NINO_IMPACTS: readonly EnsoShortageAdjustment[] = [
+  { commodity: 'wheat_australia', multiplier: 1.45, rationale: 'El Niño dries Australian winter wheat belt; -20 % yield typical.' },
+  { commodity: 'rice_southeast_asia', multiplier: 1.3, rationale: 'El Niño suppresses SE Asian monsoon; rice paddies under-watered.' },
+  { commodity: 'soy_south_america', multiplier: 1.25, rationale: 'El Niño shortens South American summer rains; -15 % soy yield.' },
+  { commodity: 'corn_north_america', multiplier: 1.15, rationale: 'El Niño raises drought risk in CA / Midwest +40 %.' },
+];
+
+const LA_NINA_IMPACTS: readonly EnsoShortageAdjustment[] = [
+  { commodity: 'wheat_north_america', multiplier: 1.3, rationale: 'La Niña drought in US southern plains; -15 % wheat yield typical.' },
+  { commodity: 'wheat_australia', multiplier: 1.2, rationale: 'La Niña floods Australian wheat belt; quality + harvest losses.' },
+  { commodity: 'coffee_east_africa', multiplier: 1.25, rationale: 'La Niña drought in East African coffee belt.' },
+  { commodity: 'corn_north_america', multiplier: 0.95, rationale: 'La Niña usually wetter for US Midwest corn — slight downside.' },
+];
+
+/** Adjustments to apply when the phase is active. Returns an empty
+ *  array for neutral. */
+export function adjustmentsFor(phase: EnsoPhase): readonly EnsoShortageAdjustment[] {
+  switch (phase) {
+    case 'el_nino':  { return EL_NINO_IMPACTS; }
+    case 'la_nina':  { return LA_NINA_IMPACTS; }
+    default:         { return []; }
+  }
+}
+
+/** Apply the active phase's adjustment to a base shortage probability,
+ *  clamped to [0, 1]. Returns the original value when neutral. */
+export function applyAdjustment(
+  baseProbability: number,
+  commodity: EnsoCommodityKey,
+  phase: EnsoPhase,
+): number {
+  const adj = adjustmentsFor(phase).find((a) => a.commodity === commodity);
+  if (!adj) return baseProbability;
+  const next = baseProbability * adj.multiplier;
+  return Math.max(0, Math.min(1, next));
+}


### PR DESCRIPTION
Pure deterministic engine. NOAA CPC ONI parser + phase classification + per-commodity shortage probability multipliers.

## Files
- src/services/climate/enso-monitor.ts (engine)
- src/services/climate/__tests__/enso-monitor.test.mts (22 tests)
- package.json (test:climate)

## Engine surface
- parseOniAscii (tolerant of comments + blank lines)
- currentPhaseRun (longest matching trailing run)
- outlookFor (4-tail drift-based narrative; deliberately anchored)
- buildSnapshot
- adjustmentsFor + applyAdjustment (static EL_NINO/LA_NINA impact table)

## Impact table (reviewed 2026-05-05)
- El Niño: AU wheat 1.45×, SE Asia rice 1.30×, SA soy 1.25×, NA corn 1.15×
- La Niña: NA wheat 1.30×, AU wheat 1.20×, EAfrica coffee 1.25×, NA corn 0.95×

## Validation
- npm run test:climate: 22/22
- npm run typecheck:all: clean

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>