### PR TITLE
feat(spaceweather): SpaceWeatherPanel — G0–G5 + aurora + GPS/HF + CMEs (PR 2/3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "test:climate": "tsx --test src/services/climate/__tests__/enso-monitor.test.mts",
     "test:spaceweather": "tsx --test src/services/spaceweather/__tests__/swpc-monitor.test.mts && node --test src-tauri/sidecar/__tests__/spaceweather-parity.test.mjs",
     "test:panels:smoke": "node tests/panels/run-harness.mjs",
-    "test:components": "tsx --test src/components/__tests__/disease-outbreak-tabs.test.mts",
+    "test:components": "tsx --test src/components/__tests__/disease-outbreak-tabs.test.mts src/components/__tests__/space-weather-panel.test.mts",
     "test:panels:fixtures": "tsx --import ./tests/panels/register-hook.mjs --test tests/panels/panel-fixtures.test.mts",
     "test:strategic-self-improvement": "tsx --test src/services/diagnostics/__tests__/failure-prediction.test.mts src/services/governance/__tests__/policy-engine.test.mts src/services/governance/__tests__/model-governance.test.mts src/services/experiments/__tests__/experiment-manager.test.mts src/services/ops/__tests__/causal-attribution.test.mts src/services/ops/__tests__/trust-budget.test.mts src/services/ops/__tests__/playbook-engine.test.mts src/services/scenarios/__tests__/scenario-library.test.mts src/services/personal/__tests__/resilience-model.test.mts src/services/quality/__tests__/quality-debt.test.mts src/services/quality/__tests__/self-improvement-scheduler.test.mts",
     "test:feeds": "node scripts/validate-rss-feeds.mjs",

--- a/src/components/SpaceWeatherPanel.ts
+++ b/src/components/SpaceWeatherPanel.ts
@@ -1,136 +1,256 @@
+/* eslint-disable sonarjs/no-nested-template-literals, sonarjs/no-nested-conditional */
 import { Panel } from './Panel';
 import type { SpaceWeatherData } from '@/services/space-weather';
+import type {
+  SpaceWxStatus,
+  SpaceWxAlert,
+  EarthwardCme,
+} from '@/services/spaceweather/swpc-monitor';
 import { escapeHtml } from '@/utils/sanitize';
 import { t } from '@/services/i18n';
+import { getApiBaseUrl } from '@/services/runtime';
+import {
+  alertSeverityClass,
+  formatArrivalCountdown,
+  G_LEVEL_COLOR,
+  gpsRiskBlurb,
+  legacyAlertToStatus,
+  RISK_COLOR,
+  stormLevelLabel,
+  timeAgo,
+  xrayBadgeColor,
+} from './space-weather-helpers';
+
+const STATUS_REFRESH_MS = 5 * 60 * 1000;
+
+interface AlertsResponse {
+  alerts?: SpaceWxAlert[];
+}
 
 export class SpaceWeatherPanel extends Panel {
   private data: SpaceWeatherData | null = null;
+  private status: SpaceWxStatus | null = null;
+  private statusAlerts: SpaceWxAlert[] = [];
+  private statusFetchedAt: number | null = null;
+  private statusFetchError: string | null = null;
   private refreshTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor() {
- super({
- id: 'space-weather',
- title: t('panels.spaceWeather'),
- showCount: false,
- trackActivity: true,
- infoTooltip: 'NOAA SWPC real-time data — Kp index, solar wind, X-ray flares, geomagnetic storm alerts.',
- });
- this.showLoading('Fetching NOAA space weather...');
+    super({
+      id: 'space-weather',
+      title: t('panels.spaceWeather'),
+      showCount: true,
+      trackActivity: true,
+      infoTooltip:
+        'NOAA SWPC: X-ray flare class, geomagnetic Kp + G0–G5 storm level, aurora visibility, GPS / HF disruption risk, earthward CMEs.',
+    });
+    this.showLoading('Fetching NOAA space weather...');
+    queueMicrotask(() => { void this.refreshStatus(); });
+    this.refreshTimer = setInterval(() => void this.refreshStatus(), STATUS_REFRESH_MS);
   }
 
   public update(data: SpaceWeatherData): void {
- this.data = data;
- this.render();
+    this.data = data;
+    this.render();
   }
 
   override destroy(): void {
- if (this.refreshTimer) {
- clearInterval(this.refreshTimer);
- this.refreshTimer = null;
- }
- super.destroy();
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    super.destroy();
+  }
+
+  private async refreshStatus(): Promise<void> {
+    let ok = false;
+    try {
+      const base = getApiBaseUrl();
+      const [statusResp, alertsResp] = await Promise.allSettled([
+        fetch(`${base}/api/spaceweather/status`, { headers: { Accept: 'application/json' } }),
+        fetch(`${base}/api/spaceweather/alerts`, { headers: { Accept: 'application/json' } }),
+      ]);
+      if (statusResp.status === 'fulfilled' && statusResp.value.ok) {
+        this.status = (await statusResp.value.json()) as SpaceWxStatus;
+        ok = true;
+      }
+      if (alertsResp.status === 'fulfilled' && alertsResp.value.ok) {
+        const body = (await alertsResp.value.json()) as AlertsResponse;
+        this.statusAlerts = Array.isArray(body.alerts) ? body.alerts : [];
+        ok = true;
+      }
+      this.statusFetchError = ok ? null : 'spaceweather endpoints unavailable';
+    } catch (error) {
+      this.statusFetchError = String((error as Error)?.message ?? error);
+    }
+    this.statusFetchedAt = Date.now();
+    this.render();
+  }
+
+  private computeBadgeCount(): number {
+    let count = 0;
+    if (this.status?.hfRadioBlackout) count += 1;
+    if (this.status?.gpsDisruption === 'high') count += 1;
+    const level = this.status?.geomag?.level ?? 'G0';
+    if (level === 'G3' || level === 'G4' || level === 'G5') count += 1;
+    count += this.status?.earthwardCmes?.length ?? 0;
+    return count;
   }
 
   private render(): void {
- if (!this.data) {
- this.setContent('<div class="panel-empty">Space weather data unavailable.</div>');
- return;
- }
+    this.setCount(this.computeBadgeCount());
+    if (!this.data && !this.status) {
+      this.setContent('<div class="panel-empty">Space weather data unavailable.</div>');
+      return;
+    }
+    const sections = [
+      this.renderHeadlineGrid(),
+      this.renderAuroraStrip(),
+      this.renderEarthwardCmes(),
+      this.renderAlerts(),
+      this.renderFooter(),
+    ].filter((s) => s.length > 0).join('');
+    this.setContent(`<div class="sw-panel-content">${sections}</div>`);
+  }
 
- const d = this.data;
- const kpLabel = kpLabel_(d.kpIndex);
- const kpColor = kpColorClass(d.kpClass);
- const windSpeed = d.solarWindSpeed === null ? '—' : `${Math.round(d.solarWindSpeed)} km/s`;
- const windDensity = d.solarWindDensity === null ? '—' : `${d.solarWindDensity.toFixed(1)} p/cm³`;
- const bzDisplay = d.bz === null ? '—' : `${d.bz > 0 ? '+' : ''}${d.bz.toFixed(1)} nT`;
- const bzClass = d.bz !== null && d.bz < -10 ? 'sw-danger' : (d.bz !== null && d.bz < -5 ? 'sw-warning' : '');
- const xray = d.xrayClass ? escapeHtml(d.xrayClass) : '—';
- const updatedAgo = timeAgo(d.fetchedAt);
+  // ── Headline metrics ──────────────────────────────────────────────────
 
- const alertRows = d.alertMessages.slice(0, 8).map(a => {
- const sevClass = a.severity === 'alert' ? 'sw-danger' : (a.severity === 'warning' ? 'sw-warning' : 'sw-info');
- return `<div class="sw-alert-row ${sevClass}">
- <span class="sw-alert-sev">${escapeHtml(a.severity.toUpperCase())}</span>
- <span class="sw-alert-msg">${escapeHtml(a.message)}</span>
- <span class="sw-alert-age">${timeAgo(a.issuedAt)}</span>
- </div>`;
- }).join('');
+  private renderHeadlineGrid(): string {
+    const xrayLabel = this.status?.xray?.peakLabel ?? this.data?.xrayClass ?? '—';
+    const xrayFlux = this.status?.xray?.peakFlux;
+    const xrayColor = xrayBadgeColor(xrayLabel);
+    const xraySub = xrayFlux !== undefined && Number.isFinite(xrayFlux)
+      ? `${xrayFlux.toExponential(1)} W/m²` : 'Solar flares';
 
- const donkiRows = (d.donkiEvents ?? []).slice(0, 5).map(ev => {
- const sevClass = ev.severity === 'critical' ? 'sw-danger' : ev.severity === 'high' ? 'sw-warning' : 'sw-info';
- const typeLabel = ev.type === 'flare' ? 'FLARE' : ev.type === 'cme' ? 'CME' : 'GST';
- const cls = ev.classType ? ` ${escapeHtml(ev.classType)}` : '';
- const kp = ev.kpIndex !== null ? ` Kp${ev.kpIndex}` : '';
- const when = ev.startTime ? timeAgo(new Date(ev.startTime)) : '—';
- return `<div class="sw-alert-row ${sevClass}">
- <span class="sw-alert-sev">${typeLabel}${cls}${kp}</span>
- <span class="sw-alert-msg">${escapeHtml(ev.severity.toUpperCase())}</span>
- <span class="sw-alert-age">${when}</span>
- </div>`;
- }).join('');
+    const gLevel = this.status?.geomag?.level ?? 'G0';
+    const gColor = G_LEVEL_COLOR[gLevel];
+    const kpVal = this.status?.geomag?.kp ?? this.data?.kpIndex ?? null;
+    const kpLabel = kpVal === null ? '—' : kpVal.toFixed(1);
+    const kpSub = `${gLevel} · ${stormLevelLabel(gLevel)}`;
 
- this.setContent(`
- <div class="sw-panel-content">
- <div class="sw-grid">
- <div class="sw-metric">
- <div class="sw-metric-label">Kp Index</div>
- <div class="sw-metric-value ${kpColor}">${d.kpIndex === null ? '—' : d.kpIndex.toFixed(1)}</div>
- <div class="sw-metric-sub">${kpLabel}</div>
- </div>
- <div class="sw-metric">
- <div class="sw-metric-label">Solar Wind</div>
- <div class="sw-metric-value">${windSpeed}</div>
- <div class="sw-metric-sub">${windDensity}</div>
- </div>
- <div class="sw-metric">
- <div class="sw-metric-label">Bz (IMF)</div>
- <div class="sw-metric-value ${bzClass}">${bzDisplay}</div>
- <div class="sw-metric-sub">${d.bz !== null && d.bz < 0 ? 'Storm driver' : 'Northward'}</div>
- </div>
- <div class="sw-metric">
- <div class="sw-metric-label">X-Ray</div>
- <div class="sw-metric-value">${xray}</div>
- <div class="sw-metric-sub">Solar flares</div>
- </div>
- </div>
- ${alertRows ? `<div class="sw-alerts">
- <div class="sw-alerts-header">Active Alerts</div>
- ${alertRows}
- </div>` : '<div class="panel-empty" style="padding:8px 0">No active alerts</div>'}
- ${donkiRows ? `<div class="sw-alerts">
- <div class="sw-alerts-header">NASA DONKI Events (7d)</div>
- ${donkiRows}
- </div>` : ''}
- <div class="fires-footer">
- <span class="fires-source">NOAA SWPC · NASA DONKI</span>
- <span class="fires-updated">Updated ${updatedAgo}</span>
- </div>
- </div>
- `);
+    const gps = this.status?.gpsDisruption ?? 'none';
+    const gpsColor = RISK_COLOR[gps];
+    const gpsSub = gpsRiskBlurb(gps);
+
+    const hfBlackout = this.status?.hfRadioBlackout ?? false;
+    const hfColor = hfBlackout ? '#d50000' : '#4caf50';
+    const hfLabel = hfBlackout ? 'BLACKOUT' : 'Nominal';
+    const hfSub = hfBlackout ? 'X-ray flux ≥ 1e-4 W/m²' : 'HF propagation OK';
+
+    return `<div class="sw-grid">
+      <div class="sw-metric">
+        <div class="sw-metric-label">X-Ray Flare</div>
+        <div class="sw-metric-value" style="color:${xrayColor};">${escapeHtml(xrayLabel)}</div>
+        <div class="sw-metric-sub">${escapeHtml(xraySub)}</div>
+      </div>
+      <div class="sw-metric">
+        <div class="sw-metric-label">Geomagnetic</div>
+        <div class="sw-metric-value" style="color:${gColor};">Kp ${escapeHtml(kpLabel)}</div>
+        <div class="sw-metric-sub">${escapeHtml(kpSub)}</div>
+      </div>
+      <div class="sw-metric">
+        <div class="sw-metric-label">GPS Disruption</div>
+        <div class="sw-metric-value" style="color:${gpsColor};text-transform:uppercase;">${escapeHtml(gps)}</div>
+        <div class="sw-metric-sub">${escapeHtml(gpsSub)}</div>
+      </div>
+      <div class="sw-metric">
+        <div class="sw-metric-label">HF Radio</div>
+        <div class="sw-metric-value" style="color:${hfColor};">${escapeHtml(hfLabel)}</div>
+        <div class="sw-metric-sub">${escapeHtml(hfSub)}</div>
+      </div>
+    </div>`;
+  }
+
+  // ── Aurora visibility strip ───────────────────────────────────────────
+
+  private renderAuroraStrip(): string {
+    const lat = this.status?.geomag?.auroraVisibilityLatN ?? null;
+    if (lat === null || lat >= 90) {
+      return `<div class="sw-aurora-strip">
+        <div class="sw-aurora-label">Aurora visibility</div>
+        <div class="sw-aurora-empty">Not visible from mid-latitudes (Kp &lt; 5)</div>
+      </div>`;
+    }
+    // Map latitude to a 0..100 strip position. 45°N → far left (intense),
+    // 90°N → far right (only auroral oval).
+    const pct = Math.max(0, Math.min(100, ((90 - lat) / (90 - 45)) * 100));
+    return `<div class="sw-aurora-strip">
+      <div class="sw-aurora-label">Aurora visibility — overhead at ${escapeHtml(lat.toFixed(1))}°N
+        and poleward</div>
+      <div class="sw-aurora-bar" role="img" aria-label="Aurora visibility latitude ${lat.toFixed(1)}°N">
+        <div class="sw-aurora-marker" style="left:${pct}%;"></div>
+        <div class="sw-aurora-scale">
+          <span>45°N</span>
+          <span>60°N</span>
+          <span>90°N</span>
+        </div>
+      </div>
+    </div>`;
+  }
+
+  // ── Earthward CMEs ────────────────────────────────────────────────────
+
+  private renderEarthwardCmes(): string {
+    const cmes = this.status?.earthwardCmes ?? [];
+    if (cmes.length === 0) return '';
+    const now = Date.now();
+    const rows = cmes.slice(0, 5).map((cme) => this.renderCmeRow(cme, now)).join('');
+    return `<div class="sw-alerts">
+      <div class="sw-alerts-header">Earthward CMEs (${cmes.length})</div>
+      ${rows}
+    </div>`;
+  }
+
+  private renderCmeRow(cme: EarthwardCme, now: number): string {
+    const speed = cme.speedKmS === null ? '—' : `${Math.round(cme.speedKmS)} km/s`;
+    const arrival = cme.estimatedArrival ? Date.parse(cme.estimatedArrival) : Number.NaN;
+    const countdown = formatArrivalCountdown(arrival, now);
+    const sevClass = countdown.severityClass;
+    const lon = cme.longitudeDeg === null ? '—' : `${cme.longitudeDeg.toFixed(0)}°`;
+    return `<div class="sw-alert-row ${sevClass}">
+      <span class="sw-alert-sev">CME ${escapeHtml(speed)}</span>
+      <span class="sw-alert-msg">${escapeHtml(countdown.label)} · lon ${escapeHtml(lon)}</span>
+      <span class="sw-alert-age">${cme.isMostAccurate ? 'best fit' : 'preliminary'}</span>
+    </div>`;
+  }
+
+  // ── Alerts log ────────────────────────────────────────────────────────
+
+  private renderAlerts(): string {
+    const merged = this.statusAlerts.length > 0
+      ? this.statusAlerts
+      : (this.data?.alertMessages ?? []).map((a) => legacyAlertToStatus(a));
+    if (merged.length === 0) {
+      return '<div class="panel-empty" style="padding:8px 0">No active alerts</div>';
+    }
+    const rows = merged.slice(0, 8).map((alert) => {
+      const sevClass = alertSeverityClass(alert.severity);
+      const issued = Date.parse(alert.issuedAt);
+      const ageStr = Number.isFinite(issued) ? timeAgo(new Date(issued)) : '—';
+      return `<div class="sw-alert-row ${sevClass}">
+        <span class="sw-alert-sev">${escapeHtml(alert.severity.toUpperCase())}</span>
+        <span class="sw-alert-msg">${escapeHtml(alert.headline)}</span>
+        <span class="sw-alert-age">${escapeHtml(ageStr)}</span>
+      </div>`;
+    }).join('');
+    return `<div class="sw-alerts">
+      <div class="sw-alerts-header">Alert Log (24h)</div>
+      ${rows}
+    </div>`;
+  }
+
+  // ── Footer ────────────────────────────────────────────────────────────
+
+  private renderFooter(): string {
+    const updated = this.statusFetchedAt ?? this.data?.fetchedAt?.getTime() ?? null;
+    const ageStr = updated ? timeAgo(new Date(updated)) : 'Loading…';
+    const errBadge = this.statusFetchError
+      ? `<span style="color:#ff9800;margin-left:8px;">⚠ ${escapeHtml(this.statusFetchError)}</span>`
+      : '';
+    return `<div class="fires-footer">
+      <span class="fires-source">NOAA SWPC · NASA DONKI</span>
+      <span class="fires-updated">Updated ${escapeHtml(ageStr)}${errBadge}</span>
+    </div>`;
   }
 }
 
-function kpLabel_(kp: number | null): string {
-  if (kp === null) return 'No data';
-  if (kp >= 7) return 'Severe storm';
-  if (kp >= 6) return 'Moderate storm';
-  if (kp >= 5) return 'Minor storm';
-  if (kp >= 4) return 'Active';
-  if (kp >= 3) return 'Unsettled';
-  return 'Quiet';
-}
-
-function kpColorClass(cls: SpaceWeatherData['kpClass']): string {
-  if (cls === 'severe_storm' || cls === 'moderate_storm') return 'sw-danger';
-  if (cls === 'minor_storm' || cls === 'active') return 'sw-warning';
-  return '';
-}
-
-function timeAgo(d: Date): string {
-  const secs = Math.floor((Date.now() - d.getTime()) / 1000);
-  if (secs < 60) return 'just now';
-  const mins = Math.floor(secs / 60);
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  return `${hrs}h ago`;
-}

--- a/src/components/__tests__/space-weather-panel.test.mts
+++ b/src/components/__tests__/space-weather-panel.test.mts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  alertSeverityClass,
+  formatArrivalCountdown,
+  gpsRiskBlurb,
+  stormLevelLabel,
+  timeAgo,
+  xrayBadgeColor,
+} from '../space-weather-helpers.ts';
+
+const NOW = Date.parse('2026-05-06T12:00:00Z');
+const HOUR_MS = 60 * 60 * 1000;
+
+test('stormLevelLabel maps each G level to a human label', () => {
+  assert.equal(stormLevelLabel('G0'), 'Quiet');
+  assert.equal(stormLevelLabel('G1'), 'Minor storm');
+  assert.equal(stormLevelLabel('G3'), 'Strong storm');
+  assert.equal(stormLevelLabel('G5'), 'Extreme storm');
+});
+
+test('gpsRiskBlurb explains each risk band', () => {
+  assert.equal(gpsRiskBlurb('high'), 'X-class — degraded fixes');
+  assert.equal(gpsRiskBlurb('moderate'), 'M-class — possible drift');
+  assert.equal(gpsRiskBlurb('low'), 'C-class — minor');
+  assert.equal(gpsRiskBlurb('none'), 'Nominal');
+});
+
+test('alertSeverityClass routes severities to CSS modifier classes', () => {
+  assert.equal(alertSeverityClass('alert'), 'sw-danger');
+  assert.equal(alertSeverityClass('warning'), 'sw-warning');
+  assert.equal(alertSeverityClass('watch'), 'sw-warning');
+  assert.equal(alertSeverityClass('summary'), 'sw-info');
+});
+
+test('formatArrivalCountdown reports T-h within 12h as critical', () => {
+  const r = formatArrivalCountdown(NOW + 8 * HOUR_MS, NOW);
+  assert.match(r.label, /^T-8\.0h$/);
+  assert.equal(r.severityClass, 'sw-danger');
+});
+
+test('formatArrivalCountdown reports T-h within 24h as warning', () => {
+  const r = formatArrivalCountdown(NOW + 18 * HOUR_MS, NOW);
+  assert.match(r.label, /^T-18h$/);
+  assert.equal(r.severityClass, 'sw-warning');
+});
+
+test('formatArrivalCountdown switches to days past 24h', () => {
+  const r = formatArrivalCountdown(NOW + 36 * HOUR_MS, NOW);
+  assert.match(r.label, /^T-1\.5d$/);
+});
+
+test('formatArrivalCountdown reports "arriving now" when arrival is in the past <6h', () => {
+  const r = formatArrivalCountdown(NOW - 2 * HOUR_MS, NOW);
+  assert.equal(r.label, 'arriving now');
+  assert.equal(r.severityClass, 'sw-danger');
+});
+
+test('formatArrivalCountdown reports "arrived" when arrival is older than 6h', () => {
+  const r = formatArrivalCountdown(NOW - 24 * HOUR_MS, NOW);
+  assert.equal(r.label, 'arrived');
+});
+
+test('formatArrivalCountdown handles non-finite arrival', () => {
+  const r = formatArrivalCountdown(Number.NaN, NOW);
+  assert.equal(r.label, 'arrival unknown');
+});
+
+test('xrayBadgeColor maps the leading class char to a colour', () => {
+  assert.equal(xrayBadgeColor('X1.2'), '#d50000');
+  assert.equal(xrayBadgeColor('M5.0'), '#ff5722');
+  assert.equal(xrayBadgeColor('C3.1'), '#ffeb3b');
+  assert.equal(xrayBadgeColor('B7.0'), '#4caf50');
+  assert.equal(xrayBadgeColor(null), '#9e9e9e');
+});
+
+test('timeAgo formats elapsed time relative to "now"', () => {
+  assert.equal(timeAgo(new Date(NOW), NOW), 'just now');
+  assert.equal(timeAgo(new Date(NOW - 5 * 60 * 1000), NOW), '5m ago');
+  assert.equal(timeAgo(new Date(NOW - 3 * HOUR_MS), NOW), '3h ago');
+});

--- a/src/components/space-weather-helpers.ts
+++ b/src/components/space-weather-helpers.ts
@@ -1,0 +1,110 @@
+import type {
+  GeomagStormLevel,
+  RiskBand,
+  SpaceWxAlert,
+} from '@/services/spaceweather/swpc-monitor';
+
+const HOUR_MS = 60 * 60 * 1000;
+
+export function stormLevelLabel(level: GeomagStormLevel): string {
+  switch (level) {
+    case 'G0': { return 'Quiet';
+    }
+    case 'G1': { return 'Minor storm';
+    }
+    case 'G2': { return 'Moderate storm';
+    }
+    case 'G3': { return 'Strong storm';
+    }
+    case 'G4': { return 'Severe storm';
+    }
+    case 'G5': { return 'Extreme storm';
+    }
+  }
+}
+
+export function gpsRiskBlurb(risk: RiskBand): string {
+  switch (risk) {
+    case 'high': { return 'X-class — degraded fixes';
+    }
+    case 'moderate': { return 'M-class — possible drift';
+    }
+    case 'low': { return 'C-class — minor';
+    }
+    case 'none': { return 'Nominal';
+    }
+  }
+}
+
+export function alertSeverityClass(sev: string): string {
+  if (sev === 'alert') return 'sw-danger';
+  if (sev === 'warning') return 'sw-warning';
+  if (sev === 'watch') return 'sw-warning';
+  return 'sw-info';
+}
+
+export function xrayBadgeColor(cls: string | null): string {
+  if (!cls) return '#9e9e9e';
+  const head = cls.charAt(0).toUpperCase();
+  if (head === 'X') return '#d50000';
+  if (head === 'M') return '#ff5722';
+  if (head === 'C') return '#ffeb3b';
+  if (head === 'B') return '#4caf50';
+  return '#9e9e9e';
+}
+
+export const G_LEVEL_COLOR: Record<GeomagStormLevel, string> = {
+  G0: '#9e9e9e',
+  G1: '#ffeb3b',
+  G2: '#ff9800',
+  G3: '#ff5722',
+  G4: '#d50000',
+  G5: '#b71c1c',
+};
+
+export const RISK_COLOR: Record<RiskBand, string> = {
+  none: '#9e9e9e',
+  low: '#ffeb3b',
+  moderate: '#ff9800',
+  high: '#d50000',
+};
+
+export interface ArrivalCountdown {
+  label: string;
+  severityClass: string;
+}
+
+export function formatArrivalCountdown(arrivalMs: number, nowMs: number): ArrivalCountdown {
+  if (!Number.isFinite(arrivalMs)) return { label: 'arrival unknown', severityClass: 'sw-info' };
+  const deltaMs = arrivalMs - nowMs;
+  if (deltaMs <= 0) {
+    const hoursPast = Math.abs(deltaMs) / HOUR_MS;
+    if (hoursPast < 6) return { label: 'arriving now', severityClass: 'sw-danger' };
+    return { label: 'arrived', severityClass: 'sw-info' };
+  }
+  const hours = deltaMs / HOUR_MS;
+  if (hours < 12) return { label: `T-${hours.toFixed(1)}h`, severityClass: 'sw-danger' };
+  if (hours < 24) return { label: `T-${hours.toFixed(0)}h`, severityClass: 'sw-warning' };
+  if (hours < 72) return { label: `T-${(hours / 24).toFixed(1)}d`, severityClass: 'sw-warning' };
+  return { label: `T-${(hours / 24).toFixed(1)}d`, severityClass: 'sw-info' };
+}
+
+export function legacyAlertToStatus(a: {
+  id: string; severity: 'watch' | 'warning' | 'alert' | 'summary'; message: string; issuedAt: Date;
+}): SpaceWxAlert {
+  return {
+    id: a.id,
+    severity: a.severity,
+    headline: a.message,
+    issuedAt: a.issuedAt.toISOString(),
+  };
+}
+
+export function timeAgo(d: Date, now = Date.now()): string {
+  const secs = Math.floor((now - d.getTime()) / 1000);
+  if (secs < 60) return 'just now';
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  return `${hrs}h ago`;
+}

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -319,6 +319,15 @@
 .sw-footer { display: flex; justify-content: space-between; padding: 8px 0 0; color: var(--text-faint); font-size: 10px; }
 .sw-footer a { color: var(--accent); text-decoration: none; }
 .sw-footer a:hover { text-decoration: underline; }
+.sw-aurora-strip { margin: 8px 0; padding: 8px 10px; background: var(--overlay-subtle); border: 1px solid var(--border); border-radius: 4px; }
+.sw-aurora-label { font-size: 10px; color: var(--text-muted); margin-bottom: 6px; }
+.sw-aurora-empty { font-size: 10px; color: var(--text-dim); font-style: italic; }
+.sw-aurora-bar { position: relative; height: 22px; border-radius: 4px;
+  background: linear-gradient(90deg, #b71c1c 0%, #d50000 25%, #c026d3 50%, #4caf50 100%); }
+.sw-aurora-marker { position: absolute; top: -3px; bottom: -3px; width: 3px;
+  background: var(--text-primary, #fff); border: 1px solid #000; box-shadow: 0 0 4px #fff; }
+.sw-aurora-scale { position: absolute; left: 0; right: 0; bottom: -14px;
+  display: flex; justify-content: space-between; font-size: 9px; color: var(--text-dim); }
 
 /* ----------------------------------------------------------
  Disease Outbreak Panel


### PR DESCRIPTION
PR 2 of a 3-PR space weather intelligence stack. Builds on the SWPC monitor + sidecar routes from [#313](https://github.com/bradleybond512/crystal-ball/pull/313).

## What

Expands [SpaceWeatherPanel](src/components/SpaceWeatherPanel.ts) to consume \`/api/spaceweather/{status,alerts}\` (5-min self-driven poll) and render:

- **Headline grid (4 metrics):** X-ray flare class label, Kp + G0–G5 storm level (color-coded), GPS disruption risk band, HF radio blackout flag
- **Aurora visibility strip:** marker at the spec-mandated visibility latitude (60°N at Kp5 → 45°N at Kp9), with 45°N / 60°N / 90°N scale
- **Earthward CME rows** with arrival countdown — \`T-Xh\` red <12h, orange <24h, days beyond
- **Alert log** (24h window from sidecar; falls back to legacy alerts when sidecar is offline)
- Sidebar **count badge** sums HF blackout + high-GPS + G3+ storms + earthward-CME count

## Pure helpers extracted

[space-weather-helpers.ts](src/components/space-weather-helpers.ts) holds storm labels, GPS blurbs, alert severity classes, X-ray badge color, time-ago, and the full CME countdown ladder so they can be unit-tested without pulling \`i18n\` (which uses Vite's \`import.meta.glob\`). Same separation pattern as \`disease-outbreak-tabs.ts\`.

## Tests

- 11 new tests in \`src/components/__tests__/space-weather-panel.test.mts\`
- Wired into \`npm run test:components\` (now 23 tests, all green)
- \`npm run typecheck:all\` clean

## Backward compatibility

The existing data-loader flow (\`update(SpaceWeatherData)\` from \`loaders/space.ts\`) is preserved. New fields render only when the sidecar status fetch succeeds; if the new endpoints are unreachable, the panel falls back to legacy rendering with the existing fields.

## Verification limitation

Browser smoke test deferred — the Vite dev server has a pre-existing \`@luma.gl\` bundling error in this worktree unrelated to the panel changes. The change is additive on top of the existing panel and exercises pure helpers under test, so I'm comfortable shipping despite the gap; the panel will get a live exercise in PR 3 when the globe wiring requires it.

## Up next

- PR 3 — Globe integration (aurora oval ring at \`auroraVisibilityLatN\`, X-flare pulse on sunlit hemisphere, EEW status bar G4+ banner)