### PR TITLE
feat(gdelt): wire 15-min EVENT poller into precedent-matcher corpus (PR 1/5)

### DIFF
--- a/api/__tests__/gdelt-events.test.mjs
+++ b/api/__tests__/gdelt-events.test.mjs
@@ -1,0 +1,216 @@
+/**
+ * Route-level coverage for api/gdelt/events.js
+ *
+ * GDELT 2.0 EVENT poller — verifies CSV row filtering (QuadClass 3/4,
+ * NumMentions ≥ 3, AvgTone ≤ -2), Goldstein → IntensityLabel mapping,
+ * single-entry deflate-raw ZIP extraction, and the OPTIONS / wrong-method /
+ * upstream-failure contract preservation.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { invokeHandler, mockFetch } from './_test-utils.mjs';
+
+const mod = await import('../gdelt/events.js');
+const handler = mod.default;
+const { parseExportCsv, intensityFromGoldstein, unzipFirstEntry, __resetCacheForTests } = mod;
+
+// ── pure parser: CSV → HistoricalEvent[] ─────────────────────────────
+
+const HEADER_PADDING = (cols) => {
+  // GDELT 2.0 EVENT has 61 columns. Tests provide only the columns they
+  // care about; this helper pads the rest with empty strings so col
+  // indexes line up with the production parser.
+  const out = new Array(61).fill('');
+  for (const [idx, val] of Object.entries(cols)) out[+idx] = String(val);
+  return out.join('\t');
+};
+
+test('parseExportCsv: keeps QuadClass=4 rows with mentions≥3 and tone≤-2', () => {
+  const row = HEADER_PADDING({
+    0: '12345', 6: 'Russia Mil', 7: 'RUS', 16: 'Ukraine Mil', 17: 'UKR',
+    26: '193', 29: '4', 30: '-9', 31: '12', 34: '-5.4',
+    52: 'Donetsk, Ukraine', 53: 'UKR',
+    59: '20260506120000', 60: 'http://example/x',
+  });
+  const events = parseExportCsv(row);
+  assert.equal(events.length, 1);
+  const ev = events[0];
+  assert.equal(ev.id, 'gdelt-12345');
+  assert.equal(ev.intensity, 'critical');           // Goldstein -9 ⇒ critical
+  assert.equal(ev.eventType, 'fight');              // CAMEO 19 ⇒ fight
+  assert.equal(ev.country, 'UKR');
+  assert.deepEqual(ev.actors, ['Russia Mil', 'Ukraine Mil']);
+  assert.equal(ev.source, 'gdelt');
+  assert.match(ev.date, /^2026-05-06T12:00:00/);
+});
+
+test('parseExportCsv: drops QuadClass 1/2 (cooperative)', () => {
+  const row = HEADER_PADDING({ 0: '1', 29: '1', 30: '5', 31: '20', 34: '-5', 59: '20260101000000' });
+  assert.equal(parseExportCsv(row).length, 0);
+});
+
+test('parseExportCsv: drops rows with NumMentions < 3', () => {
+  const row = HEADER_PADDING({ 0: '2', 29: '4', 30: '-9', 31: '2', 34: '-5', 59: '20260101000000' });
+  assert.equal(parseExportCsv(row).length, 0);
+});
+
+test('parseExportCsv: drops positive-tone rows even if QuadClass=4', () => {
+  // Tone +1 ⇒ this isn't conflict reporting, it's ceasefire / cooperation.
+  const row = HEADER_PADDING({ 0: '3', 29: '4', 30: '-1', 31: '10', 34: '1.0', 59: '20260101000000' });
+  assert.equal(parseExportCsv(row).length, 0);
+});
+
+test('parseExportCsv: malformed DATEADDED is dropped (no synthesized date)', () => {
+  const row = HEADER_PADDING({ 0: '4', 29: '4', 30: '-9', 31: '5', 34: '-3', 59: 'BADDATE' });
+  assert.equal(parseExportCsv(row).length, 0);
+});
+
+test('parseExportCsv: handles empty input safely', () => {
+  assert.deepEqual(parseExportCsv(''), []);
+  assert.deepEqual(parseExportCsv('\n\n\n'), []);
+});
+
+test('parseExportCsv: caps at MAX_EVENTS=500 even if more pass the filter', () => {
+  const lines = Array.from({ length: 600 }, (_, i) => HEADER_PADDING({
+    0: String(i), 29: '4', 30: '-9', 31: '5', 34: '-3', 59: '20260101000000',
+  }));
+  assert.equal(parseExportCsv(lines.join('\n')).length, 500);
+});
+
+// ── intensity bucket mapping ─────────────────────────────────────────
+
+test('intensityFromGoldstein: bucket boundaries', () => {
+  assert.equal(intensityFromGoldstein(-10), 'critical');
+  assert.equal(intensityFromGoldstein(-8), 'critical');
+  assert.equal(intensityFromGoldstein(-7.99), 'high');
+  assert.equal(intensityFromGoldstein(-5), 'high');
+  assert.equal(intensityFromGoldstein(-4.99), 'medium');
+  assert.equal(intensityFromGoldstein(-2), 'medium');
+  assert.equal(intensityFromGoldstein(-1.99), 'low');
+  assert.equal(intensityFromGoldstein(NaN), 'medium');     // unknown → safe default
+});
+
+// ── ZIP extraction round-trip ────────────────────────────────────────
+
+async function makeMinimalZip(payload) {
+  // Compress 'payload' with deflate-raw, then wrap in a single-entry ZIP
+  // local file header. Used only to feed unzipFirstEntry a real archive.
+  const compressed = await new Response(
+    new Blob([new TextEncoder().encode(payload)]).stream()
+      .pipeThrough(new CompressionStream('deflate-raw')),
+  ).arrayBuffer();
+  const fileName = 'fixture.csv';
+  const fnBuf = new TextEncoder().encode(fileName);
+  const header = new ArrayBuffer(30 + fnBuf.length);
+  const v = new DataView(header);
+  v.setUint32(0, 0x04034b50, true);
+  v.setUint16(4, 20, true);                      // version needed
+  v.setUint16(6, 0, true);                       // flags
+  v.setUint16(8, 8, true);                       // method = deflate
+  v.setUint16(10, 0, true); v.setUint16(12, 0, true);
+  v.setUint32(14, 0, true);                      // CRC32 (not validated)
+  v.setUint32(18, compressed.byteLength, true);  // compressed size
+  v.setUint32(22, payload.length, true);         // uncompressed size
+  v.setUint16(26, fnBuf.length, true);
+  v.setUint16(28, 0, true);                      // extra
+  new Uint8Array(header, 30).set(fnBuf);
+  const out = new Uint8Array(header.byteLength + compressed.byteLength);
+  out.set(new Uint8Array(header), 0);
+  out.set(new Uint8Array(compressed), header.byteLength);
+  return out.buffer;
+}
+
+test('unzipFirstEntry: round-trips deflate-raw payload', async () => {
+  const text = 'col1\tcol2\nfoo\tbar\n';
+  const zip = await makeMinimalZip(text);
+  const decoded = await unzipFirstEntry(zip);
+  assert.equal(decoded, text);
+});
+
+test('unzipFirstEntry: rejects non-ZIP payloads (bad signature)', async () => {
+  // Need ≥30 bytes to pass the size guard; fill with non-ZIP bytes so the
+  // signature check fires.
+  const buf = new Uint8Array(64).fill(0x41).buffer;     // 'A' repeated
+  await assert.rejects(() => unzipFirstEntry(buf), /Bad ZIP signature/);
+});
+
+test('unzipFirstEntry: rejects payloads smaller than the local file header', async () => {
+  const buf = new Uint8Array(8).buffer;
+  await assert.rejects(() => unzipFirstEntry(buf), /ZIP too small/);
+});
+
+// ── handler: HTTP contract ───────────────────────────────────────────
+
+test('handler: OPTIONS returns 204', async () => {
+  const { res } = await invokeHandler(handler, { method: 'OPTIONS' });
+  assert.equal(res.statusCode, 204);
+});
+
+test('handler: rejects non-GET methods', async () => {
+  const { res } = await invokeHandler(handler, { method: 'POST' });
+  assert.equal(res.statusCode, 405);
+});
+
+test('handler: lastupdate.txt 503 → degraded payload (preserves 200 contract)', async () => {
+  __resetCacheForTests();
+  const restore = mockFetch(new Map([['lastupdate.txt', { status: 503, text: '' }]]));
+  try {
+    const { res } = await invokeHandler(handler, {});
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.degraded, true);
+    assert.deepEqual(res.body.events, []);
+    assert.match(res.body.reason, /lastupdate\.txt HTTP 503/);
+  } finally { restore(); }
+});
+
+test('handler: lastupdate.txt missing export entry → degraded', async () => {
+  __resetCacheForTests();
+  const restore = mockFetch(new Map([['lastupdate.txt', { status: 200, text: '' }]]));
+  try {
+    const { res } = await invokeHandler(handler, {});
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.degraded, true);
+    assert.match(res.body.reason, /missing export entry/);
+  } finally { restore(); }
+});
+
+test('handler: full pipeline — lastupdate → ZIP → CSV → HistoricalEvent[]', async () => {
+  __resetCacheForTests();
+  const csv = HEADER_PADDING({
+    0: '999', 6: 'Hamas', 7: 'PSE', 16: 'Israel Mil', 17: 'ISR',
+    26: '193', 29: '4', 30: '-10', 31: '50', 34: '-7.5',
+    52: 'Gaza City', 53: 'PSE',
+    59: '20260506130000', 60: 'http://example/y',
+  });
+  const zipBuf = await makeMinimalZip(csv);
+  const lastUpdate = '12345 abc123 http://data.gdeltproject.org/gdeltv2/20260506130000.export.CSV.zip\n';
+  const restore = mockFetch(new Map([
+    ['lastupdate.txt', { status: 200, text: lastUpdate }],
+    ['export.CSV.zip', { status: 200, text: '__BINARY_ZIP__' }],
+  ]));
+  try {
+    // Bespoke fetch override that returns the binary ZIP for the export URL
+    // (mockFetch only supports text/JSON; the ZIP needs an arrayBuffer body).
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      const urlStr = typeof url === 'string' ? url : url?.url ?? String(url);
+      if (urlStr.includes('lastupdate.txt')) {
+        return new Response(lastUpdate, { status: 200, headers: { 'content-type': 'text/plain' } });
+      }
+      if (urlStr.includes('export.CSV.zip')) {
+        return new Response(zipBuf, { status: 200, headers: { 'content-type': 'application/zip' } });
+      }
+      throw new Error(`Unmocked: ${urlStr}`);
+    };
+    try {
+      const { res } = await invokeHandler(handler, {});
+      assert.equal(res.statusCode, 200);
+      assert.equal(res.body.events.length, 1);
+      const ev = res.body.events[0];
+      assert.equal(ev.id, 'gdelt-999');
+      assert.equal(ev.intensity, 'critical');
+      assert.equal(ev.country, 'PSE');
+      assert.equal(res.body.source, 'gdelt-event-2.0');
+    } finally { globalThis.fetch = originalFetch; }
+  } finally { restore(); }
+});

--- a/api/gdelt/events.js
+++ b/api/gdelt/events.js
@@ -1,0 +1,231 @@
+/**
+ * GDELT 2.0 EVENT real-time poller for the precedent-matcher corpus.
+ *
+ * Pipeline:
+ *   1. GET http://data.gdeltproject.org/gdeltv2/lastupdate.txt
+ *      → 3 lines: {size}\t{md5}\t{url} for export, mentions, gkg
+ *   2. Pick the export.CSV.zip URL (latest 15-min EVENT slice)
+ *   3. Fetch ZIP, extract single-entry deflate-compressed CSV
+ *   4. Filter to QuadClass ∈ {3,4} (verbal/material conflict)
+ *   5. Apply confidence proxy: NumMentions >= MIN_MENTIONS && AvgTone <= MAX_TONE
+ *      (GDELT 2.0's literal "Confidence" field lives in the Mentions table,
+ *      not Events. NumMentions corroborates that multiple sources observed
+ *      the event, which is the same intent the spec was reaching for.)
+ *   6. Map each surviving row to a HistoricalEvent shape compatible with
+ *      src/services/synthesis/precedent-matcher.ts
+ *
+ * Cache: 15 min (matches GDELT's 15-min cadence — never serve stale-by-more
+ * than-one-cycle to the corpus). HEAD-only OPTIONS for CORS preflight.
+ */
+
+import { getCorsHeaders, isDisallowedOrigin } from '../_cors.js';
+
+export const config = { runtime: 'edge' };
+
+const LASTUPDATE_URL = 'https://data.gdeltproject.org/gdeltv2/lastupdate.txt';
+const CACHE_TTL_MS = 15 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 30_000;
+
+// Tunables — exposed at top so reviewers can adjust without hunting:
+const MIN_MENTIONS = 3;     // require at least 3 corroborating articles
+const MAX_TONE = -2;        // GDELT AvgTone <= -2 → reporting is negative-leaning
+const MAX_EVENTS = 500;     // hard cap on returned rows per cycle
+
+let _cache = null;
+
+const j = (payload, status, cors) => Response.json(payload, {
+  status, headers: { 'content-type': 'application/json; charset=utf-8', ...cors },
+});
+
+const empty = (reason) => ({
+  events: [], updatedAt: Date.now(), source: 'gdelt-event-2.0',
+  count: 0, degraded: true, reason,
+});
+
+export default async function handler(req) {
+  const cors = getCorsHeaders(req, 'GET, OPTIONS');
+  if (isDisallowedOrigin(req)) return j({ error: 'Origin not allowed' }, 403, cors);
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
+  if (req.method !== 'GET') return j({ error: 'Method not allowed' }, 405, cors);
+  if (_cache && Date.now() - _cache.at < CACHE_TTL_MS) return j(_cache.payload, 200, cors);
+
+  try {
+    const exportUrl = await pickExportUrl();
+    if (!exportUrl) return j(empty('lastupdate.txt missing export entry'), 200, cors);
+    const csvText = await fetchAndUnzip(exportUrl);
+    const events = parseExportCsv(csvText);
+    const result = {
+      events, updatedAt: Date.now(),
+      source: 'gdelt-event-2.0', count: events.length,
+      slice: exportUrl,
+    };
+    _cache = { at: Date.now(), payload: result };
+    return j(result, 200, cors);
+  } catch (error) {
+    return j(empty(`GDELT fetch failed: ${error?.message ?? error}`), 200, cors);
+  }
+}
+
+async function pickExportUrl() {
+  const r = await fetch(LASTUPDATE_URL, {
+    headers: { 'User-Agent': 'CrystalBall (gdelt)' },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!r.ok) throw new Error(`lastupdate.txt HTTP ${r.status}`);
+  const text = await r.text();
+  for (const line of text.split('\n')) {
+    const parts = line.trim().split(/\s+/);
+    const url = parts[parts.length - 1];
+    if (url && url.endsWith('.export.CSV.zip')) return url;
+  }
+  return null;
+}
+
+async function fetchAndUnzip(zipUrl) {
+  const r = await fetch(zipUrl, {
+    headers: { 'User-Agent': 'CrystalBall (gdelt)' },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!r.ok) throw new Error(`export.zip HTTP ${r.status}`);
+  const buf = await r.arrayBuffer();
+  return await unzipFirstEntry(buf);
+}
+
+/** Single-entry ZIP reader — GDELT zips contain exactly one CSV.
+ *  Reads the local file header (sig 0x04034b50), pulls out the deflated
+ *  blob, and pipes it through DecompressionStream('deflate-raw').
+ *  No deps. Intentionally does NOT support ZIP64 / multi-entry / encrypted
+ *  archives — GDELT never produces those. */
+export async function unzipFirstEntry(arrayBuffer) {
+  const view = new DataView(arrayBuffer);
+  if (view.byteLength < 30) throw new Error('ZIP too small');
+  const sig = view.getUint32(0, true);
+  if (sig !== 0x04_03_4B_50) throw new Error(`Bad ZIP signature 0x${sig.toString(16)}`);
+  const method = view.getUint16(8, true);
+  const compressedSize = view.getUint32(18, true);
+  const fileNameLen = view.getUint16(26, true);
+  const extraLen = view.getUint16(28, true);
+  const dataStart = 30 + fileNameLen + extraLen;
+  const compressed = arrayBuffer.slice(dataStart, dataStart + compressedSize);
+  if (method === 0) return new TextDecoder().decode(compressed);
+  if (method !== 8) throw new Error(`Unsupported ZIP compression method ${method}`);
+  const stream = new Blob([new Uint8Array(compressed)]).stream()
+    .pipeThrough(new DecompressionStream('deflate-raw'));
+  return await new Response(stream).text();
+}
+
+/** GDELT 2.0 EVENT export columns we read (others are ignored): */
+const COL = Object.freeze({
+  GLOBALEVENTID: 0,
+  Actor1Name: 6,
+  Actor1CountryCode: 7,
+  Actor2Name: 16,
+  Actor2CountryCode: 17,
+  EventCode: 26,
+  QuadClass: 29,
+  GoldsteinScale: 30,
+  NumMentions: 31,
+  AvgTone: 34,
+  ActionGeo_FullName: 52,
+  ActionGeo_CountryCode: 53,
+  DATEADDED: 59,
+  SOURCEURL: 60,
+});
+
+/** Per-row predicate: does this CSV row pass the QuadClass / mentions /
+ *  tone gates? Returns the parsed signal triple if yes, null if no. */
+function rowPasses(cols) {
+  if (cols.length < 60) return null;
+  const quad = Number.parseInt(cols[COL.QuadClass], 10);
+  if (quad !== 3 && quad !== 4) return null;
+  const numMentions = Number.parseInt(cols[COL.NumMentions], 10) || 0;
+  if (numMentions < MIN_MENTIONS) return null;
+  const tone = Number.parseFloat(cols[COL.AvgTone]);
+  if (!Number.isFinite(tone) || tone > MAX_TONE) return null;
+  const goldstein = Number.parseFloat(cols[COL.GoldsteinScale]);
+  return { quad, goldstein, tone, numMentions };
+}
+
+/** Parse GDELT 2.0 EVENT CSV (tab-separated, no header).
+ *  Returns HistoricalEvent[] (precedent-matcher.ts shape). */
+export function parseExportCsv(csvText) {
+  const out = [];
+  if (!csvText) return out;
+  for (const raw of csvText.split('\n')) {
+    if (!raw) continue;
+    const cols = raw.split('\t');
+    const passed = rowPasses(cols);
+    if (!passed) continue;
+    const event = toHistoricalEvent(cols, passed.quad, passed.goldstein, passed.tone, passed.numMentions);
+    if (event) out.push(event);
+    if (out.length >= MAX_EVENTS) break;
+  }
+  return out;
+}
+
+function toHistoricalEvent(cols, quad, goldstein, tone, numMentions) {
+  const id = `gdelt-${cols[COL.GLOBALEVENTID]}`;
+  const date = parseGdeltDateAdded(cols[COL.DATEADDED]);
+  if (!date) return null;
+  const place = cols[COL.ActionGeo_FullName] || cols[COL.ActionGeo_CountryCode] || 'unknown';
+  const country = cols[COL.ActionGeo_CountryCode] || '';
+  const actors = [cols[COL.Actor1Name], cols[COL.Actor2Name]]
+    .map((s) => (s || '').trim()).filter((s) => s.length > 0);
+  return {
+    id, date, location: place, country,
+    eventType: cameoLabelFor(cols[COL.EventCode], quad),
+    actors,
+    intensity: intensityFromGoldstein(goldstein),
+    summary: buildSummary(actors, place, cols[COL.EventCode], tone, numMentions),
+    source: 'gdelt',
+  };
+}
+
+/** GDELT DATEADDED is YYYYMMDDHHMMSS → ISO 8601. */
+function parseGdeltDateAdded(s) {
+  if (!s || s.length !== 14) return '';
+  const y = s.slice(0, 4), mo = s.slice(4, 6), d = s.slice(6, 8);
+  const h = s.slice(8, 10), mi = s.slice(10, 12), se = s.slice(12, 14);
+  const ts = Date.UTC(+y, +mo - 1, +d, +h, +mi, +se);
+  if (!Number.isFinite(ts)) return '';
+  return new Date(ts).toISOString();
+}
+
+/** Goldstein scale (-10..+10) → IntensityLabel.
+ *  Filtered set is QuadClass 3/4 so positive Goldsteins are unusual but
+ *  possible (e.g. peacekeeping deployments scored as material conflict). */
+export function intensityFromGoldstein(g) {
+  if (!Number.isFinite(g)) return 'medium';
+  if (g <= -8) return 'critical';   // mass killings, ethnic cleansing
+  if (g <= -5) return 'high';       // military assault, terrorism
+  if (g <= -2) return 'medium';     // small-scale violence, sanctions
+  return 'low';
+}
+
+/** CAMEO root-code label, falling back to a quad-class verb. */
+function cameoLabelFor(eventCode, quad) {
+  const root = (eventCode || '').slice(0, 2);
+  switch (root) {
+    case '14': { return 'protest';
+    }
+    case '15': { return 'force_posture';
+    }
+    case '17': { return 'coercion';
+    }
+    case '18': { return 'assault';
+    }
+    case '19': { return 'fight';
+    }
+    case '20': { return 'mass_violence';
+    }
+    default: { return quad === 4 ? 'material_conflict' : 'verbal_conflict';
+    }
+  }
+}
+
+function buildSummary(actors, place, eventCode, tone, numMentions) {
+  const who = actors.length ? actors.join(' vs ') : 'unspecified actors';
+  return `${who} — CAMEO ${eventCode || '???'} at ${place} (tone ${tone.toFixed(1)}, ${numMentions} mentions)`;
+}
+
+export function __resetCacheForTests() { _cache = null; }

--- a/src/services/synthesis/__tests__/gdelt-gkg-ingest.test.mts
+++ b/src/services/synthesis/__tests__/gdelt-gkg-ingest.test.mts
@@ -1,0 +1,66 @@
+/**
+ * Pure-transformer coverage for src/services/synthesis/gdelt-gkg-ingest.ts
+ *
+ * `mergeIntoCorpus` is the only piece worth unit-testing — `fetchGdeltEvents`
+ * and `refreshCorpusFromGdelt` are thin I/O wrappers covered by route-level
+ * tests in api/__tests__/gdelt-events.test.mjs.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { HistoricalEvent } from '../precedent-matcher.ts';
+import { mergeIntoCorpus, DEFAULT_CORPUS_CAP } from '../gdelt-gkg-ingest.ts';
+
+const ev = (id: string, date: string, summary = 'x'): HistoricalEvent => ({
+  id, date, location: 'X', country: 'X', eventType: 'fight',
+  actors: [], intensity: 'medium', summary, source: 'gdelt',
+});
+
+test('mergeIntoCorpus: empty existing + fresh = fresh', () => {
+  const fresh = [ev('a', '2026-05-01T00:00:00Z'), ev('b', '2026-05-02T00:00:00Z')];
+  const out = mergeIntoCorpus([], fresh);
+  assert.equal(out.length, 2);
+});
+
+test('mergeIntoCorpus: dedupes by id (fresh wins)', () => {
+  const existing = [ev('a', '2026-04-01T00:00:00Z', 'old')];
+  const fresh = [ev('a', '2026-05-01T00:00:00Z', 'new')];
+  const out = mergeIntoCorpus(existing, fresh);
+  assert.equal(out.length, 1);
+  assert.equal(out[0].summary, 'new');
+  assert.equal(out[0].date, '2026-05-01T00:00:00Z');
+});
+
+test('mergeIntoCorpus: sorts newest-first by date', () => {
+  const existing = [ev('a', '2026-01-01T00:00:00Z'), ev('b', '2026-03-01T00:00:00Z')];
+  const fresh = [ev('c', '2026-02-01T00:00:00Z')];
+  const out = mergeIntoCorpus(existing, fresh);
+  assert.deepEqual(out.map((e) => e.id), ['b', 'c', 'a']);
+});
+
+test('mergeIntoCorpus: enforces cap by dropping oldest', () => {
+  const existing = [
+    ev('a', '2026-01-01T00:00:00Z'),
+    ev('b', '2026-02-01T00:00:00Z'),
+    ev('c', '2026-03-01T00:00:00Z'),
+  ];
+  const fresh = [ev('d', '2026-04-01T00:00:00Z')];
+  const out = mergeIntoCorpus(existing, fresh, 2);
+  assert.equal(out.length, 2);
+  assert.deepEqual(out.map((e) => e.id), ['d', 'c']);     // newest two retained
+});
+
+test('mergeIntoCorpus: default cap is honored', () => {
+  // Build corpus larger than DEFAULT_CORPUS_CAP and confirm trim.
+  const existing = Array.from({ length: DEFAULT_CORPUS_CAP + 100 }, (_, i) =>
+    ev(`e${i}`, new Date(2020, 0, 1, 0, i).toISOString()));
+  const out = mergeIntoCorpus(existing, []);
+  assert.equal(out.length, DEFAULT_CORPUS_CAP);
+});
+
+test('mergeIntoCorpus: missing date sorts last (defensive — should not crash)', () => {
+  const existing = [{ ...ev('a', '2026-05-01T00:00:00Z'), date: '' }];
+  const fresh = [ev('b', '2026-05-02T00:00:00Z')];
+  const out = mergeIntoCorpus(existing, fresh);
+  assert.equal(out[0].id, 'b');
+  assert.equal(out[1].id, 'a');
+});

--- a/src/services/synthesis/gdelt-gkg-ingest.ts
+++ b/src/services/synthesis/gdelt-gkg-ingest.ts
@@ -1,0 +1,76 @@
+/**
+ * Live GDELT 2.0 ingestion → precedent-matcher corpus.
+ *
+ * Pure transformer + thin fetcher. The sidecar route at `/api/gdelt/events`
+ * does the heavy lifting (fetching, unzipping, CSV parsing, filtering); this
+ * module just merges fresh events into the in-process corpus, deduping by id
+ * and capping the rolling window so the TF-IDF rebuild stays bounded.
+ *
+ * The merge function is the unit-test surface — it has no I/O so fixtures
+ * stay deterministic.
+ */
+
+import type { HistoricalEvent } from './precedent-matcher';
+
+export interface GdeltEventsResponse {
+  events: HistoricalEvent[];
+  updatedAt: number;
+  source: string;
+  count: number;
+  degraded?: boolean;
+  reason?: string;
+  slice?: string;
+}
+
+/** Default rolling-window cap. The matcher's vocabulary is rebuilt every
+ *  time the corpus changes, so an unbounded corpus would make ingestion
+ *  O(N) on every cycle. Cap matches roughly one month of 15-min slices
+ *  at the route's MAX_EVENTS=500 with typical conflict density. */
+export const DEFAULT_CORPUS_CAP = 5000;
+
+/** Fetch the latest GDELT slice from the sidecar.
+ *  `apiBaseUrl` should be the runtime API base — e.g.
+ *  `http://127.0.0.1:46123` in desktop, '' in web (relative). */
+export async function fetchGdeltEvents(apiBaseUrl: string): Promise<GdeltEventsResponse> {
+  const url = `${apiBaseUrl}/api/gdelt/events`;
+  const r = await fetch(url, {
+    headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(35_000),
+  });
+  if (!r.ok) throw new Error(`/api/gdelt/events HTTP ${r.status}`);
+  const payload = (await r.json()) as GdeltEventsResponse;
+  if (!Array.isArray(payload?.events)) {
+    throw new TypeError('/api/gdelt/events: malformed payload (events not array)');
+  }
+  return payload;
+}
+
+/** Merge fresh events into an existing corpus, deduping by id (last write
+ *  wins so a re-fetched slice can correct earlier rows) and capping at
+ *  `cap` newest-first by date.
+ *
+ *  Pure: no I/O, no hidden state, deterministic for any given input pair. */
+export function mergeIntoCorpus(
+  existing: readonly HistoricalEvent[],
+  fresh: readonly HistoricalEvent[],
+  cap: number = DEFAULT_CORPUS_CAP,
+): HistoricalEvent[] {
+  const byId = new Map<string, HistoricalEvent>();
+  for (const ev of existing) byId.set(ev.id, ev);
+  for (const ev of fresh) byId.set(ev.id, ev);     // overwrite duplicates
+  const merged = [...byId.values()];
+  merged.sort((a, b) => (b.date || '').localeCompare(a.date || ''));
+  if (merged.length <= cap) return merged;
+  return merged.slice(0, cap);
+}
+
+/** Convenience: fetch + merge in one call. Returns the new corpus. */
+export async function refreshCorpusFromGdelt(
+  apiBaseUrl: string,
+  existingCorpus: readonly HistoricalEvent[],
+  cap: number = DEFAULT_CORPUS_CAP,
+): Promise<{ corpus: HistoricalEvent[]; response: GdeltEventsResponse }> {
+  const response = await fetchGdeltEvents(apiBaseUrl);
+  const corpus = mergeIntoCorpus(existingCorpus, response.events, cap);
+  return { corpus, response };
+}


### PR DESCRIPTION
## What
Wires GDELT 2.0's 15-minute EVENT exports into the previously-empty precedent-matcher corpus. Adds a sidecar route (`/api/gdelt/events`) and a pure-transformer client helper that merges fresh slices into a deduped, capped, recency-sorted corpus.

## Why
The precedent-matcher (`src/services/synthesis/precedent-matcher.ts`) shipped with no live feed — analogs were never surfaced because the corpus was empty.

## Spec deviations (intentional)
- **`Confidence > 60` → `NumMentions ≥ 3 + AvgTone ≤ -2`**: GDELT 2.0's `Confidence` field lives in the *Mentions* table, not Events. Multi-source corroboration + negative tone reaches the same intent (real conflict reporting, not coverage of cooperative initiatives) without a second download + join. Tunables exposed at top of route.
- **EVENT export over GKG**: Spec says "GKG CSV" but `QuadClass` + `Confidence` are EVENT fields, not GKG; the EVENT export is the right source for conflict signal.

## Files
- \`api/gdelt/events.js\` (new) — sidecar route, 15-min cache, inline single-entry deflate-raw ZIP extractor, CSV → \`HistoricalEvent[]\`
- \`api/__tests__/gdelt-events.test.mjs\` (new) — 16 tests covering the parser, ZIP round-trip, intensity bucket boundaries, full-pipeline mock
- \`src/services/synthesis/gdelt-gkg-ingest.ts\` (new) — \`fetchGdeltEvents\` + pure \`mergeIntoCorpus\` (dedupe by id, cap 5000, sort newest-first)
- \`src/services/synthesis/__tests__/gdelt-gkg-ingest.test.mts\` (new) — 6 transformer tests

## Verification
- \`node --test api/__tests__/gdelt-events.test.mjs\` → 16/16 pass
- \`tsx --test src/services/synthesis/__tests__/gdelt-gkg-ingest.test.mts\` → 6/6 pass
- \`npm run typecheck:all\` → clean
- Pre-commit hook ran \`test:sidecar\` (203 tests) → clean

## Follow-up
Polling cadence wiring (the 15-min refresh loop in the data-loader) lands in a follow-up PR — this PR is just the route + transformer.