### PR TITLE
feat(webcams): God's Eye globe pin layer (PR 7/7) — final

### DIFF
--- a/src/components/GodsVisionView.ts
+++ b/src/components/GodsVisionView.ts
@@ -16,6 +16,8 @@ import { GlobeArcs } from '@/components/gods-vision/GlobeArcs';
 import { GlobeHeatmap } from '@/components/gods-vision/GlobeHeatmap';
 import { GlobeReactorBeacons } from '@/components/GlobeReactorBeacons';
 import { GlobeSeismicWaves } from '@/components/GlobeSeismicWaves';
+import { GlobeWebcamLayer } from '@/services/webcams/webcam-globe-layer';
+import { fetchUnifiedWebcams } from '@/services/webcams/fetcher';
 import { FlyModeController } from '@/components/gods-vision/FlyMode/FlyModeController';
 import { BuildingTileManager } from '@/services/building-tiles';
 import type { FlySubMode } from '@/components/gods-vision/FlyMode/flyModeKeybinds';
@@ -74,6 +76,7 @@ export class GodsVisionView {
   private fourD: Globe4DManager | null = null;
   private reactorBeacons: GlobeReactorBeacons | null = null;
   private seismicWaves: GlobeSeismicWaves | null = null;
+  private webcamLayer: GlobeWebcamLayer | null = null;
   private globePulse: GlobePulse | null = null;
   private globeArcs: GlobeArcs | null = null;
   private globeHeatmap: GlobeHeatmap | null = null;
@@ -173,6 +176,15 @@ export class GodsVisionView {
  this.reactorBeacons.mount();
  this.seismicWaves = new GlobeSeismicWaves(viewer);
  this.seismicWaves.mount();
+ this.webcamLayer = new GlobeWebcamLayer(viewer, {
+ fetchFeeds: async () => {
+ const cat = await fetchUnifiedWebcams({ category: 'fire,volcano,coastal' });
+ return cat.feeds;
+ },
+ highSalienceOnly: true,
+ });
+ void this.webcamLayer.mount();
+ this.cleanupHandlers.push(() => { this.webcamLayer?.destroy(); this.webcamLayer = null; });
  }
 
  // Auto-follow engine

--- a/src/components/UnifiedWebcamPanel.ts
+++ b/src/components/UnifiedWebcamPanel.ts
@@ -41,7 +41,23 @@ export class UnifiedWebcamPanel extends Panel {
   constructor() {
     super({ id: 'unified-webcams', title: 'Webcams', className: 'panel-wide' });
     void this.load();
+    window.addEventListener('webcam:select', this.handleGlobeSelect as EventListener);
   }
+
+  private handleGlobeSelect = (e: Event): void => {
+    const detail = (e as CustomEvent<{ feedId?: string; feed?: WebcamFeed }>).detail;
+    if (!detail) return;
+    if (detail.feed) {
+      this.selectedFeed = detail.feed;
+      this.render();
+    } else if (detail.feedId) {
+      const found = this.feeds.find((f) => f.id === detail.feedId);
+      if (found) {
+        this.selectedFeed = found;
+        this.render();
+      }
+    }
+  };
 
   private async load(): Promise<void> {
     this.loading = true;

--- a/src/services/webcams/webcam-globe-layer.ts
+++ b/src/services/webcams/webcam-globe-layer.ts
@@ -1,0 +1,147 @@
+import {
+  Cartesian2,
+  Cartesian3,
+  Color,
+  CustomDataSource,
+  DistanceDisplayCondition,
+  Entity,
+  HeightReference,
+  NearFarScalar,
+  ScreenSpaceEventHandler,
+  ScreenSpaceEventType,
+  type Viewer,
+} from 'cesium';
+import type { WebcamFeed } from './webcam-types';
+
+const HIGH_SALIENCE_CATEGORIES = ['fire', 'volcano', 'coastal'] as const;
+
+const CATEGORY_PIN_COLOR: Record<string, Color> = {
+  fire: Color.fromCssColorString('#f85149'),
+  volcano: Color.fromCssColorString('#bc8cff'),
+  coastal: Color.fromCssColorString('#3fb950'),
+  weather: Color.fromCssColorString('#58a6ff'),
+  stream: Color.fromCssColorString('#56d4dd'),
+  traffic: Color.fromCssColorString('#d29922'),
+  nature: Color.fromCssColorString('#7ee787'),
+};
+
+const CATEGORY_GLYPH: Record<string, string> = {
+  fire: '🔥',
+  volcano: '🌋',
+  coastal: '🌊',
+  weather: '☁',
+  stream: '💧',
+  traffic: '🚗',
+  nature: '🌲',
+};
+
+export interface WebcamGlobeLayerOptions {
+  fetchFeeds?: () => Promise<WebcamFeed[]>;
+  highSalienceOnly?: boolean;
+}
+
+export class GlobeWebcamLayer {
+  private viewer: Viewer;
+  private dataSource: CustomDataSource | null = null;
+  private entities = new Map<string, Entity>();
+  private mounted = false;
+  private clickHandler: ScreenSpaceEventHandler | null = null;
+  private feedById = new Map<string, WebcamFeed>();
+  private fetchFeeds: () => Promise<WebcamFeed[]>;
+  private highSalienceOnly: boolean;
+
+  constructor(viewer: Viewer, options: WebcamGlobeLayerOptions = {}) {
+    this.viewer = viewer;
+    this.fetchFeeds = options.fetchFeeds ?? (() => Promise.resolve([]));
+    this.highSalienceOnly = options.highSalienceOnly ?? true;
+  }
+
+  async mount(): Promise<void> {
+    if (this.mounted) return;
+    this.mounted = true;
+    this.dataSource = new CustomDataSource('webcam-pins');
+    await this.viewer.dataSources.add(this.dataSource);
+
+    this.clickHandler = new ScreenSpaceEventHandler(this.viewer.scene.canvas);
+    this.clickHandler.setInputAction((event: { position: Cartesian2 }) => {
+      const picked: unknown = this.viewer.scene.pick(event.position);
+      if (!picked || typeof picked !== 'object') return;
+      const entityId = (picked as { id?: unknown }).id;
+      if (entityId instanceof Entity && typeof entityId.id === 'string') {
+        const feed = this.feedById.get(entityId.id);
+        if (feed) this.dispatchSelect(feed);
+      }
+    }, ScreenSpaceEventType.LEFT_CLICK);
+
+    await this.refresh();
+  }
+
+  destroy(): void {
+    if (!this.mounted) return;
+    this.mounted = false;
+    if (this.clickHandler) {
+      this.clickHandler.destroy();
+      this.clickHandler = null;
+    }
+    this.entities.clear();
+    this.feedById.clear();
+    if (this.dataSource) {
+      this.viewer.dataSources.remove(this.dataSource, true);
+      this.dataSource = null;
+    }
+  }
+
+  async refresh(): Promise<void> {
+    if (!this.dataSource) return;
+    const allFeeds = await this.fetchFeeds();
+    const feeds = this.highSalienceOnly
+      ? allFeeds.filter((f) => HIGH_SALIENCE_CATEGORIES.includes(f.category as typeof HIGH_SALIENCE_CATEGORIES[number]))
+      : allFeeds;
+    this.dataSource.entities.removeAll();
+    this.entities.clear();
+    this.feedById.clear();
+    for (const feed of feeds) {
+      this.feedById.set(feed.id, feed);
+      const entity = new Entity({
+        id: feed.id,
+        position: Cartesian3.fromDegrees(feed.lon, feed.lat),
+        point: {
+          color: CATEGORY_PIN_COLOR[feed.category] ?? Color.WHITE,
+          pixelSize: 10,
+          outlineColor: Color.BLACK,
+          outlineWidth: 1,
+          heightReference: HeightReference.CLAMP_TO_GROUND,
+          scaleByDistance: new NearFarScalar(1.5e5, 1.4, 1.5e7, 0.6),
+          distanceDisplayCondition: new DistanceDisplayCondition(0, 2.5e7),
+        },
+        label: {
+          text: CATEGORY_GLYPH[feed.category] ?? '●',
+          font: '14px sans-serif',
+          fillColor: Color.WHITE,
+          showBackground: false,
+          distanceDisplayCondition: new DistanceDisplayCondition(0, 5e6),
+        },
+        description: this.buildDescription(feed),
+      });
+      this.dataSource.entities.add(entity);
+      this.entities.set(feed.id, entity);
+    }
+  }
+
+  setHighSalienceOnly(value: boolean): void {
+    this.highSalienceOnly = value;
+    void this.refresh();
+  }
+
+  private buildDescription(feed: WebcamFeed): string {
+    return `<div style="font-family:sans-serif;padding:6px;">
+      <strong>${feed.name}</strong><br/>
+      <small>${feed.source} · ${feed.category}</small><br/>
+      <img src="${feed.snapshotUrl}" style="max-width:200px;margin-top:4px;border-radius:3px;"/>
+    </div>`;
+  }
+
+  private dispatchSelect(feed: WebcamFeed): void {
+    window.dispatchEvent(new CustomEvent('webcam:select', { detail: { feedId: feed.id, feed } }));
+  }
+}


### PR DESCRIPTION
Stacks on [#307](https://github.com/bradleybond512/crystal-ball/pull/307). Final PR in the 7-PR webcam expansion stack.

## What this adds

### `src/services/webcams/webcam-globe-layer.ts` — `GlobeWebcamLayer`
- Follows the existing `GlobeReactorBeacons` pattern (CustomDataSource + per-feature Entity)
- Each cam → category-colored point + glyph label: 🔥 fire / 🌋 volcano / 🌊 coastal / ☁ weather / 💧 stream / 🚗 traffic / 🌲 nature
- `DistanceDisplayCondition` + `NearFarScalar` so pins fade out beyond ~25,000 km altitude — avoids clutter when zoomed all the way out
- `highSalienceOnly` defaults to true: **only fire / volcano / coastal cams pin on the globe.** The other 1000+ cams stay in the panel only — this is essential because Windy alone can be 5000 cams.
- `ScreenSpaceEventHandler(LEFT_CLICK)` → dispatches `window.dispatchEvent(new CustomEvent('webcam:select', { detail: { feedId, feed } }))`
- InfoBox description popup includes the snapshot thumbnail + source/category
- Idempotent `mount()` / `destroy()` + `refresh()` for re-fetch

### Wiring
- `GodsVisionView.ts` instantiates `GlobeWebcamLayer` alongside `GlobeReactorBeacons` after the viewer comes up. Cleanup handler registered to destroy on view teardown.
- `UnifiedWebcamPanel` (from PR 6) listens for `'webcam:select'` on window — clicking a globe pin opens that feed's fullscreen viewer in the panel.

## Verification
- `npm run typecheck:all` — clean
- `npm run test:webcams` — 107/107 pass
- `npm run lint` on touched files — clean

## Stack summary
| PR | Title | Status |
|----|-------|--------|
| [#302](https://github.com/bradleybond512/crystal-ball/pull/302) | WebcamFeed types + aggregator + FAA adapter | open, auto-rebase |
| [#303](https://github.com/bradleybond512/crystal-ball/pull/303) | FAA cam METAR + flight rule + ADS-B enrichment | open, auto-rebase |
| [#304](https://github.com/bradleybond512/crystal-ball/pull/304) | DOT 511 WA/CO/FL + USGS volcano cams | open, auto-rebase |
| [#305](https://github.com/bradleybond512/crystal-ball/pull/305) | NPS + AlertWildfire + USGS stream gauges | open, auto-rebase |
| [#306](https://github.com/bradleybond512/crystal-ball/pull/306) | Windy paginated + NOAA coastal + master aggregator | open, auto-rebase |
| [#307](https://github.com/bradleybond512/crystal-ball/pull/307) | UnifiedWebcamPanel UI | open, auto-rebase |
| [this PR] | God's Eye globe pin layer | this |

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>