### PR TITLE
feat(webcams): client-side smoke / motion detection (Phase 2 PR D)

### DIFF
--- a/src/components/UnifiedWebcamPanel.ts
+++ b/src/components/UnifiedWebcamPanel.ts
@@ -11,7 +11,10 @@ import {
   projectEquirectangular,
   type OfflineStatus,
 } from '@/services/webcams/panel-extras';
+import { runSmokeDetection, type SmokeAnalysis } from '@/services/webcams/smoke-detector';
 import type { WebcamCategory, WebcamFeed, WebcamSource } from '@/services/webcams/webcam-types';
+
+const SMOKE_DETECT_INTERVAL_MS = 10 * 60 * 1000;
 
 type ViewMode = 'grid' | 'list' | 'map';
 
@@ -49,6 +52,9 @@ export class UnifiedWebcamPanel extends Panel {
   private lastError: string | null = null;
   private offlineStatus = new Map<string, { status: OfflineStatus; checkedAt: number }>();
   private offlineProbeTimer: ReturnType<typeof setInterval> | null = null;
+  private smokeDetectTimer: ReturnType<typeof setInterval> | null = null;
+  private smokeStatus = new Map<string, { analysis: SmokeAnalysis; ranAt: number }>();
+  private smokeDetectEnabled = true;
   private toastEl: HTMLElement | null = null;
 
   constructor() {
@@ -58,12 +64,19 @@ export class UnifiedWebcamPanel extends Panel {
     this.offlineProbeTimer = setInterval(() => {
       void this.probeVisibleFeeds();
     }, OFFLINE_REPROBE_INTERVAL_MS);
+    this.smokeDetectTimer = setInterval(() => {
+      void this.runSmokeDetectForFireCams();
+    }, SMOKE_DETECT_INTERVAL_MS);
   }
 
   public destroy(): void {
     if (this.offlineProbeTimer != null) {
       clearInterval(this.offlineProbeTimer);
       this.offlineProbeTimer = null;
+    }
+    if (this.smokeDetectTimer != null) {
+      clearInterval(this.smokeDetectTimer);
+      this.smokeDetectTimer = null;
     }
     window.removeEventListener('webcam:select', this.handleGlobeSelect as EventListener);
     super.destroy();
@@ -219,6 +232,26 @@ export class UnifiedWebcamPanel extends Panel {
     count.style.fontSize = '12px';
     count.textContent = `${this.displayed.length} of ${this.feeds.length} cams`;
     bar.append(count);
+
+    const smokeToggle = document.createElement('label');
+    smokeToggle.style.fontSize = '11px';
+    smokeToggle.style.opacity = '0.8';
+    smokeToggle.style.cursor = 'pointer';
+    smokeToggle.style.display = 'inline-flex';
+    smokeToggle.style.alignItems = 'center';
+    smokeToggle.style.gap = '4px';
+    const smokeCheckbox = document.createElement('input');
+    smokeCheckbox.type = 'checkbox';
+    smokeCheckbox.checked = this.smokeDetectEnabled;
+    smokeCheckbox.addEventListener('change', () => {
+      this.smokeDetectEnabled = smokeCheckbox.checked;
+      if (this.smokeDetectEnabled) void this.runSmokeDetectForFireCams();
+      else this.smokeStatus.clear();
+      this.render();
+    });
+    smokeToggle.append(smokeCheckbox);
+    smokeToggle.append(document.createTextNode('Smoke Detection'));
+    bar.append(smokeToggle);
 
     return bar;
   }
@@ -414,6 +447,29 @@ export class UnifiedWebcamPanel extends Panel {
       overlay.style.fontSize = '13px';
       overlay.style.pointerEvents = 'none';
       card.append(overlay);
+    }
+
+    const smoke = this.smokeStatus.get(f.id);
+    if (smoke?.analysis.isAlert) {
+      const badge = document.createElement('div');
+      badge.textContent = '🔥 Motion Detected';
+      badge.title = `Smoke prob ${(smoke.analysis.smokeProbability * 100).toFixed(0)}%`;
+      badge.style.position = 'absolute';
+      badge.style.top = '4px';
+      badge.style.left = '4px';
+      badge.style.background = 'rgba(248, 81, 73, 0.92)';
+      badge.style.color = '#fff';
+      badge.style.padding = '2px 6px';
+      badge.style.borderRadius = '3px';
+      badge.style.fontSize = '10px';
+      badge.style.fontWeight = '600';
+      badge.style.cursor = 'pointer';
+      badge.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this.selectedFeed = f;
+        this.render();
+      });
+      card.append(badge);
     }
 
     card.append(img);
@@ -754,6 +810,31 @@ export class UnifiedWebcamPanel extends Panel {
     wrap.append(legend);
 
     return wrap;
+  }
+
+  // ── Smoke / motion detection (AlertWildfire) ────────────────────────
+
+  private async runSmokeDetectForFireCams(): Promise<void> {
+    if (!this.smokeDetectEnabled) return;
+    const fireCams = this.displayed
+      .filter((f) => f.source === 'ALERTWILDFIRE')
+      .slice(0, 24); // viewport budget — heavy work, keep small
+    if (fireCams.length === 0) return;
+    let updated = false;
+    for (const cam of fireCams) {
+      const existing = this.smokeStatus.get(cam.id);
+      if (existing && Date.now() - existing.ranAt < SMOKE_DETECT_INTERVAL_MS / 2) continue;
+      try {
+        const result = await runSmokeDetection(cam.id, cam.snapshotUrl);
+        if (result.analysis) {
+          this.smokeStatus.set(cam.id, { analysis: result.analysis, ranAt: result.ranAt });
+          updated = true;
+        }
+      } catch {
+        // canvas / CORS errors are expected for cross-origin streams; ignore.
+      }
+    }
+    if (updated) this.render();
   }
 
   // ── Offline probing ──────────────────────────────────────────────────

--- a/src/services/webcams/__tests__/smoke-detector.test.mts
+++ b/src/services/webcams/__tests__/smoke-detector.test.mts
@@ -1,0 +1,187 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  SMOKE_DETECT_DOWNSAMPLE_H,
+  SMOKE_DETECT_DOWNSAMPLE_W,
+  SMOKE_INTERVAL_MS,
+  analyzeFrameDelta,
+  runSmokeDetection,
+  type FrameSample,
+  type SmokeAnalysis,
+} from '../smoke-detector.ts';
+
+function uniformFrame(w: number, h: number, gray: number): FrameSample {
+  const px = new Uint8ClampedArray(w * h * 4);
+  for (let i = 0; i < w * h; i++) {
+    px[i * 4] = gray;
+    px[i * 4 + 1] = gray;
+    px[i * 4 + 2] = gray;
+    px[i * 4 + 3] = 255;
+  }
+  return { width: w, height: h, pixels: px };
+}
+
+function frameWithUpperBand(
+  w: number,
+  h: number,
+  baseGray: number,
+  bandGray: number,
+  bandRows: number,
+): FrameSample {
+  const px = new Uint8ClampedArray(w * h * 4);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const idx = (y * w + x) * 4;
+      const v = y < bandRows ? bandGray : baseGray;
+      px[idx] = v;
+      px[idx + 1] = v;
+      px[idx + 2] = v;
+      px[idx + 3] = 255;
+    }
+  }
+  return { width: w, height: h, pixels: px };
+}
+
+// ── analyzeFrameDelta ───────────────────────────────────────────────────
+
+test('analyzeFrameDelta: identical frames → zero delta, no alert', () => {
+  const a = uniformFrame(40, 30, 100);
+  const b = uniformFrame(40, 30, 100);
+  const r = analyzeFrameDelta(a, b);
+  assert.equal(r.meanDelta, 0);
+  assert.equal(r.motionPixels, 0);
+  assert.equal(r.changedFraction, 0);
+  assert.equal(r.isAlert, false);
+});
+
+test('analyzeFrameDelta: mismatched dims → empty result', () => {
+  const a = uniformFrame(40, 30, 100);
+  const b = uniformFrame(20, 30, 100);
+  const r = analyzeFrameDelta(a, b);
+  assert.equal(r.totalPixels, 0);
+  assert.equal(r.isAlert, false);
+});
+
+test('analyzeFrameDelta: large upper-third change + many changed pixels → alert', () => {
+  // h=30, upper third = rows 0..9 (10 rows of upper band changing dramatically)
+  const a = frameWithUpperBand(40, 30, 50, 50, 10); // uniform
+  const b = frameWithUpperBand(40, 30, 50, 200, 10); // big change in upper 10 rows
+  const r = analyzeFrameDelta(a, b);
+  assert.ok(r.upperRegionMeanDelta > 100, `upper delta ${r.upperRegionMeanDelta}`);
+  assert.ok(r.changedFraction > 0.08, `frac ${r.changedFraction}`);
+  assert.equal(r.isAlert, true);
+  assert.ok(r.smokeProbability > 0.5);
+});
+
+test('analyzeFrameDelta: lower-third change only → no alert (smoke signature is upper)', () => {
+  const a = uniformFrame(40, 30, 50);
+  // Change rows 20..29 (lower third) — upper third unchanged
+  const px = new Uint8ClampedArray(40 * 30 * 4);
+  for (let y = 0; y < 30; y++) {
+    for (let x = 0; x < 40; x++) {
+      const idx = (y * 40 + x) * 4;
+      const v = y >= 20 ? 200 : 50;
+      px[idx] = v;
+      px[idx + 1] = v;
+      px[idx + 2] = v;
+      px[idx + 3] = 255;
+    }
+  }
+  const b: FrameSample = { width: 40, height: 30, pixels: px };
+  const r = analyzeFrameDelta(a, b);
+  assert.ok(r.upperRegionMeanDelta < 5);
+  assert.equal(r.isAlert, false);
+});
+
+test('analyzeFrameDelta: tiny change in upper region → no alert', () => {
+  const a = uniformFrame(40, 30, 50);
+  const b = uniformFrame(40, 30, 51); // 1-channel delta everywhere
+  const r = analyzeFrameDelta(a, b);
+  assert.equal(r.isAlert, false);
+  assert.ok(r.smokeProbability < 0.5);
+});
+
+test('analyzeFrameDelta: changedFraction is correct', () => {
+  // half pixels changed by a lot, half unchanged
+  const w = 20;
+  const h = 30; // total 600 pixels
+  const a = uniformFrame(w, h, 50);
+  const px = new Uint8ClampedArray(w * h * 4);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const idx = (y * w + x) * 4;
+      const v = x < w / 2 ? 200 : 50;
+      px[idx] = v;
+      px[idx + 1] = v;
+      px[idx + 2] = v;
+      px[idx + 3] = 255;
+    }
+  }
+  const b: FrameSample = { width: w, height: h, pixels: px };
+  const r = analyzeFrameDelta(a, b);
+  assert.ok(Math.abs(r.changedFraction - 0.5) < 0.01, `got ${r.changedFraction}`);
+});
+
+test('analyzeFrameDelta: smokeProbability ranges in [0, 1]', () => {
+  const a = uniformFrame(40, 30, 50);
+  const b = uniformFrame(40, 30, 250); // huge delta everywhere
+  const r = analyzeFrameDelta(a, b);
+  assert.ok(r.smokeProbability >= 0 && r.smokeProbability <= 1);
+});
+
+// ── runSmokeDetection (mock sampler) ────────────────────────────────────
+
+test('runSmokeDetection: returns analysis when sampler succeeds', async () => {
+  const a = frameWithUpperBand(40, 30, 50, 50, 10);
+  const b = frameWithUpperBand(40, 30, 50, 200, 10);
+  const samples = [a, b];
+  const sampler = async (): Promise<FrameSample | null> => samples.shift() ?? null;
+  const r = await runSmokeDetection('cam-1', 'http://x/y.jpg', { sampler, intervalMs: 1 });
+  assert.equal(r.camId, 'cam-1');
+  assert.ok(r.analysis !== null);
+  assert.equal(r.analysis.isAlert, true);
+});
+
+test('runSmokeDetection: null when first sample fails', async () => {
+  const sampler = async (): Promise<FrameSample | null> => null;
+  const r = await runSmokeDetection('cam', 'x', { sampler, intervalMs: 1 });
+  assert.equal(r.analysis, null);
+});
+
+test('runSmokeDetection: null when second sample fails', async () => {
+  const a = uniformFrame(40, 30, 50);
+  let i = 0;
+  const sampler = async (): Promise<FrameSample | null> => {
+    i++;
+    return i === 1 ? a : null;
+  };
+  const r = await runSmokeDetection('cam', 'x', { sampler, intervalMs: 1 });
+  assert.equal(r.analysis, null);
+});
+
+// ── Constants ───────────────────────────────────────────────────────────
+
+test('SMOKE_DETECT_DOWNSAMPLE_W is 160', () => {
+  assert.equal(SMOKE_DETECT_DOWNSAMPLE_W, 160);
+});
+
+test('SMOKE_DETECT_DOWNSAMPLE_H is 120', () => {
+  assert.equal(SMOKE_DETECT_DOWNSAMPLE_H, 120);
+});
+
+test('SMOKE_INTERVAL_MS is 5000', () => {
+  assert.equal(SMOKE_INTERVAL_MS, 5000);
+});
+
+// Suppress unused warning for SmokeAnalysis type re-export check
+const _t: SmokeAnalysis = {
+  smokeProbability: 0,
+  motionPixels: 0,
+  totalPixels: 0,
+  changedFraction: 0,
+  meanDelta: 0,
+  upperRegionMeanDelta: 0,
+  isAlert: false,
+};
+test('SmokeAnalysis type sanity', () => assert.equal(_t.isAlert, false));

--- a/src/services/webcams/smoke-detector.ts
+++ b/src/services/webcams/smoke-detector.ts
@@ -1,0 +1,172 @@
+export interface FrameSample {
+  width: number;
+  height: number;
+  /** RGBA pixel buffer in row-major order. Length = width * height * 4. */
+  pixels: Uint8ClampedArray;
+}
+
+export interface SmokeAnalysis {
+  smokeProbability: number;
+  motionPixels: number;
+  totalPixels: number;
+  changedFraction: number;
+  meanDelta: number;
+  upperRegionMeanDelta: number;
+  isAlert: boolean;
+}
+
+export const SMOKE_DETECT_DOWNSAMPLE_W = 160;
+export const SMOKE_DETECT_DOWNSAMPLE_H = 120;
+export const SMOKE_INTERVAL_MS = 5000;
+
+// Trigger thresholds — calibrated from the spec.
+const ALERT_MEAN_DELTA = 15;
+const ALERT_CHANGED_FRACTION = 0.08;
+const PIXEL_CHANGE_THRESHOLD = 24; // per-channel delta required to count a pixel as "changed"
+
+function sigmoid(x: number): number {
+  return 1 / (1 + Math.exp(-x));
+}
+
+/** Pure pixel-delta analysis. The browser-side caller is responsible for
+ *  sampling two frames (5s apart, downsampled to 160×120) and providing
+ *  them here; this module computes the motion / smoke signature without
+ *  any DOM or network. */
+export function analyzeFrameDelta(a: FrameSample, b: FrameSample): SmokeAnalysis {
+  if (a.width !== b.width || a.height !== b.height) {
+    return {
+      smokeProbability: 0,
+      motionPixels: 0,
+      totalPixels: 0,
+      changedFraction: 0,
+      meanDelta: 0,
+      upperRegionMeanDelta: 0,
+      isAlert: false,
+    };
+  }
+  const W = a.width;
+  const H = a.height;
+  const total = W * H;
+  if (total === 0) {
+    return {
+      smokeProbability: 0,
+      motionPixels: 0,
+      totalPixels: 0,
+      changedFraction: 0,
+      meanDelta: 0,
+      upperRegionMeanDelta: 0,
+      isAlert: false,
+    };
+  }
+  const upperCutoff = Math.floor(H / 3);
+
+  let motionPixels = 0;
+  let totalDelta = 0;
+  let upperDelta = 0;
+  let upperCount = 0;
+
+  for (let y = 0; y < H; y++) {
+    for (let x = 0; x < W; x++) {
+      const idx = (y * W + x) * 4;
+      const dr = Math.abs(a.pixels[idx]! - b.pixels[idx]!);
+      const dg = Math.abs(a.pixels[idx + 1]! - b.pixels[idx + 1]!);
+      const db = Math.abs(a.pixels[idx + 2]! - b.pixels[idx + 2]!);
+      const meanChannel = (dr + dg + db) / 3;
+      totalDelta += meanChannel;
+      if (meanChannel > PIXEL_CHANGE_THRESHOLD) motionPixels++;
+      if (y < upperCutoff) {
+        upperDelta += meanChannel;
+        upperCount++;
+      }
+    }
+  }
+
+  const meanDelta = totalDelta / total;
+  const upperRegionMeanDelta = upperCount > 0 ? upperDelta / upperCount : 0;
+  const changedFraction = motionPixels / total;
+
+  // Smoke signature: high upper-third delta plus enough changed pixels overall.
+  const upperWeight = upperRegionMeanDelta / 30; // normalize against expected dynamic range
+  const fractionWeight = changedFraction * 5;
+  const score = upperWeight + fractionWeight - 0.5;
+  const smokeProbability = sigmoid(score);
+
+  const isAlert =
+    upperRegionMeanDelta > ALERT_MEAN_DELTA && changedFraction > ALERT_CHANGED_FRACTION;
+
+  return {
+    smokeProbability,
+    motionPixels,
+    totalPixels: total,
+    changedFraction,
+    meanDelta,
+    upperRegionMeanDelta,
+    isAlert,
+  };
+}
+
+// ── Browser-side sampler ───────────────────────────────────────────────
+
+/** Loads an image URL into a downsampled FrameSample. Browser-only;
+ *  callers from Node tests should use the pure analyzeFrameDelta with
+ *  hand-built FrameSample fixtures. */
+export async function sampleFrame(
+  snapshotUrl: string,
+  cacheBust: number = Date.now(),
+): Promise<FrameSample | null> {
+  if (typeof document === 'undefined' || typeof Image === 'undefined') return null;
+  return new Promise<FrameSample | null>((resolve) => {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.addEventListener('load', () => {
+      try {
+        const canvas = document.createElement('canvas');
+        canvas.width = SMOKE_DETECT_DOWNSAMPLE_W;
+        canvas.height = SMOKE_DETECT_DOWNSAMPLE_H;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+          resolve(null);
+          return;
+        }
+        ctx.drawImage(img, 0, 0, SMOKE_DETECT_DOWNSAMPLE_W, SMOKE_DETECT_DOWNSAMPLE_H);
+        const data = ctx.getImageData(0, 0, SMOKE_DETECT_DOWNSAMPLE_W, SMOKE_DETECT_DOWNSAMPLE_H);
+        resolve({ width: data.width, height: data.height, pixels: data.data });
+      } catch {
+        resolve(null);
+      }
+    });
+    img.addEventListener('error', () => resolve(null));
+    const sep = snapshotUrl.includes('?') ? '&' : '?';
+    img.src = `${snapshotUrl}${sep}smoke=${cacheBust}`;
+  });
+}
+
+export interface SmokeDetectorConfig {
+  intervalMs?: number;
+  /** Optional override for sampleFrame (testing). */
+  sampler?: (url: string, t: number) => Promise<FrameSample | null>;
+}
+
+export interface SmokeDetectionResult {
+  camId: string;
+  analysis: SmokeAnalysis | null;
+  ranAt: number;
+}
+
+/** High-level: runs analyzeFrameDelta against two samples. Pure given the
+ *  sampler — the caller can mock it. */
+export async function runSmokeDetection(
+  camId: string,
+  snapshotUrl: string,
+  config: SmokeDetectorConfig = {},
+): Promise<SmokeDetectionResult> {
+  const sampler = config.sampler ?? sampleFrame;
+  const intervalMs = config.intervalMs ?? SMOKE_INTERVAL_MS;
+  const ranAt = Date.now();
+  const a = await sampler(snapshotUrl, ranAt);
+  if (!a) return { camId, analysis: null, ranAt };
+  await new Promise<void>((resolve) => setTimeout(resolve, intervalMs));
+  const b = await sampler(snapshotUrl, Date.now());
+  if (!b) return { camId, analysis: null, ranAt };
+  return { camId, analysis: analyzeFrameDelta(a, b), ranAt };
+}


### PR DESCRIPTION
## Summary

Frame-delta analysis for AlertWildfire cams. Two snapshots 5s apart get downsampled to 160×120, the per-pixel RGB delta is computed, and the upper third of the frame (sky region) is weighted as a smoke signature. No ML, no external service — pure pixel math in the renderer.

## Algorithm

```
isAlert = upperRegionMeanDelta > 15 AND changedFraction > 0.08
smokeProbability = sigmoid(upperWeight + fractionWeight - 0.5)
```

Where `changedFraction` is the fraction of pixels with mean per-channel delta > 24 (out of 255). Pixel-change threshold and weights documented in the source.

## Files

- `src/services/webcams/smoke-detector.ts`
  - `analyzeFrameDelta(a, b)` — pure, no DOM
  - `sampleFrame(url)` — browser-only Image → 160×120 canvas → ImageData
  - `runSmokeDetection(camId, url, { sampler, intervalMs })` — high-level orchestrator with injectable sampler (used by tests)
- `UnifiedWebcamPanel`
  - Runs detection every 10 min for the first 24 visible `ALERTWILDFIRE` cams (viewport budget)
  - Cards with `isAlert=true` show an orange `🔥 Motion Detected` badge linking to fullscreen
  - Toolbar has a `Smoke Detection` checkbox; off clears the cache
  - `destroy()` clears the new timer

## Verification

- `npm run typecheck:all` — green
- 14 new tests covering: identical frames, mismatched dims, upper-third spike triggering alert, lower-third change NOT triggering (correct upper-region weighting), tiny noise → no alert, changedFraction accuracy, sampler-injection round trip
- Full webcam suite **187 tests** all green

## Stack position

PR D of 4 — final phase 2 PR. Stacked on PR C (#311).