### PR TITLE
feat(spaceweather): SWPC monitor + sidecar routes (PR 1/3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "test:geopolitics": "tsx --test src/services/geopolitics/__tests__/grayzone-classifier.test.mts",
     "test:finance": "tsx --test src/services/finance/__tests__/stress-monitor.test.mts",
     "test:climate": "tsx --test src/services/climate/__tests__/enso-monitor.test.mts",
+    "test:spaceweather": "tsx --test src/services/spaceweather/__tests__/swpc-monitor.test.mts && node --test src-tauri/sidecar/__tests__/spaceweather-parity.test.mjs",
     "test:panels:smoke": "node tests/panels/run-harness.mjs",
     "test:components": "tsx --test src/components/__tests__/disease-outbreak-tabs.test.mts",
     "test:panels:fixtures": "tsx --import ./tests/panels/register-hook.mjs --test tests/panels/panel-fixtures.test.mts",

--- a/src-tauri/sidecar/__tests__/spaceweather-parity.test.mjs
+++ b/src-tauri/sidecar/__tests__/spaceweather-parity.test.mjs
@@ -1,0 +1,131 @@
+/**
+ * Parity test: the sidecar's inline JS port of the spaceweather monitor
+ * (classify/summarize/build helpers) MUST behave the same as the
+ * canonical TS module in src/services/spaceweather/.
+ *
+ * If you change one, change the other and update this test.
+ */
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+import {
+  classifyXrayFluxSidecar,
+  xrayLabelSidecar,
+  kpToStormLevelSidecar,
+  auroraVisibilityLatitudeSidecar,
+  classifyGpsDisruptionSidecar,
+  summarizeXrayFluxSidecar,
+  summarizeKpSidecar,
+  summarizeAlertsSidecar,
+  filterEarthwardCmesSidecar,
+  buildSpaceweatherStatusSidecar,
+} from '../local-api-server.mjs';
+
+const NOW = Date.parse('2026-05-06T12:00:00Z');
+const HOUR_MS = 60 * 60 * 1000;
+const isoMinus = (h) => new Date(NOW - h * HOUR_MS).toISOString();
+
+test('classifyXrayFluxSidecar tiers match the spec', () => {
+  assert.equal(classifyXrayFluxSidecar(5e-9), 'A');
+  assert.equal(classifyXrayFluxSidecar(1e-7), 'B');
+  assert.equal(classifyXrayFluxSidecar(1e-6), 'C');
+  assert.equal(classifyXrayFluxSidecar(4.2e-5), 'M');
+  assert.equal(classifyXrayFluxSidecar(1e-4), 'X');
+});
+
+test('xrayLabelSidecar matches TS formatting', () => {
+  assert.equal(xrayLabelSidecar(4.2e-5), 'M4.2');
+  assert.equal(xrayLabelSidecar(1e-4), 'X1.0');
+  assert.equal(xrayLabelSidecar(1e-2), 'X99.0');
+});
+
+test('kpToStormLevelSidecar covers G0..G5', () => {
+  assert.equal(kpToStormLevelSidecar(0), 'G0');
+  assert.equal(kpToStormLevelSidecar(4.99), 'G0');
+  assert.equal(kpToStormLevelSidecar(5), 'G1');
+  assert.equal(kpToStormLevelSidecar(7), 'G3');
+  assert.equal(kpToStormLevelSidecar(9), 'G5');
+});
+
+test('auroraVisibilityLatitudeSidecar matches TS anchors', () => {
+  assert.equal(auroraVisibilityLatitudeSidecar(4), 90);
+  assert.equal(auroraVisibilityLatitudeSidecar(5), 60);
+  assert.equal(auroraVisibilityLatitudeSidecar(7), 55);
+  assert.equal(auroraVisibilityLatitudeSidecar(7.5), 52.5);
+  assert.equal(auroraVisibilityLatitudeSidecar(9), 45);
+});
+
+test('classifyGpsDisruptionSidecar maps flare class to risk band', () => {
+  assert.equal(classifyGpsDisruptionSidecar('X'), 'high');
+  assert.equal(classifyGpsDisruptionSidecar('M'), 'moderate');
+  assert.equal(classifyGpsDisruptionSidecar('C'), 'low');
+  assert.equal(classifyGpsDisruptionSidecar('B'), 'none');
+  assert.equal(classifyGpsDisruptionSidecar(null), 'none');
+});
+
+test('summarizeXrayFluxSidecar picks the peak in window', () => {
+  const points = [
+    { time_tag: isoMinus(0.5), flux: 1.5e-4 },
+    { time_tag: isoMinus(0.3), flux: 9e-5 },
+    { time_tag: isoMinus(0.1), flux: 4e-5 },
+  ];
+  const x = summarizeXrayFluxSidecar(points, NOW);
+  assert.ok(x);
+  assert.equal(x.peakClass, 'X');
+  assert.equal(x.peakLabel, 'X1.5');
+  assert.equal(x.xClassActive, true);
+});
+
+test('summarizeKpSidecar reports latest Kp + max in window', () => {
+  const points = [
+    { time_tag: isoMinus(20), kp: 4 },
+    { time_tag: isoMinus(8), kp: 6 },
+    { time_tag: isoMinus(2), kp: 7 },
+  ];
+  const k = summarizeKpSidecar(points, NOW);
+  assert.ok(k);
+  assert.equal(k.kp, 7);
+  assert.equal(k.level, 'G3');
+  assert.equal(k.auroraVisibilityLatN, 55);
+  assert.equal(k.kpMax24h, 7);
+});
+
+test('summarizeAlertsSidecar classifies severities', () => {
+  const raw = [
+    { product_id: 'K07', message: 'ALERT: Geomagnetic K-index of 7\nDetails…',  issue_datetime: isoMinus(2) },
+    { product_id: 'K05', message: 'WATCH: G2 (Moderate) Geomagnetic Storm',     issue_datetime: isoMinus(3) },
+    { product_id: 'X1A', message: 'WARNING: X-ray flare M5+ likely',            issue_datetime: isoMinus(4) },
+  ];
+  const a = summarizeAlertsSidecar(raw, NOW);
+  assert.equal(a.length, 3);
+  assert.deepEqual(a.map((x) => x.severity), ['alert', 'watch', 'warning']);
+});
+
+test('filterEarthwardCmesSidecar keeps |lon| ≤ 30°, drops stale arrivals', () => {
+  const cmes = [
+    { activityID: 'cme-eward', startTime: isoMinus(2),
+      cmeAnalyses: [{ longitude: 12, halfAngle: 40, speed: 920, isMostAccurate: true,
+                       time21_5: isoMinus(-30) }] },
+    { activityID: 'cme-off',   startTime: isoMinus(3),
+      cmeAnalyses: [{ longitude: 110, halfAngle: 30, speed: 700, isMostAccurate: true,
+                       time21_5: isoMinus(-40) }] },
+    { activityID: 'cme-old',   startTime: isoMinus(72),
+      cmeAnalyses: [{ longitude: 5, halfAngle: 40, speed: 900, isMostAccurate: true,
+                       time21_5: isoMinus(36) }] },
+  ];
+  const out = filterEarthwardCmesSidecar(cmes, NOW);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].id, 'cme-eward');
+});
+
+test('buildSpaceweatherStatusSidecar mirrors TS top-level shape', () => {
+  const xray = [{ time_tag: isoMinus(0.5), flux: 1.5e-4 }];
+  const kp = [{ time_tag: isoMinus(2), kp: 7 }];
+  const status = buildSpaceweatherStatusSidecar({ xrayFlux: xray, kpIndex: kp, cmes: [], now: NOW });
+  assert.ok(status.xray);
+  assert.ok(status.geomag);
+  assert.equal(status.gpsDisruption, 'high');
+  assert.equal(status.hfRadioBlackout, true);
+  assert.equal(status.geomag.level, 'G3');
+  assert.equal(status.geomag.auroraVisibilityLatN, 55);
+  assert.equal(typeof status.asOf, 'string');
+});

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -1510,6 +1510,299 @@ export function computeFreightStressSidecar(series, observations) {
     trend, stressScore, stressLevel, observationCount: sorted.length, asOf: last.date };
 }
 
+// ── Space Weather helpers (mirror src/services/spaceweather/swpc-monitor.ts) ──
+
+const SPACEWX_HOUR_MS = 60 * 60 * 1000;
+const SPACEWX_XRAY_WINDOW_MS = 6 * SPACEWX_HOUR_MS;
+const SPACEWX_KP_WINDOW_MS = 24 * SPACEWX_HOUR_MS;
+const SPACEWX_ALERTS_WINDOW_MS = 24 * SPACEWX_HOUR_MS;
+const SPACEWX_EARTHWARD_LON_DEG = 30;
+const SPACEWX_CACHE_TTL_MS = 5 * 60 * 1000;
+
+let spacewxStatusCache = null;
+let spacewxStatusCachedAt = 0;
+let spacewxAlertsCache = null;
+let spacewxAlertsCachedAt = 0;
+
+export function classifyXrayFluxSidecar(flux) {
+  if (!Number.isFinite(flux) || flux <= 0) return 'A';
+  if (flux >= 1e-4) return 'X';
+  if (flux >= 1e-5) return 'M';
+  if (flux >= 1e-6) return 'C';
+  if (flux >= 1e-7) return 'B';
+  return 'A';
+}
+
+export function xrayLabelSidecar(flux) {
+  const cls = classifyXrayFluxSidecar(flux);
+  if (cls === 'A') {
+    const m = Math.max(1, Math.round(flux / 1e-8));
+    return `A${Math.min(9, m)}`;
+  }
+  const baseByCls = { B: 1e-7, C: 1e-6, M: 1e-5, X: 1e-4 };
+  const mantissa = flux / baseByCls[cls];
+  return `${cls}${Math.min(99, mantissa).toFixed(1)}`;
+}
+
+export function kpToStormLevelSidecar(kp) {
+  if (!Number.isFinite(kp) || kp < 5) return 'G0';
+  if (kp >= 9) return 'G5';
+  if (kp >= 8) return 'G4';
+  if (kp >= 7) return 'G3';
+  if (kp >= 6) return 'G2';
+  return 'G1';
+}
+
+export function auroraVisibilityLatitudeSidecar(kp) {
+  if (!Number.isFinite(kp) || kp < 5) return 90;
+  if (kp >= 9) return 45;
+  const anchors = [
+    { kp: 5, lat: 60 }, { kp: 6, lat: 57.5 }, { kp: 7, lat: 55 },
+    { kp: 8, lat: 50 }, { kp: 9, lat: 45 },
+  ];
+  for (let i = 0; i < anchors.length - 1; i += 1) {
+    const a = anchors[i];
+    const b = anchors[i + 1];
+    if (kp >= a.kp && kp <= b.kp) {
+      const t = (kp - a.kp) / (b.kp - a.kp);
+      return Math.round((a.lat + (b.lat - a.lat) * t) / 0.5) * 0.5;
+    }
+  }
+  return 90;
+}
+
+export function classifyGpsDisruptionSidecar(cls) {
+  if (cls === 'X') return 'high';
+  if (cls === 'M') return 'moderate';
+  if (cls === 'C') return 'low';
+  return 'none';
+}
+
+function classifyAlertSeveritySidecar(headline) {
+  if (/\bALERT\b/i.test(headline)) return 'alert';
+  if (/\bWARNING\b/i.test(headline)) return 'warning';
+  if (/\bWATCH\b/i.test(headline)) return 'watch';
+  return 'summary';
+}
+
+export function summarizeXrayFluxSidecar(points, now, windowMs = SPACEWX_XRAY_WINDOW_MS) {
+  if (!Array.isArray(points)) return null;
+  const cutoff = now - windowMs;
+  let peak = -Infinity;
+  let peakAt = '';
+  let current = -Infinity;
+  let currentAt = -Infinity;
+  let count = 0;
+  for (const p of points) {
+    if (!p || !Number.isFinite(p.flux)) continue;
+    const t = Date.parse(p.time_tag);
+    if (!Number.isFinite(t) || t < cutoff || t > now) continue;
+    count += 1;
+    if (p.flux > peak) { peak = p.flux; peakAt = p.time_tag; }
+    if (t > currentAt) { currentAt = t; current = p.flux; }
+  }
+  if (count === 0 || !Number.isFinite(peak)) return null;
+  const peakClass = classifyXrayFluxSidecar(peak);
+  return {
+    peakFlux: peak,
+    currentFlux: Number.isFinite(current) ? current : peak,
+    peakClass,
+    peakLabel: xrayLabelSidecar(peak),
+    peakAt,
+    xClassActive: peakClass === 'X',
+    sampleCount: count,
+  };
+}
+
+export function summarizeKpSidecar(points, now, windowMs = SPACEWX_KP_WINDOW_MS) {
+  if (!Array.isArray(points)) return null;
+  const cutoff = now - windowMs;
+  let latest = null;
+  let latestT = -Infinity;
+  let max = -Infinity;
+  for (const p of points) {
+    if (!p || !Number.isFinite(p.kp)) continue;
+    const t = Date.parse(p.time_tag);
+    if (!Number.isFinite(t) || t < cutoff || t > now) continue;
+    if (t > latestT) { latestT = t; latest = p; }
+    if (p.kp > max) max = p.kp;
+  }
+  if (!latest) return null;
+  const kp = latest.kp;
+  return {
+    kp,
+    level: kpToStormLevelSidecar(kp),
+    auroraVisibilityLatN: auroraVisibilityLatitudeSidecar(kp),
+    observedAt: latest.time_tag,
+    kpMax24h: Number.isFinite(max) ? max : kp,
+  };
+}
+
+export function summarizeAlertsSidecar(raw, now, windowMs = SPACEWX_ALERTS_WINDOW_MS) {
+  if (!Array.isArray(raw)) return [];
+  const cutoff = now - windowMs;
+  const out = [];
+  for (const r of raw) {
+    if (!r?.message) continue;
+    const t = Date.parse(r.issue_datetime);
+    if (!Number.isFinite(t) || t < cutoff || t > now) continue;
+    const headline = String(r.message).split('\n').map((s) => s.trim()).find((s) => s.length > 0) || '';
+    if (headline.length === 0) continue;
+    out.push({
+      id: `${r.product_id ?? 'swpc'}-${r.issue_datetime}`,
+      severity: classifyAlertSeveritySidecar(headline),
+      headline,
+      issuedAt: r.issue_datetime,
+    });
+  }
+  out.sort((a, b) => Date.parse(b.issuedAt) - Date.parse(a.issuedAt));
+  return out;
+}
+
+export function filterEarthwardCmesSidecar(raw, now, lonTolDeg = SPACEWX_EARTHWARD_LON_DEG) {
+  if (!Array.isArray(raw)) return [];
+  const out = [];
+  for (const cme of raw) {
+    if (!cme || !Array.isArray(cme.cmeAnalyses) || cme.cmeAnalyses.length === 0) continue;
+    const analysis = cme.cmeAnalyses.find((a) => a?.isMostAccurate)
+      ?? cme.cmeAnalyses[cme.cmeAnalyses.length - 1];
+    if (!analysis) continue;
+    const lon = typeof analysis.longitude === 'number' ? analysis.longitude : null;
+    if (lon === null || Math.abs(lon) > lonTolDeg) continue;
+    const arrivalT = analysis.time21_5 ? Date.parse(analysis.time21_5) : NaN;
+    if (Number.isFinite(arrivalT) && arrivalT < now - 12 * SPACEWX_HOUR_MS) continue;
+    out.push({
+      id: cme.activityID ?? `cme-${out.length}`,
+      startTime: cme.startTime ?? null,
+      speedKmS: typeof analysis.speed === 'number' ? analysis.speed : null,
+      estimatedArrival: analysis.time21_5 ?? null,
+      longitudeDeg: lon,
+      latitudeDeg: typeof analysis.latitude === 'number' ? analysis.latitude : null,
+      halfAngleDeg: typeof analysis.halfAngle === 'number' ? analysis.halfAngle : null,
+      isMostAccurate: analysis.isMostAccurate === true,
+      link: cme.link ?? null,
+    });
+  }
+  out.sort((a, b) => {
+    const ta = a.estimatedArrival ? Date.parse(a.estimatedArrival) : Infinity;
+    const tb = b.estimatedArrival ? Date.parse(b.estimatedArrival) : Infinity;
+    return ta - tb;
+  });
+  return out;
+}
+
+export function buildSpaceweatherStatusSidecar(input) {
+  const now = input.now ?? Date.now();
+  const xray = summarizeXrayFluxSidecar(input.xrayFlux, now);
+  const geomag = summarizeKpSidecar(input.kpIndex, now);
+  const earthwardCmes = filterEarthwardCmesSidecar(input.cmes, now);
+  const peakClass = xray?.peakClass ?? null;
+  return {
+    xray,
+    geomag,
+    gpsDisruption: classifyGpsDisruptionSidecar(peakClass),
+    hfRadioBlackout: !!xray && xray.peakFlux >= 1e-4,
+    earthwardCmes,
+    asOf: new Date(now).toISOString(),
+  };
+}
+
+async function fetchJsonSidecar(url, timeoutMs = 12_000) {
+  try {
+    const resp = await fetchWithTimeout(url, {
+      headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
+    }, timeoutMs);
+    if (!resp.ok) return null;
+    return await resp.json();
+  } catch {
+    return null;
+  }
+}
+
+function normalizeXrayPoints(raw) {
+  if (!Array.isArray(raw)) return [];
+  const out = [];
+  for (const r of raw) {
+    if (!r) continue;
+    const flux = Number(r.flux ?? r.observed_flux);
+    const energy = String(r.energy ?? '');
+    if (!Number.isFinite(flux)) continue;
+    // GOES exposes both 0.05-0.4nm and 0.1-0.8nm channels — keep the long channel
+    // when energy tag is present, otherwise accept anything.
+    if (energy && !energy.includes('0.1-0.8')) continue;
+    const time_tag = String(r.time_tag ?? '');
+    if (!time_tag) continue;
+    out.push({ time_tag, flux, energy });
+  }
+  return out;
+}
+
+function normalizeKpPoints(raw) {
+  // SWPC returns ["time_tag","kp_index","estimated_kp","kp"] header row + data.
+  if (!Array.isArray(raw) || raw.length < 2) return [];
+  const out = [];
+  for (let i = 1; i < raw.length; i += 1) {
+    const row = raw[i];
+    if (!Array.isArray(row) || row.length < 2) continue;
+    const time_tag = String(row[0] ?? '');
+    const kp = Number(row[1]);
+    if (!time_tag || !Number.isFinite(kp)) continue;
+    out.push({ time_tag, kp });
+  }
+  return out;
+}
+
+function normalizeAlertRaw(raw) {
+  if (!Array.isArray(raw)) return [];
+  const out = [];
+  for (const r of raw) {
+    if (!r || typeof r.message !== 'string') continue;
+    const issue = r.issue_datetime ? String(r.issue_datetime) : null;
+    if (!issue) continue;
+    // SWPC's issue_datetime is naïve UTC; append Z so Date.parse works.
+    const issueIso = issue.endsWith('Z') ? issue : `${issue.replace(' ', 'T')}Z`;
+    out.push({
+      product_id: r.product_id ?? null,
+      message: r.message,
+      issue_datetime: issueIso,
+    });
+  }
+  return out;
+}
+
+export async function fetchSpaceweatherStatusSidecar() {
+  const now = Date.now();
+  if (spacewxStatusCache && now - spacewxStatusCachedAt < SPACEWX_CACHE_TTL_MS) {
+    return spacewxStatusCache;
+  }
+  const [xrayRaw, kpRaw, cmeRaw] = await Promise.all([
+    fetchJsonSidecar('https://services.swpc.noaa.gov/json/goes/primary/xrays-6-hour.json'),
+    fetchJsonSidecar('https://services.swpc.noaa.gov/products/noaa-planetary-k-index.json'),
+    fetchJsonSidecar('https://services.swpc.noaa.gov/json/donki/cme.json'),
+  ]);
+  const status = buildSpaceweatherStatusSidecar({
+    xrayFlux: normalizeXrayPoints(xrayRaw),
+    kpIndex: normalizeKpPoints(kpRaw),
+    cmes: Array.isArray(cmeRaw) ? cmeRaw : [],
+    now,
+  });
+  spacewxStatusCache = status;
+  spacewxStatusCachedAt = now;
+  return status;
+}
+
+export async function fetchSpaceweatherAlertsSidecar() {
+  const now = Date.now();
+  if (spacewxAlertsCache && now - spacewxAlertsCachedAt < SPACEWX_CACHE_TTL_MS) {
+    return spacewxAlertsCache;
+  }
+  const raw = await fetchJsonSidecar('https://services.swpc.noaa.gov/products/alerts.json');
+  const alerts = summarizeAlertsSidecar(normalizeAlertRaw(raw), now);
+  spacewxAlertsCache = alerts;
+  spacewxAlertsCachedAt = now;
+  return alerts;
+}
+
 async function fetchWithTimeout(url, options = {}, timeoutMs = 12_000) {
   // Use node:https with IPv4 forced — Node.js built-in fetch (undici) tries IPv6
   // first and some servers (EIA, NASA FIRMS) have broken IPv6 causing ETIMEDOUT.
@@ -4785,6 +5078,16 @@ async function dispatch(requestUrl, req, routes, context) {
  } catch {
  return json([], 200);
  }
+  }
+
+  // ── Space Weather status + alerts (mirrors src/services/spaceweather/swpc-monitor.ts) ──
+  if (requestUrl.pathname === '/api/spaceweather/status') {
+    const status = await fetchSpaceweatherStatusSidecar();
+    return json(status);
+  }
+  if (requestUrl.pathname === '/api/spaceweather/alerts') {
+    const alerts = await fetchSpaceweatherAlertsSidecar();
+    return json({ alerts, asOf: new Date().toISOString() });
   }
 
   // ── Air Quality proxy (Open-Meteo, no API key, forwards lat/lon) ──────────

--- a/src/services/spaceweather/__tests__/swpc-monitor.test.mts
+++ b/src/services/spaceweather/__tests__/swpc-monitor.test.mts
@@ -1,0 +1,228 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  auroraVisibilityLatitude,
+  buildStatus,
+  classifyGpsDisruption,
+  classifyXrayFlux,
+  filterEarthwardCmes,
+  kpToStormLevel,
+  summarizeAlerts,
+  xrayLabel,
+} from '../swpc-monitor.ts';
+import type {
+  DonkiCmeRaw,
+  KpIndexPoint,
+  MonitorInput,
+  SwpcAlertRaw,
+  XrayFluxPoint,
+} from '../swpc-monitor.ts';
+
+const NOW = Date.parse('2026-05-06T12:00:00Z');
+const HOUR_MS = 60 * 60 * 1000;
+
+function isoMinus(hours: number, baseMs = NOW): string {
+  return new Date(baseMs - hours * HOUR_MS).toISOString();
+}
+
+function emptyInput(over: Partial<MonitorInput> = {}): MonitorInput {
+  return { xrayFlux: [], kpIndex: [], alerts: [], cmes: [], now: NOW, ...over };
+}
+
+// ── X-ray classification ───────────────────────────────────────────────────
+
+test('classifyXrayFlux thresholds A/B/C/M/X', () => {
+  assert.equal(classifyXrayFlux(5e-9), 'A');
+  assert.equal(classifyXrayFlux(5e-8), 'A');
+  assert.equal(classifyXrayFlux(1e-7), 'B');
+  assert.equal(classifyXrayFlux(5e-7), 'B');
+  assert.equal(classifyXrayFlux(1e-6), 'C');
+  assert.equal(classifyXrayFlux(4e-6), 'C');
+  assert.equal(classifyXrayFlux(1e-5), 'M');
+  assert.equal(classifyXrayFlux(4.2e-5), 'M');
+  assert.equal(classifyXrayFlux(1e-4), 'X');
+  assert.equal(classifyXrayFlux(2e-3), 'X');
+});
+
+test('classifyXrayFlux is defensive for invalid inputs', () => {
+  assert.equal(classifyXrayFlux(0), 'A');
+  assert.equal(classifyXrayFlux(-1), 'A');
+  assert.equal(classifyXrayFlux(Number.NaN), 'A');
+});
+
+test('xrayLabel formats class + mantissa', () => {
+  assert.equal(xrayLabel(4.2e-5), 'M4.2');
+  assert.equal(xrayLabel(1.0e-4), 'X1.0');
+  assert.equal(xrayLabel(2.5e-4), 'X2.5');
+  assert.equal(xrayLabel(7.3e-7), 'B7.3');
+  assert.equal(xrayLabel(3.1e-6), 'C3.1');
+});
+
+test('xrayLabel clamps extreme X-class peaks', () => {
+  // 1e-2 W/m² → X100 — clamp at X99 for label width.
+  assert.equal(xrayLabel(1e-2), 'X99.0');
+});
+
+// ── Kp / aurora ────────────────────────────────────────────────────────────
+
+test('kpToStormLevel uses spec-mandated G0..G5 thresholds', () => {
+  assert.equal(kpToStormLevel(0), 'G0');
+  assert.equal(kpToStormLevel(4.99), 'G0');
+  assert.equal(kpToStormLevel(5), 'G1');
+  assert.equal(kpToStormLevel(6), 'G2');
+  assert.equal(kpToStormLevel(7), 'G3');
+  assert.equal(kpToStormLevel(8), 'G4');
+  assert.equal(kpToStormLevel(9), 'G5');
+});
+
+test('auroraVisibilityLatitude matches the spec anchors', () => {
+  assert.equal(auroraVisibilityLatitude(4), 90);
+  assert.equal(auroraVisibilityLatitude(5), 60);
+  assert.equal(auroraVisibilityLatitude(7), 55);
+  assert.equal(auroraVisibilityLatitude(9), 45);
+});
+
+test('auroraVisibilityLatitude interpolates linearly between anchors', () => {
+  // Between Kp7 (55°N) and Kp8 (50°N), Kp7.5 → 52.5°N (rounded to 0.5°).
+  assert.equal(auroraVisibilityLatitude(7.5), 52.5);
+  // Above Kp9 → clamped at 45°N.
+  assert.equal(auroraVisibilityLatitude(10), 45);
+});
+
+// ── GPS / HF ───────────────────────────────────────────────────────────────
+
+test('classifyGpsDisruption maps flare class to risk band', () => {
+  assert.equal(classifyGpsDisruption('X'), 'high');
+  assert.equal(classifyGpsDisruption('M'), 'moderate');
+  assert.equal(classifyGpsDisruption('C'), 'low');
+  assert.equal(classifyGpsDisruption('B'), 'none');
+  assert.equal(classifyGpsDisruption('A'), 'none');
+  assert.equal(classifyGpsDisruption(null), 'none');
+});
+
+// ── CME filtering ──────────────────────────────────────────────────────────
+
+test('filterEarthwardCmes keeps CMEs with longitude within 30° of disk centre', () => {
+  const earthward: DonkiCmeRaw = {
+    activityID: 'cme-eward',
+    startTime: isoMinus(2),
+    cmeAnalyses: [{ longitude: 12, latitude: 5, halfAngle: 40, speed: 920,
+      time21_5: isoMinus(-30), isMostAccurate: true }],
+    link: 'https://example/test',
+  };
+  const offEarth: DonkiCmeRaw = {
+    activityID: 'cme-off',
+    startTime: isoMinus(3),
+    cmeAnalyses: [{ longitude: 110, latitude: 0, halfAngle: 30, speed: 700,
+      time21_5: isoMinus(-40), isMostAccurate: true }],
+  };
+  const filtered = filterEarthwardCmes([earthward, offEarth], NOW);
+  assert.equal(filtered.length, 1);
+  assert.equal(filtered[0]?.id, 'cme-eward');
+  assert.equal(filtered[0]?.speedKmS, 920);
+  assert.equal(filtered[0]?.isMostAccurate, true);
+});
+
+test('filterEarthwardCmes prefers the most-accurate analysis when present', () => {
+  const cme: DonkiCmeRaw = {
+    activityID: 'cme-multi',
+    startTime: isoMinus(4),
+    cmeAnalyses: [
+      { longitude: 60, halfAngle: 30, speed: 500, isMostAccurate: false, time21_5: isoMinus(-20) },
+      { longitude: 8, halfAngle: 40, speed: 1100, isMostAccurate: true, time21_5: isoMinus(-25) },
+    ],
+  };
+  const filtered = filterEarthwardCmes([cme], NOW);
+  assert.equal(filtered.length, 1);
+  assert.equal(filtered[0]?.speedKmS, 1100);
+});
+
+test('filterEarthwardCmes drops CMEs whose modeled arrival is in the past >12h', () => {
+  const stale: DonkiCmeRaw = {
+    activityID: 'cme-old',
+    startTime: isoMinus(72),
+    cmeAnalyses: [{ longitude: 5, halfAngle: 40, speed: 900,
+      time21_5: isoMinus(36), isMostAccurate: true }],
+  };
+  const filtered = filterEarthwardCmes([stale], NOW);
+  assert.equal(filtered.length, 0);
+});
+
+// ── Alerts ─────────────────────────────────────────────────────────────────
+
+test('summarizeAlerts classifies ALERT/WARNING/WATCH/summary by headline', () => {
+  const raw: SwpcAlertRaw[] = [
+    { product_id: 'K07',  message: 'ALERT: Geomagnetic K-index of 7\nDetails…',  issue_datetime: isoMinus(2) },
+    { product_id: 'K05',  message: 'WATCH: G2 (Moderate) Geomagnetic Storm',     issue_datetime: isoMinus(3) },
+    { product_id: 'X1A',  message: 'WARNING: X-ray flare M5+ likely',            issue_datetime: isoMinus(4) },
+    { product_id: 'OUT',  message: 'Daily report — no significant activity',     issue_datetime: isoMinus(50) },
+  ];
+  const summarized = summarizeAlerts(raw, NOW);
+  assert.equal(summarized.length, 3);
+  const sevs = summarized.map((a) => a.severity);
+  assert.deepEqual(sevs, ['alert', 'watch', 'warning']);
+});
+
+// ── Full status ────────────────────────────────────────────────────────────
+
+test('buildStatus returns null xray/geomag for empty inputs but stable shape', () => {
+  const status = buildStatus(emptyInput());
+  assert.equal(status.xray, null);
+  assert.equal(status.geomag, null);
+  assert.equal(status.gpsDisruption, 'none');
+  assert.equal(status.hfRadioBlackout, false);
+  assert.deepEqual(status.earthwardCmes, []);
+  assert.equal(typeof status.asOf, 'string');
+});
+
+test('buildStatus flags HF blackout + high GPS risk on X-class', () => {
+  const xrayFlux: XrayFluxPoint[] = [
+    { time_tag: isoMinus(0.5), flux: 1.5e-4, energy: '0.1-0.8nm' },
+    { time_tag: isoMinus(0.3), flux: 9e-5,    energy: '0.1-0.8nm' },
+    { time_tag: isoMinus(0.1), flux: 4e-5,    energy: '0.1-0.8nm' },
+  ];
+  const status = buildStatus(emptyInput({ xrayFlux }));
+  assert.ok(status.xray);
+  assert.equal(status.xray?.peakClass, 'X');
+  assert.equal(status.xray?.peakLabel, 'X1.5');
+  assert.equal(status.xray?.xClassActive, true);
+  assert.equal(status.gpsDisruption, 'high');
+  assert.equal(status.hfRadioBlackout, true);
+});
+
+test('buildStatus reports geomag level + aurora latitude from latest Kp', () => {
+  const kpIndex: KpIndexPoint[] = [
+    { time_tag: isoMinus(20), kp: 4 },
+    { time_tag: isoMinus(8),  kp: 6 },
+    { time_tag: isoMinus(2),  kp: 7 },
+  ];
+  const status = buildStatus(emptyInput({ kpIndex }));
+  assert.ok(status.geomag);
+  assert.equal(status.geomag?.kp, 7);
+  assert.equal(status.geomag?.level, 'G3');
+  assert.equal(status.geomag?.auroraVisibilityLatN, 55);
+  assert.equal(status.geomag?.kpMax24h, 7);
+});
+
+test('buildStatus skips X-ray and Kp samples outside the configured windows', () => {
+  // 12h ago is outside the 6h X-ray window but inside the 24h Kp window.
+  const xrayFlux: XrayFluxPoint[] = [
+    { time_tag: isoMinus(12), flux: 5e-4 },
+  ];
+  const kpIndex: KpIndexPoint[] = [
+    { time_tag: isoMinus(12), kp: 6 },
+  ];
+  const status = buildStatus(emptyInput({ xrayFlux, kpIndex }));
+  assert.equal(status.xray, null);
+  assert.ok(status.geomag);
+});
+
+test('buildStatus C-class flare → low GPS risk, no HF blackout', () => {
+  const xrayFlux: XrayFluxPoint[] = [
+    { time_tag: isoMinus(1), flux: 3e-6 },
+  ];
+  const status = buildStatus(emptyInput({ xrayFlux }));
+  assert.equal(status.gpsDisruption, 'low');
+  assert.equal(status.hfRadioBlackout, false);
+});

--- a/src/services/spaceweather/swpc-monitor.ts
+++ b/src/services/spaceweather/swpc-monitor.ts
@@ -1,0 +1,423 @@
+/**
+ * Space Weather Monitor (pure-deterministic).
+ *
+ * Classifies NOAA SWPC + NASA DONKI feed snapshots into derived state:
+ *   - X-ray flare class A/B/C/M/X from peak flux (W/m²)
+ *   - Geomagnetic storm level G0–G5 from planetary Kp
+ *   - Aurora visibility latitude from Kp (60°N at Kp5 → 45°N at Kp9)
+ *   - GPS disruption risk (high / moderate / low / none)
+ *   - HF radio blackout flag (X-ray peak ≥ 1e-4 W/m²)
+ *   - Earthward CME filter (heliographic longitude ≤ 30° from disk center)
+ *
+ * Inputs are caller-provided typed bags from sidecar fetches. No DOM, no
+ * fetch, no globals — deterministic for fixture-based tests.
+ */
+
+export type XrayClass = 'A' | 'B' | 'C' | 'M' | 'X';
+
+export type GeomagStormLevel = 'G0' | 'G1' | 'G2' | 'G3' | 'G4' | 'G5';
+
+export type RiskBand = 'none' | 'low' | 'moderate' | 'high';
+
+export type SwpcAlertSeverity = 'summary' | 'watch' | 'warning' | 'alert';
+
+// ── Raw inputs from SWPC / DONKI ────────────────────────────────────────────
+
+/** A point from the GOES X-ray flux feed (`xrays-6-hour.json`). */
+export interface XrayFluxPoint {
+  /** ISO timestamp. */
+  time_tag: string;
+  /** Watts per square metre, integrated 1–8 Å channel. */
+  flux: number;
+  /** GOES energy band, typically `'0.1-0.8nm'`. */
+  energy?: string;
+  /** Optional satellite tag — left unused but preserved for callers. */
+  satellite?: number | string;
+}
+
+/** A row from the SWPC planetary-K-index product. */
+export interface KpIndexPoint {
+  time_tag: string;
+  kp: number;
+}
+
+/** A row from the SWPC alerts product. */
+export interface SwpcAlertRaw {
+  product_id?: string;
+  message: string;
+  /** ISO timestamp; SWPC uses naïve UTC strings — caller pre-normalizes. */
+  issue_datetime: string;
+}
+
+/** A subset of NASA DONKI CME analysis fields used to classify earth-directed events. */
+export interface DonkiCmeRaw {
+  activityID?: string;
+  startTime?: string | null;
+  cmeAnalyses?: {
+    /** Heliographic latitude of CME source, degrees. */
+    latitude?: number | null;
+    /** Heliographic longitude, degrees. Earth lies near 0°. */
+    longitude?: number | null;
+    /** Half-angle of cone, degrees. */
+    halfAngle?: number | null;
+    /** Speed in km/s. */
+    speed?: number | null;
+    /** ISO timestamp the CME crosses 21.5 Rsun shock front. */
+    time21_5?: string | null;
+    isMostAccurate?: boolean;
+    note?: string | null;
+  }[] | null;
+  link?: string | null;
+}
+
+// ── Derived shapes ─────────────────────────────────────────────────────────
+
+export interface XrayFluxState {
+  /** Peak observed flux in window, W/m². */
+  peakFlux: number;
+  /** Most recent observation flux, W/m². */
+  currentFlux: number;
+  /** Flare class label of `peakFlux`. */
+  peakClass: XrayClass;
+  /** Numeric label, e.g. peak `4.2e-5` → `'M4.2'`. */
+  peakLabel: string;
+  /** ISO timestamp of `peakFlux`. */
+  peakAt: string;
+  /** Did peak cross the X-class threshold (≥1e-4)? */
+  xClassActive: boolean;
+  /** Sample count used. */
+  sampleCount: number;
+}
+
+export interface GeomagState {
+  kp: number;
+  level: GeomagStormLevel;
+  /** Lowest geomagnetic latitude (°N) at which aurora is visible overhead.
+   * 90 = invisible. */
+  auroraVisibilityLatN: number;
+  observedAt: string;
+  /** Recent rolling max within the window (e.g. last 24h). */
+  kpMax24h: number;
+}
+
+export interface EarthwardCme {
+  id: string;
+  startTime: string | null;
+  speedKmS: number | null;
+  /** ISO timestamp; null when DONKI analysis lacks an arrival. */
+  estimatedArrival: string | null;
+  longitudeDeg: number | null;
+  latitudeDeg: number | null;
+  halfAngleDeg: number | null;
+  isMostAccurate: boolean;
+  link: string | null;
+}
+
+export interface SpaceWxAlert {
+  id: string;
+  severity: SwpcAlertSeverity;
+  /** First non-empty line of the SWPC message. */
+  headline: string;
+  issuedAt: string;
+}
+
+export interface SpaceWxStatus {
+  xray: XrayFluxState | null;
+  geomag: GeomagState | null;
+  /** "high" if X-class flare active, "moderate" for M, "low" for C, else "none". */
+  gpsDisruption: RiskBand;
+  /** True iff peak X-ray flux ≥ 1e-4 W/m² in the window. */
+  hfRadioBlackout: boolean;
+  earthwardCmes: EarthwardCme[];
+  asOf: string;
+}
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+const XRAY_THRESHOLDS: { cls: XrayClass; min: number }[] = [
+  { cls: 'X', min: 1e-4 },
+  { cls: 'M', min: 1e-5 },
+  { cls: 'C', min: 1e-6 },
+  { cls: 'B', min: 1e-7 },
+  { cls: 'A', min: 0 },
+];
+
+const KP_TO_LEVEL: { kp: number; level: GeomagStormLevel }[] = [
+  { kp: 9, level: 'G5' },
+  { kp: 8, level: 'G4' },
+  { kp: 7, level: 'G3' },
+  { kp: 6, level: 'G2' },
+  { kp: 5, level: 'G1' },
+];
+
+/** Spec-mandated aurora visibility anchors. Kp values between are linearly
+ * interpolated; below Kp5, aurora is not realistically visible from
+ * mid-latitudes so we report 90° as a sentinel. */
+const AURORA_ANCHORS: { kp: number; latN: number }[] = [
+  { kp: 5, latN: 60 },
+  { kp: 6, latN: 57.5 },
+  { kp: 7, latN: 55 },
+  { kp: 8, latN: 50 },
+  { kp: 9, latN: 45 },
+];
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+export function classifyXrayFlux(fluxWPerM2: number): XrayClass {
+  if (!Number.isFinite(fluxWPerM2) || fluxWPerM2 <= 0) return 'A';
+  for (const tier of XRAY_THRESHOLDS) {
+    if (fluxWPerM2 >= tier.min) return tier.cls;
+  }
+  return 'A';
+}
+
+export function xrayLabel(fluxWPerM2: number): string {
+  const cls = classifyXrayFlux(fluxWPerM2);
+  if (cls === 'A') {
+    // A-class displays as the integer mantissa of flux × 1e8 (e.g. 5e-8 → A5).
+    const m = Math.max(1, Math.round(fluxWPerM2 / 1e-8));
+    return `A${Math.min(9, m)}`;
+  }
+  const baseByCls: Record<Exclude<XrayClass, 'A'>, number> = {
+    B: 1e-7,
+    C: 1e-6,
+    M: 1e-5,
+    X: 1e-4,
+  };
+  const base = baseByCls[cls];
+  const mantissa = fluxWPerM2 / base;
+  // X-class mantissa can exceed 9 (e.g. X28); clamp at 99 for label width.
+  const clamped = Math.min(99, mantissa);
+  return `${cls}${clamped.toFixed(1)}`;
+}
+
+export function kpToStormLevel(kp: number): GeomagStormLevel {
+  if (!Number.isFinite(kp) || kp < 5) return 'G0';
+  for (const tier of KP_TO_LEVEL) {
+    if (kp >= tier.kp) return tier.level;
+  }
+  return 'G0';
+}
+
+export function auroraVisibilityLatitude(kp: number): number {
+  if (!Number.isFinite(kp) || kp < 5) return 90;
+  if (kp >= 9) return 45;
+  // Linear interpolate between anchor pairs.
+  for (let i = 0; i < AURORA_ANCHORS.length - 1; i += 1) {
+    const a = AURORA_ANCHORS[i];
+    const b = AURORA_ANCHORS[i + 1];
+    if (a && b && kp >= a.kp && kp <= b.kp) {
+      const t = (kp - a.kp) / (b.kp - a.kp);
+      return roundTo(a.latN + (b.latN - a.latN) * t, 0.5);
+    }
+  }
+  return 90;
+}
+
+function roundTo(value: number, step: number): number {
+  return Math.round(value / step) * step;
+}
+
+export function classifyGpsDisruption(xrayPeakClass: XrayClass | null): RiskBand {
+  if (xrayPeakClass === 'X') return 'high';
+  if (xrayPeakClass === 'M') return 'moderate';
+  if (xrayPeakClass === 'C') return 'low';
+  return 'none';
+}
+
+// ── Core computation ───────────────────────────────────────────────────────
+
+export interface MonitorInput {
+  xrayFlux: XrayFluxPoint[];
+  kpIndex: KpIndexPoint[];
+  alerts: SwpcAlertRaw[];
+  cmes: DonkiCmeRaw[];
+  /** Now-ish, ms since epoch. Defaults to Date.now() at call time. */
+  now?: number;
+  /** Window for "currently active" classification. Defaults to 6h. */
+  xrayWindowMs?: number;
+  /** Window for `kpMax24h` — defaults to 24h. */
+  kpWindowMs?: number;
+  /** Earthward longitude tolerance in degrees from disk center (0°).
+   * Default 30° follows the SWPC convention for earth-directed CMEs. */
+  earthwardLongitudeDeg?: number;
+}
+
+function summarizeXray(
+  points: XrayFluxPoint[],
+  now: number,
+  windowMs: number,
+): XrayFluxState | null {
+  const cutoff = now - windowMs;
+  let peak = -Infinity;
+  let peakAt = '';
+  let current = -Infinity;
+  let currentAt = -Infinity;
+  let count = 0;
+  for (const p of points) {
+    if (!Number.isFinite(p.flux)) continue;
+    const t = Date.parse(p.time_tag);
+    if (!Number.isFinite(t) || t < cutoff || t > now) continue;
+    count += 1;
+    if (p.flux > peak) {
+      peak = p.flux;
+      peakAt = p.time_tag;
+    }
+    if (t > currentAt) {
+      currentAt = t;
+      current = p.flux;
+    }
+  }
+  if (count === 0 || !Number.isFinite(peak)) return null;
+  const peakClass = classifyXrayFlux(peak);
+  return {
+    peakFlux: peak,
+    currentFlux: Number.isFinite(current) ? current : peak,
+    peakClass,
+    peakLabel: xrayLabel(peak),
+    peakAt,
+    xClassActive: peakClass === 'X',
+    sampleCount: count,
+  };
+}
+
+function summarizeKp(
+  points: KpIndexPoint[],
+  now: number,
+  windowMs: number,
+): GeomagState | null {
+  const cutoff = now - windowMs;
+  let latest: KpIndexPoint | null = null;
+  let latestT = -Infinity;
+  let max = -Infinity;
+  for (const p of points) {
+    if (!Number.isFinite(p.kp)) continue;
+    const t = Date.parse(p.time_tag);
+    if (!Number.isFinite(t) || t < cutoff || t > now) continue;
+    if (t > latestT) {
+      latestT = t;
+      latest = p;
+    }
+    if (p.kp > max) max = p.kp;
+  }
+  if (!latest) return null;
+  const kp = latest.kp;
+  const level = kpToStormLevel(kp);
+  return {
+    kp,
+    level,
+    auroraVisibilityLatN: auroraVisibilityLatitude(kp),
+    observedAt: latest.time_tag,
+    kpMax24h: Number.isFinite(max) ? max : kp,
+  };
+}
+
+function classifyAlertSeverity(headline: string): SwpcAlertSeverity {
+  if (/\bALERT\b/i.test(headline)) return 'alert';
+  if (/\bWARNING\b/i.test(headline)) return 'warning';
+  if (/\bWATCH\b/i.test(headline)) return 'watch';
+  return 'summary';
+}
+
+export function summarizeAlerts(
+  raw: SwpcAlertRaw[],
+  now: number,
+  windowMs: number = DAY_MS,
+): SpaceWxAlert[] {
+  const cutoff = now - windowMs;
+  const out: SpaceWxAlert[] = [];
+  for (const r of raw) {
+    if (!r?.message) continue;
+    const t = Date.parse(r.issue_datetime);
+    if (!Number.isFinite(t) || t < cutoff || t > now) continue;
+    const headline = r.message.split('\n').map((s) => s.trim()).find((s) => s.length > 0) ?? '';
+    if (headline.length === 0) continue;
+    out.push({
+      id: `${r.product_id ?? 'swpc'}-${r.issue_datetime}`,
+      severity: classifyAlertSeverity(headline),
+      headline,
+      issuedAt: r.issue_datetime,
+    });
+  }
+  out.sort((a, b) => Date.parse(b.issuedAt) - Date.parse(a.issuedAt));
+  return out;
+}
+
+type CmeAnalysis = NonNullable<DonkiCmeRaw['cmeAnalyses']>[number];
+
+function pickPrimaryAnalysis(analyses: CmeAnalysis[]): CmeAnalysis | null {
+  return analyses.find((a) => a?.isMostAccurate) ?? analyses[analyses.length - 1] ?? null;
+}
+
+function toEarthwardCme(
+  cme: DonkiCmeRaw,
+  analysis: CmeAnalysis,
+  fallbackId: string,
+): EarthwardCme {
+  return {
+    id: cme.activityID ?? fallbackId,
+    startTime: cme.startTime ?? null,
+    speedKmS: typeof analysis.speed === 'number' ? analysis.speed : null,
+    estimatedArrival: analysis.time21_5 ?? null,
+    longitudeDeg: typeof analysis.longitude === 'number' ? analysis.longitude : null,
+    latitudeDeg: typeof analysis.latitude === 'number' ? analysis.latitude : null,
+    halfAngleDeg: typeof analysis.halfAngle === 'number' ? analysis.halfAngle : null,
+    isMostAccurate: analysis.isMostAccurate === true,
+    link: cme.link ?? null,
+  };
+}
+
+function isEarthwardAnalysis(analysis: CmeAnalysis, now: number, lonTolDeg: number): boolean {
+  const lon = typeof analysis.longitude === 'number' ? analysis.longitude : null;
+  if (lon === null || Math.abs(lon) > lonTolDeg) return false;
+  const arrivalT = analysis.time21_5 ? Date.parse(analysis.time21_5) : Number.NaN;
+  if (Number.isFinite(arrivalT) && arrivalT < now - 12 * HOUR_MS) return false;
+  return true;
+}
+
+export function filterEarthwardCmes(
+  raw: DonkiCmeRaw[],
+  now: number,
+  earthwardLongitudeDeg = 30,
+): EarthwardCme[] {
+  const out: EarthwardCme[] = [];
+  for (const cme of raw) {
+    if (!Array.isArray(cme.cmeAnalyses) || cme.cmeAnalyses.length === 0) continue;
+    const analysis = pickPrimaryAnalysis(cme.cmeAnalyses);
+    if (!analysis) continue;
+    if (!isEarthwardAnalysis(analysis, now, earthwardLongitudeDeg)) continue;
+    out.push(toEarthwardCme(cme, analysis, `cme-${out.length}`));
+  }
+  out.sort((a, b) => {
+    const ta = a.estimatedArrival ? Date.parse(a.estimatedArrival) : Infinity;
+    const tb = b.estimatedArrival ? Date.parse(b.estimatedArrival) : Infinity;
+    return ta - tb;
+  });
+  return out;
+}
+
+export function buildStatus(input: MonitorInput): SpaceWxStatus {
+  const now = input.now ?? Date.now();
+  const xrayWindow = input.xrayWindowMs ?? 6 * HOUR_MS;
+  const kpWindow = input.kpWindowMs ?? DAY_MS;
+  const xray = summarizeXray(input.xrayFlux, now, xrayWindow);
+  const geomag = summarizeKp(input.kpIndex, now, kpWindow);
+  const earthwardCmes = filterEarthwardCmes(
+    input.cmes,
+    now,
+    input.earthwardLongitudeDeg ?? 30,
+  );
+  const gpsDisruption = classifyGpsDisruption(xray?.peakClass ?? null);
+  const hfRadioBlackout = !!xray && xray.peakFlux >= 1e-4;
+  return {
+    xray,
+    geomag,
+    gpsDisruption,
+    hfRadioBlackout,
+    earthwardCmes,
+    asOf: new Date(now).toISOString(),
+  };
+}


### PR DESCRIPTION
PR 1 of a 3-PR space weather intelligence stack.

## What

Pure-deterministic monitor in [src/services/spaceweather/swpc-monitor.ts](src/services/spaceweather/swpc-monitor.ts) classifies NOAA SWPC + NASA DONKI snapshots into:

- **X-ray flare class** A/B/C/M/X with mantissa label (e.g. peak \`4.2e-5 W/m²\` → \`M4.2\`)
- **Geomagnetic storm level** G0–G5 from planetary Kp (Kp5→G1 … Kp9→G5)
- **Aurora visibility latitude** linear-interpolated between anchors: 60°N at Kp5, 55°N at Kp7, 45°N at Kp9
- **GPS disruption risk** band: X→high, M→moderate, C→low, else none
- **HF radio blackout** flag (peak X-ray flux ≥ 1e-4 W/m²)
- **Earthward CME filter** (heliographic |lon| ≤ 30° from disk centre, drops arrivals >12h in the past)

## Sidecar

Two new routes in [src-tauri/sidecar/local-api-server.mjs](src-tauri/sidecar/local-api-server.mjs):

- \`GET /api/spaceweather/status\` → \`SpaceWxStatus\` (xray + geomag + gpsDisruption + hfRadioBlackout + earthwardCmes)
- \`GET /api/spaceweather/alerts\` → \`{ alerts: SpaceWxAlert[], asOf }\`

Both fetch SWPC's free, no-key feeds and run the same classifier (mirrored in JS, locked by parity test). 5-minute response cache.

## Tests

- 17 TS unit tests in \`swpc-monitor.test.mts\`
- 10 sidecar parity tests in \`spaceweather-parity.test.mjs\` lock the JS mirror against the canonical TS module
- Full \`test:sidecar\` suite (203 tests) still green
- \`typecheck:all\` clean

## Up next

- PR 2 — \`SpaceWeatherPanel\` consumes the new status + alerts endpoints
- PR 3 — Globe integration (aurora oval ring, X-flare pulse, EEW G4+ banner)