### PR TITLE
feat(webcams): proximity index + event triggers (Phase 2 PR B)

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -9372,6 +9372,79 @@ async function dispatch(requestUrl, req, routes, context) {
  return json(result);
   }
 
+  // ── Proximity search across the master catalog (Phase 2 PR B) ──
+  if (requestUrl.pathname === '/api/webcams/near') {
+ const lat = Number(requestUrl.searchParams.get('lat'));
+ const lon = Number(requestUrl.searchParams.get('lon'));
+ const radiusKm = Number(requestUrl.searchParams.get('radiusKm') ?? 100);
+ const categoryFilter = requestUrl.searchParams.get('category')?.toLowerCase() ?? null;
+ if (!Number.isFinite(lat) || !Number.isFinite(lon) || !Number.isFinite(radiusKm) || radiusKm <= 0) {
+ return json({ feeds: [], error: 'lat, lon, radiusKm required' }, 400);
+ }
+ const port = process.env.SIDECAR_PORT ?? '46123';
+ try {
+ const r = await fetchWithTimeout(`http://127.0.0.1:${port}/api/webcams`, { headers: { Accept: 'application/json' } }, 20000);
+ if (!r.ok) return json({ feeds: [], error: `master HTTP ${r.status}` }, 502);
+ const data = await r.json();
+ const all = Array.isArray(data?.feeds) ? data.feeds : [];
+ const haversine = (lat1, lon1, lat2, lon2) => {
+ const toRad = (d) => (d * Math.PI) / 180;
+ const dLat = toRad(lat2 - lat1);
+ const dLon = toRad(lon2 - lon1);
+ const a = Math.sin(dLat / 2) ** 2 + Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+ const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+ return 6371.0088 * c;
+ };
+ const scored = [];
+ for (const f of all) {
+ if (categoryFilter && f.category !== categoryFilter) continue;
+ if (!Number.isFinite(f.lat) || !Number.isFinite(f.lon)) continue;
+ const km = haversine(lat, lon, f.lat, f.lon);
+ if (km <= radiusKm) scored.push({ feed: f, km });
+ }
+ scored.sort((a, b) => a.km - b.km);
+ const feeds = scored.map(s => ({ ...s.feed, distanceKm: Number(s.km.toFixed(2)) }));
+ return json({ feeds, count: feeds.length, queryLat: lat, queryLon: lon, radiusKm, updatedAt: Math.floor(Date.now() / 1000) });
+ } catch (error) {
+ return json({ feeds: [], error: error?.message ?? 'fetch failed' }, 502);
+ }
+  }
+
+  // ── Active webcam-trigger events (Phase 2 PR B) ──
+  // GET returns the rolling-window list; POST appends a renderer-derived event.
+  // The registry is in-memory because triggers are best-effort and recoverable
+  // — losing them on sidecar restart is fine; the renderer re-evaluates.
+  if (requestUrl.pathname === '/api/webcams/triggers') {
+ if (req.method === 'POST') {
+ try {
+ const chunks = [];
+ for await (const c of req) chunks.push(c);
+ const body = JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+ if (body && typeof body === 'object' && body.kind && Array.isArray(body.affectedCamIds)) {
+ globalThis.__webcamTriggerRegistry ??= [];
+ globalThis.__webcamTriggerRegistry.push({
+ kind: body.kind,
+ triggeredAt: typeof body.triggeredAt === 'number' ? body.triggeredAt : Date.now(),
+ affectedCamIds: body.affectedCamIds,
+ reason: String(body.reason ?? ''),
+ metadata: body.metadata && typeof body.metadata === 'object' ? body.metadata : {},
+ });
+ if (globalThis.__webcamTriggerRegistry.length > 200) {
+ globalThis.__webcamTriggerRegistry.splice(0, globalThis.__webcamTriggerRegistry.length - 200);
+ }
+ return json({ ok: true });
+ }
+ return json({ ok: false, error: 'invalid event' }, 400);
+ } catch {
+ return json({ ok: false, error: 'invalid JSON' }, 400);
+ }
+ }
+ const events = Array.isArray(globalThis.__webcamTriggerRegistry) ? globalThis.__webcamTriggerRegistry : [];
+ const cutoff = Date.now() - 30 * 60 * 1000;
+ const active = events.filter(e => e.triggeredAt >= cutoff);
+ return json({ active, updatedAt: Math.floor(Date.now() / 1000) });
+  }
+
   if (context.cloudFallback && cloudPreferred.has(requestUrl.pathname)) {
  const cloudResponse = await tryCloudFallback(requestUrl, req, context);
  if (cloudResponse) return cloudResponse;

--- a/src/services/webcams/__tests__/webcam-event-triggers.test.mts
+++ b/src/services/webcams/__tests__/webcam-event-triggers.test.mts
@@ -1,0 +1,230 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  FIRE_RADIUS_KM,
+  FLOOD_RADIUS_KM,
+  KNOWN_VOLCANO_COORDS,
+  SEISMIC_MIN_MAGNITUDE,
+  SEISMIC_VOLCANO_RADIUS_KM,
+  WebcamTriggerRegistry,
+  evaluateFireTrigger,
+  evaluateFloodTrigger,
+  evaluateSeismicVolcanoTrigger,
+} from '../webcam-event-triggers.ts';
+import { WebcamSpatialIndex } from '../webcam-spatial.ts';
+import type { WebcamFeed } from '../webcam-types.ts';
+
+function feed(overrides: Partial<WebcamFeed>): WebcamFeed {
+  return {
+    id: 'cam',
+    source: 'FAA',
+    name: 'Cam',
+    lat: 0,
+    lon: 0,
+    snapshotUrl: 'x',
+    refreshIntervalSec: 60,
+    category: 'weather',
+    metadata: {},
+    ...overrides,
+  };
+}
+
+const KILAUEA = KNOWN_VOLCANO_COORDS[0]!;
+const NOW = 1_745_000_000_000;
+
+// ── Seismic / Volcano ───────────────────────────────────────────────────
+
+test('seismic_volcano: M4.5+ near volcano with cam → trigger', () => {
+  const index = new WebcamSpatialIndex({
+    feeds: [
+      feed({ id: 'kil-cam', lat: KILAUEA.lat, lon: KILAUEA.lon, category: 'volcano' }),
+    ],
+  });
+  const trig = evaluateSeismicVolcanoTrigger(
+    {
+      id: 'usgs:1',
+      lat: KILAUEA.lat + 0.05,
+      lon: KILAUEA.lon + 0.05,
+      magnitude: 5.1,
+      occurredAt: NOW,
+    },
+    index,
+    NOW,
+  );
+  assert.ok(trig);
+  assert.equal(trig.kind, 'seismic_volcano');
+  assert.deepEqual(trig.affectedCamIds, ['kil-cam']);
+  assert.equal(trig.metadata.volcano, 'Kilauea');
+});
+
+test('seismic_volcano: below M4.5 threshold → no trigger', () => {
+  const index = new WebcamSpatialIndex({
+    feeds: [feed({ id: 'kil-cam', lat: KILAUEA.lat, lon: KILAUEA.lon, category: 'volcano' })],
+  });
+  const trig = evaluateSeismicVolcanoTrigger(
+    { id: 'q', lat: KILAUEA.lat, lon: KILAUEA.lon, magnitude: SEISMIC_MIN_MAGNITUDE - 0.1, occurredAt: NOW },
+    index,
+  );
+  assert.equal(trig, null);
+});
+
+test('seismic_volcano: outside 150km of any volcano → no trigger', () => {
+  const index = new WebcamSpatialIndex({
+    feeds: [feed({ id: 'kil-cam', lat: KILAUEA.lat, lon: KILAUEA.lon, category: 'volcano' })],
+  });
+  // ~5° east of Kilauea = ~530 km away
+  const trig = evaluateSeismicVolcanoTrigger(
+    { id: 'q', lat: KILAUEA.lat, lon: KILAUEA.lon + 5, magnitude: 6.0, occurredAt: NOW },
+    index,
+  );
+  assert.equal(trig, null);
+});
+
+test('seismic_volcano: no volcano cams → no trigger', () => {
+  const index = new WebcamSpatialIndex({
+    feeds: [feed({ id: 'fire-cam', lat: KILAUEA.lat, lon: KILAUEA.lon, category: 'fire' })],
+  });
+  const trig = evaluateSeismicVolcanoTrigger(
+    { id: 'q', lat: KILAUEA.lat, lon: KILAUEA.lon, magnitude: 5.0, occurredAt: NOW },
+    index,
+  );
+  assert.equal(trig, null);
+});
+
+test('seismic_volcano: null magnitude → no trigger', () => {
+  const index = new WebcamSpatialIndex({
+    feeds: [feed({ id: 'kil-cam', lat: KILAUEA.lat, lon: KILAUEA.lon, category: 'volcano' })],
+  });
+  const trig = evaluateSeismicVolcanoTrigger(
+    { id: 'q', lat: KILAUEA.lat, lon: KILAUEA.lon, magnitude: null, occurredAt: NOW },
+    index,
+  );
+  assert.equal(trig, null);
+});
+
+// ── Fire ────────────────────────────────────────────────────────────────
+
+test('fire: incident within FIRE_RADIUS_KM of fire cam → trigger', () => {
+  const index = new WebcamSpatialIndex({
+    feeds: [
+      feed({ id: 'aw-1', lat: 38.0, lon: -120.0, category: 'fire' }),
+      feed({ id: 'aw-2', lat: 38.0, lon: -119.0, category: 'fire' }), // ~88 km east
+      feed({ id: 'unrelated', lat: 38.0, lon: -120.0, category: 'weather' }),
+    ],
+  });
+  const trig = evaluateFireTrigger(
+    { id: 'fire-1', lat: 38.0, lon: -120.0, name: 'Test Fire', detectedAt: NOW },
+    index,
+    NOW,
+  );
+  assert.ok(trig);
+  assert.equal(trig.kind, 'fire');
+  assert.ok(trig.affectedCamIds.includes('aw-1'));
+  assert.ok(!trig.affectedCamIds.includes('unrelated'));
+});
+
+test('fire: incident far from any fire cam → no trigger', () => {
+  const index = new WebcamSpatialIndex({
+    feeds: [feed({ id: 'aw', lat: 38, lon: -120, category: 'fire' })],
+  });
+  const trig = evaluateFireTrigger(
+    { id: 'f', lat: 25, lon: -80, name: 'X', detectedAt: NOW },
+    index,
+  );
+  assert.equal(trig, null);
+});
+
+test('fire: confirmed FIRE_RADIUS_KM constant is 75', () => {
+  assert.equal(FIRE_RADIUS_KM, 75);
+});
+
+// ── Flood ───────────────────────────────────────────────────────────────
+
+test('flood: gauge at action stage with nearby stream cam → trigger', () => {
+  const index = new WebcamSpatialIndex({
+    feeds: [feed({ id: 'gauge-cam', lat: 38.5, lon: -121.5, category: 'stream' })],
+  });
+  const trig = evaluateFloodTrigger(
+    { siteNo: '11447650', lat: 38.5, lon: -121.5, stageLabel: 'action', observedAt: NOW },
+    index,
+    NOW,
+  );
+  assert.ok(trig);
+  assert.equal(trig.kind, 'flood');
+  assert.deepEqual(trig.affectedCamIds, ['gauge-cam']);
+});
+
+test('flood: picks nearest stream cam when multiple in range', () => {
+  const index = new WebcamSpatialIndex({
+    feeds: [
+      feed({ id: 'far', lat: 38.5, lon: -121.0, category: 'stream' }), // ~43km east
+      feed({ id: 'near', lat: 38.5, lon: -121.5, category: 'stream' }),
+    ],
+  });
+  const trig = evaluateFloodTrigger(
+    { siteNo: 's', lat: 38.5, lon: -121.5, stageLabel: 'major', observedAt: NOW },
+    index,
+  );
+  assert.ok(trig);
+  assert.deepEqual(trig.affectedCamIds, ['near']);
+});
+
+test('flood: invalid stageLabel rejected', () => {
+  const index = new WebcamSpatialIndex({
+    feeds: [feed({ id: 'g', lat: 38.5, lon: -121.5, category: 'stream' })],
+  });
+  const trig = evaluateFloodTrigger(
+    {
+      siteNo: 's',
+      lat: 38.5,
+      lon: -121.5,
+      // @ts-expect-error — testing runtime validation
+      stageLabel: 'normal',
+      observedAt: NOW,
+    },
+    index,
+  );
+  assert.equal(trig, null);
+});
+
+test('flood: gauge with no stream cams in range → no trigger', () => {
+  const index = new WebcamSpatialIndex({
+    feeds: [feed({ id: 'g', lat: 38, lon: -121, category: 'stream' })],
+  });
+  const trig = evaluateFloodTrigger(
+    { siteNo: 's', lat: 50, lon: -100, stageLabel: 'major', observedAt: NOW },
+    index,
+  );
+  assert.equal(trig, null);
+});
+
+test('flood: confirmed FLOOD_RADIUS_KM constant is 50', () => {
+  assert.equal(FLOOD_RADIUS_KM, 50);
+});
+
+// ── Registry ────────────────────────────────────────────────────────────
+
+test('WebcamTriggerRegistry: stores and returns active events within window', () => {
+  const reg = new WebcamTriggerRegistry(60_000); // 60s window
+  reg.push({
+    kind: 'fire',
+    triggeredAt: NOW,
+    affectedCamIds: ['a'],
+    reason: 'r',
+    metadata: {},
+  });
+  const active = reg.active(NOW + 30_000);
+  assert.equal(active.length, 1);
+});
+
+test('WebcamTriggerRegistry: drops events outside window', () => {
+  const reg = new WebcamTriggerRegistry(60_000);
+  reg.push({ kind: 'fire', triggeredAt: NOW, affectedCamIds: ['a'], reason: 'r', metadata: {} });
+  const active = reg.active(NOW + 120_000);
+  assert.equal(active.length, 0);
+});
+
+test('SEISMIC_VOLCANO_RADIUS_KM constant exposed for callers', () => {
+  assert.equal(SEISMIC_VOLCANO_RADIUS_KM, 150);
+});

--- a/src/services/webcams/__tests__/webcam-spatial.test.mts
+++ b/src/services/webcams/__tests__/webcam-spatial.test.mts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { WebcamSpatialIndex, haversineKm } from '../webcam-spatial.ts';
+import type { WebcamFeed } from '../webcam-types.ts';
+
+function feed(overrides: Partial<WebcamFeed>): WebcamFeed {
+  return {
+    id: 'cam',
+    source: 'FAA',
+    name: 'Cam',
+    lat: 0,
+    lon: 0,
+    snapshotUrl: 'x',
+    refreshIntervalSec: 60,
+    category: 'weather',
+    metadata: {},
+    ...overrides,
+  };
+}
+
+// ── haversineKm ─────────────────────────────────────────────────────────
+
+test('haversineKm: zero distance for same point', () => {
+  assert.equal(haversineKm(40, -74, 40, -74), 0);
+});
+
+test('haversineKm: NYC ↔ LA approx 3935 km (within 1%)', () => {
+  const km = haversineKm(40.7128, -74.006, 34.0522, -118.2437);
+  assert.ok(Math.abs(km - 3935) < 40, `got ${km}`);
+});
+
+test('haversineKm: 1° latitude near equator ~111.2 km', () => {
+  const km = haversineKm(0, 0, 1, 0);
+  assert.ok(Math.abs(km - 111.2) < 1, `got ${km}`);
+});
+
+// ── nearest ─────────────────────────────────────────────────────────────
+
+test('nearest: returns cams within radius sorted by distance', () => {
+  const index = new WebcamSpatialIndex({
+    feeds: [
+      feed({ id: 'a', lat: 40.0, lon: -74.0 }),
+      feed({ id: 'b', lat: 40.5, lon: -74.0 }),
+      feed({ id: 'c', lat: 50.0, lon: -74.0 }),
+    ],
+  });
+  const out = index.nearest(40.0, -74.0, 100);
+  assert.deepEqual(out.map((f) => f.id), ['a', 'b']);
+});
+
+test('nearest: respects maxResults', () => {
+  const feeds = Array.from({ length: 10 }, (_, i) =>
+    feed({ id: `cam-${i}`, lat: 40 + i * 0.01, lon: -74 }),
+  );
+  const index = new WebcamSpatialIndex({ feeds });
+  const out = index.nearest(40, -74, 1000, { maxResults: 3 });
+  assert.equal(out.length, 3);
+});
+
+test('nearest: returns empty for zero/negative radius', () => {
+  const index = new WebcamSpatialIndex({ feeds: [feed({ id: 'a', lat: 40, lon: -74 })] });
+  assert.deepEqual(index.nearest(40, -74, 0), []);
+  assert.deepEqual(index.nearest(40, -74, -5), []);
+});
+
+test('nearest: ignores invalid lat/lon coords on input', () => {
+  const index = new WebcamSpatialIndex({ feeds: [] });
+  assert.deepEqual(index.nearest(NaN, -74, 50), []);
+});
+
+// ── inBbox ──────────────────────────────────────────────────────────────
+
+test('inBbox: filters by rectangle', () => {
+  const index = new WebcamSpatialIndex({
+    feeds: [
+      feed({ id: 'a', lat: 41, lon: -86 }),
+      feed({ id: 'b', lat: 35, lon: -100 }),
+      feed({ id: 'c', lat: 41.5, lon: -85.5 }),
+    ],
+  });
+  const out = index.inBbox(40, -90, 42, -80);
+  assert.deepEqual(out.map((f) => f.id).sort(), ['a', 'c']);
+});
+
+// ── byCategory ──────────────────────────────────────────────────────────
+
+test('byCategory: filters by exact category match', () => {
+  const index = new WebcamSpatialIndex({
+    feeds: [
+      feed({ id: 'a', category: 'fire' }),
+      feed({ id: 'b', category: 'volcano' }),
+      feed({ id: 'c', category: 'fire' }),
+    ],
+  });
+  const out = index.byCategory('fire');
+  assert.deepEqual(out.map((f) => f.id).sort(), ['a', 'c']);
+});
+
+test('size: reflects feed count', () => {
+  const index = new WebcamSpatialIndex({
+    feeds: [feed({ id: 'a' }), feed({ id: 'b' })],
+  });
+  assert.equal(index.size(), 2);
+});

--- a/src/services/webcams/webcam-event-triggers.ts
+++ b/src/services/webcams/webcam-event-triggers.ts
@@ -1,0 +1,182 @@
+import { WebcamSpatialIndex, haversineKm } from './webcam-spatial.ts';
+import type { WebcamFeed } from './webcam-types';
+
+export type WebcamTriggerKind = 'seismic_volcano' | 'fire' | 'flood';
+
+export interface SeismicEventInput {
+  id: string;
+  lat: number;
+  lon: number;
+  magnitude: number | null;
+  occurredAt: number;
+}
+
+export interface FireIncidentInput {
+  id: string;
+  lat: number;
+  lon: number;
+  name: string;
+  detectedAt: number;
+}
+
+export interface FloodGaugeInput {
+  siteNo: string;
+  lat: number;
+  lon: number;
+  stageLabel: 'action' | 'minor' | 'moderate' | 'major';
+  observedAt: number;
+}
+
+export interface WebcamTriggerEvent {
+  kind: WebcamTriggerKind;
+  triggeredAt: number;
+  affectedCamIds: string[];
+  reason: string;
+  metadata: Record<string, string | number>;
+}
+
+// ── Seismic / Volcano ───────────────────────────────────────────────────
+
+export const KNOWN_VOLCANO_COORDS: readonly { name: string; lat: number; lon: number }[] = [
+  { name: 'Kilauea', lat: 19.4067, lon: -155.2834 },
+  { name: 'Mauna Loa', lat: 19.475, lon: -155.608 },
+  { name: 'Yellowstone', lat: 44.46, lon: -110.829 },
+  { name: 'Mount St. Helens', lat: 46.276, lon: -122.218 },
+  { name: 'Mount Hood', lat: 45.331, lon: -121.711 },
+  { name: 'Mount Rainier', lat: 46.836, lon: -121.731 },
+  { name: 'Redoubt', lat: 60.485, lon: -152.742 },
+  { name: 'Pavlof', lat: 55.42, lon: -161.894 },
+  { name: 'Cleveland', lat: 52.825, lon: -169.944 },
+  { name: 'Shishaldin', lat: 54.756, lon: -163.97 },
+];
+
+export const SEISMIC_VOLCANO_RADIUS_KM = 150;
+export const SEISMIC_MIN_MAGNITUDE = 4.5;
+
+export function evaluateSeismicVolcanoTrigger(
+  event: SeismicEventInput,
+  index: WebcamSpatialIndex,
+  now: number = Date.now(),
+): WebcamTriggerEvent | null {
+  if (event.magnitude == null || event.magnitude < SEISMIC_MIN_MAGNITUDE) return null;
+  const closeVolcano = KNOWN_VOLCANO_COORDS.find(
+    (v) => haversineKm(event.lat, event.lon, v.lat, v.lon) <= SEISMIC_VOLCANO_RADIUS_KM,
+  );
+  if (!closeVolcano) return null;
+  const candidates = index
+    .byCategory('volcano')
+    .filter((f) => haversineKm(closeVolcano.lat, closeVolcano.lon, f.lat, f.lon) <= 50);
+  if (candidates.length === 0) return null;
+  return {
+    kind: 'seismic_volcano',
+    triggeredAt: now,
+    affectedCamIds: candidates.map((c) => c.id),
+    reason: `M${event.magnitude.toFixed(1)} quake within ${SEISMIC_VOLCANO_RADIUS_KM}km of ${closeVolcano.name}`,
+    metadata: {
+      eventId: event.id,
+      volcano: closeVolcano.name,
+      magnitude: event.magnitude,
+    },
+  };
+}
+
+// ── Fire ────────────────────────────────────────────────────────────────
+
+export const FIRE_RADIUS_KM = 75;
+
+export function evaluateFireTrigger(
+  incident: FireIncidentInput,
+  index: WebcamSpatialIndex,
+  now: number = Date.now(),
+): WebcamTriggerEvent | null {
+  const fireCams = index.byCategory('fire');
+  const matched = fireCams.filter(
+    (f) => haversineKm(incident.lat, incident.lon, f.lat, f.lon) <= FIRE_RADIUS_KM,
+  );
+  if (matched.length === 0) return null;
+  return {
+    kind: 'fire',
+    triggeredAt: now,
+    affectedCamIds: matched.map((c) => c.id),
+    reason: `Active fire incident "${incident.name}" within ${FIRE_RADIUS_KM}km`,
+    metadata: { incidentId: incident.id, incidentName: incident.name },
+  };
+}
+
+// ── Flood ───────────────────────────────────────────────────────────────
+
+export const FLOOD_RADIUS_KM = 50;
+const FLOOD_STAGES = new Set<FloodGaugeInput['stageLabel']>([
+  'action',
+  'minor',
+  'moderate',
+  'major',
+]);
+
+export function evaluateFloodTrigger(
+  gauge: FloodGaugeInput,
+  index: WebcamSpatialIndex,
+  now: number = Date.now(),
+): WebcamTriggerEvent | null {
+  if (!FLOOD_STAGES.has(gauge.stageLabel)) return null;
+  const streamCams = index.byCategory('stream');
+  if (streamCams.length === 0) return null;
+  let nearest: WebcamFeed | null = null;
+  let nearestKm = Infinity;
+  for (const cam of streamCams) {
+    const km = haversineKm(gauge.lat, gauge.lon, cam.lat, cam.lon);
+    if (km <= FLOOD_RADIUS_KM && km < nearestKm) {
+      nearestKm = km;
+      nearest = cam;
+    }
+  }
+  if (!nearest) return null;
+  return {
+    kind: 'flood',
+    triggeredAt: now,
+    affectedCamIds: [nearest.id],
+    reason: `Stream gauge ${gauge.siteNo} at ${gauge.stageLabel} stage`,
+    metadata: { siteNo: gauge.siteNo, stage: gauge.stageLabel, distanceKm: Number(nearestKm.toFixed(2)) },
+  };
+}
+
+// ── Registry ────────────────────────────────────────────────────────────
+
+export class WebcamTriggerRegistry {
+  private readonly events: WebcamTriggerEvent[] = [];
+  private readonly maxAgeMs: number;
+
+  constructor(maxAgeMs: number = 30 * 60 * 1000) {
+    this.maxAgeMs = maxAgeMs;
+  }
+
+  push(event: WebcamTriggerEvent): void {
+    this.events.push(event);
+  }
+
+  active(now: number = Date.now()): WebcamTriggerEvent[] {
+    const cutoff = now - this.maxAgeMs;
+    return this.events.filter((e) => e.triggeredAt >= cutoff);
+  }
+
+  clear(): void {
+    this.events.length = 0;
+  }
+}
+
+let SINGLETON: WebcamTriggerRegistry | null = null;
+export function getWebcamTriggerRegistry(): WebcamTriggerRegistry {
+  SINGLETON ??= new WebcamTriggerRegistry();
+  return SINGLETON;
+}
+
+// ── Browser-side bridge: dispatches `webcam:highlight` for UI consumers ──
+
+export function emitWebcamHighlight(event: WebcamTriggerEvent): void {
+  if (typeof window === 'undefined' || typeof CustomEvent === 'undefined') return;
+  window.dispatchEvent(
+    new CustomEvent('webcam:highlight', {
+      detail: { kind: event.kind, camIds: event.affectedCamIds, reason: event.reason },
+    }),
+  );
+}

--- a/src/services/webcams/webcam-spatial.ts
+++ b/src/services/webcams/webcam-spatial.ts
@@ -1,0 +1,66 @@
+import type { WebcamCatalog, WebcamCategory, WebcamFeed } from './webcam-types';
+
+const EARTH_RADIUS_KM = 6371.0088;
+
+function toRadians(deg: number): number {
+  return (deg * Math.PI) / 180;
+}
+
+export function haversineKm(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number,
+): number {
+  const dLat = toRadians(lat2 - lat1);
+  const dLon = toRadians(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRadians(lat1)) * Math.cos(toRadians(lat2)) * Math.sin(dLon / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return EARTH_RADIUS_KM * c;
+}
+
+export interface NearestOptions {
+  maxResults?: number;
+}
+
+export class WebcamSpatialIndex {
+  private readonly feeds: readonly WebcamFeed[];
+
+  constructor(catalog: WebcamCatalog | { feeds: WebcamFeed[] }) {
+    this.feeds = Array.isArray(catalog?.feeds) ? [...catalog.feeds] : [];
+  }
+
+  size(): number {
+    return this.feeds.length;
+  }
+
+  nearest(lat: number, lon: number, radiusKm: number, opts: NearestOptions = {}): WebcamFeed[] {
+    if (!Number.isFinite(lat) || !Number.isFinite(lon) || !Number.isFinite(radiusKm)) return [];
+    if (radiusKm <= 0) return [];
+    const maxResults = opts.maxResults ?? 50;
+    const scored: { feed: WebcamFeed; km: number }[] = [];
+    for (const f of this.feeds) {
+      if (!Number.isFinite(f.lat) || !Number.isFinite(f.lon)) continue;
+      const km = haversineKm(lat, lon, f.lat, f.lon);
+      if (km <= radiusKm) scored.push({ feed: f, km });
+    }
+    scored.sort((a, b) => a.km - b.km);
+    return scored.slice(0, maxResults).map((s) => s.feed);
+  }
+
+  inBbox(minLat: number, minLon: number, maxLat: number, maxLon: number): WebcamFeed[] {
+    return this.feeds.filter(
+      (f) => f.lat >= minLat && f.lat <= maxLat && f.lon >= minLon && f.lon <= maxLon,
+    );
+  }
+
+  byCategory(category: WebcamCategory): WebcamFeed[] {
+    return this.feeds.filter((f) => f.category === category);
+  }
+
+  all(): readonly WebcamFeed[] {
+    return this.feeds;
+  }
+}


### PR DESCRIPTION
## Summary

Pure-deterministic Haversine spatial index plus three event-trigger evaluators that surface relevant cams when something is happening nearby. Closes the loop between phase 1's catalog and the rest of the app's incident streams.

## Modules

- `src/services/webcams/webcam-spatial.ts`
  - `WebcamSpatialIndex` — `nearest(lat, lon, radiusKm, { maxResults })`, `inBbox`, `byCategory`
  - `haversineKm(lat1, lon1, lat2, lon2)` exported utility
- `src/services/webcams/webcam-event-triggers.ts`
  - **SeismicVolcanoTrigger** — M≥4.5 within 150 km of a known volcano + 50 km cam (10 hardcoded volcano coords from the USGS catalog)
  - **FireTrigger** — 75 km radius from active fire-intel incidents
  - **FloodTrigger** — USGS gauge at `action` stage or higher, 50 km radius, picks nearest stream cam
  - `WebcamTriggerRegistry` (default 30 min rolling window) + `emitWebcamHighlight` window-event bridge

## Sidecar

- `/api/webcams/near?lat&lon&radiusKm&category` — proxies through the master `/api/webcams` and computes Haversine in-process, returns `{ feeds, count, queryLat, queryLon, radiusKm }` with each feed annotated with `distanceKm`
- `/api/webcams/triggers` — GET returns the rolling-window list; POST appends a renderer-derived event

## Verification

- `npm run typecheck:all` — green
- 27 new tests (Haversine NYC↔LA within 1%, nearest-sort, maxResults, bbox, category, all 3 trigger thresholds, registry window). Full webcam suite **152 tests** all green.

## Stack position

PR B of 4. Stacked on `claude/webcams-pr8-dot-extended` (#309 = PR A).