### PR TITLE
feat(aviation): intel service + sidecar routes (PR 1/3)

### DIFF
--- a/api/aviation/_aviation-helpers.js
+++ b/api/aviation/_aviation-helpers.js
@@ -1,0 +1,202 @@
+/**
+ * Shared helpers for the /api/aviation/* sidecar routes.
+ *
+ * The renderer-side normalizers live in TS at
+ * src/services/aviation/aviation-intel-normalize.ts. The sidecar can't
+ * import those directly (no build step on Node-side .mjs), so the
+ * normalizers are mirrored here in plain JS. Pure functions; no I/O.
+ *
+ * Keep the two implementations in sync. The TS unit tests are the
+ * source of truth for shape; this JS variant trades type safety for
+ * the ability to run inside the sidecar process.
+ */
+
+import { getCorsHeaders, isDisallowedOrigin } from '../_cors.js';
+
+const FETCH_TIMEOUT_MS = 12_000;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+const cache = new Map();
+
+export function jsonResponse(payload, status, cors) {
+  return Response.json(payload, {
+    status,
+    headers: { 'content-type': 'application/json; charset=utf-8', ...cors },
+  });
+}
+
+export function preflight(req, allowMethods) {
+  const cors = getCorsHeaders(req, allowMethods);
+  if (isDisallowedOrigin(req)) {
+    return { cors, response: jsonResponse({ error: 'Origin not allowed' }, 403, cors) };
+  }
+  if (req.method === 'OPTIONS') {
+    return { cors, response: new Response(null, { status: 204, headers: cors }) };
+  }
+  if (req.method !== 'GET') {
+    return { cors, response: jsonResponse({ error: 'Method not allowed' }, 405, cors) };
+  }
+  return { cors, response: null };
+}
+
+export function degraded(reason, source) {
+  return {
+    data: [],
+    fetchedAt: Date.now(),
+    degraded: true,
+    reason,
+    source,
+  };
+}
+
+export function envelope(data, source) {
+  return {
+    data,
+    fetchedAt: Date.now(),
+    degraded: false,
+    source,
+  };
+}
+
+export async function fetchUpstream(url, init = {}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const headers = {
+      'User-Agent': 'CrystalBall/aviation-intel (https://crystalball.app)',
+      Accept: 'application/json',
+      ...init.headers,
+    };
+    const response = await fetch(url, { ...init, headers, signal: controller.signal });
+    return response;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function withCache(key, source, build) {
+  const hit = cache.get(key);
+  if (hit && Date.now() - hit.at < CACHE_TTL_MS) return hit.payload;
+  try {
+    const payload = await build();
+    cache.set(key, { at: Date.now(), payload });
+    return payload;
+  } catch (error) {
+    return degraded(error?.message ?? String(error), source);
+  }
+}
+
+// Normalizers
+
+export function pickString(...values) {
+  for (const v of values) {
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  return null;
+}
+
+export function pickFinite(...values) {
+  for (const v of values) {
+    if (typeof v === 'number' && Number.isFinite(v)) return v;
+    if (typeof v === 'string' && v.trim()) {
+      const n = Number(v);
+      if (Number.isFinite(n)) return n;
+    }
+  }
+  return null;
+}
+
+export function parseTimestamp(...values) {
+  for (const v of values) {
+    if (typeof v === 'number' && Number.isFinite(v)) {
+      return v < 10_000_000_000 ? v * 1000 : v;
+    }
+    if (typeof v === 'string' && v.trim()) {
+      const t = Date.parse(v);
+      if (Number.isFinite(t)) return t;
+    }
+  }
+  return null;
+}
+
+export function extractItems(payload, keys) {
+  if (Array.isArray(payload)) return payload;
+  if (payload && typeof payload === 'object') {
+    for (const key of keys) {
+      const v = payload[key];
+      if (Array.isArray(v)) return v;
+    }
+  }
+  return [];
+}
+
+export function classifyMilitaryType(callsign, acTypeRaw) {
+  const prefixes = {
+    RCH: 'transport', REACH: 'transport',
+    CNV: 'tanker', PAT: 'tanker', GOLD: 'tanker', SHELL: 'tanker',
+    TEAL: 'recon', HOMER: 'recon', MAGIC: 'recon', SENTRY: 'recon', RIVET: 'recon',
+    PYTHON: 'fighter', RAGE: 'fighter', VIPER: 'fighter', EAGLE: 'fighter',
+    RAIDER: 'bomber', DOOM: 'bomber', BISON: 'bomber',
+    ARMY: 'helo', PEDRO: 'helo', DUSTOFF: 'helo',
+  };
+  if (callsign) {
+    const upper = callsign.replace(/\d{1,8}$/, '').toUpperCase();
+    for (const [prefix, type] of Object.entries(prefixes)) {
+      if (upper.startsWith(prefix)) return type;
+    }
+  }
+  const t = typeof acTypeRaw === 'string' ? acTypeRaw.toUpperCase() : '';
+  if (/^C-?(5|17|130)|^KC-?\d|KC-?135|KC-?46/.test(t)) return 'tanker';
+  if (/^F-?(15|16|18|22|35)/.test(t)) return 'fighter';
+  if (/^B-?(1|2|52)/.test(t)) return 'bomber';
+  if (/AWACS|RC-?135|U-?2|RQ-?4/.test(t)) return 'recon';
+  if (/^(UH|HH|CH|MH)-?\d/.test(t)) return 'helo';
+  return 'unknown';
+}
+
+export function normalizeMilitary(payload) {
+  let items;
+  if (Array.isArray(payload)) items = payload;
+  else if (Array.isArray(payload?.ac)) items = payload.ac;
+  else if (Array.isArray(payload?.aircraft)) items = payload.aircraft;
+  else if (Array.isArray(payload?.states)) {
+    items = payload.states.map((row) => {
+      if (!Array.isArray(row)) return null;
+      return {
+        icao24: row[0],
+        callsign: row[1],
+        origin_country: row[2],
+        last_contact: typeof row[4] === 'number' ? row[4] * 1000 : null,
+        lon: row[5],
+        lat: row[6],
+        baro_altitude: row[7],
+        velocity: row[9],
+        track: row[10],
+        squawk: row[14],
+      };
+    });
+  } else items = [];
+  const out = [];
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue;
+    const callsign = (pickString(item.flight, item.r, item.callsign) ?? '').trim() || null;
+    const icao24 = (pickString(item.hex, item.icao24, item.icao) ?? '').toLowerCase().trim();
+    if (!icao24) continue;
+    const altMeters = pickFinite(item.alt_baro, item.geom_alt, item.baro_altitude);
+    out.push({
+      icao24,
+      callsign,
+      type: classifyMilitaryType(callsign, item.t),
+      country: pickString(item.r_country, item.origin_country, item.country) ?? null,
+      lat: pickFinite(item.lat, item.latitude),
+      lon: pickFinite(item.lon, item.longitude),
+      altitudeFt: altMeters === null ? pickFinite(item.alt_geom) : Math.round(altMeters * 3.280_84),
+      velocityKts: pickFinite(item.gs, item.velocity),
+      heading: pickFinite(item.track, item.heading),
+      squawk: pickString(item.squawk),
+      lastSeen: parseTimestamp(item.seen, item.last_contact) ?? Date.now(),
+      emergency: ['7500', '7600', '7700'].includes(String(item.squawk ?? '')),
+    });
+  }
+  return out;
+}

--- a/api/aviation/delays.js
+++ b/api/aviation/delays.js
@@ -1,0 +1,85 @@
+/**
+ * FAA NAS Status airport delay program proxy.
+ *
+ * Upstream candidates (one will respond JSON, others may 404 — we try
+ * in order):
+ *   - https://nasstatus.faa.gov/api/airport-conditions
+ *   - https://nasstatus.faa.gov/api/airport-events
+ *   - https://nasstatus.faa.gov/api/airport-volume   (XML; not parsed)
+ */
+
+import {
+  degraded,
+  envelope,
+  extractItems,
+  fetchUpstream,
+  jsonResponse,
+  parseTimestamp,
+  pickFinite,
+  pickString,
+  preflight,
+  withCache,
+} from './_aviation-helpers.js';
+
+export const config = { runtime: 'edge' };
+
+const SOURCE = 'nasstatus.faa.gov';
+const CACHE_KEY = 'aviation:delays';
+
+const UPSTREAMS = [
+  'https://nasstatus.faa.gov/api/airport-conditions',
+  'https://nasstatus.faa.gov/api/airport-events',
+];
+
+function classifyProgram(raw) {
+  const u = (raw ?? '').toUpperCase();
+  if (u.includes('STOP')) return 'ground_stop';
+  if (u.includes('GROUND') || u.includes('GDP')) return 'ground_delay';
+  if (u.includes('ARRIVAL') || u.includes('AAR')) return 'arrival_delay';
+  return 'other';
+}
+
+function normalizeDelay(item, idx) {
+  if (!item || typeof item !== 'object') return null;
+  const airport = (pickString(item.airport, item.iata, item.icao, item.location) ?? '').toUpperCase();
+  if (!airport) return null;
+  return {
+    id: `delay-${airport}-${idx}`,
+    airport,
+    reason: pickString(item.reason, item.cause, item.eventType) ?? 'unspecified',
+    avgDelayMinutes: pickFinite(item.avgDelay, item.avg_delay_minutes, item.average_delay_minutes),
+    maxDelayMinutes: pickFinite(item.maxDelay, item.max_delay_minutes),
+    programType: classifyProgram(pickString(item.eventType, item.programType, item.type)),
+    startedAt: parseTimestamp(item.startTime, item.startedAt),
+    endsAt: parseTimestamp(item.endTime, item.endsAt),
+  };
+}
+
+async function fetchDelays() {
+  let lastError;
+  for (const url of UPSTREAMS) {
+    try {
+      const response = await fetchUpstream(url);
+      if (!response.ok) {
+        lastError = `HTTP ${response.status} from ${url}`;
+        continue;
+      }
+      const payload = await response.json();
+      const items = extractItems(payload, ['delays', 'events', 'data', 'airports']);
+      const data = items
+        .map((item, idx) => normalizeDelay(item, idx))
+        .filter(Boolean);
+      return envelope(data, SOURCE);
+    } catch (error) {
+      lastError = error?.message ?? String(error);
+    }
+  }
+  return degraded(lastError ?? 'all upstreams failed', SOURCE);
+}
+
+export default async function handler(req) {
+  const { cors, response } = preflight(req, 'GET, OPTIONS');
+  if (response) return response;
+  const result = await withCache(CACHE_KEY, SOURCE, fetchDelays);
+  return jsonResponse(result, 200, cors);
+}

--- a/api/aviation/military.js
+++ b/api/aviation/military.js
@@ -1,0 +1,62 @@
+/**
+ * Military aircraft proxy. Combines:
+ *   - https://api.adsb.lol/v2/mil   (free, no key, primary)
+ *   - https://opensky-network.org/api/states/all (free, no key, fallback)
+ * Deduplicates by ICAO24.
+ */
+
+import {
+  envelope,
+  fetchUpstream,
+  jsonResponse,
+  normalizeMilitary,
+  preflight,
+  withCache,
+} from './_aviation-helpers.js';
+
+export const config = { runtime: 'edge' };
+
+const SOURCE = 'adsb.lol+opensky';
+const CACHE_KEY = 'aviation:military';
+
+async function fetchAdsbMil() {
+  try {
+    const resp = await fetchUpstream('https://api.adsb.lol/v2/mil');
+    if (!resp.ok) return [];
+    const payload = await resp.json();
+    return normalizeMilitary(payload);
+  } catch {
+    return [];
+  }
+}
+
+async function fetchOpenSkyMilFallback() {
+  try {
+    const resp = await fetchUpstream('https://opensky-network.org/api/states/all');
+    if (!resp.ok) return [];
+    const payload = await resp.json();
+    return normalizeMilitary(payload).filter((ac) => ac.type !== 'unknown');
+  } catch {
+    return [];
+  }
+}
+
+async function fetchMilitary() {
+  const out = new Map();
+  for (const ac of await fetchAdsbMil()) {
+    out.set(ac.icao24, ac);
+  }
+  if (out.size === 0) {
+    for (const ac of await fetchOpenSkyMilFallback()) {
+      out.set(ac.icao24, ac);
+    }
+  }
+  return envelope([...out.values()], SOURCE);
+}
+
+export default async function handler(req) {
+  const { cors, response } = preflight(req, 'GET, OPTIONS');
+  if (response) return response;
+  const result = await withCache(CACHE_KEY, SOURCE, fetchMilitary);
+  return jsonResponse(result, 200, cors);
+}

--- a/api/aviation/notams.js
+++ b/api/aviation/notams.js
@@ -1,0 +1,133 @@
+/**
+ * FAA NOTAM proxy — TFRs and FDC NOTAMs.
+ *
+ * Upstream: https://external-api.faa.gov/notamapi/v1/notams
+ * Note: FAA's NOTAM API requires `client_id` + `client_secret` query
+ * params (developer signup at developer.faa.gov is free). When the
+ * env vars are missing the route returns a degraded envelope instead
+ * of a 5xx, so the panel renders gracefully on first install.
+ */
+
+import {
+  degraded,
+  envelope,
+  extractItems,
+  fetchUpstream,
+  jsonResponse,
+  parseTimestamp,
+  pickString,
+  preflight,
+  withCache,
+} from './_aviation-helpers.js';
+
+export const config = { runtime: 'edge' };
+
+const SOURCE = 'faa.gov/notamapi';
+const CACHE_KEY = 'aviation:notams';
+
+function normalizeClassification(rawClassification, text) {
+  const upper = (rawClassification ?? '').toUpperCase();
+  if (upper === 'FDC' || /TFR/i.test(text)) return /TFR/i.test(text) ? 'TFR' : 'FDC';
+  if (upper === 'DOM' || upper === 'INTL') return upper;
+  return 'OTHER';
+}
+
+function ddmToDecimal(deg, min, hemi) {
+  const d = Number.parseInt(deg, 10);
+  const m = Number.parseInt(min, 10);
+  if (!Number.isFinite(d) || !Number.isFinite(m)) return null;
+  const sign = hemi === 'S' || hemi === 'W' ? -1 : 1;
+  return (d + m / 60) * sign;
+}
+
+const NOTAM_LAT_RE = /(\d{1,2})(\d{2})([NS])/;
+const NOTAM_LON_RE = /(\d{1,3})(\d{2})([EW])/;
+const NOTAM_RAD_RE = /(\d{1,3})\s*NM/i;
+
+function parseCenterRadius(text) {
+  const lat = text.match(NOTAM_LAT_RE);
+  const lon = text.match(NOTAM_LON_RE);
+  const r = text.match(NOTAM_RAD_RE);
+  if (!lat || !lon || !r) return undefined;
+  const latDec = ddmToDecimal(lat[1], lat[2], lat[3]);
+  const lonDec = ddmToDecimal(lon[1], lon[2], lon[3]);
+  const radiusNm = Number.parseInt(r[1], 10);
+  if (latDec === null || lonDec === null || !Number.isFinite(radiusNm)) return undefined;
+  return { lat: latDec, lon: lonDec, radiusNm };
+}
+
+const NOTAM_FL_RE = /(?:SFC|GND).*?FL\s?(\d{2,3})/i;
+const NOTAM_FT_RE = /(\d{3,5})\s*FT?\s*MSL/i;
+
+function parseAltitudeBand(text) {
+  const fl = text.match(NOTAM_FL_RE);
+  if (fl) return { min: 0, max: Number.parseInt(fl[1], 10) * 100 };
+  const ft = text.match(NOTAM_FT_RE);
+  if (ft) return { min: 0, max: Number.parseInt(ft[1], 10) };
+  return undefined;
+}
+
+function normalizeNotamItem(item, idx) {
+  if (!item || typeof item !== 'object') return null;
+  const props = item.properties ?? item;
+  const core = props.coreNOTAMData ?? props.notamTranslation ?? props;
+  const notam = core.notam ?? core;
+  const text = pickString(notam.text, notam.message, notam.simpleText, notam.notamText, props.notamText);
+  if (!text) return null;
+  const notamNumber = pickString(notam.number, notam.notamNumber, notam.id) ?? '';
+  const classifierRaw = pickString(notam.classification, notam.notamType, props.classification);
+  const classification = normalizeClassification(classifierRaw, text);
+  const center = parseCenterRadius(text);
+  const altitudeFt = parseAltitudeBand(text);
+  return {
+    id: notamNumber || `notam-${idx}`,
+    notamNumber,
+    classification,
+    affectedFir: pickString(notam.affectedFIR, notam.fir),
+    featureName: pickString(notam.featureName, notam.feature),
+    icaoId: pickString(notam.icaoLocation, notam.location, notam.icaoId),
+    text: text.trim(),
+    effectiveStart: parseTimestamp(notam.effectiveStart, notam.startDate),
+    effectiveEnd: parseTimestamp(notam.effectiveEnd, notam.endDate),
+    ...(center ? { center } : {}),
+    ...(altitudeFt ? { altitudeFt } : {}),
+    presidential: /\bpresidential|VIP movement|VIP\b/i.test(text),
+  };
+}
+
+async function fetchNotams() {
+  const clientId = process.env.FAA_NOTAM_CLIENT_ID;
+  const clientSecret = process.env.FAA_NOTAM_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    return degraded(
+      'FAA NOTAM credentials not configured — set FAA_NOTAM_CLIENT_ID/SECRET env vars',
+      SOURCE,
+    );
+  }
+  const params = new URLSearchParams({
+    pageSize: '100',
+    pageNum: '0',
+    notamType: 'NOTAM',
+    classification: 'FDC,DOM',
+    client_id: clientId,
+    client_secret: clientSecret,
+  });
+  const url = `https://external-api.faa.gov/notamapi/v1/notams?${params}`;
+  const response = await fetchUpstream(url);
+  if (!response.ok) {
+    return degraded(`FAA upstream HTTP ${response.status}`, SOURCE);
+  }
+  const payload = await response.json();
+  const items = extractItems(payload, ['items', 'data', 'notams']);
+  const data = items
+    .map((item, idx) => normalizeNotamItem(item, idx))
+    .filter(Boolean);
+  return envelope(data, SOURCE);
+}
+
+export default async function handler(req) {
+  const { cors, response } = preflight(req, 'GET, OPTIONS');
+  if (response) return response;
+  const result = await withCache(CACHE_KEY, SOURCE, fetchNotams);
+  return jsonResponse(result, 200, cors);
+}

--- a/api/aviation/pireps.js
+++ b/api/aviation/pireps.js
@@ -1,0 +1,83 @@
+/**
+ * AWC PIREP proxy.
+ * Upstream: https://aviationweather.gov/cgi-bin/json/PirepJSON.php?distm=200
+ */
+
+import {
+  envelope,
+  extractItems,
+  fetchUpstream,
+  jsonResponse,
+  parseTimestamp,
+  pickFinite,
+  pickString,
+  preflight,
+  withCache,
+} from './_aviation-helpers.js';
+
+export const config = { runtime: 'edge' };
+
+const SOURCE = 'aviationweather.gov';
+const CACHE_KEY = 'aviation:pireps';
+
+function inferHazard(icing, turb, text) {
+  if (icing && String(icing).trim()) return 'icing';
+  if (turb && String(turb).trim()) return 'turbulence';
+  if (/\bICE|ICING\b/i.test(text)) return 'icing';
+  if (/\bTURB|CHOP|BMPY\b/i.test(text)) return 'turbulence';
+  if (/WIND SHEAR|WS\b/i.test(text)) return 'wind_shear';
+  return 'other';
+}
+
+function inferIntensity(icing, turb, text) {
+  const raw = `${String(icing ?? '')} ${String(turb ?? '')} ${text}`.toUpperCase();
+  if (raw.includes('EXTRM') || raw.includes('XTRM')) return 'extreme';
+  if (raw.includes('SEV')) return 'severe';
+  if (raw.includes('MOD')) return 'moderate';
+  if (raw.includes('LGT') || raw.includes('LIGHT')) return 'light';
+  if (raw.includes('TRC') || raw.includes('TRACE')) return 'trace';
+  return 'light';
+}
+
+function normalizePirep(item, idx) {
+  if (!item || typeof item !== 'object') return null;
+  const props = item.properties ?? item;
+  const rawText = pickString(props.rawOb, props.text, props.rawPirep);
+  if (!rawText) return null;
+  const hazard = inferHazard(props.icingType, props.turbType, rawText);
+  if (hazard === 'other') return null;
+  return {
+    id: pickString(props.id, props.aircraftRef) ?? `pirep-${idx}`,
+    hazard,
+    intensity: inferIntensity(props.icingInt, props.turbInt, rawText),
+    altitudeFt: pickFinite(props.fltlvl, props.altitude_ft_msl),
+    lat: pickFinite(props.lat, props.latitude),
+    lon: pickFinite(props.lon, props.longitude),
+    reportedAt: parseTimestamp(props.obsTime, props.obs_time) ?? Date.now(),
+    aircraftType: pickString(props.acType, props.aircraft_type),
+    rawText: rawText.trim(),
+  };
+}
+
+async function fetchPireps() {
+  const url = 'https://aviationweather.gov/cgi-bin/json/PirepJSON.php?distm=200';
+  const response = await fetchUpstream(url);
+  if (!response.ok) {
+    throw new Error(`PIREP upstream HTTP ${response.status}`);
+  }
+  const payload = await response.json();
+  const items = extractItems(payload, ['data', 'features', 'pireps']);
+  const out = [];
+  for (const [idx, item] of items.entries()) {
+    const norm = normalizePirep(item, idx);
+    if (norm) out.push(norm);
+  }
+  return envelope(out, SOURCE);
+}
+
+export default async function handler(req) {
+  const { cors, response } = preflight(req, 'GET, OPTIONS');
+  if (response) return response;
+  const result = await withCache(CACHE_KEY, SOURCE, fetchPireps);
+  return jsonResponse(result, 200, cors);
+}

--- a/api/aviation/sigmets.js
+++ b/api/aviation/sigmets.js
@@ -1,0 +1,157 @@
+/**
+ * Aviation Weather Center SIGMET / AIRMET proxy.
+ * Upstreams (free, no key):
+ *   - SIGMETs:  https://aviationweather.gov/cgi-bin/json/SigmetJSON.php
+ *   - AIRMETs:  https://aviationweather.gov/cgi-bin/json/AirmetJSON.php
+ */
+
+import {
+  degraded,
+  envelope,
+  extractItems,
+  fetchUpstream,
+  jsonResponse,
+  parseTimestamp,
+  pickString,
+  preflight,
+  withCache,
+} from './_aviation-helpers.js';
+
+export const config = { runtime: 'edge' };
+
+const SOURCE = 'aviationweather.gov';
+const CACHE_KEY = 'aviation:sigmets';
+
+function inferHazard(rawHazard, text) {
+  const raw = (typeof rawHazard === 'string' ? rawHazard : '').toUpperCase();
+  if (raw.includes('VA') || /VOLCANIC ASH|ASHTOPS/i.test(text)) return 'volcanic_ash';
+  if (raw.includes('TURB') || /\bTURB|TURBULENCE\b/i.test(text)) return 'turbulence';
+  if (raw.includes('ICE') || /\bICE|ICING\b/i.test(text)) return 'icing';
+  if (raw.includes('TS') || /TS\b|THUNDERSTORM/i.test(text)) return 'thunderstorm';
+  if (raw === 'MTN OBSCN' || /MTN OBSCN|MOUNTAIN OBSCURATION/i.test(text)) return 'mountain_obscuration';
+  if (raw === 'IFR' || /\bIFR\b/i.test(text)) return 'ifr';
+  return 'other';
+}
+
+function inferSeverity(rawSeverity, text) {
+  const raw = (typeof rawSeverity === 'string' ? rawSeverity : '').toUpperCase();
+  if (raw.includes('SEV') || /SEVERE/i.test(text)) return 'severe';
+  if (raw.includes('EXTRM') || /EXTREME/i.test(text)) return 'extreme';
+  if (raw.includes('MOD') || /MODERATE|MOD\b/i.test(text)) return 'moderate';
+  return 'light';
+}
+
+function ddmToDecimal(deg, min, hemi) {
+  const d = Number.parseInt(deg, 10);
+  const m = Number.parseInt(min, 10);
+  if (!Number.isFinite(d) || !Number.isFinite(m)) return null;
+  return (d + m / 60) * (hemi === 'S' || hemi === 'W' ? -1 : 1);
+}
+
+const SIG_AREA_RE = /(\d{2,3})(\d{2})([NS])\s+(\d{2,3})(\d{2})([EW])/g;
+
+function parseAreaString(s) {
+  const out = [];
+  for (const m of String(s).matchAll(SIG_AREA_RE)) {
+    const lat = ddmToDecimal(m[1], m[2], m[3]);
+    const lon = ddmToDecimal(m[4], m[5], m[6]);
+    if (lat !== null && lon !== null) out.push({ lat, lon });
+  }
+  return out;
+}
+
+function parseLonLatPairs(arr) {
+  const out = [];
+  for (const pt of arr) {
+    if (Array.isArray(pt) && pt.length >= 2) {
+      const lon = Number(pt[0]);
+      const lat = Number(pt[1]);
+      if (Number.isFinite(lon) && Number.isFinite(lat)) out.push({ lat, lon });
+    } else if (pt && typeof pt === 'object') {
+      const lat = Number(pt.lat ?? pt.latitude);
+      const lon = Number(pt.lon ?? pt.longitude);
+      if (Number.isFinite(lat) && Number.isFinite(lon)) out.push({ lat, lon });
+    }
+  }
+  return out;
+}
+
+function extractPolygon(geometry, coords, area) {
+  if (geometry && geometry.type === 'Polygon' && Array.isArray(geometry.coordinates)) {
+    const ring = geometry.coordinates[0];
+    if (Array.isArray(ring)) return parseLonLatPairs(ring);
+  }
+  if (Array.isArray(coords)) return parseLonLatPairs(coords);
+  if (typeof area === 'string') return parseAreaString(area);
+  return [];
+}
+
+const SIG_FL_RANGE_RE = /FL\s*(\d{2,3})\s*[-/]\s*FL?\s*(\d{2,3})/i;
+
+function extractAltitude(low, hi, text) {
+  const lo = Number(low);
+  const high = Number(hi);
+  if (Number.isFinite(lo) && Number.isFinite(high)) return { min: lo, max: high };
+  const m = text.match(SIG_FL_RANGE_RE);
+  if (m) return { min: Number.parseInt(m[1], 10) * 100, max: Number.parseInt(m[2], 10) * 100 };
+  return undefined;
+}
+
+function normalizeSigmet(item, idx, isAirmet) {
+  if (!item || typeof item !== 'object') return null;
+  const props = item.properties ?? item;
+  const text = pickString(props.rawSigmet, props.rawAirmet, props.text, props.rawAir, props.rawSig);
+  if (!text) return null;
+  const altitudeFt = extractAltitude(props.altitudeLow1, props.altitudeHi1, text);
+  return {
+    id: pickString(props.id, props.airSigmetId) ?? `sigmet-${idx}`,
+    hazard: inferHazard(props.hazard, text),
+    severity: inferSeverity(props.severity, text),
+    ...(altitudeFt ? { altitudeFt } : {}),
+    polygon: extractPolygon(item.geometry, props.coords, props.area),
+    text: text.trim(),
+    validFrom: parseTimestamp(props.validTimeFrom, props.validFrom) ?? Date.now(),
+    validTo: parseTimestamp(props.validTimeTo, props.validTo) ?? Date.now() + 6 * 3_600_000,
+    isAirmet,
+  };
+}
+
+async function readSettled(settled, keys, isAirmet) {
+  if (settled.status !== 'fulfilled' || !settled.value.ok) return null;
+  const payload = await settled.value.json();
+  const items = extractItems(payload, keys);
+  const out = [];
+  for (const [idx, item] of items.entries()) {
+    const norm = normalizeSigmet(item, idx, isAirmet);
+    if (norm) out.push(norm);
+  }
+  return out;
+}
+
+async function fetchSigmets() {
+  const [sigResp, airResp] = await Promise.allSettled([
+    fetchUpstream('https://aviationweather.gov/cgi-bin/json/SigmetJSON.php'),
+    fetchUpstream('https://aviationweather.gov/cgi-bin/json/AirmetJSON.php'),
+  ]);
+  const sigmets = await readSettled(sigResp, ['data', 'features', 'sigmets'], false);
+  const airmets = await readSettled(airResp, ['data', 'features', 'airmets'], true);
+  const out = [...(sigmets ?? []), ...(airmets ?? [])];
+  const reasons = [];
+  if (sigmets === null) reasons.push('SIGMET upstream failed');
+  if (airmets === null) reasons.push('AIRMET upstream failed');
+  if (out.length === 0 && reasons.length > 0) {
+    return degraded(reasons.join('; '), SOURCE);
+  }
+  const env = envelope(out, SOURCE);
+  if (reasons.length > 0) {
+    return { ...env, degraded: true, reason: reasons.join('; ') };
+  }
+  return env;
+}
+
+export default async function handler(req) {
+  const { cors, response } = preflight(req, 'GET, OPTIONS');
+  if (response) return response;
+  const result = await withCache(CACHE_KEY, SOURCE, fetchSigmets);
+  return jsonResponse(result, 200, cors);
+}

--- a/api/aviation/volcanic-ash.js
+++ b/api/aviation/volcanic-ash.js
@@ -1,0 +1,88 @@
+/**
+ * VAAC volcanic ash advisory proxy.
+ *
+ * Upstream: https://aviationweather.gov/cgi-bin/json/VolcanoJSON.php
+ * Free, no key. The endpoint sometimes returns an empty array even
+ * when active advisories exist — that's authoritative.
+ */
+
+import {
+  envelope,
+  extractItems,
+  fetchUpstream,
+  jsonResponse,
+  parseTimestamp,
+  pickFinite,
+  pickString,
+  preflight,
+  withCache,
+} from './_aviation-helpers.js';
+
+export const config = { runtime: 'edge' };
+
+const SOURCE = 'aviationweather.gov/volcano';
+const CACHE_KEY = 'aviation:volcanic-ash';
+
+function parseLonLatPairs(arr) {
+  const out = [];
+  for (const pt of arr) {
+    if (Array.isArray(pt) && pt.length >= 2) {
+      const lon = Number(pt[0]);
+      const lat = Number(pt[1]);
+      if (Number.isFinite(lon) && Number.isFinite(lat)) out.push({ lat, lon });
+    }
+  }
+  return out;
+}
+
+function extractPolygon(geometry) {
+  if (geometry && geometry.type === 'Polygon' && Array.isArray(geometry.coordinates)) {
+    const ring = geometry.coordinates[0];
+    if (Array.isArray(ring)) return parseLonLatPairs(ring);
+  }
+  return [];
+}
+
+function normalizeAdvisory(item, idx) {
+  if (!item || typeof item !== 'object') return null;
+  const props = item.properties ?? item;
+  const polygon = extractPolygon(item.geometry);
+  if (polygon.length < 3) return null;
+  return {
+    id: pickString(props.id, props.advisoryId) ?? `vaac-${idx}`,
+    volcano: pickString(props.volcano, props.name) ?? 'unknown',
+    polygon,
+    altitudeFt: {
+      min: pickFinite(props.altitudeLow, props.minAlt) ?? 0,
+      max: pickFinite(props.altitudeHi, props.maxAlt) ?? 0,
+    },
+    validFrom: parseTimestamp(props.validFrom, props.startTime) ?? Date.now(),
+    validTo: parseTimestamp(props.validTo, props.endTime) ?? Date.now() + 6 * 3_600_000,
+    source: 'NOAA',
+    text: pickString(props.text, props.advisoryText, props.rawText) ?? '',
+  };
+}
+
+async function fetchVolcanicAsh() {
+  const response = await fetchUpstream(
+    'https://aviationweather.gov/cgi-bin/json/VolcanoJSON.php',
+  );
+  if (!response.ok) {
+    throw new Error(`Volcano upstream HTTP ${response.status}`);
+  }
+  const payload = await response.json();
+  const items = extractItems(payload, ['data', 'features', 'volcanoes', 'advisories']);
+  const out = [];
+  for (const [idx, item] of items.entries()) {
+    const norm = normalizeAdvisory(item, idx);
+    if (norm) out.push(norm);
+  }
+  return envelope(out, SOURCE);
+}
+
+export default async function handler(req) {
+  const { cors, response } = preflight(req, 'GET, OPTIONS');
+  if (response) return response;
+  const result = await withCache(CACHE_KEY, SOURCE, fetchVolcanicAsh);
+  return jsonResponse(result, 200, cors);
+}

--- a/src/services/aviation/__tests__/aviation-intel-normalize.test.mts
+++ b/src/services/aviation/__tests__/aviation-intel-normalize.test.mts
@@ -1,0 +1,295 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  normalizeDelays,
+  normalizeMilitaryAircraft,
+  normalizeNotams,
+  normalizePireps,
+  normalizeSigmets,
+  normalizeVolcanicAsh,
+} from '../aviation-intel-normalize';
+
+describe('normalizeNotams', () => {
+  it('returns [] for malformed payload without throwing', () => {
+    assert.deepEqual(normalizeNotams(null), []);
+    assert.deepEqual(normalizeNotams({ items: 'not an array' }), []);
+    assert.deepEqual(normalizeNotams(undefined), []);
+  });
+
+  it('parses FAA NOTAM API style envelope', () => {
+    const payload = {
+      items: [
+        {
+          properties: {
+            coreNOTAMData: {
+              notam: {
+                number: '1/2345',
+                classification: 'FDC',
+                affectedFIR: 'KZAU',
+                featureName: 'Air Show',
+                icaoLocation: 'KORD',
+                text: 'TFR PRESIDENTIAL VIP MOVEMENT 4030N 08740W RADIUS 30 NM SFC FL180',
+                effectiveStart: '2026-01-15T00:00:00Z',
+                effectiveEnd: '2026-01-15T06:00:00Z',
+              },
+            },
+          },
+        },
+      ],
+    };
+    const out = normalizeNotams(payload);
+    assert.equal(out.length, 1);
+    const n = out[0]!;
+    assert.equal(n.notamNumber, '1/2345');
+    assert.equal(n.classification, 'TFR');
+    assert.equal(n.presidential, true);
+    assert.ok(n.center);
+    assert.equal(n.center!.radiusNm, 30);
+    assert.ok(Math.abs(n.center!.lat - 40.5) < 0.1);
+    assert.ok(Math.abs(n.center!.lon + 87.667) < 0.1);
+    assert.deepEqual(n.altitudeFt, { min: 0, max: 18_000 });
+  });
+
+  it('skips items with no text', () => {
+    const out = normalizeNotams({ items: [{ properties: { coreNOTAMData: { notam: {} } } }] });
+    assert.deepEqual(out, []);
+  });
+
+  it('classifies TFR keyword even when classification field is missing', () => {
+    const payload = {
+      items: [
+        {
+          properties: {
+            coreNOTAMData: {
+              notam: { text: 'TFR for stadium event 4015N 11630W RADIUS 5 NM SFC FL050' },
+            },
+          },
+        },
+      ],
+    };
+    assert.equal(normalizeNotams(payload)[0]!.classification, 'TFR');
+  });
+});
+
+describe('normalizeSigmets', () => {
+  it('classifies volcanic ash hazard from text', () => {
+    const payload = {
+      data: [
+        {
+          properties: {
+            rawSigmet: 'VOLCANIC ASH SFC/FL250 OBS AT 1200Z',
+            validTimeFrom: 1_700_000_000,
+            validTimeTo: 1_700_010_000,
+          },
+          geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [-145, 60],
+                [-140, 60],
+                [-140, 62],
+                [-145, 62],
+                [-145, 60],
+              ],
+            ],
+          },
+        },
+      ],
+    };
+    const out = normalizeSigmets(payload);
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.hazard, 'volcanic_ash');
+    assert.equal(out[0]!.polygon.length, 5);
+    assert.equal(out[0]!.polygon[0]!.lat, 60);
+    assert.equal(out[0]!.polygon[0]!.lon, -145);
+  });
+
+  it('classifies turbulence hazard with severe severity', () => {
+    const payload = {
+      data: [
+        { properties: { rawSigmet: 'SEVERE TURB FL300/FL400 FCST', hazard: 'TURB', severity: 'SEV' } },
+      ],
+    };
+    const out = normalizeSigmets(payload);
+    assert.equal(out[0]!.hazard, 'turbulence');
+    assert.equal(out[0]!.severity, 'severe');
+    assert.deepEqual(out[0]!.altitudeFt, { min: 30_000, max: 40_000 });
+  });
+
+  it('marks records as AIRMET when isAirmet=true', () => {
+    const out = normalizeSigmets(
+      { data: [{ properties: { rawAirmet: 'AIRMET TANGO MOD TURB' } }] },
+      true,
+    );
+    assert.equal(out[0]!.isAirmet, true);
+  });
+
+  it('returns [] for empty payload', () => {
+    assert.deepEqual(normalizeSigmets({}), []);
+  });
+});
+
+describe('normalizePireps', () => {
+  it('parses pilot turbulence report', () => {
+    const payload = {
+      data: [
+        {
+          properties: {
+            rawOb: 'KORD UA /OV ORD180020/TM 1430/FL280/TP B738/TB MOD CHOP',
+            turbType: 'CHOP',
+            turbInt: 'MOD',
+            fltlvl: 28_000,
+            lat: 41.5,
+            lon: -87.5,
+            obsTime: '2026-01-15T14:30:00Z',
+            acType: 'B738',
+          },
+        },
+      ],
+    };
+    const out = normalizePireps(payload);
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.hazard, 'turbulence');
+    assert.equal(out[0]!.intensity, 'moderate');
+    assert.equal(out[0]!.altitudeFt, 28_000);
+    assert.equal(out[0]!.aircraftType, 'B738');
+  });
+
+  it('detects icing PIREP', () => {
+    const out = normalizePireps({
+      data: [{ properties: { rawOb: 'UA /OV /TM /FL120 /TP /IC LGT', icingType: 'RIME' } }],
+    });
+    assert.equal(out[0]!.hazard, 'icing');
+  });
+
+  it('skips PIREPs without a recognizable hazard', () => {
+    const out = normalizePireps({
+      data: [{ properties: { rawOb: 'UA /OV /TM /FL060 /TP /SK SCT' } }],
+    });
+    assert.equal(out.length, 0);
+  });
+});
+
+describe('normalizeMilitaryAircraft', () => {
+  it('parses adsb.lol /v2/mil response', () => {
+    const payload = {
+      ac: [
+        {
+          hex: 'AE2BB7',
+          flight: 'RCH4001',
+          r: 'United States',
+          t: 'C17',
+          lat: 40.0,
+          lon: -100.0,
+          alt_baro: 35_000,
+          gs: 410,
+          track: 90,
+          squawk: '7700',
+          seen: 0.5,
+        },
+      ],
+    };
+    const out = normalizeMilitaryAircraft(payload);
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.icao24, 'ae2bb7');
+    assert.equal(out[0]!.callsign, 'RCH4001');
+    assert.equal(out[0]!.type, 'transport');
+    assert.equal(out[0]!.emergency, true);
+  });
+
+  it('parses OpenSky states/all array-of-arrays shape', () => {
+    const payload = {
+      states: [
+        ['ae0001', 'EAGLE01 ', 'United States', 0, 1_700_000_000, -120, 35, 12_000, false, 250, 100, 0, null, 12_000, '1200'],
+      ],
+    };
+    const out = normalizeMilitaryAircraft(payload);
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.icao24, 'ae0001');
+    assert.equal(out[0]!.type, 'fighter');
+  });
+
+  it('classifies KC-135 as tanker by aircraft type', () => {
+    const out = normalizeMilitaryAircraft({
+      ac: [{ hex: 'ae9999', flight: 'GOLD55', t: 'KC-135R', lat: 30, lon: -100 }],
+    });
+    assert.equal(out[0]!.type, 'tanker');
+  });
+
+  it('returns [] when payload has no recognizable shape', () => {
+    assert.deepEqual(normalizeMilitaryAircraft('not aviation'), []);
+  });
+});
+
+describe('normalizeDelays', () => {
+  it('parses FAA NAS Status airport conditions', () => {
+    const payload = {
+      delays: [
+        {
+          airport: 'EWR',
+          reason: 'Wind/Volume',
+          eventType: 'GROUND DELAY',
+          avgDelay: 38,
+          maxDelay: 75,
+          startTime: '2026-01-15T18:00:00Z',
+          endTime: '2026-01-15T22:00:00Z',
+        },
+      ],
+    };
+    const out = normalizeDelays(payload);
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.airport, 'EWR');
+    assert.equal(out[0]!.programType, 'ground_delay');
+    assert.equal(out[0]!.avgDelayMinutes, 38);
+  });
+
+  it('classifies ground stop', () => {
+    const out = normalizeDelays({
+      delays: [{ airport: 'JFK', eventType: 'GROUND STOP', reason: 'Equipment' }],
+    });
+    assert.equal(out[0]!.programType, 'ground_stop');
+  });
+
+  it('skips entries without an airport identifier', () => {
+    assert.deepEqual(normalizeDelays({ delays: [{ reason: 'orphan' }] }), []);
+  });
+});
+
+describe('normalizeVolcanicAsh', () => {
+  it('parses ash advisory polygon', () => {
+    const payload = {
+      data: [
+        {
+          properties: {
+            volcano: 'Bezymianny',
+            text: 'VA SFC/FL250',
+            altitudeLow: 0,
+            altitudeHi: 25_000,
+          },
+          geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [160, 55],
+                [165, 55],
+                [165, 58],
+                [160, 58],
+                [160, 55],
+              ],
+            ],
+          },
+        },
+      ],
+    };
+    const out = normalizeVolcanicAsh(payload);
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.volcano, 'Bezymianny');
+    assert.equal(out[0]!.altitudeFt.max, 25_000);
+    assert.equal(out[0]!.polygon.length, 5);
+  });
+
+  it('skips advisories without a polygon', () => {
+    assert.deepEqual(normalizeVolcanicAsh({ data: [{ properties: { volcano: 'X' } }] }), []);
+  });
+});

--- a/src/services/aviation/aviation-intel-normalize.ts
+++ b/src/services/aviation/aviation-intel-normalize.ts
@@ -1,0 +1,503 @@
+/**
+ * Aviation intelligence — pure-deterministic normalizers.
+ *
+ * Each function takes a raw upstream JSON payload (already parsed) and
+ * returns a typed array. No I/O. The sidecar routes call fetch + JSON.parse
+ * + these normalizers; unit tests call them with static fixtures.
+ *
+ * Plan invariants:
+ *   - Bad upstream payloads must NOT throw - return [] and let the caller
+ *     mark the envelope `degraded`.
+ *   - String fields are trimmed; missing/non-finite numbers become null
+ *     (not NaN) so JSON serialization stays clean.
+ */
+
+import type {
+  AirportGroundDelay,
+  AviationNotam,
+  AviationPirep,
+  AviationSigmet,
+  MilitaryAircraft,
+  NotamClassification,
+  PirepHazard,
+  SigmetHazard,
+  VolcanicAshAdvisory,
+} from './aviation-intel-types';
+
+// FAA NOTAM normalizer
+
+export function normalizeNotams(payload: unknown): AviationNotam[] {
+  const items = extractItems(payload, ['items', 'data', 'notams']);
+  const out: AviationNotam[] = [];
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue;
+    const root = item as Record<string, unknown>;
+    const props = (root.properties as Record<string, unknown> | undefined) ?? root;
+    const core =
+      (props.coreNOTAMData as Record<string, unknown> | undefined) ??
+      (props.notamTranslation as Record<string, unknown> | undefined) ??
+      props;
+    const notam = (core.notam as Record<string, unknown> | undefined) ?? core;
+    const text = pickString(
+      notam.text,
+      notam.message,
+      notam.simpleText,
+      notam.notamText,
+      props.notamText,
+    );
+    if (!text) continue;
+    const notamNumber = pickString(notam.number, notam.notamNumber, notam.id) ?? '';
+    const classifierRaw = pickString(notam.classification, notam.notamType, props.classification);
+    const classification = classifierRaw
+      ? normalizeClassification(classifierRaw, text)
+      : normalizeClassification('', text);
+    const center = parseCenterRadius(text);
+    const altitudeFt = parseAltitudeBand(text);
+    out.push({
+      id: notamNumber || `notam-${out.length}`,
+      notamNumber,
+      classification,
+      affectedFir: pickString(notam.affectedFIR, notam.fir) ?? null,
+      featureName: pickString(notam.featureName, notam.feature) ?? null,
+      icaoId: pickString(notam.icaoLocation, notam.location, notam.icaoId) ?? null,
+      text: text.trim(),
+      effectiveStart: parseTimestamp(notam.effectiveStart, notam.startDate),
+      effectiveEnd: parseTimestamp(notam.effectiveEnd, notam.endDate),
+      ...(center ? { center } : {}),
+      ...(altitudeFt ? { altitudeFt } : {}),
+      presidential: /\bpresidential|VIP movement|VIP\b/i.test(text),
+    });
+  }
+  return out;
+}
+
+function normalizeClassification(raw: string, text: string): NotamClassification {
+  const upper = raw.toUpperCase();
+  if (upper === 'FDC' || /TFR/i.test(text)) return /TFR/i.test(text) ? 'TFR' : 'FDC';
+  if (upper === 'DOM' || upper === 'INTL') return upper as NotamClassification;
+  return 'OTHER';
+}
+
+const CENTER_RE = /(\d{1,2})(\d{2})([NS])/;
+const RADIUS_RE = /(\d{1,3})\s*NM/i;
+const LON_RE = /(\d{1,3})(\d{2})([EW])/;
+
+function parseCenterRadius(text: string): { lat: number; lon: number; radiusNm: number } | undefined {
+  // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec, sonarjs/prefer-regexp-exec
+  const lat = text.match(CENTER_RE);
+  // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec, sonarjs/prefer-regexp-exec
+  const lon = text.match(LON_RE);
+  // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec, sonarjs/prefer-regexp-exec
+  const r = text.match(RADIUS_RE);
+  if (!lat || !lon || !r) return undefined;
+  const latDec = ddmToDecimal(lat[1]!, lat[2]!, lat[3]!);
+  const lonDec = ddmToDecimal(lon[1]!, lon[2]!, lon[3]!);
+  const radiusNm = Number.parseInt(r[1]!, 10);
+  if (!Number.isFinite(latDec) || !Number.isFinite(lonDec) || !Number.isFinite(radiusNm)) return undefined;
+  return { lat: latDec, lon: lonDec, radiusNm };
+}
+
+function ddmToDecimal(deg: string, min: string, hemi: string): number {
+  const d = Number.parseInt(deg, 10);
+  const mins = Number.parseInt(min, 10);
+  if (!Number.isFinite(d) || !Number.isFinite(mins)) return Number.NaN;
+  const dec = d + mins / 60;
+  const sign = hemi === 'S' || hemi === 'W' ? -1 : 1;
+  return dec * sign;
+}
+
+const FL_RE = /(?:SFC|GND).*?FL\s?(\d{2,3})/i;
+const FT_RE = /(\d{3,5})\s*FT?\s*MSL/i;
+
+function parseAltitudeBand(text: string): { min: number | null; max: number | null } | undefined {
+  // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec, sonarjs/prefer-regexp-exec
+  const fl = text.match(FL_RE);
+  if (fl?.[1]) return { min: 0, max: Number.parseInt(fl[1], 10) * 100 };
+  // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec, sonarjs/prefer-regexp-exec
+  const ft = text.match(FT_RE);
+  if (ft?.[1]) return { min: 0, max: Number.parseInt(ft[1], 10) };
+  return undefined;
+}
+
+// SIGMET / AIRMET normalizer
+
+export function normalizeSigmets(payload: unknown, isAirmet = false): AviationSigmet[] {
+  const items = extractItems(payload, ['data', 'features', 'sigmets', 'airmets']);
+  const out: AviationSigmet[] = [];
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue;
+    const root = item as Record<string, unknown>;
+    const props = (root.properties as Record<string, unknown> | undefined) ?? root;
+    const text = pickString(props.rawSigmet, props.rawAirmet, props.text, props.rawAir, props.rawSig);
+    if (!text) continue;
+    const hazard = inferHazard(props.hazard, text);
+    const severity = inferSeverity(props.severity, text);
+    const polygon = extractPolygon(root.geometry, props.coords, props.area);
+    const altitudeFt = extractAltitude(props.altitudeLow1, props.altitudeHi1, text);
+    out.push({
+      id: pickString(props.id, props.airSigmetId) ?? `sigmet-${out.length}`,
+      hazard,
+      severity,
+      ...(altitudeFt ? { altitudeFt } : {}),
+      polygon,
+      text: text.trim(),
+      validFrom: parseTimestamp(props.validTimeFrom, props.validFrom) ?? Date.now(),
+      validTo: parseTimestamp(props.validTimeTo, props.validTo) ?? Date.now() + 6 * 3_600_000,
+      isAirmet,
+    });
+  }
+  return out;
+}
+
+function inferHazard(rawHazard: unknown, text: string): SigmetHazard {
+  const raw = (typeof rawHazard === 'string' ? rawHazard : '').toUpperCase();
+  if (raw.includes('VA') || /VOLCANIC ASH|ASHTOPS/i.test(text)) return 'volcanic_ash';
+  if (raw.includes('TURB') || /\bTURB|TURBULENCE\b/i.test(text)) return 'turbulence';
+  if (raw.includes('ICE') || /\bICE|ICING\b/i.test(text)) return 'icing';
+  if (raw.includes('TS') || /TS\b|THUNDERSTORM/i.test(text)) return 'thunderstorm';
+  if (raw === 'MTN OBSCN' || /MTN OBSCN|MOUNTAIN OBSCURATION/i.test(text)) return 'mountain_obscuration';
+  if (raw === 'IFR' || /\bIFR\b/i.test(text)) return 'ifr';
+  return 'other';
+}
+
+function inferSeverity(rawSeverity: unknown, text: string): AviationSigmet['severity'] {
+  const raw = (typeof rawSeverity === 'string' ? rawSeverity : '').toUpperCase();
+  if (raw.includes('SEV') || /SEVERE/i.test(text)) return 'severe';
+  if (raw.includes('EXTRM') || /EXTREME/i.test(text)) return 'extreme';
+  if (raw.includes('MOD') || /MODERATE|MOD\b/i.test(text)) return 'moderate';
+  return 'light';
+}
+
+function extractPolygon(
+  geometry: unknown,
+  coords: unknown,
+  area: unknown,
+): { lat: number; lon: number }[] {
+  if (geometry && typeof geometry === 'object') {
+    const g = geometry as { type?: string; coordinates?: unknown };
+    if (g.type === 'Polygon' && Array.isArray(g.coordinates)) {
+      const ring: unknown = g.coordinates[0];
+      if (Array.isArray(ring)) return parseLonLatPairs(ring as unknown[]);
+    }
+  }
+  if (Array.isArray(coords)) return parseLonLatPairs(coords);
+  if (typeof area === 'string') return parseAreaString(area);
+  return [];
+}
+
+function parseLonLatPairs(arr: unknown[]): { lat: number; lon: number }[] {
+  const out: { lat: number; lon: number }[] = [];
+  for (const pt of arr) {
+    if (Array.isArray(pt) && pt.length >= 2) {
+      const lon = Number(pt[0]);
+      const lat = Number(pt[1]);
+      if (Number.isFinite(lon) && Number.isFinite(lat)) out.push({ lat, lon });
+    } else if (pt && typeof pt === 'object') {
+      const p = pt as { lat?: unknown; lon?: unknown; latitude?: unknown; longitude?: unknown };
+      const lat = Number(p.lat ?? p.latitude);
+      const lon = Number(p.lon ?? p.longitude);
+      if (Number.isFinite(lat) && Number.isFinite(lon)) out.push({ lat, lon });
+    }
+  }
+  return out;
+}
+
+const AREA_PAIR_RE = /(\d{2,3})(\d{2})([NS])\s+(\d{2,3})(\d{2})([EW])/g;
+
+function parseAreaString(s: string): { lat: number; lon: number }[] {
+  const out: { lat: number; lon: number }[] = [];
+  for (const m of s.matchAll(AREA_PAIR_RE)) {
+    const lat = ddmToDecimal(m[1]!, m[2]!, m[3]!);
+    const lon = ddmToDecimal(m[4]!, m[5]!, m[6]!);
+    if (Number.isFinite(lat) && Number.isFinite(lon)) out.push({ lat, lon });
+  }
+  return out;
+}
+
+const FL_RANGE_RE = /FL\s*(\d{2,3})\s*[-/]\s*FL?\s*(\d{2,3})/i;
+
+function extractAltitude(
+  low: unknown,
+  hi: unknown,
+  text: string,
+): { min: number; max: number } | undefined {
+  const lo = Number(low);
+  const high = Number(hi);
+  if (Number.isFinite(lo) && Number.isFinite(high)) {
+    return { min: lo, max: high };
+  }
+  // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec, sonarjs/prefer-regexp-exec
+  const flMatch = text.match(FL_RANGE_RE);
+  if (flMatch) {
+    return { min: Number.parseInt(flMatch[1]!, 10) * 100, max: Number.parseInt(flMatch[2]!, 10) * 100 };
+  }
+  return undefined;
+}
+
+// PIREP normalizer
+
+export function normalizePireps(payload: unknown): AviationPirep[] {
+  const items = extractItems(payload, ['data', 'features', 'pireps']);
+  const out: AviationPirep[] = [];
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue;
+    const root = item as Record<string, unknown>;
+    const props = (root.properties as Record<string, unknown> | undefined) ?? root;
+    const rawText = pickString(props.rawOb, props.text, props.rawPirep);
+    if (!rawText) continue;
+    const hazard = inferPirepHazard(props.icingType, props.turbType, rawText);
+    if (hazard === 'other') continue;
+    const intensity = inferPirepIntensity(props.icingInt, props.turbInt, rawText);
+    out.push({
+      id: pickString(props.id, props.aircraftRef) ?? `pirep-${out.length}`,
+      hazard,
+      intensity,
+      altitudeFt: pickFinite(props.fltlvl, props.altitude_ft_msl) ?? null,
+      lat: pickFinite(props.lat, props.latitude) ?? null,
+      lon: pickFinite(props.lon, props.longitude) ?? null,
+      reportedAt: parseTimestamp(props.obsTime, props.obs_time) ?? Date.now(),
+      aircraftType: pickString(props.acType, props.aircraft_type) ?? null,
+      rawText: rawText.trim(),
+    });
+  }
+  return out;
+}
+
+function asStringTrimmed(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function inferPirepHazard(icing: unknown, turb: unknown, text: string): PirepHazard {
+  if (asStringTrimmed(icing)) return 'icing';
+  if (asStringTrimmed(turb)) return 'turbulence';
+  if (/\bICE|ICING\b/i.test(text)) return 'icing';
+  if (/\bTURB|CHOP|BMPY\b/i.test(text)) return 'turbulence';
+  if (/WIND SHEAR|WS\b/i.test(text)) return 'wind_shear';
+  return 'other';
+}
+
+function inferPirepIntensity(
+  icing: unknown,
+  turb: unknown,
+  text: string,
+): AviationPirep['intensity'] {
+  const raw = `${asStringTrimmed(icing)} ${asStringTrimmed(turb)} ${text}`.toUpperCase();
+  if (raw.includes('EXTRM') || raw.includes('XTRM')) return 'extreme';
+  if (raw.includes('SEV')) return 'severe';
+  if (raw.includes('MOD')) return 'moderate';
+  if (raw.includes('LGT') || raw.includes('LIGHT')) return 'light';
+  if (raw.includes('TRC') || raw.includes('TRACE')) return 'trace';
+  return 'light';
+}
+
+// Military aircraft normalizer
+
+const MIL_CALLSIGN_PREFIXES: Record<string, MilitaryAircraft['type']> = {
+  RCH: 'transport',
+  REACH: 'transport',
+  CNV: 'tanker',
+  PAT: 'tanker',
+  GOLD: 'tanker',
+  SHELL: 'tanker',
+  TEAL: 'recon',
+  HOMER: 'recon',
+  MAGIC: 'recon',
+  SENTRY: 'recon',
+  RIVET: 'recon',
+  PYTHON: 'fighter',
+  RAGE: 'fighter',
+  VIPER: 'fighter',
+  EAGLE: 'fighter',
+  RAIDER: 'bomber',
+  DOOM: 'bomber',
+  BISON: 'bomber',
+  ARMY: 'helo',
+  PEDRO: 'helo',
+  DUSTOFF: 'helo',
+};
+
+export function normalizeMilitaryAircraft(payload: unknown): MilitaryAircraft[] {
+  const items = extractMilitaryItems(payload);
+  const out: MilitaryAircraft[] = [];
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue;
+    const r = item as Record<string, unknown>;
+    const callsign = (pickString(r.flight, r.r, r.callsign) ?? '').trim() || null;
+    const icao24 = (pickString(r.hex, r.icao24, r.icao) ?? '').toLowerCase().trim();
+    if (!icao24) continue;
+    const altMeters = pickFinite(r.alt_baro, r.geom_alt, r.baro_altitude);
+    out.push({
+      icao24,
+      callsign,
+      type: classifyMilitaryType(callsign, r.t),
+      country: pickString(r.r_country, r.origin_country, r.country) ?? null,
+      lat: pickFinite(r.lat, r.latitude) ?? null,
+      lon: pickFinite(r.lon, r.longitude) ?? null,
+      altitudeFt: altMeters === null ? pickFinite(r.alt_geom) : metersToFeet(altMeters),
+      velocityKts: pickFinite(r.gs, r.velocity) ?? null,
+      heading: pickFinite(r.track, r.heading) ?? null,
+      squawk: pickString(r.squawk) ?? null,
+      lastSeen: parseTimestamp(r.seen, r.last_contact) ?? Date.now(),
+      emergency: ['7500', '7600', '7700'].includes(asStringTrimmed(r.squawk)),
+    });
+  }
+  return out;
+}
+
+function extractMilitaryItems(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) return payload;
+  if (payload && typeof payload === 'object') {
+    const p = payload as Record<string, unknown>;
+    if (Array.isArray(p.ac)) return p.ac;
+    if (Array.isArray(p.aircraft)) return p.aircraft;
+    if (Array.isArray(p.states)) {
+      // OpenSky states/all shape: array-of-arrays.
+      return p.states.map((row: unknown) => {
+        if (!Array.isArray(row)) return null;
+        const r = row as readonly unknown[];
+        return {
+          icao24: r[0] as unknown,
+          callsign: r[1] as unknown,
+          origin_country: r[2] as unknown,
+          last_contact: typeof r[4] === 'number' ? r[4] * 1000 : null,
+          lon: r[5] as unknown,
+          lat: r[6] as unknown,
+          baro_altitude: r[7] as unknown,
+          velocity: r[9] as unknown,
+          track: r[10] as unknown,
+          squawk: r[14] as unknown,
+        };
+      });
+    }
+    if (Array.isArray(p.data)) return p.data;
+  }
+  return [];
+}
+
+function classifyMilitaryType(
+  callsign: string | null,
+  acTypeRaw: unknown,
+): MilitaryAircraft['type'] {
+  if (callsign) {
+    const upper = callsign.replace(/\d{1,8}$/, '').toUpperCase();
+    for (const [prefix, type] of Object.entries(MIL_CALLSIGN_PREFIXES)) {
+      if (upper.startsWith(prefix)) return type;
+    }
+  }
+  const t = typeof acTypeRaw === 'string' ? acTypeRaw.toUpperCase() : '';
+  if (/^C-?(5|17|130)|^KC-?\d|KC-?135|KC-?46/.test(t)) return 'tanker';
+  if (/^F-?(15|16|18|22|35)/.test(t)) return 'fighter';
+  if (/^B-?(1|2|52)/.test(t)) return 'bomber';
+  if (/AWACS|RC-?135|U-?2|RQ-?4/.test(t)) return 'recon';
+  if (/^(UH|HH|CH|MH)-?\d/.test(t)) return 'helo';
+  return 'unknown';
+}
+
+function metersToFeet(m: number): number {
+  return Math.round(m * 3.280_84);
+}
+
+// Airport delays normalizer
+
+export function normalizeDelays(payload: unknown): AirportGroundDelay[] {
+  const items = extractItems(payload, ['delays', 'events', 'data', 'airports']);
+  const out: AirportGroundDelay[] = [];
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue;
+    const r = item as Record<string, unknown>;
+    const airport = (pickString(r.airport, r.iata, r.icao, r.location) ?? '').toUpperCase();
+    if (!airport) continue;
+    out.push({
+      airport,
+      reason: pickString(r.reason, r.cause, r.eventType) ?? 'unspecified',
+      avgDelayMinutes: pickFinite(r.avgDelay, r.avg_delay_minutes, r.average_delay_minutes),
+      maxDelayMinutes: pickFinite(r.maxDelay, r.max_delay_minutes),
+      programType: classifyProgram(pickString(r.eventType, r.programType, r.type) ?? ''),
+      startedAt: parseTimestamp(r.startTime, r.startedAt),
+      endsAt: parseTimestamp(r.endTime, r.endsAt),
+    });
+  }
+  return out;
+}
+
+function classifyProgram(raw: string): AirportGroundDelay['programType'] {
+  const u = raw.toUpperCase();
+  if (u.includes('STOP')) return 'ground_stop';
+  if (u.includes('GROUND') || u.includes('GDP')) return 'ground_delay';
+  if (u.includes('ARRIVAL') || u.includes('AAR')) return 'arrival_delay';
+  return 'other';
+}
+
+// VAAC ash normalizer
+
+export function normalizeVolcanicAsh(payload: unknown): VolcanicAshAdvisory[] {
+  const items = extractItems(payload, ['data', 'features', 'volcanoes', 'advisories']);
+  const out: VolcanicAshAdvisory[] = [];
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue;
+    const r = item as Record<string, unknown>;
+    const props = (r.properties as Record<string, unknown> | undefined) ?? r;
+    const polygon = extractPolygon(r.geometry, props.coords, props.area);
+    if (polygon.length < 3) continue;
+    const text = pickString(props.text, props.advisoryText, props.rawText) ?? '';
+    const lo = pickFinite(props.altitudeLow, props.minAlt) ?? 0;
+    const hi = pickFinite(props.altitudeHi, props.maxAlt) ?? 0;
+    out.push({
+      id: pickString(props.id, props.advisoryId) ?? `vaac-${out.length}`,
+      volcano: pickString(props.volcano, props.name) ?? 'unknown',
+      polygon,
+      altitudeFt: { min: lo, max: hi },
+      validFrom: parseTimestamp(props.validFrom, props.startTime) ?? Date.now(),
+      validTo: parseTimestamp(props.validTo, props.endTime) ?? Date.now() + 6 * 3_600_000,
+      source: 'NOAA',
+      text,
+    });
+  }
+  return out;
+}
+
+// Helpers
+
+function extractItems(payload: unknown, keys: readonly string[]): unknown[] {
+  if (Array.isArray(payload)) return payload;
+  if (payload && typeof payload === 'object') {
+    const p = payload as Record<string, unknown>;
+    for (const key of keys) {
+      const v = p[key];
+      if (Array.isArray(v)) return v;
+    }
+  }
+  return [];
+}
+
+function pickString(...values: unknown[]): string | undefined {
+  for (const v of values) {
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  return undefined;
+}
+
+function pickFinite(...values: unknown[]): number | null {
+  for (const v of values) {
+    if (typeof v === 'number' && Number.isFinite(v)) return v;
+    if (typeof v === 'string' && v.trim()) {
+      const n = Number(v);
+      if (Number.isFinite(n)) return n;
+    }
+  }
+  return null;
+}
+
+function parseTimestamp(...values: unknown[]): number | null {
+  for (const v of values) {
+    if (typeof v === 'number' && Number.isFinite(v)) {
+      // Heuristic: <= 10 digits -> seconds, otherwise ms.
+      return v < 10_000_000_000 ? v * 1000 : v;
+    }
+    if (typeof v === 'string' && v.trim()) {
+      const t = Date.parse(v);
+      if (Number.isFinite(t)) return t;
+    }
+  }
+  return null;
+}

--- a/src/services/aviation/aviation-intel-service.ts
+++ b/src/services/aviation/aviation-intel-service.ts
@@ -1,0 +1,178 @@
+/**
+ * Aviation Intelligence Service — PR 1.
+ *
+ * Renderer-side wrapper that fetches the five aviation feeds via the
+ * sidecar (so CORS / API-key concerns are confined to the Node process)
+ * and returns typed envelopes. Cached for 5 minutes by default.
+ *
+ * Pure deterministic core lives in `aviation-intel-normalize.ts`; this
+ * module is the thin I/O layer.
+ */
+
+import { getApiBaseUrl } from '../runtime';
+import type {
+  AirportGroundDelay,
+  AviationFetchEnvelope,
+  AviationNotam,
+  AviationPirep,
+  AviationSigmet,
+  MilitaryAircraft,
+  VolcanicAshAdvisory,
+} from './aviation-intel-types';
+
+export type {
+  AviationNotam,
+  AviationSigmet,
+  AviationPirep,
+  MilitaryAircraft,
+  AirportGroundDelay,
+  VolcanicAshAdvisory,
+  AviationFetchEnvelope,
+} from './aviation-intel-types';
+
+const POLL_INTERVAL_MS = 5 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 12 * 1000;
+
+interface CacheEntry<T> {
+  envelope: AviationFetchEnvelope<T>;
+  fetchedAt: number;
+}
+
+const cache = new Map<string, CacheEntry<unknown>>();
+const inflight = new Map<string, Promise<AviationFetchEnvelope<unknown>>>();
+
+async function fetchWithCache<T>(
+  path: string,
+  defaultEnvelope: () => AviationFetchEnvelope<T>,
+): Promise<AviationFetchEnvelope<T>> {
+  const now = Date.now();
+  const hit = cache.get(path) as CacheEntry<T> | undefined;
+  if (hit && now - hit.fetchedAt < POLL_INTERVAL_MS) {
+    return hit.envelope;
+  }
+
+  const existing = inflight.get(path) as Promise<AviationFetchEnvelope<T>> | undefined;
+  if (existing) return existing;
+
+  const promise = (async (): Promise<AviationFetchEnvelope<T>> => {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+      const response = await fetch(`${getApiBaseUrl()}${path}`, { signal: controller.signal });
+      clearTimeout(timer);
+      if (!response.ok) {
+        const fallback = defaultEnvelope();
+        return { ...fallback, degraded: true, reason: `HTTP ${response.status}` };
+      }
+      const body = (await response.json()) as AviationFetchEnvelope<T>;
+      cache.set(path, { envelope: body, fetchedAt: now });
+      return body;
+    } catch (error) {
+      const fallback = defaultEnvelope();
+      return {
+        ...fallback,
+        degraded: true,
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    } finally {
+      inflight.delete(path);
+    }
+  })();
+
+  inflight.set(path, promise as Promise<AviationFetchEnvelope<unknown>>);
+  return promise;
+}
+
+function emptyEnvelope<T>(source: string): () => AviationFetchEnvelope<T> {
+  return () => ({
+    data: [],
+    fetchedAt: Date.now(),
+    degraded: true,
+    reason: 'unavailable',
+    source,
+  });
+}
+
+// Public fetchers
+
+export async function fetchNotams(): Promise<AviationFetchEnvelope<AviationNotam>> {
+  return fetchWithCache<AviationNotam>('/api/aviation/notams', emptyEnvelope('faa.gov/notamapi'));
+}
+
+export async function fetchSigmets(): Promise<AviationFetchEnvelope<AviationSigmet>> {
+  return fetchWithCache<AviationSigmet>(
+    '/api/aviation/sigmets',
+    emptyEnvelope('aviationweather.gov'),
+  );
+}
+
+export async function fetchPireps(): Promise<AviationFetchEnvelope<AviationPirep>> {
+  return fetchWithCache<AviationPirep>(
+    '/api/aviation/pireps',
+    emptyEnvelope('aviationweather.gov'),
+  );
+}
+
+export async function fetchMilitaryAircraft(): Promise<AviationFetchEnvelope<MilitaryAircraft>> {
+  return fetchWithCache<MilitaryAircraft>(
+    '/api/aviation/military',
+    emptyEnvelope('adsb.lol+opensky'),
+  );
+}
+
+export async function fetchAirportDelays(): Promise<AviationFetchEnvelope<AirportGroundDelay>> {
+  return fetchWithCache<AirportGroundDelay>('/api/aviation/delays', emptyEnvelope('nasstatus.faa.gov'));
+}
+
+export async function fetchVolcanicAsh(): Promise<AviationFetchEnvelope<VolcanicAshAdvisory>> {
+  return fetchWithCache<VolcanicAshAdvisory>(
+    '/api/aviation/volcanic-ash',
+    emptyEnvelope('aviationweather.gov'),
+  );
+}
+
+// Aggregate snapshot used by the panel + globe layer
+
+export interface AviationIntelSnapshot {
+  notams: AviationFetchEnvelope<AviationNotam>;
+  sigmets: AviationFetchEnvelope<AviationSigmet>;
+  pireps: AviationFetchEnvelope<AviationPirep>;
+  military: AviationFetchEnvelope<MilitaryAircraft>;
+  delays: AviationFetchEnvelope<AirportGroundDelay>;
+  volcanicAsh: AviationFetchEnvelope<VolcanicAshAdvisory>;
+}
+
+export async function fetchAviationIntelSnapshot(): Promise<AviationIntelSnapshot> {
+  const [notams, sigmets, pireps, military, delays, volcanicAsh] = await Promise.all([
+    fetchNotams(),
+    fetchSigmets(),
+    fetchPireps(),
+    fetchMilitaryAircraft(),
+    fetchAirportDelays(),
+    fetchVolcanicAsh(),
+  ]);
+  return { notams, sigmets, pireps, military, delays, volcanicAsh };
+}
+
+// TFR + presidential filtering helpers
+
+export function selectTfrs(notams: readonly AviationNotam[]): AviationNotam[] {
+  return notams.filter(
+    (n) => n.classification === 'TFR' || /TFR/i.test(n.text),
+  );
+}
+
+export function selectPresidentialTfrs(notams: readonly AviationNotam[]): AviationNotam[] {
+  return selectTfrs(notams).filter((n) => n.presidential);
+}
+
+export function clearAviationCache(): void {
+  cache.clear();
+  inflight.clear();
+}
+
+export const __TEST_HOOKS__ = {
+  cache,
+  inflight,
+  POLL_INTERVAL_MS,
+};

--- a/src/services/aviation/aviation-intel-types.ts
+++ b/src/services/aviation/aviation-intel-types.ts
@@ -1,0 +1,135 @@
+/**
+ * Aviation intelligence — public types.
+ *
+ * Five upstream feeds normalized to typed structures the panel + globe
+ * can consume without re-parsing. Pure data; no I/O.
+ */
+
+export type AviationFeedKind =
+  | 'notams'
+  | 'sigmets'
+  | 'pireps'
+  | 'military'
+  | 'delays';
+
+export interface AviationFetchEnvelope<T> {
+  data: T[];
+  fetchedAt: number;
+  /** True when the upstream returned an error or auth failure and the
+   *  envelope is empty by design. UI should show a degraded indicator,
+   *  not an error toast. */
+  degraded: boolean;
+  reason?: string;
+  source: string;
+}
+
+// NOTAM (FAA)
+
+export type NotamClassification = 'TFR' | 'FDC' | 'DOM' | 'INTL' | 'OTHER';
+
+export interface AviationNotam {
+  id: string;
+  notamNumber: string;
+  classification: NotamClassification;
+  affectedFir: string | null;
+  featureName: string | null;
+  icaoId: string | null;
+  text: string;
+  effectiveStart: number | null;
+  effectiveEnd: number | null;
+  /** Decoded location when the NOTAM contains a center+radius (TFRs do). */
+  center?: { lat: number; lon: number; radiusNm: number };
+  /** Decoded altitude band in feet AGL when present. */
+  altitudeFt?: { min: number | null; max: number | null };
+  /** True when the NOTAM text mentions presidential / VIP movement. */
+  presidential: boolean;
+}
+
+// SIGMET / AIRMET (NWS Aviation Weather Center)
+
+export type SigmetHazard =
+  | 'volcanic_ash'
+  | 'turbulence'
+  | 'icing'
+  | 'thunderstorm'
+  | 'mountain_obscuration'
+  | 'ifr'
+  | 'other';
+
+export interface AviationSigmet {
+  id: string;
+  hazard: SigmetHazard;
+  severity: 'light' | 'moderate' | 'severe' | 'extreme';
+  /** Parsed from the SIGMET text (e.g. "FL250-450"). */
+  altitudeFt?: { min: number; max: number };
+  /** Polygon ring (lat, lon pairs) when the upstream provided coords. */
+  polygon: { lat: number; lon: number }[];
+  text: string;
+  validFrom: number;
+  validTo: number;
+  /** AIRMET vs SIGMET — both share the same shape. */
+  isAirmet: boolean;
+}
+
+// PIREP (pilot reports)
+
+export type PirepHazard = 'turbulence' | 'icing' | 'wind_shear' | 'other';
+
+export interface AviationPirep {
+  id: string;
+  hazard: PirepHazard;
+  intensity: 'trace' | 'light' | 'moderate' | 'severe' | 'extreme';
+  altitudeFt: number | null;
+  lat: number | null;
+  lon: number | null;
+  reportedAt: number;
+  aircraftType: string | null;
+  rawText: string;
+}
+
+// Military aircraft
+
+export interface MilitaryAircraft {
+  icao24: string;
+  callsign: string | null;
+  /** Coarse classification from the callsign prefix or known ICAO24 list. */
+  type: 'transport' | 'tanker' | 'recon' | 'fighter' | 'bomber' | 'helo' | 'unknown';
+  country: string | null;
+  lat: number | null;
+  lon: number | null;
+  altitudeFt: number | null;
+  velocityKts: number | null;
+  heading: number | null;
+  squawk: string | null;
+  lastSeen: number;
+  /** True when emergency squawk is set. */
+  emergency: boolean;
+}
+
+// Airport ground delay programs
+
+export interface AirportGroundDelay {
+  airport: string;
+  reason: string;
+  /** Average delay in minutes; null when not yet computed by upstream. */
+  avgDelayMinutes: number | null;
+  /** Maximum delay in minutes; null when not provided. */
+  maxDelayMinutes: number | null;
+  programType: 'ground_stop' | 'ground_delay' | 'arrival_delay' | 'other';
+  startedAt: number | null;
+  endsAt: number | null;
+}
+
+// VAAC volcanic ash advisories — included in the SIGMET feed when active
+
+export interface VolcanicAshAdvisory {
+  id: string;
+  volcano: string;
+  /** Polygon of the active ash cloud. */
+  polygon: { lat: number; lon: number }[];
+  altitudeFt: { min: number; max: number };
+  validFrom: number;
+  validTo: number;
+  source: 'VAAC' | 'NOAA';
+  text: string;
+}


### PR DESCRIPTION
First of three PRs adding aviation intelligence to Crystal Ball.

## What this PR adds

Five aviation feeds normalized to typed envelopes:

- **NOTAMs (FAA)**: TFR + FDC parsing with center/radius + altitude band decoding, presidential VIP detection. Requires `FAA_NOTAM_CLIENT_ID/SECRET` env vars (free signup at developer.faa.gov); returns degraded envelope if missing.
- **SIGMETs/AIRMETs (AWC)**: hazard classifier (volcanic_ash / turbulence / icing / thunderstorm / mountain_obscuration / ifr), severity, polygon extraction. Free public feeds at aviationweather.gov.
- **PIREPs (AWC)**: pilot turbulence + icing reports with intensity grading.
- **Military aircraft**: adsb.lol /v2/mil primary (free), OpenSky states/all fallback (free, rate-limited). Callsign + aircraft-type classifier (transport / tanker / recon / fighter / bomber / helo).
- **Airport delays (FAA NAS Status)**: ground stop / ground delay / AAR.
- **Bonus**: VAAC volcanic ash advisories (aviationweather.gov/VolcanoJSON).

## Architecture

- Pure-deterministic core in [aviation-intel-normalize.ts](src/services/aviation/aviation-intel-normalize.ts) — input bytes → typed array, no I/O. 20 unit tests cover all five feeds plus malformed payload handling.
- Sidecar routes ([api/aviation/*.js](api/aviation/)) cache 5min, fail to `degraded: true` envelope on upstream error, never throw.
- Renderer service ([aviation-intel-service.ts](src/services/aviation/aviation-intel-service.ts)) wraps sidecar fetches with cache + in-flight dedup. Polls every 5min.

## Tests

`npm run typecheck` ✓ clean
`npx tsx --test src/services/aviation/__tests__/aviation-intel-normalize.test.mts` ✓ 20 pass / 0 fail

## What's next

- **PR 2**: AviationIntelPanel.ts — 5-tab UI panel (NOTAMs / SIGMETs / PIREPs / Military / Delays)
- **PR 3**: Globe aviation layer — TFR polygons + SIGMET zones + military aircraft entities + VAAC ash clouds

🤖 Generated with [Claude Code](https://claude.com/claude-code)