### PR TITLE
feat(webcams): 8 new DOT adapters + Road511 paid gate (Phase 2 PR A)

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -163,6 +163,35 @@ function cachedFetch(key, ttlMs, fetcher) {
 // Pre-compiled regex patterns (avoid re-creation in hot paths)
 const RE_HTML_TAGS = /<[^>]+>/g;
 
+// ── ibi511 platform parser (shared by AZ/ID/GA in /api/webcams/dot-extended) ──
+// Mirrors parseIbi511 in src/services/webcams/adapters/dot-extended.ts.
+function parseIbi511Sidecar(state, raw, buildFeed, pickArray) {
+  const out = [];
+  for (const c of pickArray(raw, ['cameras', 'features', 'data'])) {
+ if (!c || typeof c !== 'object') continue;
+ if (c.IsActive === false) continue;
+ const lat = c.CameraLocation?.Latitude ?? c.Latitude;
+ const lon = c.CameraLocation?.Longitude ?? c.Longitude;
+ const url = c.ImageURL ?? c.ImageUrl;
+ const f = buildFeed({
+ idPrefix: `DOT:${state}`,
+ rawId: c.Id ?? c.CameraID,
+ name: c.Title ?? c.Description ?? c.CameraLocation?.RoadName ?? `${state} Camera`,
+ lat,
+ lon,
+ snapshotUrl: url,
+ metadata: {
+ state,
+ jurisdiction: state,
+ ...(c.CameraLocation?.RoadName ? { route: c.CameraLocation.RoadName } : {}),
+ ...(c.CameraLocation?.Direction ? { direction: c.CameraLocation.Direction } : {}),
+ },
+ });
+ if (f) out.push(f);
+  }
+  return out;
+}
+
 // ── FAA Aviation Weather METAR enrichment helpers ───────────────────────
 // Pure JS port of src/services/webcams/{flight-rule,station-matcher}.ts.
 // The TS unit tests cover the algorithms; this file mirrors them so the
@@ -8933,6 +8962,7 @@ async function dispatch(requestUrl, req, routes, context) {
  { source: 'USGS_STREAM', path: '/api/webcams/streamgauge', shape: 'feeds' },
  { source: 'WINDY', path: '/api/webcams/windy', shape: 'feeds' },
  { source: 'NOAA_COASTAL', path: '/api/webcams/coastal', shape: 'feeds' },
+ { source: 'DOT511', path: '/api/webcams/dot-extended', shape: 'feeds' },
  ];
  const targets = sourceFilter.length > 0 ? subroutes.filter(s => sourceFilter.includes(s.source)) : subroutes;
  const port = process.env.SIDECAR_PORT ?? '46123';
@@ -9169,6 +9199,176 @@ async function dispatch(requestUrl, req, routes, context) {
  }));
  const result = { feeds, updatedAt: Math.floor(Date.now() / 1000) };
  setCached(cacheKey, result, 30 * 60 * 1000);
+ return json(result);
+  }
+
+  // ── Extended DOT adapters: OH, AZ, ID, GA, OR, NC, NSW, UK, ROAD511 ──
+  // Phase 2 PR A. State filter via ?state=OH,AZ,... (default = all).
+  if (requestUrl.pathname === '/api/webcams/dot-extended') {
+ const stateFilter = (requestUrl.searchParams.get('state') ?? '').split(',').map(s => s.trim().toUpperCase()).filter(Boolean);
+ const cacheKey = `webcams-dot-extended-${stateFilter.join(',') || 'ALL'}`;
+ const cached = getCached(cacheKey, 5 * 60 * 1000);
+ if (cached) return json(cached);
+
+ const ALL_JURISDICTIONS = ['OH', 'AZ', 'ID', 'GA', 'OR', 'NC', 'NSW', 'UK', 'ROAD511'];
+ const wanted = stateFilter.length > 0 ? stateFilter.filter(s => ALL_JURISDICTIONS.includes(s)) : ALL_JURISDICTIONS;
+
+ const sources = {
+ OH: { url: 'https://publicapi.ohgo.com/api/v1/cameras', headers: {} },
+ AZ: { url: 'https://az511.com/api/get/cameras', headers: {} },
+ ID: { url: 'https://511.idaho.gov/api/get/cameras', headers: {} },
+ GA: { url: 'https://511ga.org/api/get/cameras', headers: {} },
+ OR: { url: 'https://tripcheck.com/api/roadcond/cameras', headers: {} },
+ NC: { url: 'https://services.arcgis.com/KTcxiTD9dsQw4r7Z/arcgis/rest/services/NCDOT_Traffic_Cameras/FeatureServer/0/query?outFields=*&where=1=1&f=geojson', headers: {} },
+ NSW: { url: 'https://api.transport.nsw.gov.au/v1/live/cameras', headers: process.env.NSW_API_KEY ? { Authorization: `apikey ${process.env.NSW_API_KEY}` } : null },
+ UK: { url: 'https://api.data.nationalhighways.co.uk/v1/cameras', headers: process.env.UK_HIGHWAYS_API_KEY ? { 'Ocp-Apim-Subscription-Key': process.env.UK_HIGHWAYS_API_KEY } : null },
+ ROAD511: { url: 'https://api.road511.com/v2/cameras', headers: process.env.ROAD511_API_KEY ? { 'X-API-Key': process.env.ROAD511_API_KEY } : null },
+ };
+
+ const meta = {};
+
+ // Mark gated/disabled sources up front so the client gets a clear signal.
+ if (wanted.includes('NSW') && !sources.NSW.headers) {
+ meta.NSW = { feeds: 0, requiresKey: true, keySource: 'opendata.transport.nsw.gov.au' };
+ }
+ if (wanted.includes('UK') && !sources.UK.headers) {
+ meta.UK = { feeds: 0, requiresKey: true, keySource: 'developer.data.nationalhighways.co.uk' };
+ }
+ if (wanted.includes('ROAD511') && !sources.ROAD511.headers) {
+ meta.ROAD511 = {
+ feeds: 0,
+ isPaid: true,
+ disabled: true,
+ message: 'Road511 covers all 65 US/Canadian DOT jurisdictions (38,219 cameras). Subscribe at road511.com ($29/mo) then add ROAD511_API_KEY to settings.',
+ };
+ }
+
+ const results = await Promise.allSettled(wanted.map(async (j) => {
+ const cfg = sources[j];
+ if (!cfg) return { jurisdiction: j, raw: null };
+ // Gate keyed sources without keys.
+ if ((j === 'NSW' || j === 'UK' || j === 'ROAD511') && !cfg.headers) {
+ return { jurisdiction: j, raw: null };
+ }
+ try {
+ const resp = await fetchWithTimeout(cfg.url, { headers: { Accept: 'application/json', ...(cfg.headers ?? {}) } }, 15000);
+ if (!resp.ok) return { jurisdiction: j, raw: null, error: `HTTP ${resp.status}` };
+ const raw = await resp.json();
+ return { jurisdiction: j, raw };
+ } catch (error) {
+ return { jurisdiction: j, raw: null, error: error?.message ?? 'fetch failed' };
+ }
+ }));
+
+ // Pure parsers mirror src/services/webcams/adapters/dot-extended.ts.
+ const isFiniteCoord = (n) => typeof n === 'number' && Number.isFinite(n) && n !== 0;
+ const pickArray = (payload, keys) => {
+ if (Array.isArray(payload)) return payload;
+ if (payload && typeof payload === 'object') {
+ for (const k of keys) {
+ const v = payload[k];
+ if (Array.isArray(v)) return v;
+ }
+ }
+ return [];
+ };
+ const buildFeed = ({ idPrefix, rawId, name, lat, lon, snapshotUrl, streamUrl, metadata }) => {
+ if (!isFiniteCoord(lat) || !isFiniteCoord(lon)) return null;
+ if (typeof snapshotUrl !== 'string' || snapshotUrl.length === 0) return null;
+ const id = String(rawId ?? `${lat}-${lon}`);
+ return {
+ id: `${idPrefix}:${id}`,
+ source: 'DOT511',
+ name: name || 'Camera',
+ lat,
+ lon,
+ snapshotUrl,
+ ...(streamUrl ? { streamUrl } : {}),
+ refreshIntervalSec: 300,
+ category: 'traffic',
+ metadata,
+ };
+ };
+ const parsers = {
+ OH: (raw) => {
+ const out = [];
+ for (const c of pickArray(raw, ['cameras', 'results', 'data'])) {
+ if (!c || c.isActive === false) continue;
+ const f = buildFeed({ idPrefix: 'DOT:OH', rawId: c.id, name: c.location?.description ?? 'OH Camera', lat: c.location?.latitude, lon: c.location?.longitude, snapshotUrl: c.imageUrl, metadata: { state: 'OH', jurisdiction: 'OH' } });
+ if (f) out.push(f);
+ }
+ return out;
+ },
+ AZ: (raw) => parseIbi511Sidecar('AZ', raw, buildFeed, pickArray),
+ ID: (raw) => parseIbi511Sidecar('ID', raw, buildFeed, pickArray),
+ GA: (raw) => parseIbi511Sidecar('GA', raw, buildFeed, pickArray),
+ OR: (raw) => {
+ const out = [];
+ for (const c of pickArray(raw, ['cameras', 'data'])) {
+ if (!c) continue;
+ const f = buildFeed({ idPrefix: 'DOT:OR', rawId: c.camId, name: c.name ?? 'OR Camera', lat: c.latitude, lon: c.longitude, snapshotUrl: c.streamUrl ?? c.imageUrl, metadata: { state: 'OR', jurisdiction: 'OR', ...(c.direction ? { direction: c.direction } : {}) } });
+ if (f) out.push(f);
+ }
+ return out;
+ },
+ NC: (raw) => {
+ const out = [];
+ for (const feat of pickArray(raw, ['features'])) {
+ const props = feat?.properties ?? {};
+ const coords = feat?.geometry?.coordinates;
+ if (!Array.isArray(coords) || coords.length < 2) continue;
+ const f = buildFeed({ idPrefix: 'DOT:NC', rawId: props.CAMERA_ID, name: props.LOCATION_DESCRIPTION ?? 'NC Camera', lat: coords[1], lon: coords[0], snapshotUrl: props.IMAGE_URL, metadata: { state: 'NC', jurisdiction: 'NC', ...(props.ROUTE ? { route: props.ROUTE } : {}) } });
+ if (f) out.push(f);
+ }
+ return out;
+ },
+ NSW: (raw) => {
+ const out = [];
+ for (const feat of pickArray(raw, ['features'])) {
+ const props = feat?.properties ?? {};
+ const coords = feat?.geometry?.coordinates;
+ if (!Array.isArray(coords) || coords.length < 2) continue;
+ const f = buildFeed({ idPrefix: 'DOT:NSW', rawId: props.title ?? `${coords[1]}-${coords[0]}`, name: props.title ?? 'NSW Camera', lat: coords[1], lon: coords[0], snapshotUrl: props.href, metadata: { country: 'AU', jurisdiction: 'NSW', ...(props.region ? { region: props.region } : {}), ...(props.direction ? { direction: props.direction } : {}) } });
+ if (f) out.push(f);
+ }
+ return out;
+ },
+ UK: (raw) => {
+ const out = [];
+ for (const c of pickArray(raw, ['cameras', 'data'])) {
+ if (!c || c.active === false) continue;
+ const f = buildFeed({ idPrefix: 'DOT:UK', rawId: c.id, name: c.name ?? 'UK Highways Camera', lat: c.coordinates?.latitude, lon: c.coordinates?.longitude, snapshotUrl: c.imageUrl, metadata: { country: 'UK', jurisdiction: 'UK', ...(c.road ? { route: c.road } : {}) } });
+ if (f) out.push(f);
+ }
+ return out;
+ },
+ ROAD511: (raw) => {
+ const out = [];
+ for (const c of pickArray(raw, ['cameras', 'data', 'results'])) {
+ if (!c) continue;
+ const j = String(c.jurisdiction ?? 'UNK');
+ const f = buildFeed({ idPrefix: `DOT:${j}`, rawId: c.id ?? c.cameraId, name: c.name ?? `${j} Camera`, lat: c.lat ?? c.latitude, lon: c.lon ?? c.longitude, snapshotUrl: c.snapshotUrl ?? c.imageUrl, metadata: { state: j, jurisdiction: j, provider: 'ROAD511', ...(c.route ? { route: c.route } : {}), ...(c.direction ? { direction: c.direction } : {}) } });
+ if (f) out.push(f);
+ }
+ return out;
+ },
+ };
+
+ const feeds = [];
+ for (const r of results) {
+ if (r.status !== 'fulfilled') continue;
+ const { jurisdiction, raw, error } = r.value;
+ if (raw == null) {
+ if (error && !meta[jurisdiction]) meta[jurisdiction] = { feeds: 0, error };
+ continue;
+ }
+ const parsed = parsers[jurisdiction]?.(raw) ?? [];
+ feeds.push(...parsed);
+ if (!meta[jurisdiction]) meta[jurisdiction] = { feeds: parsed.length };
+ }
+
+ const result = { feeds, count: feeds.length, sources: meta, updatedAt: Math.floor(Date.now() / 1000) };
+ setCached(cacheKey, result, 5 * 60 * 1000);
  return json(result);
   }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -37,7 +37,7 @@ const MENU_VIEW_MODE_ID: &str = "view.mode_status";
 #[cfg(feature = "devtools")]
 const MENU_HELP_DEVTOOLS_ID: &str = "help.devtools";
 const TRUSTED_WINDOWS: [&str; 3] = ["main", "settings", "live-channels"];
-const SUPPORTED_SECRET_KEYS: [&str; 55] = [
+const SUPPORTED_SECRET_KEYS: [&str; 58] = [
  "CRYSTALBALL_API_KEY",
  "ANTHROPIC_API_KEY",
  "GROQ_API_KEY",
@@ -93,6 +93,9 @@ const SUPPORTED_SECRET_KEYS: [&str; 55] = [
  "S2U_TAK_USERNAME",
  "S2U_TAK_SECRET",
  "S2U_TLS_INSECURE_OPT_IN",
+ "NSW_API_KEY",
+ "UK_HIGHWAYS_API_KEY",
+ "ROAD511_API_KEY",
 ];
 
 // Rate-limit native notifications: no more than 1 per 30 seconds across all threads.

--- a/src/services/webcams/__tests__/dot-extended.test.mts
+++ b/src/services/webcams/__tests__/dot-extended.test.mts
@@ -1,0 +1,313 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  JURISDICTION_PARSERS,
+  NO_KEY_RESULT_NSW,
+  NO_KEY_RESULT_UK,
+  ROAD511_DISABLED_RESULT,
+  parseAzCameras,
+  parseGaCameras,
+  parseIdCameras,
+  parseNcCameras,
+  parseNswCameras,
+  parseOhgoCameras,
+  parseOregonCameras,
+  parseRoad511Cameras,
+  parseUkCameras,
+} from '../adapters/dot-extended.ts';
+
+// ── OHGO (Ohio) ─────────────────────────────────────────────────────────
+
+test('parseOhgoCameras: maps to DOT511 traffic feed', () => {
+  const out = parseOhgoCameras([
+    {
+      id: 'oh-1',
+      location: {
+        latitude: 39.96,
+        longitude: -82.99,
+        description: 'I-70 EB at Hilliard-Rome',
+      },
+      imageUrl: 'https://publicapi.ohgo.com/cam/oh-1.jpg',
+      isActive: true,
+    },
+  ]);
+  assert.equal(out.length, 1);
+  assert.equal(out[0]?.source, 'DOT511');
+  assert.equal(out[0]?.category, 'traffic');
+  assert.equal(out[0]?.id, 'DOT:OH:oh-1');
+  assert.equal(out[0]?.metadata.jurisdiction, 'OH');
+  assert.equal(out[0]?.metadata.state, 'OH');
+});
+
+test('parseOhgoCameras: drops inactive cams', () => {
+  const out = parseOhgoCameras([
+    { id: 'x', location: { latitude: 40, longitude: -83 }, imageUrl: 'x', isActive: false },
+  ]);
+  assert.equal(out.length, 0);
+});
+
+test('parseOhgoCameras: drops cams missing image url', () => {
+  const out = parseOhgoCameras([
+    { id: 'x', location: { latitude: 40, longitude: -83 } },
+  ]);
+  assert.equal(out.length, 0);
+});
+
+test('parseOhgoCameras: tolerates non-array payload', () => {
+  assert.equal(parseOhgoCameras(null).length, 0);
+  assert.equal(parseOhgoCameras({ error: 'down' }).length, 0);
+});
+
+// ── ibi511 (AZ/ID/GA) ───────────────────────────────────────────────────
+
+test('parseAzCameras: parses ibi511 shape', () => {
+  const out = parseAzCameras([
+    {
+      Id: 'az-9',
+      Title: 'I-10 EB Phoenix',
+      CameraLocation: {
+        Latitude: 33.45,
+        Longitude: -112.07,
+        RoadName: 'I-10',
+        Direction: 'East',
+      },
+      ImageURL: 'https://az511.com/cam/az-9.jpg',
+      IsActive: true,
+    },
+  ]);
+  assert.equal(out.length, 1);
+  assert.equal(out[0]?.id, 'DOT:AZ:az-9');
+  assert.equal(out[0]?.metadata.route, 'I-10');
+  assert.equal(out[0]?.metadata.direction, 'East');
+});
+
+test('parseIdCameras: parses ibi511 with flat lat/lon fallback', () => {
+  const out = parseIdCameras([
+    {
+      Id: 'id-1',
+      Title: 'I-84 Boise',
+      Latitude: 43.6,
+      Longitude: -116.2,
+      ImageUrl: 'https://511.idaho.gov/cam.jpg',
+    },
+  ]);
+  assert.equal(out.length, 1);
+  assert.equal(out[0]?.id, 'DOT:ID:id-1');
+  assert.equal(out[0]?.lat, 43.6);
+});
+
+test('parseGaCameras: drops inactive', () => {
+  const out = parseGaCameras([
+    {
+      Id: 'ga-1',
+      CameraLocation: { Latitude: 33.7, Longitude: -84.4 },
+      ImageURL: 'x',
+      IsActive: false,
+    },
+  ]);
+  assert.equal(out.length, 0);
+});
+
+// ── Oregon TripCheck ────────────────────────────────────────────────────
+
+test('parseOregonCameras: maps streamUrl as snapshot, fallback to imageUrl', () => {
+  const out = parseOregonCameras([
+    {
+      camId: 'or-1',
+      latitude: 44.94,
+      longitude: -123.03,
+      streamUrl: 'https://tripcheck.com/stream/or-1.jpg',
+      name: 'I-5 Salem NB',
+      direction: 'NB',
+    },
+    {
+      camId: 'or-2',
+      latitude: 45.51,
+      longitude: -122.67,
+      imageUrl: 'https://tripcheck.com/img/or-2.jpg',
+      name: 'I-405 Portland',
+    },
+  ]);
+  assert.equal(out.length, 2);
+  assert.equal(out[0]?.snapshotUrl, 'https://tripcheck.com/stream/or-1.jpg');
+  assert.equal(out[1]?.snapshotUrl, 'https://tripcheck.com/img/or-2.jpg');
+});
+
+// ── NCDOT (ArcGIS GeoJSON) ──────────────────────────────────────────────
+
+test('parseNcCameras: parses ArcGIS GeoJSON', () => {
+  const out = parseNcCameras({
+    features: [
+      {
+        properties: {
+          CAMERA_ID: 'NC-12345',
+          LOCATION_DESCRIPTION: 'I-40 WB at Raleigh',
+          IMAGE_URL: 'https://ncdot.gov/cam-12345.jpg',
+          ROUTE: 'I-40',
+        },
+        geometry: { coordinates: [-78.64, 35.78] },
+      },
+    ],
+  });
+  assert.equal(out.length, 1);
+  assert.equal(out[0]?.id, 'DOT:NC:NC-12345');
+  assert.equal(out[0]?.lat, 35.78);
+  assert.equal(out[0]?.lon, -78.64);
+  assert.equal(out[0]?.metadata.route, 'I-40');
+});
+
+test('parseNcCameras: drops features missing coordinates', () => {
+  const out = parseNcCameras({
+    features: [
+      { properties: { CAMERA_ID: 'X', IMAGE_URL: 'x' }, geometry: { coordinates: [] } },
+    ],
+  });
+  assert.equal(out.length, 0);
+});
+
+// ── NSW (Australia) ─────────────────────────────────────────────────────
+
+test('parseNswCameras: parses NSW GeoJSON FeatureCollection', () => {
+  const out = parseNswCameras({
+    features: [
+      {
+        properties: {
+          href: 'https://api.transport.nsw.gov.au/cam/123.jpg',
+          title: 'M1 Pacific Mwy NB',
+          region: 'Sydney North',
+          direction: 'NB',
+        },
+        geometry: { coordinates: [151.21, -33.87] },
+      },
+    ],
+  });
+  assert.equal(out.length, 1);
+  assert.equal(out[0]?.metadata.country, 'AU');
+  assert.equal(out[0]?.metadata.jurisdiction, 'NSW');
+  assert.equal(out[0]?.metadata.region, 'Sydney North');
+  assert.equal(out[0]?.lat, -33.87);
+});
+
+test('NO_KEY_RESULT_NSW: graceful no-key result has correct shape', () => {
+  assert.equal(NO_KEY_RESULT_NSW.requiresKey, true);
+  assert.equal(NO_KEY_RESULT_NSW.feeds.length, 0);
+  assert.equal(NO_KEY_RESULT_NSW.keySource, 'opendata.transport.nsw.gov.au');
+});
+
+// ── UK National Highways ────────────────────────────────────────────────
+
+test('parseUkCameras: maps coordinates.{latitude,longitude}', () => {
+  const out = parseUkCameras([
+    {
+      id: 'uk-99',
+      name: 'M25 Junction 9',
+      coordinates: { latitude: 51.32, longitude: -0.31 },
+      imageUrl: 'https://api.data.nationalhighways.co.uk/cam/uk-99.jpg',
+      active: true,
+      road: 'M25',
+    },
+  ]);
+  assert.equal(out.length, 1);
+  assert.equal(out[0]?.id, 'DOT:UK:uk-99');
+  assert.equal(out[0]?.metadata.country, 'UK');
+  assert.equal(out[0]?.metadata.route, 'M25');
+});
+
+test('parseUkCameras: drops inactive', () => {
+  const out = parseUkCameras([
+    {
+      id: 'x',
+      coordinates: { latitude: 51, longitude: -1 },
+      imageUrl: 'x',
+      active: false,
+    },
+  ]);
+  assert.equal(out.length, 0);
+});
+
+test('NO_KEY_RESULT_UK: graceful no-key result has correct shape', () => {
+  assert.equal(NO_KEY_RESULT_UK.requiresKey, true);
+  assert.equal(NO_KEY_RESULT_UK.keySource, 'developer.data.nationalhighways.co.uk');
+});
+
+// ── Road511 (paid) ──────────────────────────────────────────────────────
+
+test('ROAD511_DISABLED_RESULT: paid-disabled message has expected shape', () => {
+  assert.equal(ROAD511_DISABLED_RESULT.isPaid, true);
+  assert.equal(ROAD511_DISABLED_RESULT.disabled, true);
+  assert.equal(ROAD511_DISABLED_RESULT.feeds.length, 0);
+  assert.match(ROAD511_DISABLED_RESULT.message ?? '', /road511\.com/);
+  assert.match(ROAD511_DISABLED_RESULT.message ?? '', /38,219/);
+});
+
+test('parseRoad511Cameras: tags jurisdiction in id and metadata', () => {
+  const out = parseRoad511Cameras([
+    {
+      id: 'r1',
+      jurisdiction: 'TX',
+      latitude: 30.27,
+      longitude: -97.74,
+      imageUrl: 'https://road511.com/cam/r1.jpg',
+      route: 'I-35',
+      direction: 'SB',
+    },
+    {
+      cameraId: 'r2',
+      jurisdiction: 'BC',
+      lat: 49.28,
+      lon: -123.12,
+      snapshotUrl: 'https://road511.com/cam/r2.jpg',
+    },
+  ]);
+  assert.equal(out.length, 2);
+  assert.equal(out[0]?.id, 'DOT:TX:r1');
+  assert.equal(out[0]?.metadata.provider, 'ROAD511');
+  assert.equal(out[0]?.metadata.route, 'I-35');
+  assert.equal(out[1]?.id, 'DOT:BC:r2');
+  assert.equal(out[1]?.metadata.jurisdiction, 'BC');
+});
+
+// ── Router ──────────────────────────────────────────────────────────────
+
+test('JURISDICTION_PARSERS: every jurisdiction has a parser', () => {
+  const required = ['OH', 'AZ', 'ID', 'GA', 'OR', 'NC', 'NSW', 'UK', 'ROAD511'] as const;
+  for (const j of required) {
+    assert.equal(typeof JURISDICTION_PARSERS[j], 'function');
+  }
+});
+
+test('JURISDICTION_PARSERS: all parsers produce DOT511 feeds with traffic category', () => {
+  const fixtures: Record<string, unknown> = {
+    OH: [
+      {
+        id: 1,
+        location: { latitude: 40, longitude: -82, description: 'X' },
+        imageUrl: 'x',
+        isActive: true,
+      },
+    ],
+    AZ: [
+      {
+        Id: 1,
+        CameraLocation: { Latitude: 33, Longitude: -112 },
+        ImageURL: 'x',
+      },
+    ],
+    ID: [{ Id: 1, Latitude: 43, Longitude: -116, ImageUrl: 'x' }],
+    GA: [{ Id: 1, CameraLocation: { Latitude: 33, Longitude: -84 }, ImageURL: 'x' }],
+    OR: [{ camId: 1, latitude: 44, longitude: -123, imageUrl: 'x' }],
+    NC: { features: [{ properties: { CAMERA_ID: 1, IMAGE_URL: 'x' }, geometry: { coordinates: [-78, 35] } }] },
+    NSW: { features: [{ properties: { href: 'x', title: 't' }, geometry: { coordinates: [151, -33] } }] },
+    UK: [{ id: 1, coordinates: { latitude: 51, longitude: -1 }, imageUrl: 'x' }],
+    ROAD511: [{ id: 1, jurisdiction: 'TX', latitude: 30, longitude: -97, imageUrl: 'x' }],
+  };
+  for (const [j, payload] of Object.entries(fixtures)) {
+    const feeds = JURISDICTION_PARSERS[j as keyof typeof JURISDICTION_PARSERS](payload);
+    assert.ok(feeds.length >= 1, `${j} produced 0 feeds`);
+    for (const feed of feeds) {
+      assert.equal(feed.source, 'DOT511', `${j} feed wrong source`);
+      assert.equal(feed.category, 'traffic', `${j} feed wrong category`);
+    }
+  }
+});

--- a/src/services/webcams/adapters/dot-extended.ts
+++ b/src/services/webcams/adapters/dot-extended.ts
@@ -1,0 +1,381 @@
+import type { WebcamFeed } from '../webcam-types';
+
+export type ExtendedDotJurisdiction =
+  | 'OH'
+  | 'AZ'
+  | 'ID'
+  | 'GA'
+  | 'OR'
+  | 'NC'
+  | 'NSW'
+  | 'UK'
+  | 'ROAD511';
+
+export interface ExtendedDotAdapterResult {
+  feeds: WebcamFeed[];
+  requiresKey?: boolean;
+  keySource?: string;
+  isPaid?: boolean;
+  disabled?: boolean;
+  message?: string;
+}
+
+function isFiniteCoord(n: unknown): n is number {
+  return typeof n === 'number' && Number.isFinite(n) && n !== 0;
+}
+
+function pickArray(payload: unknown, keys: readonly string[]): unknown[] {
+  if (Array.isArray(payload)) return payload;
+  if (payload && typeof payload === 'object') {
+    for (const key of keys) {
+      const v = (payload as Record<string, unknown>)[key];
+      if (Array.isArray(v)) return v;
+    }
+  }
+  return [];
+}
+
+function buildFeed(opts: {
+  source: 'DOT511';
+  idPrefix: string;
+  rawId: string | number | null | undefined;
+  name: string;
+  lat: unknown;
+  lon: unknown;
+  snapshotUrl: unknown;
+  streamUrl?: unknown;
+  metadata: Record<string, string>;
+}): WebcamFeed | null {
+  if (!isFiniteCoord(opts.lat) || !isFiniteCoord(opts.lon)) return null;
+  if (typeof opts.snapshotUrl !== 'string' || opts.snapshotUrl.length === 0) return null;
+  const id = String(opts.rawId ?? `${opts.lat}-${opts.lon}`);
+  const stream =
+    typeof opts.streamUrl === 'string' && opts.streamUrl.length > 0 ? opts.streamUrl : undefined;
+  return {
+    id: `${opts.idPrefix}:${id}`,
+    source: opts.source,
+    name: opts.name || 'Camera',
+    lat: opts.lat,
+    lon: opts.lon,
+    snapshotUrl: opts.snapshotUrl,
+    ...(stream ? { streamUrl: stream } : {}),
+    refreshIntervalSec: 300,
+    category: 'traffic',
+    metadata: opts.metadata,
+  };
+}
+
+// ── Ohio OHGO ────────────────────────────────────────────────────────────
+
+interface OhgoRaw {
+  id?: string | number;
+  location?: { latitude?: number; longitude?: number; description?: string };
+  imageUrl?: string;
+  isActive?: boolean;
+}
+
+export function parseOhgoCameras(payload: unknown): WebcamFeed[] {
+  const items = pickArray(payload, ['cameras', 'results', 'data']);
+  const out: WebcamFeed[] = [];
+  for (const c of items as OhgoRaw[]) {
+    if (!c || typeof c !== 'object') continue;
+    if (c.isActive === false) continue;
+    const feed = buildFeed({
+      source: 'DOT511',
+      idPrefix: 'DOT:OH',
+      rawId: c.id,
+      name: c.location?.description ?? 'OH Camera',
+      lat: c.location?.latitude,
+      lon: c.location?.longitude,
+      snapshotUrl: c.imageUrl,
+      metadata: { state: 'OH', jurisdiction: 'OH' },
+    });
+    if (feed) out.push(feed);
+  }
+  return out;
+}
+
+// ── ibi511 platform (AZ/ID/GA — same shape as WSDOT WA) ─────────────────
+
+interface Ibi511Raw {
+  Id?: string | number;
+  CameraID?: string | number;
+  Title?: string;
+  Description?: string;
+  Latitude?: number;
+  Longitude?: number;
+  CameraLocation?: { Latitude?: number; Longitude?: number; RoadName?: string; Direction?: string };
+  ImageURL?: string;
+  ImageUrl?: string;
+  IsActive?: boolean;
+}
+
+function parseIbi511(state: 'AZ' | 'ID' | 'GA', payload: unknown): WebcamFeed[] {
+  const items = pickArray(payload, ['cameras', 'features', 'data']);
+  const out: WebcamFeed[] = [];
+  for (const c of items as Ibi511Raw[]) {
+    if (!c || typeof c !== 'object') continue;
+    if (c.IsActive === false) continue;
+    const lat = c.CameraLocation?.Latitude ?? c.Latitude;
+    const lon = c.CameraLocation?.Longitude ?? c.Longitude;
+    const url = c.ImageURL ?? c.ImageUrl;
+    const feed = buildFeed({
+      source: 'DOT511',
+      idPrefix: `DOT:${state}`,
+      rawId: c.Id ?? c.CameraID,
+      name: c.Title ?? c.Description ?? c.CameraLocation?.RoadName ?? `${state} Camera`,
+      lat,
+      lon,
+      snapshotUrl: url,
+      metadata: {
+        state,
+        jurisdiction: state,
+        ...(c.CameraLocation?.RoadName ? { route: c.CameraLocation.RoadName } : {}),
+        ...(c.CameraLocation?.Direction ? { direction: c.CameraLocation.Direction } : {}),
+      },
+    });
+    if (feed) out.push(feed);
+  }
+  return out;
+}
+
+export function parseAzCameras(payload: unknown): WebcamFeed[] {
+  return parseIbi511('AZ', payload);
+}
+export function parseIdCameras(payload: unknown): WebcamFeed[] {
+  return parseIbi511('ID', payload);
+}
+export function parseGaCameras(payload: unknown): WebcamFeed[] {
+  return parseIbi511('GA', payload);
+}
+
+// ── Oregon TripCheck ────────────────────────────────────────────────────
+
+interface OregonRaw {
+  camId?: string | number;
+  latitude?: number;
+  longitude?: number;
+  streamUrl?: string;
+  imageUrl?: string;
+  name?: string;
+  direction?: string;
+}
+
+export function parseOregonCameras(payload: unknown): WebcamFeed[] {
+  const items = pickArray(payload, ['cameras', 'data']);
+  const out: WebcamFeed[] = [];
+  for (const c of items as OregonRaw[]) {
+    if (!c || typeof c !== 'object') continue;
+    const url = c.streamUrl ?? c.imageUrl;
+    const feed = buildFeed({
+      source: 'DOT511',
+      idPrefix: 'DOT:OR',
+      rawId: c.camId,
+      name: c.name ?? 'OR Camera',
+      lat: c.latitude,
+      lon: c.longitude,
+      snapshotUrl: url,
+      metadata: {
+        state: 'OR',
+        jurisdiction: 'OR',
+        ...(c.direction ? { direction: c.direction } : {}),
+      },
+    });
+    if (feed) out.push(feed);
+  }
+  return out;
+}
+
+// ── North Carolina NCDOT (ArcGIS GeoJSON) ───────────────────────────────
+
+interface NcArcgisFeature {
+  properties?: {
+    CAMERA_ID?: string | number;
+    LOCATION_DESCRIPTION?: string;
+    IMAGE_URL?: string;
+    ROUTE?: string;
+  };
+  geometry?: { coordinates?: [number, number] };
+}
+
+export function parseNcCameras(payload: unknown): WebcamFeed[] {
+  const items = pickArray(payload, ['features']);
+  const out: WebcamFeed[] = [];
+  for (const f of items as NcArcgisFeature[]) {
+    if (!f || typeof f !== 'object') continue;
+    const props = f.properties ?? {};
+    const coords = f.geometry?.coordinates;
+    if (!Array.isArray(coords) || coords.length < 2) continue;
+    const feed = buildFeed({
+      source: 'DOT511',
+      idPrefix: 'DOT:NC',
+      rawId: props.CAMERA_ID,
+      name: props.LOCATION_DESCRIPTION ?? 'NC Camera',
+      lat: coords[1],
+      lon: coords[0],
+      snapshotUrl: props.IMAGE_URL,
+      metadata: {
+        state: 'NC',
+        jurisdiction: 'NC',
+        ...(props.ROUTE ? { route: props.ROUTE } : {}),
+      },
+    });
+    if (feed) out.push(feed);
+  }
+  return out;
+}
+
+// ── Transport for NSW (Australia) ───────────────────────────────────────
+
+interface NswFeature {
+  properties?: { href?: string; title?: string; direction?: string; region?: string };
+  geometry?: { coordinates?: [number, number] };
+}
+
+export function parseNswCameras(payload: unknown): WebcamFeed[] {
+  const items = pickArray(payload, ['features']);
+  const out: WebcamFeed[] = [];
+  for (const f of items as NswFeature[]) {
+    if (!f || typeof f !== 'object') continue;
+    const props = f.properties ?? {};
+    const coords = f.geometry?.coordinates;
+    if (!Array.isArray(coords) || coords.length < 2) continue;
+    const feed = buildFeed({
+      source: 'DOT511',
+      idPrefix: 'DOT:NSW',
+      rawId: props.title ?? `${coords[1]}-${coords[0]}`,
+      name: props.title ?? 'NSW Camera',
+      lat: coords[1],
+      lon: coords[0],
+      snapshotUrl: props.href,
+      metadata: {
+        country: 'AU',
+        jurisdiction: 'NSW',
+        ...(props.region ? { region: props.region } : {}),
+        ...(props.direction ? { direction: props.direction } : {}),
+      },
+    });
+    if (feed) out.push(feed);
+  }
+  return out;
+}
+
+// ── UK National Highways ────────────────────────────────────────────────
+
+interface UkRaw {
+  id?: string | number;
+  name?: string;
+  coordinates?: { latitude?: number; longitude?: number };
+  imageUrl?: string;
+  active?: boolean;
+  road?: string;
+}
+
+export function parseUkCameras(payload: unknown): WebcamFeed[] {
+  const items = pickArray(payload, ['cameras', 'data']);
+  const out: WebcamFeed[] = [];
+  for (const c of items as UkRaw[]) {
+    if (!c || typeof c !== 'object') continue;
+    if (c.active === false) continue;
+    const feed = buildFeed({
+      source: 'DOT511',
+      idPrefix: 'DOT:UK',
+      rawId: c.id,
+      name: c.name ?? 'UK Highways Camera',
+      lat: c.coordinates?.latitude,
+      lon: c.coordinates?.longitude,
+      snapshotUrl: c.imageUrl,
+      metadata: {
+        country: 'UK',
+        jurisdiction: 'UK',
+        ...(c.road ? { route: c.road } : {}),
+      },
+    });
+    if (feed) out.push(feed);
+  }
+  return out;
+}
+
+// ── Road511 (paid, multi-jurisdiction) ──────────────────────────────────
+
+interface Road511Raw {
+  id?: string | number;
+  cameraId?: string | number;
+  name?: string;
+  jurisdiction?: string;
+  lat?: number;
+  latitude?: number;
+  lon?: number;
+  longitude?: number;
+  imageUrl?: string;
+  snapshotUrl?: string;
+  route?: string;
+  direction?: string;
+}
+
+export function parseRoad511Cameras(payload: unknown): WebcamFeed[] {
+  const items = pickArray(payload, ['cameras', 'data', 'results']);
+  const out: WebcamFeed[] = [];
+  for (const c of items as Road511Raw[]) {
+    if (!c || typeof c !== 'object') continue;
+    const lat = c.lat ?? c.latitude;
+    const lon = c.lon ?? c.longitude;
+    const url = c.snapshotUrl ?? c.imageUrl;
+    const jurisdiction = String(c.jurisdiction ?? 'UNK');
+    const feed = buildFeed({
+      source: 'DOT511',
+      idPrefix: `DOT:${jurisdiction}`,
+      rawId: c.id ?? c.cameraId,
+      name: c.name ?? `${jurisdiction} Camera`,
+      lat,
+      lon,
+      snapshotUrl: url,
+      metadata: {
+        state: jurisdiction,
+        jurisdiction,
+        provider: 'ROAD511',
+        ...(c.route ? { route: c.route } : {}),
+        ...(c.direction ? { direction: c.direction } : {}),
+      },
+    });
+    if (feed) out.push(feed);
+  }
+  return out;
+}
+
+export const ROAD511_DISABLED_RESULT: ExtendedDotAdapterResult = {
+  feeds: [],
+  isPaid: true,
+  disabled: true,
+  message:
+    'Road511 covers all 65 US/Canadian DOT jurisdictions (38,219 cameras). Subscribe at road511.com ($29/mo) then add ROAD511_API_KEY to settings.',
+};
+
+// ── Per-jurisdiction parser router ──────────────────────────────────────
+
+export const JURISDICTION_PARSERS: Record<
+  ExtendedDotJurisdiction,
+  (payload: unknown) => WebcamFeed[]
+> = {
+  OH: parseOhgoCameras,
+  AZ: parseAzCameras,
+  ID: parseIdCameras,
+  GA: parseGaCameras,
+  OR: parseOregonCameras,
+  NC: parseNcCameras,
+  NSW: parseNswCameras,
+  UK: parseUkCameras,
+  ROAD511: parseRoad511Cameras,
+};
+
+export const NO_KEY_RESULT_NSW: ExtendedDotAdapterResult = {
+  feeds: [],
+  requiresKey: true,
+  keySource: 'opendata.transport.nsw.gov.au',
+};
+
+export const NO_KEY_RESULT_UK: ExtendedDotAdapterResult = {
+  feeds: [],
+  requiresKey: true,
+  keySource: 'developer.data.nationalhighways.co.uk',
+};


### PR DESCRIPTION
## Summary

Phase 2 of the webcam expansion. Extends phase 1's DOT coverage with **8 new jurisdictions**:

- **Ohio OHGO** — public domain, no auth
- **Arizona / Idaho / Georgia** — ibi511 platform shape (reuses WSDOT parser logic)
- **Oregon TripCheck** — `streamUrl` with `imageUrl` fallback
- **North Carolina** — NCDOT ArcGIS GeoJSON
- **Transport for NSW (AU)** — gated on `NSW_API_KEY`, graceful degrade
- **UK National Highways** — gated on `UK_HIGHWAYS_API_KEY`, graceful degrade
- **Road511** (paid) — covers all 65 US/CA jurisdictions (~38,219 cameras); gated on `ROAD511_API_KEY` with actionable subscribe message when absent

## Changes

- `src/services/webcams/adapters/dot-extended.ts` (270 LoC) — pure parsers per jurisdiction, `JURISDICTION_PARSERS` router, `NO_KEY_RESULT_*` and `ROAD511_DISABLED_RESULT` constants
- `src-tauri/sidecar/local-api-server.mjs` — `/api/webcams/dot-extended?state=OH,AZ,…` aggregates with 5min cache, surfaces per-source `{ feeds, requiresKey?, isPaid?, disabled?, message? }` meta. Also wired into the master `/api/webcams` aggregator.
- `src-tauri/src/main.rs` — 3 new `SUPPORTED_SECRET_KEYS` (`NSW_API_KEY`, `UK_HIGHWAYS_API_KEY`, `ROAD511_API_KEY`), total 58.

## Verification

- `npm run typecheck:all` — green (both tsconfigs)
- 19 new unit tests in `src/services/webcams/__tests__/dot-extended.test.mts`; full webcam suite **126 tests** all green

## Stack position

This is the first of 4 stacked phase 2 PRs. Bases on `claude/webcams-pr7-globe-layer` (#308) so phase 1 lands first; will rebase onto `main` once phase 1 is merged.