### PR TITLE
feat(economic): bundle FRED commodity/FX/vol + OFR FSI stress (PR 4/5)

### DIFF
--- a/api/__tests__/economic-stress.test.mjs
+++ b/api/__tests__/economic-stress.test.mjs
@@ -1,0 +1,178 @@
+/**
+ * Route-level coverage for api/economic/stress.js
+ *
+ * Verifies bundled FRED + OFR fetch, per-indicator degradation isolation
+ * (one broken upstream doesn't poison the rest), 90-day window cutoff in
+ * the OFR timeseries parser, OPTIONS / wrong-method, and cache TTL.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { invokeHandler, mockFetch } from './_test-utils.mjs';
+
+const mod = await import('../economic/stress.js');
+const handler = mod.default;
+const { parseOfrTimeseries, __resetCacheForTests } = mod;
+
+// ── parseOfrTimeseries ──────────────────────────────────────────────
+
+test('parseOfrTimeseries: handles raw array shape', () => {
+  const payload = [
+    [Date.parse('2026-04-01T00:00:00Z'), 1.5],
+    [Date.parse('2026-04-15T00:00:00Z'), 2.0],
+  ];
+  const out = parseOfrTimeseries(payload, '2026-01-01');
+  assert.equal(out.length, 2);
+  assert.deepEqual(out[0], { date: '2026-04-01', value: 1.5 });
+});
+
+test('parseOfrTimeseries: handles { data: [...] } shape', () => {
+  const payload = { data: [[Date.parse('2026-04-01T00:00:00Z'), 1.5]] };
+  const out = parseOfrTimeseries(payload, '2026-01-01');
+  assert.equal(out.length, 1);
+});
+
+test('parseOfrTimeseries: filters by since cutoff', () => {
+  const payload = [
+    [Date.parse('2025-01-01T00:00:00Z'), 1.0],     // outside window
+    [Date.parse('2026-04-01T00:00:00Z'), 2.0],
+  ];
+  const out = parseOfrTimeseries(payload, '2026-01-01');
+  assert.equal(out.length, 1);
+  assert.equal(out[0].value, 2.0);
+});
+
+test('parseOfrTimeseries: sorts ascending by date', () => {
+  const payload = [
+    [Date.parse('2026-04-15T00:00:00Z'), 2.0],
+    [Date.parse('2026-04-01T00:00:00Z'), 1.5],
+  ];
+  const out = parseOfrTimeseries(payload, '2026-01-01');
+  assert.deepEqual(out.map((o) => o.date), ['2026-04-01', '2026-04-15']);
+});
+
+test('parseOfrTimeseries: drops malformed rows safely', () => {
+  const payload = [
+    [Date.parse('2026-04-01T00:00:00Z'), 1.5],
+    null,
+    'not an array',
+    [Date.parse('2026-04-15T00:00:00Z'), 'NaN-string'],
+    [Date.parse('2026-05-01T00:00:00Z'), 3.0],
+  ];
+  const out = parseOfrTimeseries(payload, '2026-01-01');
+  assert.equal(out.length, 2);
+});
+
+test('parseOfrTimeseries: empty/non-array payload returns []', () => {
+  assert.deepEqual(parseOfrTimeseries(null, '2026-01-01'), []);
+  assert.deepEqual(parseOfrTimeseries({}, '2026-01-01'), []);
+  assert.deepEqual(parseOfrTimeseries('garbage', '2026-01-01'), []);
+});
+
+// ── HTTP contract ────────────────────────────────────────────────────
+
+test('handler: OPTIONS returns 204', async () => {
+  const { res } = await invokeHandler(handler, { method: 'OPTIONS' });
+  assert.equal(res.statusCode, 204);
+});
+
+test('handler: rejects non-GET methods', async () => {
+  const { res } = await invokeHandler(handler, { method: 'POST' });
+  assert.equal(res.statusCode, 405);
+});
+
+test('handler: missing FRED_API_KEY → FRED indicators degraded, OFR still attempted', async () => {
+  __resetCacheForTests();
+  const prevKey = process.env.FRED_API_KEY;
+  delete process.env.FRED_API_KEY;
+  const restore = mockFetch(new Map([
+    ['financialresearch.gov', { status: 200, json: [[Date.now(), 0.5]] }],
+  ]));
+  try {
+    const { res } = await invokeHandler(handler, {});
+    assert.equal(res.statusCode, 200);
+    const fredIndicators = res.body.indicators.filter((i) => i.source === 'fred');
+    assert.equal(fredIndicators.length, 4);
+    for (const ind of fredIndicators) {
+      assert.equal(ind.degraded, true);
+      assert.match(ind.reason, /FRED_API_KEY not set/);
+    }
+    const ofr = res.body.indicators.find((i) => i.source === 'ofr');
+    assert.ok(ofr);
+    assert.notEqual(ofr.degraded, true);     // OFR still succeeded
+  } finally {
+    if (prevKey) process.env.FRED_API_KEY = prevKey;
+    restore();
+  }
+});
+
+test('handler: happy path bundles 4 FRED + 1 OFR indicators', async () => {
+  __resetCacheForTests();
+  process.env.FRED_API_KEY = 'fake-key';
+  const fredPayload = {
+    observations: [
+      { date: '2026-04-01', value: '100.0' },
+      { date: '2026-04-15', value: '102.5' },
+    ],
+  };
+  const restore = mockFetch(new Map([
+    ['stlouisfed.org', { status: 200, json: fredPayload }],
+    ['financialresearch.gov', { status: 200, json: [[Date.parse('2026-04-15T00:00:00Z'), 0.5]] }],
+  ]));
+  try {
+    const { res } = await invokeHandler(handler, {});
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.indicators.length, 5);
+    assert.equal(res.body.degraded, false);
+    const brent = res.body.indicators.find((i) => i.id === 'DCOILBRENTEU');
+    assert.ok(brent);
+    assert.equal(brent.latest.value, 102.5);
+    assert.equal(brent.history.length, 2);
+    const ofr = res.body.indicators.find((i) => i.id === 'OFRFSI');
+    assert.ok(ofr);
+    assert.equal(ofr.latest.value, 0.5);
+  } finally {
+    delete process.env.FRED_API_KEY;
+    restore();
+  }
+});
+
+test('handler: degraded:true on bundle ONLY if every indicator is degraded', async () => {
+  __resetCacheForTests();
+  process.env.FRED_API_KEY = 'fake-key';
+  const restore = mockFetch(new Map([
+    ['stlouisfed.org', { status: 503, json: {} }],
+    ['financialresearch.gov', { status: 503, json: {} }],
+  ]));
+  try {
+    const { res } = await invokeHandler(handler, {});
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.degraded, true);
+    for (const ind of res.body.indicators) assert.equal(ind.degraded, true);
+  } finally {
+    delete process.env.FRED_API_KEY;
+    restore();
+  }
+});
+
+test('handler: warm cache skips upstream within TTL', async () => {
+  __resetCacheForTests();
+  process.env.FRED_API_KEY = 'fake-key';
+  let upstreamCalls = 0;
+  const restore = mockFetch(new Map([
+    ['stlouisfed.org', { status: 200, json: { observations: [{ date: '2026-04-01', value: '1' }] } }],
+    ['financialresearch.gov', { status: 200, json: [] }],
+  ]));
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = (url, init) => { upstreamCalls++; return origFetch(url, init); };
+  try {
+    await invokeHandler(handler, {});       // cold → 5 calls (4 FRED + 1 OFR)
+    const coldCalls = upstreamCalls;
+    await invokeHandler(handler, {});       // warm → no calls
+    assert.equal(upstreamCalls, coldCalls);
+    assert.ok(coldCalls >= 5, `expected at least 5 cold-start fetches, got ${coldCalls}`);
+  } finally {
+    globalThis.fetch = origFetch;
+    delete process.env.FRED_API_KEY;
+    restore();
+  }
+});

--- a/api/economic/stress.js
+++ b/api/economic/stress.js
@@ -1,0 +1,156 @@
+/**
+ * Economic stress bundle — FRED commodity/FX/vol series + OFR FSI.
+ *
+ * GET /api/economic/stress
+ *   → { indicators: StressIndicator[], updatedAt, source, degraded? }
+ *
+ * Indicators bundled:
+ *   - Brent crude oil      (FRED: DCOILBRENTEU)
+ *   - Gold spot            (FRED: GOLDAMGBD228NLBM)         [historical series]
+ *   - USD/EUR exchange     (FRED: DEXUSEU)
+ *   - VIX equity volatility (FRED: VIXCLS)
+ *   - OFR Financial Stress Index (data.financialresearch.gov: OFRFSI)
+ *
+ * Each indicator carries the latest observation plus a rolling 90-day
+ * window so consumers can plot a sparkline / compute deltas without a
+ * second roundtrip.
+ *
+ * Cache: 1 h. FRED daily series rarely move within an hour and the OFR
+ * FSI publishes daily, so an hourly cadence is the minimum useful TTL.
+ *
+ * Why bundled rather than per-series client orchestration: stress
+ * indicators are correlated — a consumer asking "is the macro under
+ * stress?" wants all of them at once, not 5 round-trips. The caller
+ * still gets per-indicator degraded flags so a single broken upstream
+ * doesn't poison the whole response.
+ */
+
+import { getCorsHeaders, isDisallowedOrigin } from '../_cors.js';
+
+export const config = { runtime: 'edge' };
+
+const CACHE_TTL_MS = 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 12_000;
+
+const WINDOW_DAYS = 90;
+
+const FRED_SERIES = Object.freeze([
+  { id: 'DCOILBRENTEU',      label: 'Brent crude oil ($/bbl)',     category: 'commodity' },
+  { id: 'GOLDAMGBD228NLBM',  label: 'Gold London PM fix ($/oz)',   category: 'commodity' },
+  { id: 'DEXUSEU',           label: 'USD/EUR exchange',            category: 'fx' },
+  { id: 'VIXCLS',            label: 'VIX equity volatility',       category: 'volatility' },
+]);
+
+const OFR_FSI_URL = 'https://data.financialresearch.gov/v1/series/timeseries?mnemonic=OFRFSI';
+//  ^ The spec wrote `?mnemonic=OFR_FSI&endpoint=get`; the published mnemonic
+//    is `OFRFSI` (no underscore) and the timeseries endpoint returns
+//    [[ms, value], ...] which is what we want for the 90-day window.
+
+let _cache = null;
+
+const j = (payload, status, cors) => Response.json(payload, {
+  status, headers: { 'content-type': 'application/json; charset=utf-8', ...cors },
+});
+
+export default async function handler(req) {
+  const cors = getCorsHeaders(req, 'GET, OPTIONS');
+  if (isDisallowedOrigin(req)) return j({ error: 'Origin not allowed' }, 403, cors);
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
+  if (req.method !== 'GET') return j({ error: 'Method not allowed' }, 405, cors);
+  if (_cache && Date.now() - _cache.at < CACHE_TTL_MS) return j(_cache.payload, 200, cors);
+
+  const fredKey = process.env.FRED_API_KEY;
+  const sinceIso = isoDay(Date.now() - WINDOW_DAYS * 24 * 60 * 60 * 1000);
+
+  // Per-series fetches run in parallel; each handles its own failure so
+  // a single broken upstream degrades only itself, not the whole bundle.
+  const indicators = await Promise.all([
+    ...FRED_SERIES.map((meta) => fetchFredSeries(meta, fredKey, sinceIso)),
+    fetchOfrFsi(sinceIso),
+  ]);
+
+  const result = {
+    indicators,
+    updatedAt: Date.now(),
+    source: 'fred+ofr',
+    window: { sinceIso, days: WINDOW_DAYS },
+    degraded: indicators.every((i) => i.degraded === true),
+  };
+  _cache = { at: Date.now(), payload: result };
+  return j(result, 200, cors);
+}
+
+async function fetchFredSeries(meta, apiKey, sinceIso) {
+  const baseShape = { id: meta.id, label: meta.label, category: meta.category, source: 'fred' };
+  if (!apiKey) {
+    return { ...baseShape, degraded: true, reason: 'FRED_API_KEY not set', latest: null, history: [] };
+  }
+  const params = new URLSearchParams({
+    series_id: meta.id, api_key: apiKey, file_type: 'json',
+    sort_order: 'asc', observation_start: sinceIso,
+  });
+  const url = `https://api.stlouisfed.org/fred/series/observations?${params.toString()}`;
+  try {
+    const r = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    if (!r.ok) {
+      return { ...baseShape, degraded: true, reason: `FRED HTTP ${r.status}`, latest: null, history: [] };
+    }
+    const payload = await r.json();
+    const observations = Array.isArray(payload?.observations) ? payload.observations : [];
+    const history = observations
+      .map((o) => ({ date: o?.date ?? '', value: o?.value === '.' ? null : Number.parseFloat(o?.value) }))
+      .filter((o) => o.date && Number.isFinite(o.value));
+    const latest = history.length ? history[history.length - 1] : null;
+    return { ...baseShape, latest, history };
+  } catch (error) {
+    return { ...baseShape, degraded: true, reason: `FRED fetch failed: ${error?.message ?? error}`, latest: null, history: [] };
+  }
+}
+
+async function fetchOfrFsi(sinceIso) {
+  const baseShape = {
+    id: 'OFRFSI', label: 'OFR Financial Stress Index',
+    category: 'composite', source: 'ofr',
+  };
+  try {
+    const r = await fetch(OFR_FSI_URL, {
+      headers: { Accept: 'application/json', 'User-Agent': 'CrystalBall (ofr-fsi)' },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!r.ok) {
+      return { ...baseShape, degraded: true, reason: `OFR HTTP ${r.status}`, latest: null, history: [] };
+    }
+    const payload = await r.json();
+    const history = parseOfrTimeseries(payload, sinceIso);
+    const latest = history.length ? history[history.length - 1] : null;
+    return { ...baseShape, latest, history };
+  } catch (error) {
+    return { ...baseShape, degraded: true, reason: `OFR fetch failed: ${error?.message ?? error}`, latest: null, history: [] };
+  }
+}
+
+/** OFR returns either `[[ms, value], ...]` (timeseries endpoint) or
+ *  `{ data: [[ms, value], ...] }`. Normalize and filter to the window.
+ *  Exported for unit testing. */
+export function parseOfrTimeseries(payload, sinceIso) {
+  let rows = [];
+  if (Array.isArray(payload)) rows = payload;
+  else if (Array.isArray(payload?.data)) rows = payload.data;
+  const sinceMs = Date.parse(sinceIso) || 0;
+  const out = [];
+  for (const row of rows) {
+    if (!Array.isArray(row) || row.length < 2) continue;
+    const [tsRaw, valRaw] = row;
+    const ts = typeof tsRaw === 'number' ? tsRaw : Date.parse(String(tsRaw));
+    const value = typeof valRaw === 'number' ? valRaw : Number.parseFloat(valRaw);
+    if (!Number.isFinite(ts) || !Number.isFinite(value)) continue;
+    if (ts < sinceMs) continue;
+    out.push({ date: new Date(ts).toISOString().slice(0, 10), value });
+  }
+  out.sort((a, b) => a.date.localeCompare(b.date));
+  return out;
+}
+
+function isoDay(ms) { return new Date(ms).toISOString().slice(0, 10); }
+
+export function __resetCacheForTests() { _cache = null; }


### PR DESCRIPTION
## What
Adds \`/api/economic/stress\` — a bundled fetcher that pulls 5 macro-stress indicators in parallel and exposes them with 90-day history per indicator.

## Why bundled?
Stress indicators are correlated. A consumer asking "is the macro under stress?" wants all five at once, not 5 round-trips. Per-indicator \`degraded\` flags isolate failures so one broken upstream doesn't poison the whole response. Bundle-level \`degraded:true\` only when every indicator is degraded.

## Indicators
| ID | Source | Label |
| --- | --- | --- |
| DCOILBRENTEU | FRED | Brent crude oil ($/bbl) |
| GOLDAMGBD228NLBM | FRED | Gold London PM fix ($/oz) |
| DEXUSEU | FRED | USD/EUR exchange |
| VIXCLS | FRED | VIX equity volatility |
| OFRFSI | OFR | Financial Stress Index |

## Spec deviations (intentional)
- **OFR mnemonic**: spec listed \`OFR_FSI\` but the OFR data API publishes it as \`OFRFSI\` (no underscore) on the \`/v1/series/timeseries\` endpoint. URL adjusted accordingly.

## Files
- \`api/economic/stress.js\` (new) — sidecar route, 1h cache, parallel fetch, per-indicator failure isolation
- \`api/__tests__/economic-stress.test.mjs\` (new) — 12 tests (parser shape variants, window cutoff, env-gate, full happy path, full-degraded, warm-cache TTL)

## Verification
- \`node --test api/__tests__/economic-stress.test.mjs\` → 12/12 pass
- \`npm run typecheck:all\` → clean

## Tunables
\`CACHE_TTL_MS=1h\`, \`WINDOW_DAYS=90\`, \`FETCH_TIMEOUT_MS=12s\` exposed at top of file.