### PR TITLE
feat(otx): wire 30-min subscribed-pulses polling loop into apt-tracker (PR 3/5)

### DIFF
--- a/api/__tests__/otx-pulses.test.mjs
+++ b/api/__tests__/otx-pulses.test.mjs
@@ -1,0 +1,141 @@
+/**
+ * Route-level coverage for api/otx/pulses.js
+ *
+ * Verifies env-var gate, rolling-cache merge (newest-first by `modified`,
+ * dedupe by id, cap at 200), modified_since delta on subsequent fetches,
+ * stale-cache fallback on upstream failure, OPTIONS / wrong-method, and
+ * cache TTL behavior.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { invokeHandler, mockFetch } from './_test-utils.mjs';
+
+const mod = await import('../otx/pulses.js');
+const handler = mod.default;
+const { mergePulses, __resetStateForTests } = mod;
+
+const pulse = (id, modifiedIso, name = 'p') => ({
+  id, modified: modifiedIso, name, adversary: 'APT99',
+  tags: ['APT99'], indicators: [{ indicator: '1.2.3.4', type: 'IPv4' }],
+});
+
+// ── pure merge ────────────────────────────────────────────────────────
+
+test('mergePulses: dedupes by id (fresh wins)', () => {
+  const state = { pulses: [pulse('a', '2026-05-01T00:00:00Z', 'old')], lastPolledAt: 0, lastModifiedIso: '' };
+  const fresh = [pulse('a', '2026-05-02T00:00:00Z', 'new')];
+  const out = mergePulses(state, fresh);
+  assert.equal(out.pulses.length, 1);
+  assert.equal(out.pulses[0].name, 'new');
+});
+
+test('mergePulses: sorts newest-first by modified', () => {
+  const state = { pulses: [pulse('a', '2026-01-01T00:00:00Z'), pulse('b', '2026-03-01T00:00:00Z')], lastPolledAt: 0, lastModifiedIso: '' };
+  const fresh = [pulse('c', '2026-02-01T00:00:00Z')];
+  const out = mergePulses(state, fresh);
+  assert.deepEqual(out.pulses.map((p) => p.id), ['b', 'c', 'a']);
+});
+
+test('mergePulses: caps at 200 dropping oldest', () => {
+  const existing = Array.from({ length: 250 }, (_, i) =>
+    pulse(`e${i}`, new Date(2020, 0, 1, 0, i).toISOString()));
+  const out = mergePulses({ pulses: existing, lastPolledAt: 0, lastModifiedIso: '' }, []);
+  assert.equal(out.pulses.length, 200);
+});
+
+test('mergePulses: lastModifiedIso tracks newest pulse for next delta', () => {
+  const state = { pulses: [], lastPolledAt: 0, lastModifiedIso: '' };
+  const fresh = [pulse('a', '2026-04-01T00:00:00Z'), pulse('b', '2026-04-15T00:00:00Z')];
+  const out = mergePulses(state, fresh);
+  assert.equal(out.lastModifiedIso, '2026-04-15T00:00:00Z');
+});
+
+test('mergePulses: empty fresh keeps existing modified anchor', () => {
+  const state = { pulses: [pulse('a', '2026-04-01T00:00:00Z')], lastPolledAt: 0, lastModifiedIso: '2026-04-01T00:00:00Z' };
+  const out = mergePulses(state, []);
+  assert.equal(out.lastModifiedIso, '2026-04-01T00:00:00Z');
+});
+
+test('mergePulses: drops items missing id', () => {
+  const out = mergePulses({ pulses: [], lastPolledAt: 0, lastModifiedIso: '' }, [{ modified: '2026-01-01T00:00:00Z' }]);
+  assert.equal(out.pulses.length, 0);
+});
+
+// ── HTTP contract ─────────────────────────────────────────────────────
+
+test('handler: OPTIONS returns 204', async () => {
+  const { res } = await invokeHandler(handler, { method: 'OPTIONS' });
+  assert.equal(res.statusCode, 204);
+});
+
+test('handler: rejects non-GET methods', async () => {
+  const { res } = await invokeHandler(handler, { method: 'POST' });
+  assert.equal(res.statusCode, 405);
+});
+
+test('handler: missing OTX_API_KEY → degraded', async () => {
+  __resetStateForTests();
+  const prev = process.env.OTX_API_KEY;
+  delete process.env.OTX_API_KEY;
+  try {
+    const { res } = await invokeHandler(handler, {});
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.degraded, true);
+    assert.match(res.body.reason, /OTX_API_KEY not set/);
+  } finally { if (prev) process.env.OTX_API_KEY = prev; }
+});
+
+test('handler: cold-start happy path → fetches with no modified_since', async () => {
+  __resetStateForTests();
+  process.env.OTX_API_KEY = 'fake';
+  const seenUrls = [];
+  const restore = mockFetch(new Map([[
+    'otx.alienvault.com',
+    { status: 200, json: { results: [pulse('p1', '2026-04-15T00:00:00Z'), pulse('p2', '2026-04-14T00:00:00Z')] } },
+  ]]));
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = (url, init) => { seenUrls.push(typeof url === 'string' ? url : url?.url); return origFetch(url, init); };
+  try {
+    const { res } = await invokeHandler(handler, {});
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.pulses.length, 2);
+    assert.equal(res.body.lastModifiedIso, '2026-04-15T00:00:00Z');
+    assert.ok(!seenUrls[0].includes('modified_since'), 'cold start must not send modified_since');
+  } finally {
+    globalThis.fetch = origFetch;
+    restore();
+    delete process.env.OTX_API_KEY;
+  }
+});
+
+test('handler: warm-cache request within TTL skips upstream', async () => {
+  __resetStateForTests();
+  process.env.OTX_API_KEY = 'fake';
+  let upstreamCalls = 0;
+  const restore = mockFetch(new Map([['otx.alienvault.com', { status: 200, json: { results: [pulse('p1', '2026-04-15T00:00:00Z')] } }]]));
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = (url, init) => { upstreamCalls++; return origFetch(url, init); };
+  try {
+    await invokeHandler(handler, {});         // cold → 1 upstream call
+    await invokeHandler(handler, {});         // warm → no upstream call
+    assert.equal(upstreamCalls, 1);
+  } finally {
+    globalThis.fetch = origFetch;
+    restore();
+    delete process.env.OTX_API_KEY;
+  }
+});
+
+test('handler: upstream failure with empty cache → degraded', async () => {
+  __resetStateForTests();
+  process.env.OTX_API_KEY = 'fake';
+  const restore = mockFetch(new Map([['otx.alienvault.com', { status: 500, json: {} }]]));
+  try {
+    const { res } = await invokeHandler(handler, {});
+    assert.equal(res.body.degraded, true);
+    assert.match(res.body.reason, /HTTP 500/);
+  } finally {
+    restore();
+    delete process.env.OTX_API_KEY;
+  }
+});

--- a/api/otx/pulses.js
+++ b/api/otx/pulses.js
@@ -1,0 +1,124 @@
+/**
+ * AlienVault OTX subscribed-pulses polling loop with rolling 200-pulse
+ * window. Distinct from the existing /api/otx-pulses route, which is a
+ * single-shot fetch (no incremental polling, no rolling cache).
+ *
+ * GET /api/otx/pulses
+ *   → { pulses: OtxPulse[], updatedAt, count, source, lastPolledAt }
+ *
+ * Behavior:
+ *   - 30-min upstream poll cadence (CACHE_TTL_MS). Within the TTL, returns
+ *     the cached rolling window without hitting OTX.
+ *   - On each upstream fetch, uses modified_since={lastPolledAt} so OTX
+ *     only returns delta. New pulses are merged into the rolling cache,
+ *     deduped by id, sorted newest-first by `modified`, capped at 200.
+ *   - Cold start fetches with limit=50, no modified_since.
+ *
+ * Companion client helper at src/services/cyber/otx-ingest.ts maps each
+ * cached pulse through apt-tracker.matchPulseToGroup → pulseToActivityEvent
+ * to feed the APT activity ledger.
+ */
+
+import { getCorsHeaders, isDisallowedOrigin } from '../_cors.js';
+
+export const config = { runtime: 'edge' };
+
+const UPSTREAM = 'https://otx.alienvault.com/api/v1/pulses/subscribed';
+const CACHE_TTL_MS = 30 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 15_000;
+
+const PAGE_LIMIT = 50;       // matches OTX recommended page size
+const ROLLING_CAP = 200;     // total pulses retained across polls
+
+let _state = {
+  pulses: [],          // rolling window, newest-first
+  lastPolledAt: 0,     // wall-clock ms of most recent successful upstream call
+  lastModifiedIso: '', // most-recent `modified` timestamp seen — used for delta fetches
+};
+
+const j = (payload, status, cors) => Response.json(payload, {
+  status, headers: { 'content-type': 'application/json; charset=utf-8', ...cors },
+});
+
+const degraded = (reason, extra = {}) => ({
+  pulses: [], count: 0, source: 'otx.alienvault.com',
+  updatedAt: Date.now(), degraded: true, reason, ...extra,
+});
+
+export default async function handler(req) {
+  const cors = getCorsHeaders(req, 'GET, OPTIONS');
+  if (isDisallowedOrigin(req)) return j({ error: 'Origin not allowed' }, 403, cors);
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
+  if (req.method !== 'GET') return j({ error: 'Method not allowed' }, 405, cors);
+
+  const key = process.env.OTX_API_KEY;
+  if (!key) return j(degraded('OTX_API_KEY not set'), 200, cors);
+
+  // Within TTL → serve cached rolling window without upstream call.
+  if (_state.lastPolledAt && Date.now() - _state.lastPolledAt < CACHE_TTL_MS) {
+    return j(buildResponse(), 200, cors);
+  }
+
+  try {
+    const fresh = await fetchDelta(key, _state.lastModifiedIso);
+    _state = mergePulses(_state, fresh);
+    return j(buildResponse(), 200, cors);
+  } catch (error) {
+    // On upstream failure, serve stale cache if we have one — preserve
+    // the contract so the apt-tracker doesn't lose the window during
+    // an OTX hiccup.
+    if (_state.pulses.length > 0) {
+      return j({ ...buildResponse(), staleAfterError: String(error?.message ?? error) }, 200, cors);
+    }
+    return j(degraded(`OTX fetch failed: ${error?.message ?? error}`), 200, cors);
+  }
+}
+
+async function fetchDelta(apiKey, sinceIso) {
+  const url = new URL(UPSTREAM);
+  url.searchParams.set('limit', String(PAGE_LIMIT));
+  if (sinceIso) url.searchParams.set('modified_since', sinceIso);
+  const r = await fetch(url.toString(), {
+    headers: { 'X-OTX-API-KEY': apiKey, 'User-Agent': 'CrystalBall (otx)' },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  const payload = await r.json();
+  return Array.isArray(payload?.results) ? payload.results : [];
+}
+
+/** Pure merge: combine existing rolling window with fresh delta, dedupe
+ *  by id (fresh wins so re-served pulses get updated metadata), sort
+ *  newest-first by `modified`, cap at ROLLING_CAP.
+ *
+ *  Exported for unit testing. Returns a new state object — does not
+ *  mutate the input. */
+export function mergePulses(state, fresh) {
+  const byId = new Map();
+  for (const p of state.pulses) if (p?.id) byId.set(p.id, p);
+  for (const p of fresh) if (p?.id) byId.set(p.id, p);
+  const merged = [...byId.values()];
+  merged.sort((a, b) => (b?.modified ?? '').localeCompare(a?.modified ?? ''));
+  const capped = merged.slice(0, ROLLING_CAP);
+  const newestModified = capped[0]?.modified ?? state.lastModifiedIso;
+  return {
+    pulses: capped,
+    lastPolledAt: Date.now(),
+    lastModifiedIso: newestModified || state.lastModifiedIso,
+  };
+}
+
+function buildResponse() {
+  return {
+    pulses: _state.pulses,
+    count: _state.pulses.length,
+    source: 'otx.alienvault.com',
+    updatedAt: Date.now(),
+    lastPolledAt: _state.lastPolledAt,
+    lastModifiedIso: _state.lastModifiedIso,
+  };
+}
+
+export function __resetStateForTests() {
+  _state = { pulses: [], lastPolledAt: 0, lastModifiedIso: '' };
+}

--- a/src/services/cyber/__tests__/otx-ingest.test.mts
+++ b/src/services/cyber/__tests__/otx-ingest.test.mts
@@ -1,0 +1,65 @@
+/**
+ * Pure-transformer tests for src/services/cyber/otx-ingest.ts
+ *
+ * Verifies that pulses → AptActivityEvent[] dispatches through
+ * matchPulseToGroup correctly: matched pulses produce events with the
+ * group's TLP severity, unmatched pulses are dropped silently.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { AptGroup } from '../apt-tracker.ts';
+import { pulsesToActivityEvents } from '../otx-ingest.ts';
+
+const APT28: AptGroup = {
+  id: 'G0007', name: 'APT28', aliases: ['Fancy Bear', 'Sofacy'],
+  country: 'Russia', targetSectors: [], recentTechniques: [], activityScore: 0,
+};
+
+const LAZARUS: AptGroup = {
+  id: 'G0032', name: 'Lazarus Group', aliases: ['HIDDEN COBRA'],
+  country: 'North Korea', targetSectors: [], recentTechniques: [], activityScore: 0,
+};
+
+const pulse = (id: string, adversary: string, modified = '2026-05-01T00:00:00Z') => ({
+  id, modified, adversary,
+  name: `Pulse on ${adversary}`,
+  tags: [adversary],
+  industries: ['Government'],
+  indicators: [{ indicator: '1.2.3.4', type: 'IPv4' }],
+  TLP: 'amber',
+});
+
+test('pulsesToActivityEvents: matched pulse → activity event with group fields', () => {
+  const events = pulsesToActivityEvents([pulse('p1', 'APT28')], [APT28, LAZARUS]);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].groupId, 'G0007');
+  assert.equal(events[0].source, 'otx');
+  assert.equal(events[0].severity, 'high');     // TLP amber → high
+});
+
+test('pulsesToActivityEvents: unmatched pulse is silently dropped', () => {
+  const events = pulsesToActivityEvents([pulse('p1', 'NotATrackedActor')], [APT28]);
+  assert.equal(events.length, 0);
+});
+
+test('pulsesToActivityEvents: matches by alias as well as primary name', () => {
+  const events = pulsesToActivityEvents([pulse('p1', 'Fancy Bear')], [APT28]);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].groupId, 'G0007');
+});
+
+test('pulsesToActivityEvents: handles mixed matched + unmatched batch', () => {
+  const batch = [
+    pulse('p1', 'APT28'),
+    pulse('p2', 'Unknown'),
+    pulse('p3', 'HIDDEN COBRA'),     // alias of Lazarus
+  ];
+  const events = pulsesToActivityEvents(batch, [APT28, LAZARUS]);
+  assert.equal(events.length, 2);
+  assert.deepEqual(events.map((e) => e.groupId).sort(), ['G0007', 'G0032']);
+});
+
+test('pulsesToActivityEvents: empty inputs return empty', () => {
+  assert.deepEqual(pulsesToActivityEvents([], [APT28]), []);
+  assert.deepEqual(pulsesToActivityEvents([pulse('p1', 'APT28')], []), []);
+});

--- a/src/services/cyber/otx-ingest.ts
+++ b/src/services/cyber/otx-ingest.ts
@@ -1,0 +1,72 @@
+/**
+ * Live OTX ingestion → APT tracker activity ledger.
+ *
+ * Pure transformer + thin fetcher. The sidecar route `/api/otx/pulses`
+ * maintains the rolling 200-pulse window; this module fetches it, runs
+ * each pulse through `matchPulseToGroup` + `pulseToActivityEvent` from
+ * apt-tracker.ts, and returns the resulting AptActivityEvent[].
+ *
+ * Pulses that don't match any known APT group are dropped — the apt
+ * tracker only cares about pulses attributable to a tracked actor.
+ */
+
+import {
+  type AptGroup,
+  type AptActivityEvent,
+  type OtxPulse,
+  matchPulseToGroup,
+  pulseToActivityEvent,
+} from './apt-tracker';
+
+export interface OtxPulsesResponse {
+  pulses: OtxPulse[];
+  count: number;
+  source: string;
+  updatedAt: number;
+  lastPolledAt: number;
+  lastModifiedIso: string;
+  degraded?: boolean;
+  reason?: string;
+  staleAfterError?: string;
+}
+
+export async function fetchOtxPulses(apiBaseUrl: string): Promise<OtxPulsesResponse> {
+  const url = `${apiBaseUrl}/api/otx/pulses`;
+  const r = await fetch(url, {
+    headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!r.ok) throw new Error(`/api/otx/pulses HTTP ${r.status}`);
+  const payload = (await r.json()) as OtxPulsesResponse;
+  if (!Array.isArray(payload?.pulses)) {
+    throw new TypeError('/api/otx/pulses: malformed payload (pulses not array)');
+  }
+  return payload;
+}
+
+/** Convert a pulses array into apt-tracker activity events.
+ *  Drops pulses with no matching group (apt-tracker tracks named actors
+ *  only — generic IOC pulses go nowhere). Pure: no I/O. */
+export function pulsesToActivityEvents(
+  pulses: readonly OtxPulse[],
+  groups: readonly AptGroup[],
+): AptActivityEvent[] {
+  const out: AptActivityEvent[] = [];
+  for (const pulse of pulses) {
+    const group = matchPulseToGroup(pulse, groups);
+    if (!group) continue;
+    const ev = pulseToActivityEvent(pulse, group);
+    if (ev) out.push(ev);
+  }
+  return out;
+}
+
+/** Fetch + transform in one call. */
+export async function refreshOtxActivity(
+  apiBaseUrl: string,
+  groups: readonly AptGroup[],
+): Promise<{ events: AptActivityEvent[]; response: OtxPulsesResponse }> {
+  const response = await fetchOtxPulses(apiBaseUrl);
+  const events = pulsesToActivityEvents(response.pulses, groups);
+  return { events, response };
+}


### PR DESCRIPTION
## What
Adds \`/api/otx/pulses\` — a delta-polling, rolling-200-pulse cache distinct from the existing \`/api/otx-pulses\` route, plus a client-side helper that maps cached pulses through apt-tracker into AptActivityEvents.

## Why
The existing \`/api/otx-pulses\` is single-shot (10-min cache, no delta polling, no rolling window). The apt-tracker needs an accumulating window of pulses across polling cycles so it can score group activity over time, not just the most recent 50 pulses.

## Behavior
- Cold start: fetches limit=50, no \`modified_since\`
- Warm cycle (≤30min since last poll): serves cached rolling window without upstream call
- After TTL: fetches with \`modified_since={newest cached pulse modified}\` so OTX returns only delta
- Merge: dedupe by id (fresh wins), sort newest-first by \`modified\`, cap at 200
- Stale-cache fallback: on upstream failure with non-empty cache, serve cached window with \`staleAfterError\` annotation so the apt-tracker window survives transient OTX hiccups

## Files
- \`api/otx/pulses.js\` (new) — sidecar route + pure \`mergePulses\` for unit tests
- \`api/__tests__/otx-pulses.test.mjs\` (new) — 12 tests (merge, env-gate, cold-start no-modified-since, TTL skip, stale fallback)
- \`src/services/cyber/otx-ingest.ts\` (new) — \`fetchOtxPulses\` + pure \`pulsesToActivityEvents\` that dispatches through apt-tracker's \`matchPulseToGroup\` → \`pulseToActivityEvent\`
- \`src/services/cyber/__tests__/otx-ingest.test.mts\` (new) — 5 transformer tests

## Verification
- \`node --test api/__tests__/otx-pulses.test.mjs\` → 12/12 pass
- \`tsx --test src/services/cyber/__tests__/otx-ingest.test.mts\` → 5/5 pass
- \`npm run typecheck:all\` → clean

## Tunables
\`PAGE_LIMIT=50\`, \`ROLLING_CAP=200\`, \`CACHE_TTL_MS=30min\`, \`FETCH_TIMEOUT_MS=15s\` exposed at top of file.