### PR TITLE
fix: bundle Little Snitch rules so NetworkRulesPanel works in production

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -63,7 +63,8 @@
       "sidecar/package.json",
       "sidecar/node",
       "../data",
-      "../src/config"
+      "../src/config",
+      "../tools/littlesnitch"
     ],
     "windows": {
       "digestAlgorithm": "sha256",


### PR DESCRIPTION
## Problem

`NetworkRulesPanel` (sidebar → Network Rules) shows **"Could not load network rules. Sidecar returned HTTP {status}"** in the production build. Empirically the sidecar returns 404, with body:

```json
{"error":"Little Snitch ruleset not found","details":"ENOENT: no such file or directory, open '/Users/.../Crystal Ball.app/Contents/Resources/sidecar/tools/littlesnitch/crystal-ball.lsrules'","candidatesTried":[
  ".app/Contents/Resources/_up_/tools/littlesnitch/crystal-ball.lsrules",
  ".app/Contents/tools/littlesnitch/crystal-ball.lsrules",
  ".app/Contents/Resources/sidecar/tools/littlesnitch/crystal-ball.lsrules"
]}
```

Dev mode worked, masking the issue: `apiDir` resolves to `<repo>/api/` in dev so the existing first candidate `apiDir/../tools/littlesnitch/crystal-ball.lsrules` finds the file at the worktree root.

## Root cause

`tools/littlesnitch/crystal-ball.lsrules` was never listed in `tauri.conf.json` → `bundle.resources`, so Tauri never copied it into `Contents/Resources/_up_/tools/littlesnitch/` in the bundled app. The sidecar's first candidate path is correct (it already targets `_up_/tools/...`); the file was just absent.

## Fix

Add `../tools/littlesnitch` to `bundle.resources`. Matches the existing pattern for `../api`, `../data`, `../src/config` (directories above `src-tauri` that Tauri lifts under `_up_/`).

## Verification

```
LOCAL_API_PORT=47012 LOCAL_API_TOKEN=devtoken123 \
  LOCAL_API_RESOURCE_DIR="$(pwd)" \
  node src-tauri/sidecar/local-api-server.mjs &

curl -H 'authorization: Bearer devtoken123' \
  http://127.0.0.1:47012/api/littlesnitch-rules
# → 200 OK, ruleCount: 55, sourcePath: <repo>/tools/littlesnitch/crystal-ball.lsrules
```

`npm run typecheck:all` clean. Pre-commit hooks (lint:conflicts, secrets:scan:staged, lint:json, typecheck:all) all pass.

After merge, the next `npm run release:prepare -- --bump patch --push` will ship a bundle that includes the file.