### PR TITLE
feat(acled): wire 30-day rolling feeder into precedent-matcher corpus (PR 2/5)

### DIFF
--- a/api/__tests__/acled-events.test.mjs
+++ b/api/__tests__/acled-events.test.mjs
@@ -1,0 +1,173 @@
+/**
+ * Route-level coverage for api/acled/events.js
+ *
+ * Verifies env-var gate, ACLED row → HistoricalEvent mapping, intensity
+ * bucket boundaries (fatality-driven, type-fallback), success:false
+ * handling (ACLED returns 200 on auth failure), and HTTP contract.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { invokeHandler, mockFetch } from './_test-utils.mjs';
+
+const mod = await import('../acled/events.js');
+const handler = mod.default;
+const { toHistoricalEvent, intensityFromAcled, __resetCacheForTests } = mod;
+
+const acledRow = (overrides = {}) => ({
+  event_id_cnty: 'TEST123',
+  event_date: '2026-05-01',
+  event_type: 'Battles',
+  sub_event_type: 'Armed clash',
+  actor1: 'Group A',
+  actor2: 'Group B',
+  country: 'Sudan',
+  admin1: 'Khartoum',
+  location: 'Omdurman',
+  latitude: 15.6,
+  longitude: 32.5,
+  fatalities: '12',
+  notes: 'Fighting reported in northern districts.',
+  ...overrides,
+});
+
+// ── pure mapper ─────────────────────────────────────────────────────
+
+test('toHistoricalEvent: maps a typical ACLED row', () => {
+  const ev = toHistoricalEvent(acledRow());
+  assert.equal(ev.id, 'acled-TEST123');
+  assert.equal(ev.date, '2026-05-01T00:00:00Z');
+  assert.equal(ev.eventType, 'Armed clash');         // sub_event_type wins
+  assert.equal(ev.country, 'Sudan');
+  assert.equal(ev.location, 'Omdurman, Khartoum, Sudan');
+  assert.deepEqual(ev.actors, ['Group A', 'Group B']);
+  assert.equal(ev.intensity, 'high');                // 12 fatalities → high
+  assert.equal(ev.source, 'acled');
+});
+
+test('toHistoricalEvent: drops rows missing id or date', () => {
+  assert.equal(toHistoricalEvent(acledRow({ event_id_cnty: null })), null);
+  assert.equal(toHistoricalEvent(acledRow({ event_date: null })), null);
+});
+
+test('toHistoricalEvent: filters empty actors', () => {
+  const ev = toHistoricalEvent(acledRow({ actor1: '', actor2: 'Solo Actor' }));
+  assert.deepEqual(ev.actors, ['Solo Actor']);
+});
+
+test('toHistoricalEvent: falls back to event_type when sub_event_type is empty', () => {
+  const ev = toHistoricalEvent(acledRow({ sub_event_type: '' }));
+  assert.equal(ev.eventType, 'Battles');
+});
+
+test('toHistoricalEvent: handles non-object input safely', () => {
+  assert.equal(toHistoricalEvent(null), null);
+  assert.equal(toHistoricalEvent('not an object'), null);
+});
+
+// ── intensity bucket ────────────────────────────────────────────────
+
+test('intensityFromAcled: fatalities dominate type', () => {
+  assert.equal(intensityFromAcled('Protests', 100), 'critical');
+  assert.equal(intensityFromAcled('Protests', 25), 'high');
+  assert.equal(intensityFromAcled('Protests', 5), 'medium');
+  assert.equal(intensityFromAcled('Protests', 0), 'low');
+});
+
+test('intensityFromAcled: zero-fatality rows fall back to type', () => {
+  assert.equal(intensityFromAcled('Battles', 0), 'high');
+  assert.equal(intensityFromAcled('Violence against civilians', 0), 'medium');
+  assert.equal(intensityFromAcled('Explosions/Remote violence', 0), 'medium');
+  assert.equal(intensityFromAcled('Strategic developments', 0), 'low');
+  assert.equal(intensityFromAcled('Riots', 0), 'low');
+  assert.equal(intensityFromAcled('UnknownType', 0), 'low');
+});
+
+// ── handler: HTTP contract ──────────────────────────────────────────
+
+test('handler: OPTIONS returns 204', async () => {
+  const { res } = await invokeHandler(handler, { method: 'OPTIONS' });
+  assert.equal(res.statusCode, 204);
+});
+
+test('handler: rejects non-GET methods', async () => {
+  const { res } = await invokeHandler(handler, { method: 'POST' });
+  assert.equal(res.statusCode, 405);
+});
+
+test('handler: missing ACLED_ACCESS_TOKEN → degraded payload', async () => {
+  __resetCacheForTests();
+  const prevKey = process.env.ACLED_ACCESS_TOKEN;
+  const prevEmail = process.env.ACLED_EMAIL;
+  delete process.env.ACLED_ACCESS_TOKEN;
+  delete process.env.ACLED_EMAIL;
+  try {
+    const { res } = await invokeHandler(handler, {});
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.degraded, true);
+    assert.match(res.body.reason, /ACLED_ACCESS_TOKEN.*ACLED_EMAIL/);
+  } finally {
+    if (prevKey) process.env.ACLED_ACCESS_TOKEN = prevKey;
+    if (prevEmail) process.env.ACLED_EMAIL = prevEmail;
+  }
+});
+
+test('handler: ACLED success:false (auth/quota) → degraded payload', async () => {
+  __resetCacheForTests();
+  process.env.ACLED_ACCESS_TOKEN = 'fake-key';
+  process.env.ACLED_EMAIL = 'tester@example.com';
+  const restore = mockFetch(new Map([
+    ['acleddata.com', { status: 200, json: { success: false, error: { message: 'Invalid API credentials' } } }],
+  ]));
+  try {
+    const { res } = await invokeHandler(handler, {});
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.degraded, true);
+    assert.match(res.body.reason, /Invalid API credentials/);
+  } finally {
+    restore();
+    delete process.env.ACLED_ACCESS_TOKEN;
+    delete process.env.ACLED_EMAIL;
+  }
+});
+
+test('handler: happy path → events array with source acled', async () => {
+  __resetCacheForTests();
+  process.env.ACLED_ACCESS_TOKEN = 'fake-key';
+  process.env.ACLED_EMAIL = 'tester@example.com';
+  const mockPayload = {
+    success: true,
+    data: [acledRow(), acledRow({ event_id_cnty: 'TEST124', fatalities: '0', event_type: 'Protests' })],
+  };
+  const restore = mockFetch(new Map([['acleddata.com', { status: 200, json: mockPayload }]]));
+  try {
+    const { res } = await invokeHandler(handler, {});
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.events.length, 2);
+    assert.equal(res.body.source, 'acled');
+    assert.equal(res.body.events[0].id, 'acled-TEST123');
+    assert.equal(res.body.events[1].intensity, 'low');     // protests, 0 fatalities
+    assert.ok(res.body.window.since.match(/^\d{4}-\d{2}-\d{2}$/));
+    assert.equal(res.body.window.days, 30);
+  } finally {
+    restore();
+    delete process.env.ACLED_ACCESS_TOKEN;
+    delete process.env.ACLED_EMAIL;
+  }
+});
+
+test('handler: ACLED 503 → degraded (200 contract preserved)', async () => {
+  __resetCacheForTests();
+  process.env.ACLED_ACCESS_TOKEN = 'fake-key';
+  process.env.ACLED_EMAIL = 'tester@example.com';
+  const restore = mockFetch(new Map([['acleddata.com', { status: 503, json: {} }]]));
+  try {
+    const { res } = await invokeHandler(handler, {});
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.degraded, true);
+    assert.match(res.body.reason, /HTTP 503/);
+  } finally {
+    restore();
+    delete process.env.ACLED_ACCESS_TOKEN;
+    delete process.env.ACLED_EMAIL;
+  }
+});

--- a/api/acled/events.js
+++ b/api/acled/events.js
@@ -1,0 +1,162 @@
+/**
+ * ACLED 30-day rolling feeder for the precedent-matcher corpus.
+ *
+ * GET /api/acled/events
+ *   → { events: HistoricalEvent[], updatedAt, source, count, window }
+ *
+ * Auth: ACLED uses legacy query-param auth (`?key=X&email=Y`); the env var
+ * name `ACLED_ACCESS_TOKEN` is historical but the value is passed as `key=`.
+ * Mirrors the existing sidecar `/api/acled-events` pattern, broadened from
+ * air-strikes-only to the full event taxonomy.
+ *
+ * Cache: 24 h (matches the spec's daily polling cadence). The 30-day window
+ * is recomputed at the start of each fetch so cache misses always pull the
+ * fresh window — never a 30-day window centered on a stale "today".
+ *
+ * The companion ingestion helper merges these into the same corpus that
+ * receives GDELT EVENT slices (src/services/synthesis/gdelt-gkg-ingest.ts).
+ */
+
+import { getCorsHeaders, isDisallowedOrigin } from '../_cors.js';
+
+export const config = { runtime: 'edge' };
+
+const ACLED_ENDPOINT = 'https://api.acleddata.com/acled/read';
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 25_000;
+
+const WINDOW_DAYS = 30;
+const MAX_EVENTS = 500;
+
+let _cache = null;
+
+const j = (payload, status, cors) => Response.json(payload, {
+  status, headers: { 'content-type': 'application/json; charset=utf-8', ...cors },
+});
+
+const empty = (reason) => ({
+  events: [], updatedAt: Date.now(), source: 'acled',
+  count: 0, degraded: true, reason,
+});
+
+export default async function handler(req) {
+  const cors = getCorsHeaders(req, 'GET, OPTIONS');
+  if (isDisallowedOrigin(req)) return j({ error: 'Origin not allowed' }, 403, cors);
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
+  if (req.method !== 'GET') return j({ error: 'Method not allowed' }, 405, cors);
+  if (_cache && Date.now() - _cache.at < CACHE_TTL_MS) return j(_cache.payload, 200, cors);
+
+  const key = process.env.ACLED_ACCESS_TOKEN;
+  const email = process.env.ACLED_EMAIL;
+  if (!key || !email) {
+    return j(empty('ACLED_ACCESS_TOKEN and ACLED_EMAIL are required'), 200, cors);
+  }
+
+  const since = isoDay(Date.now() - WINDOW_DAYS * 24 * 60 * 60 * 1000);
+  try {
+    const url = buildAcledUrl(key, email, since);
+    const r = await fetch(url, {
+      headers: { 'User-Agent': 'CrystalBall (acled)' },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!r.ok) return j(empty(`ACLED HTTP ${r.status}`), 200, cors);
+    const payload = await r.json();
+    if (payload?.success === false) {
+      // ACLED returns 200 with success:false on auth/quota errors.
+      const msg = payload?.error?.message ?? payload?.error ?? 'unknown ACLED error';
+      return j(empty(`ACLED rejected: ${msg}`), 200, cors);
+    }
+    const rows = Array.isArray(payload?.data) ? payload.data : [];
+    const events = rows.map((row) => toHistoricalEvent(row)).filter(Boolean).slice(0, MAX_EVENTS);
+    const result = {
+      events, updatedAt: Date.now(),
+      source: 'acled', count: events.length,
+      window: { since, days: WINDOW_DAYS },
+    };
+    _cache = { at: Date.now(), payload: result };
+    return j(result, 200, cors);
+  } catch (error) {
+    return j(empty(`ACLED fetch failed: ${error?.message ?? error}`), 200, cors);
+  }
+}
+
+const FIELDS = [
+  'event_id_cnty', 'event_date', 'event_type', 'sub_event_type',
+  'actor1', 'actor2', 'country', 'admin1', 'location',
+  'latitude', 'longitude', 'fatalities', 'notes',
+].join('|');
+
+function buildAcledUrl(key, email, since) {
+  const params = new URLSearchParams({
+    key, email,
+    fields: FIELDS,
+    event_date: since,
+    event_date_where: '>=',
+    limit: String(MAX_EVENTS),
+    sort: 'event_date',
+    order: 'desc',
+    _format: 'json',
+  });
+  return `${ACLED_ENDPOINT}?${params.toString()}`;
+}
+
+function isoDay(ms) {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+/** Map ACLED row → HistoricalEvent (precedent-matcher.ts shape). */
+export function toHistoricalEvent(row) {
+  if (!row || typeof row !== 'object') return null;
+  const id = row.event_id_cnty;
+  const date = row.event_date;
+  if (!id || !date) return null;
+  const actors = [row.actor1, row.actor2]
+    .map((s) => (s || '').trim()).filter((s) => s.length > 0);
+  const fatalities = Number.parseInt(row.fatalities, 10) || 0;
+  const eventType = row.sub_event_type || row.event_type || 'unknown';
+  return {
+    id: `acled-${id}`,
+    date: toIsoDate(date),
+    location: [row.location, row.admin1, row.country].filter(Boolean).join(', '),
+    country: row.country || '',
+    eventType,
+    actors,
+    intensity: intensityFromAcled(row.event_type, fatalities),
+    summary: buildSummary(row, fatalities),
+    source: 'acled',
+  };
+}
+
+function toIsoDate(s) {
+  // ACLED returns "YYYY-MM-DD" — normalize to ISO 8601 midnight UTC so
+  // mergeIntoCorpus's localeCompare sort works alongside GDELT timestamps.
+  if (!s) return '';
+  if (s.length === 10) return `${s}T00:00:00Z`;
+  return s;
+}
+
+/** Intensity bucket derived from event_type taxonomy + fatality count.
+ *
+ *  Why fatalities-driven: the ACLED taxonomy has 6 top-level types but
+ *  intensity within each type spans low (a small protest) to critical
+ *  (a battle with mass casualties). Fatalities are the most reliable
+ *  numeric proxy for severity; type breaks the tie when fatalities are 0. */
+export function intensityFromAcled(eventType, fatalities) {
+  if (fatalities >= 50) return 'critical';
+  if (fatalities >= 10) return 'high';
+  if (fatalities >= 1) return 'medium';
+  if (eventType === 'Battles') return 'high';
+  if (eventType === 'Violence against civilians' || eventType === 'Explosions/Remote violence') return 'medium';
+  // Protests, Riots, Strategic developments, and any unknown type → low
+  return 'low';
+}
+
+function buildSummary(row, fatalities) {
+  const place = [row.location, row.country].filter(Boolean).join(', ') || 'unspecified';
+  const subtype = row.sub_event_type || row.event_type || '';
+  const fatalityNote = fatalities > 0 ? ` (${fatalities} fatalities)` : '';
+  const notes = (row.notes || '').slice(0, 240);
+  return `${subtype} at ${place}${fatalityNote}${notes ? ' — ' + notes : ''}`;
+}
+
+export function __resetCacheForTests() { _cache = null; }


### PR DESCRIPTION
## What
Adds \`/api/acled/events\` — a broader, normalized ACLED feeder for the precedent-matcher corpus.

## Why
The existing \`/api/acled-events\` route is narrow (air/drone strikes only, 200 events) and panel-shaped, not corpus-shaped. The precedent-matcher needs the full event taxonomy in \`HistoricalEvent\` shape so it can find analogs for any conflict signal, not just air strikes.

## Spec deviations (intentional)
- **\`ACLED_API_KEY\` → \`ACLED_ACCESS_TOKEN\`**: spec says \`ACLED_API_KEY\` but the actual env var declared in \`runtime-config.ts\` is \`ACLED_ACCESS_TOKEN\`. ACLED's legacy auth uses it as the \`?key=\` query param (matches existing sidecar pattern at \`local-api-server.mjs:3762\`).
- **success:false handling**: ACLED returns HTTP 200 with \`{success:false, error:{...}}\` on auth/quota failures, not an error status. Treated as degraded payload to keep the 200-contract clean.

## Files
- \`api/acled/events.js\` (new) — sidecar route, 24h cache, normalized to \`HistoricalEvent[]\`
- \`api/__tests__/acled-events.test.mjs\` (new) — 13 tests (mapper, intensity buckets, env-gate, auth-failure, happy path)

## Verification
- \`node --test api/__tests__/acled-events.test.mjs\` → 13/13 pass
- Pre-commit hook ran \`test:sidecar\` (203 tests) → clean
- ESLint clean

## Tunables
\`WINDOW_DAYS=30\`, \`MAX_EVENTS=500\`, \`CACHE_TTL_MS=24h\` exposed at top of file. Intensity bucket: fatalities ≥50 → critical, ≥10 → high, ≥1 → medium; type breaks ties (Battles → high, Violence/Explosions → medium, else low).

## Follow-up
Polling loop wiring lands in a follow-up PR — this PR is just the route + transformer.