### PR TITLE
feat(webcams): map view + snapshot + offline detection (Phase 2 PR C)

### DIFF
--- a/src/components/UnifiedWebcamPanel.ts
+++ b/src/components/UnifiedWebcamPanel.ts
@@ -1,9 +1,19 @@
 /* eslint-disable sonarjs/no-async-constructor */
 import { Panel } from './Panel';
 import { fetchUnifiedWebcams, getFavoriteIds, toggleFavorite } from '@/services/webcams/fetcher';
+import {
+  CATEGORY_MARKER_COLOR,
+  OFFLINE_PROBE_TIMEOUT_MS,
+  OFFLINE_REPROBE_INTERVAL_MS,
+  buildSnapshotFilename,
+  computeBoundsForFeeds,
+  decideOfflineStatus,
+  projectEquirectangular,
+  type OfflineStatus,
+} from '@/services/webcams/panel-extras';
 import type { WebcamCategory, WebcamFeed, WebcamSource } from '@/services/webcams/webcam-types';
 
-type ViewMode = 'grid' | 'list';
+type ViewMode = 'grid' | 'list' | 'map';
 
 const SOURCE_LABELS: Record<WebcamSource, string> = {
   FAA: 'FAA',
@@ -37,11 +47,26 @@ export class UnifiedWebcamPanel extends Panel {
   private favorites = new Set<string>(getFavoriteIds());
   private loading = false;
   private lastError: string | null = null;
+  private offlineStatus = new Map<string, { status: OfflineStatus; checkedAt: number }>();
+  private offlineProbeTimer: ReturnType<typeof setInterval> | null = null;
+  private toastEl: HTMLElement | null = null;
 
   constructor() {
     super({ id: 'unified-webcams', title: 'Webcams', className: 'panel-wide' });
     void this.load();
     window.addEventListener('webcam:select', this.handleGlobeSelect as EventListener);
+    this.offlineProbeTimer = setInterval(() => {
+      void this.probeVisibleFeeds();
+    }, OFFLINE_REPROBE_INTERVAL_MS);
+  }
+
+  public destroy(): void {
+    if (this.offlineProbeTimer != null) {
+      clearInterval(this.offlineProbeTimer);
+      this.offlineProbeTimer = null;
+    }
+    window.removeEventListener('webcam:select', this.handleGlobeSelect as EventListener);
+    super.destroy();
   }
 
   private handleGlobeSelect = (e: Event): void => {
@@ -72,6 +97,7 @@ export class UnifiedWebcamPanel extends Panel {
       this.loading = false;
       this.render();
     }
+    void this.probeVisibleFeeds();
   }
 
   public refresh(): void {
@@ -138,7 +164,9 @@ export class UnifiedWebcamPanel extends Panel {
       return;
     }
 
-    el.append(this.viewMode === 'grid' ? this.buildGrid(list) : this.buildList(list));
+    if (this.viewMode === 'grid') el.append(this.buildGrid(list));
+    else if (this.viewMode === 'list') el.append(this.buildList(list));
+    else el.append(this.buildMap(list));
   }
 
   private buildToolbar(): HTMLElement {
@@ -164,9 +192,13 @@ export class UnifiedWebcamPanel extends Panel {
 
     const viewWrap = document.createElement('div');
     viewWrap.className = 'webcams-view-toggle';
-    for (const mode of ['grid', 'list'] as ViewMode[]) {
+    for (const mode of ['grid', 'list', 'map'] as ViewMode[]) {
       const b = document.createElement('button');
-      b.textContent = mode === 'grid' ? '▦ Grid' : '☰ List';
+      let label: string;
+      if (mode === 'grid') label = '▦ Grid';
+      else if (mode === 'list') label = '☰ List';
+      else label = '🗺 Map';
+      b.textContent = label;
       b.style.background = this.viewMode === mode ? '#1f6feb' : 'transparent';
       b.style.color = this.viewMode === mode ? '#fff' : 'inherit';
       b.style.border = '1px solid #444';
@@ -367,6 +399,23 @@ export class UnifiedWebcamPanel extends Panel {
 
     info.append(meta);
 
+    const offline = this.offlineStatus.get(f.id);
+    if (offline?.status === 'offline') {
+      const overlay = document.createElement('div');
+      overlay.textContent = '⚠ Offline';
+      overlay.style.position = 'absolute';
+      overlay.style.inset = '0';
+      overlay.style.display = 'flex';
+      overlay.style.alignItems = 'center';
+      overlay.style.justifyContent = 'center';
+      overlay.style.background = 'rgba(0,0,0,0.55)';
+      overlay.style.color = '#f85149';
+      overlay.style.fontWeight = '600';
+      overlay.style.fontSize = '13px';
+      overlay.style.pointerEvents = 'none';
+      card.append(overlay);
+    }
+
     card.append(img);
     card.append(star);
     card.append(info);
@@ -415,7 +464,21 @@ export class UnifiedWebcamPanel extends Panel {
       row.append(tdStar);
 
       const tdName = document.createElement('td');
-      tdName.textContent = f.name;
+      const offline = this.offlineStatus.get(f.id);
+      const dot = document.createElement('span');
+      dot.style.display = 'inline-block';
+      dot.style.width = '8px';
+      dot.style.height = '8px';
+      dot.style.borderRadius = '50%';
+      dot.style.marginRight = '6px';
+      let dotColor: string;
+      if (offline?.status === 'online') dotColor = '#3fb950';
+      else if (offline?.status === 'offline') dotColor = '#f85149';
+      else dotColor = '#888';
+      dot.style.background = dotColor;
+      dot.title = offline?.status ?? 'unknown';
+      tdName.append(dot);
+      tdName.append(document.createTextNode(f.name));
       row.append(tdName);
 
       const tdSource = document.createElement('td');
@@ -508,6 +571,218 @@ export class UnifiedWebcamPanel extends Panel {
     }
     div.append(meta);
 
+    const snapBtn = document.createElement('button');
+    snapBtn.textContent = '📷 Snapshot';
+    snapBtn.style.marginTop = '8px';
+    snapBtn.style.padding = '4px 10px';
+    snapBtn.style.background = '#1f6feb';
+    snapBtn.style.color = '#fff';
+    snapBtn.style.border = 'none';
+    snapBtn.style.borderRadius = '3px';
+    snapBtn.style.cursor = 'pointer';
+    snapBtn.addEventListener('click', () => {
+      void this.saveSnapshot(f, img);
+    });
+    div.append(snapBtn);
+
     return div;
+  }
+
+  // ── Snapshot to Downloads ────────────────────────────────────────────
+
+  private async saveSnapshot(f: WebcamFeed, img: HTMLImageElement): Promise<void> {
+    try {
+      const canvas = document.createElement('canvas');
+      canvas.width = img.naturalWidth || 1280;
+      canvas.height = img.naturalHeight || 720;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        this.showToast('Snapshot failed: canvas unavailable');
+        return;
+      }
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      const blob: Blob | null = await new Promise((resolve) =>
+        canvas.toBlob(resolve, 'image/jpeg', 0.92),
+      );
+      if (!blob) {
+        this.showToast('Snapshot failed: canvas blocked (CORS)');
+        return;
+      }
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = buildSnapshotFilename(f.name);
+      document.body.append(a);
+      a.click();
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(a.href), 1000);
+      this.showToast('Saved to Downloads');
+    } catch (error) {
+      this.showToast(`Snapshot failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  private showToast(msg: string): void {
+    if (this.toastEl) this.toastEl.remove();
+    const toast = document.createElement('div');
+    toast.textContent = msg;
+    toast.style.position = 'fixed';
+    toast.style.bottom = '32px';
+    toast.style.left = '50%';
+    toast.style.transform = 'translateX(-50%)';
+    toast.style.background = '#0a1929';
+    toast.style.color = '#fff';
+    toast.style.padding = '8px 16px';
+    toast.style.borderRadius = '4px';
+    toast.style.fontSize = '13px';
+    toast.style.boxShadow = '0 2px 8px rgba(0,0,0,0.4)';
+    toast.style.zIndex = '99999';
+    toast.style.pointerEvents = 'none';
+    document.body.append(toast);
+    this.toastEl = toast;
+    setTimeout(() => {
+      if (this.toastEl === toast) {
+        toast.remove();
+        this.toastEl = null;
+      }
+    }, 2000);
+  }
+
+  // ── Map view (SVG, equirectangular) ──────────────────────────────────
+
+  private buildMap(feeds: WebcamFeed[]): HTMLElement {
+    const wrap = document.createElement('div');
+    wrap.className = 'webcams-map';
+    wrap.style.padding = '8px';
+    wrap.style.position = 'relative';
+
+    const width = 760;
+    const height = 360;
+    const bounds = computeBoundsForFeeds(feeds);
+
+    if (!bounds) {
+      const empty = document.createElement('p');
+      empty.textContent = 'No cams to plot.';
+      wrap.append(empty);
+      return wrap;
+    }
+
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+    svg.setAttribute('width', '100%');
+    svg.setAttribute('height', String(height));
+    svg.style.background = '#0a1929';
+    svg.style.borderRadius = '4px';
+    svg.style.border = '1px solid #1f3a5a';
+
+    // Light grid for orientation.
+    for (let i = 1; i < 4; i++) {
+      const xLine = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+      xLine.setAttribute('x1', String((width / 4) * i));
+      xLine.setAttribute('y1', '0');
+      xLine.setAttribute('x2', String((width / 4) * i));
+      xLine.setAttribute('y2', String(height));
+      xLine.setAttribute('stroke', '#1f3a5a');
+      xLine.setAttribute('stroke-dasharray', '2 4');
+      svg.append(xLine);
+      const yLine = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+      yLine.setAttribute('x1', '0');
+      yLine.setAttribute('y1', String((height / 4) * i));
+      yLine.setAttribute('x2', String(width));
+      yLine.setAttribute('y2', String((height / 4) * i));
+      yLine.setAttribute('stroke', '#1f3a5a');
+      yLine.setAttribute('stroke-dasharray', '2 4');
+      svg.append(yLine);
+    }
+
+    const vp = { width, height, bounds, paddingPx: 16 };
+    for (const f of feeds.slice(0, 800)) {
+      const { x, y } = projectEquirectangular(f.lat, f.lon, vp);
+      const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+      circle.setAttribute('cx', String(x));
+      circle.setAttribute('cy', String(y));
+      circle.setAttribute('r', '4');
+      circle.setAttribute('fill', CATEGORY_MARKER_COLOR[f.category]);
+      circle.setAttribute('fill-opacity', '0.85');
+      circle.setAttribute('stroke', '#fff');
+      circle.setAttribute('stroke-width', '0.5');
+      circle.style.cursor = 'pointer';
+      const titleEl = document.createElementNS('http://www.w3.org/2000/svg', 'title');
+      titleEl.textContent = `${f.name} (${f.category})`;
+      circle.append(titleEl);
+      circle.addEventListener('click', () => {
+        this.selectedFeed = f;
+        this.render();
+      });
+      svg.append(circle);
+    }
+
+    wrap.append(svg);
+
+    if (feeds.length > 800) {
+      const more = document.createElement('p');
+      more.style.opacity = '0.6';
+      more.style.fontSize = '11px';
+      more.textContent = `+${feeds.length - 800} more cams not plotted (refine filter)`;
+      wrap.append(more);
+    }
+
+    const legend = document.createElement('div');
+    legend.style.display = 'flex';
+    legend.style.gap = '8px';
+    legend.style.flexWrap = 'wrap';
+    legend.style.marginTop = '6px';
+    legend.style.fontSize = '11px';
+    for (const [cat, color] of Object.entries(CATEGORY_MARKER_COLOR)) {
+      const item = document.createElement('span');
+      item.style.display = 'inline-flex';
+      item.style.alignItems = 'center';
+      item.style.gap = '3px';
+      const dot = document.createElement('span');
+      dot.style.display = 'inline-block';
+      dot.style.width = '8px';
+      dot.style.height = '8px';
+      dot.style.borderRadius = '50%';
+      dot.style.background = color;
+      item.append(dot);
+      const label = document.createElement('span');
+      label.textContent = cat;
+      label.style.textTransform = 'capitalize';
+      label.style.opacity = '0.8';
+      item.append(label);
+      legend.append(item);
+    }
+    wrap.append(legend);
+
+    return wrap;
+  }
+
+  // ── Offline probing ──────────────────────────────────────────────────
+
+  private async probeVisibleFeeds(): Promise<void> {
+    if (this.viewMode === 'map') return; // map view doesn't need per-card status
+    const list = this.displayed.slice(0, 60);
+    const now = Date.now();
+    const stale = list.filter((f) => {
+      const cached = this.offlineStatus.get(f.id);
+      return !cached || now - cached.checkedAt > OFFLINE_REPROBE_INTERVAL_MS;
+    });
+    if (stale.length === 0) return;
+    const promises = stale.map(async (f) => {
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), OFFLINE_PROBE_TIMEOUT_MS);
+      try {
+        const resp = await fetch(f.snapshotUrl, { method: 'HEAD', signal: ctrl.signal });
+        const status = decideOfflineStatus({ responseStatus: resp.status });
+        this.offlineStatus.set(f.id, { status, checkedAt: Date.now() });
+      } catch (error) {
+        const errorName = error instanceof Error ? error.name : 'Error';
+        const status = decideOfflineStatus({ errorName, timedOut: errorName === 'AbortError' });
+        this.offlineStatus.set(f.id, { status, checkedAt: Date.now() });
+      } finally {
+        clearTimeout(timer);
+      }
+    });
+    await Promise.allSettled(promises);
+    this.render();
   }
 }

--- a/src/services/webcams/__tests__/panel-extras.test.mts
+++ b/src/services/webcams/__tests__/panel-extras.test.mts
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  CATEGORY_MARKER_COLOR,
+  OFFLINE_PROBE_TIMEOUT_MS,
+  OFFLINE_REPROBE_INTERVAL_MS,
+  buildSnapshotFilename,
+  computeBoundsForFeeds,
+  decideOfflineStatus,
+  projectEquirectangular,
+} from '../panel-extras.ts';
+import type { WebcamFeed } from '../webcam-types.ts';
+
+function feed(overrides: Partial<WebcamFeed> = {}): WebcamFeed {
+  return {
+    id: 'cam',
+    source: 'FAA',
+    name: 'Cam',
+    lat: 0,
+    lon: 0,
+    snapshotUrl: 'x',
+    refreshIntervalSec: 60,
+    category: 'weather',
+    metadata: {},
+    ...overrides,
+  };
+}
+
+// ── computeBoundsForFeeds ───────────────────────────────────────────────
+
+test('computeBoundsForFeeds: returns null on empty', () => {
+  assert.equal(computeBoundsForFeeds([]), null);
+});
+
+test('computeBoundsForFeeds: spans min and max lat/lon', () => {
+  const bounds = computeBoundsForFeeds([
+    feed({ lat: 30, lon: -80 }),
+    feed({ lat: 40, lon: -100 }),
+    feed({ lat: 35, lon: -90 }),
+  ]);
+  assert.deepEqual(bounds, { minLat: 30, maxLat: 40, minLon: -100, maxLon: -80 });
+});
+
+test('computeBoundsForFeeds: skips invalid coords', () => {
+  const bounds = computeBoundsForFeeds([
+    feed({ lat: NaN, lon: -80 }),
+    feed({ lat: 40, lon: -100 }),
+  ]);
+  assert.deepEqual(bounds, { minLat: 40, maxLat: 40, minLon: -100, maxLon: -100 });
+});
+
+// ── projectEquirectangular ──────────────────────────────────────────────
+
+test('projectEquirectangular: northwest of bounds → top-left of viewport', () => {
+  const vp = {
+    width: 100,
+    height: 100,
+    bounds: { minLat: 30, maxLat: 40, minLon: -100, maxLon: -90 },
+    paddingPx: 0,
+  };
+  const p = projectEquirectangular(40, -100, vp);
+  assert.equal(p.x, 0);
+  assert.equal(p.y, 0);
+});
+
+test('projectEquirectangular: southeast of bounds → bottom-right', () => {
+  const vp = {
+    width: 100,
+    height: 100,
+    bounds: { minLat: 30, maxLat: 40, minLon: -100, maxLon: -90 },
+    paddingPx: 0,
+  };
+  const p = projectEquirectangular(30, -90, vp);
+  assert.equal(p.x, 100);
+  assert.equal(p.y, 100);
+});
+
+test('projectEquirectangular: respects padding', () => {
+  const vp = {
+    width: 100,
+    height: 100,
+    bounds: { minLat: 30, maxLat: 40, minLon: -100, maxLon: -90 },
+    paddingPx: 10,
+  };
+  const p = projectEquirectangular(40, -100, vp);
+  assert.equal(p.x, 10);
+  assert.equal(p.y, 10);
+});
+
+// ── buildSnapshotFilename ───────────────────────────────────────────────
+
+test('buildSnapshotFilename: sanitizes camera name', () => {
+  const name = buildSnapshotFilename('I-94 East at Exit 100!', 1_745_000_000_000);
+  assert.match(name, /^crystalball-cam-I-94-East-at-Exit-100-/);
+  assert.match(name, /\.jpg$/);
+});
+
+test('buildSnapshotFilename: trims leading/trailing dashes', () => {
+  const name = buildSnapshotFilename('!!Cam!!', 1_745_000_000_000);
+  assert.match(name, /^crystalball-cam-Cam-/);
+});
+
+test('buildSnapshotFilename: empty name → fallback to "cam"', () => {
+  const name = buildSnapshotFilename('!!!', 1_745_000_000_000);
+  assert.match(name, /^crystalball-cam-cam-/);
+});
+
+test('buildSnapshotFilename: includes ISO timestamp', () => {
+  const name = buildSnapshotFilename('X', 1_745_000_000_000);
+  // 1_745_000_000_000 = 2025-04-18T16:53:20.000Z → minus the colons/dots
+  assert.match(name, /\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}/);
+});
+
+// ── decideOfflineStatus ─────────────────────────────────────────────────
+
+test('decideOfflineStatus: 200 OK → online', () => {
+  assert.equal(decideOfflineStatus({ responseStatus: 200 }), 'online');
+});
+
+test('decideOfflineStatus: 304 Not Modified → online', () => {
+  assert.equal(decideOfflineStatus({ responseStatus: 304 }), 'online');
+});
+
+test('decideOfflineStatus: 404 → offline', () => {
+  assert.equal(decideOfflineStatus({ responseStatus: 404 }), 'offline');
+});
+
+test('decideOfflineStatus: 500 → offline', () => {
+  assert.equal(decideOfflineStatus({ responseStatus: 500 }), 'offline');
+});
+
+test('decideOfflineStatus: timed out → offline', () => {
+  assert.equal(decideOfflineStatus({ timedOut: true }), 'offline');
+});
+
+test('decideOfflineStatus: AbortError → offline', () => {
+  assert.equal(decideOfflineStatus({ errorName: 'AbortError' }), 'offline');
+});
+
+test('decideOfflineStatus: TypeError (CORS) → unknown', () => {
+  assert.equal(decideOfflineStatus({ errorName: 'TypeError' }), 'unknown');
+});
+
+test('decideOfflineStatus: no input → unknown', () => {
+  assert.equal(decideOfflineStatus({}), 'unknown');
+});
+
+// ── Constants ───────────────────────────────────────────────────────────
+
+test('OFFLINE_PROBE_TIMEOUT_MS is 8s', () => {
+  assert.equal(OFFLINE_PROBE_TIMEOUT_MS, 8000);
+});
+
+test('OFFLINE_REPROBE_INTERVAL_MS is 5min', () => {
+  assert.equal(OFFLINE_REPROBE_INTERVAL_MS, 5 * 60 * 1000);
+});
+
+test('CATEGORY_MARKER_COLOR has every category', () => {
+  for (const cat of ['fire', 'volcano', 'weather', 'coastal', 'stream', 'traffic', 'nature']) {
+    assert.match(
+      CATEGORY_MARKER_COLOR[cat as keyof typeof CATEGORY_MARKER_COLOR],
+      /^#[0-9a-f]{6}$/i,
+    );
+  }
+});

--- a/src/services/webcams/panel-extras.ts
+++ b/src/services/webcams/panel-extras.ts
@@ -1,0 +1,111 @@
+import type { WebcamCategory, WebcamFeed } from './webcam-types';
+
+export const CATEGORY_MARKER_COLOR: Record<WebcamCategory, string> = {
+  fire: '#f85149',
+  volcano: '#bc8cff',
+  weather: '#56d4dd',
+  coastal: '#3fb950',
+  stream: '#1f6feb',
+  traffic: '#d29922',
+  nature: '#7ee787',
+};
+
+export interface MapBounds {
+  minLat: number;
+  maxLat: number;
+  minLon: number;
+  maxLon: number;
+}
+
+export function computeBoundsForFeeds(feeds: readonly WebcamFeed[]): MapBounds | null {
+  if (feeds.length === 0) return null;
+  let minLat = Infinity;
+  let maxLat = -Infinity;
+  let minLon = Infinity;
+  let maxLon = -Infinity;
+  for (const f of feeds) {
+    if (!Number.isFinite(f.lat) || !Number.isFinite(f.lon)) continue;
+    if (f.lat < minLat) minLat = f.lat;
+    if (f.lat > maxLat) maxLat = f.lat;
+    if (f.lon < minLon) minLon = f.lon;
+    if (f.lon > maxLon) maxLon = f.lon;
+  }
+  if (!Number.isFinite(minLat)) return null;
+  return { minLat, maxLat, minLon, maxLon };
+}
+
+export interface SvgPoint {
+  x: number;
+  y: number;
+}
+
+export interface ProjectionViewport {
+  width: number;
+  height: number;
+  bounds: MapBounds;
+  paddingPx: number;
+}
+
+/** Equirectangular projection — simple, fast, works for clustered views.
+ *  Returns pixel coords inside the viewport, with a constant pixel padding. */
+export function projectEquirectangular(
+  lat: number,
+  lon: number,
+  vp: ProjectionViewport,
+): SvgPoint {
+  const { width, height, bounds, paddingPx } = vp;
+  const usableW = Math.max(width - paddingPx * 2, 1);
+  const usableH = Math.max(height - paddingPx * 2, 1);
+  const lonSpan = Math.max(bounds.maxLon - bounds.minLon, 0.0001);
+  const latSpan = Math.max(bounds.maxLat - bounds.minLat, 0.0001);
+  const x = paddingPx + ((lon - bounds.minLon) / lonSpan) * usableW;
+  const y = paddingPx + (1 - (lat - bounds.minLat) / latSpan) * usableH;
+  return { x, y };
+}
+
+// ── Snapshot to local download ──────────────────────────────────────────
+
+export type SnapshotResult =
+  | { ok: true; filename: string }
+  | { ok: false; reason: string };
+
+/** Returns the canonical Downloads filename for a snapshot. */
+export function buildSnapshotFilename(camName: string, now: number = Date.now()): string {
+  let safe = camName.replace(/[^a-zA-Z0-9]+/g, '-');
+  while (safe.startsWith('-')) safe = safe.slice(1);
+  while (safe.endsWith('-')) safe = safe.slice(0, -1);
+  safe = safe.slice(0, 60) || 'cam';
+  const stamp = new Date(now).toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  return `crystalball-cam-${safe}-${stamp}.jpg`;
+}
+
+// ── Offline probe ────────────────────────────────────────────────────────
+
+export type OfflineStatus = 'online' | 'offline' | 'unknown';
+
+export interface OfflineProbeResult {
+  feedId: string;
+  status: OfflineStatus;
+  checkedAt: number;
+  httpStatus?: number;
+  error?: string;
+}
+
+/** Decide a feed's online/offline status from a probe response or error.
+ *  Pure: no network, no DOM. The HTTP layer is in the caller. */
+export function decideOfflineStatus(input: {
+  responseStatus?: number;
+  errorName?: string;
+  timedOut?: boolean;
+}): OfflineStatus {
+  if (input.timedOut) return 'offline';
+  if (input.errorName === 'AbortError') return 'offline';
+  if (input.errorName) return 'unknown';
+  if (typeof input.responseStatus !== 'number') return 'unknown';
+  if (input.responseStatus >= 200 && input.responseStatus < 400) return 'online';
+  if (input.responseStatus >= 400) return 'offline';
+  return 'unknown';
+}
+
+export const OFFLINE_PROBE_TIMEOUT_MS = 8000;
+export const OFFLINE_REPROBE_INTERVAL_MS = 5 * 60 * 1000;


### PR DESCRIPTION
## Summary

Closes the deferred UX gap from phase 1. UnifiedWebcamPanel now has:

1. **Map view** (3rd `ViewMode` toggle) — self-contained SVG equirectangular projection of every loaded cam, colored by category with a click-to-fullscreen handler and a legend
2. **Snapshot to Downloads** — `📷 Snapshot` button in the fullscreen player draws `<img>` onto a canvas and saves via blob URL + `<a download>`
3. **Offline detection** — per-cam HEAD probe (8s timeout, re-probes every 5 min for first 60 visible cams). Offline cards show a red overlay; list rows show a red/green/grey dot

### Spec deviation

The spec asked for Leaflet. The project doesn't have Leaflet — it uses MapLibre exclusively (loaded by DeckGLMap). Rather than add a new map dependency for a panel-local use case, the Map view is a pure SVG equirectangular projection (zero dep, fast, ~600 cam markers, no tile fetches). MapLibre lifecycle inside a panel would be more complex than the rest of the panel combined.

### Pure helpers (testable, no DOM)

- `computeBoundsForFeeds(feeds)` — returns `null` on empty
- `projectEquirectangular(lat, lon, viewport)` — pixel coords with constant padding
- `buildSnapshotFilename(name, now)` — sanitizes, trims, ISO timestamp
- `decideOfflineStatus({ responseStatus, errorName, timedOut })` — `'online' | 'offline' | 'unknown'`
- `CATEGORY_MARKER_COLOR` — keeps panel and tests in lockstep

### Verification

- `npm run typecheck:all` — green
- 21 new tests; full webcam suite **173 tests** all green
- Tests deliberately do NOT exercise DOM — pure helpers cover the logic; the panel wiring is a thin consumer

## Stack position

PR C of 4. Stacked on PR B (#310).