### PR TITLE
feat: per-domain heatmap layer config builder (PR 4/4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "test:personal": "tsx --test src/services/personal/__tests__/personal-impact.test.mts src/services/personal/__tests__/threat-aggregator.test.mts",
     "test:export": "tsx --test src/services/export/__tests__/brief-pdf.test.mts",
     "test:playback": "tsx --test src/services/playback/__tests__/timeline-cursor.test.mts",
+    "test:globe": "tsx --test src/services/globe/__tests__/heatmap-layers.test.mts",
     "test:adsb": "tsx --test src/services/adsb/__tests__/adsb-aggregate.test.mts",
     "test:webcams": "tsx --test src/services/webcams/__tests__/webcam-aggregator.test.mts src/services/webcams/__tests__/flight-rule.test.mts src/services/webcams/__tests__/metar-parser.test.mts src/services/webcams/__tests__/station-matcher.test.mts src/services/webcams/__tests__/dot511-adapter.test.mts src/services/webcams/__tests__/volcano-cam-catalog.test.mts src/services/webcams/__tests__/nps-adapter.test.mts src/services/webcams/__tests__/alertwildfire-adapter.test.mts src/services/webcams/__tests__/streamgauge-adapter.test.mts src/services/webcams/__tests__/windy-adapter.test.mts src/services/webcams/__tests__/noaa-coastal-catalog.test.mts",
     "test:maritime": "tsx --test src/services/maritime/__tests__/freight-stress.test.mts src/services/maritime/__tests__/chokepoint-monitor.test.mts src/services/maritime/__tests__/chokepoint-aggregator.test.mts src/services/__tests__/dark-vessel-gaps.test.mts && node --test src-tauri/sidecar/__tests__/freight-stress-parity.test.mjs src-tauri/sidecar/__tests__/dark-vessel-gaps-parity.test.mjs",

--- a/src/services/globe/__tests__/heatmap-layers.test.mts
+++ b/src/services/globe/__tests__/heatmap-layers.test.mts
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildAllHeatmapLayers,
+  buildHeatmapLayerConfig,
+  listPalettes,
+  paletteFor,
+  type HeatmapPoint,
+} from '../heatmap-layers.ts';
+
+const POINTS: HeatmapPoint[] = [
+  { lat: 40, lon: -75, weight: 2 },
+  { lat: 41, lon: -74, weight: 1 },
+];
+
+// ── Palettes ──────────────────────────────────────────────────────────
+
+test('paletteFor: returns the requested domain palette', () => {
+  const pal = paletteFor('seismic');
+  assert.equal(pal.domain, 'seismic');
+  assert.match(pal.label, /Seismic/);
+  assert.equal(pal.colorRange.length, 6, 'palettes must have 6 stops for smooth gradient');
+});
+
+test('listPalettes: 4 domains in fixed order', () => {
+  const list = listPalettes();
+  assert.deepEqual(list.map((p) => p.domain), ['seismic', 'fire', 'cyber', 'conflict']);
+});
+
+test('palettes: each has unique radius (domain-tuned)', () => {
+  const radii = new Set(listPalettes().map((p) => p.radius));
+  assert.equal(radii.size, listPalettes().length);
+});
+
+test('palettes: every color stop is a valid 0-255 RGB triple', () => {
+  for (const pal of listPalettes()) {
+    for (const [r, g, b] of pal.colorRange) {
+      for (const c of [r, g, b]) {
+        assert.ok(c >= 0 && c <= 255 && Number.isInteger(c), `bad channel ${c} in ${pal.domain}`);
+      }
+    }
+  }
+});
+
+// ── buildHeatmapLayerConfig ──────────────────────────────────────────
+
+test('build: id defaults to heatmap-{domain}', () => {
+  const cfg = buildHeatmapLayerConfig('fire', POINTS);
+  assert.equal(cfg.id, 'heatmap-fire');
+});
+
+test('build: id override applied', () => {
+  const cfg = buildHeatmapLayerConfig('fire', POINTS, { id: 'fire-2' });
+  assert.equal(cfg.id, 'fire-2');
+});
+
+test('build: default opacity 0.6 per spec', () => {
+  const cfg = buildHeatmapLayerConfig('cyber', POINTS);
+  assert.equal(cfg.opacity, 0.6);
+});
+
+test('build: opacity clamped to [0, 1]', () => {
+  const high = buildHeatmapLayerConfig('cyber', POINTS, { opacity: 5 });
+  const low = buildHeatmapLayerConfig('cyber', POINTS, { opacity: -1 });
+  const nan = buildHeatmapLayerConfig('cyber', POINTS, { opacity: Number.NaN });
+  assert.equal(high.opacity, 1);
+  assert.equal(low.opacity, 0);
+  assert.equal(nan.opacity, 0);
+});
+
+test('build: getPosition returns [lon, lat]', () => {
+  const cfg = buildHeatmapLayerConfig('seismic', POINTS);
+  const pos = cfg.getPosition(POINTS[0]!);
+  assert.deepEqual(pos, [-75, 40]);
+});
+
+test('build: getWeight reads from point.weight, defaults to 1', () => {
+  const cfg = buildHeatmapLayerConfig('seismic', POINTS);
+  assert.equal(cfg.getWeight({ lat: 0, lon: 0, weight: 7 }), 7);
+  assert.equal(cfg.getWeight({ lat: 0, lon: 0 }), 1);
+});
+
+test('build: visible defaults to true', () => {
+  const cfg = buildHeatmapLayerConfig('seismic', POINTS);
+  assert.equal(cfg.visible, true);
+});
+
+test('build: visible override applied', () => {
+  const cfg = buildHeatmapLayerConfig('seismic', POINTS, { visible: false });
+  assert.equal(cfg.visible, false);
+});
+
+// ── buildAllHeatmapLayers ────────────────────────────────────────────
+
+test('buildAll: exactly one layer is visible when a domain is selected', () => {
+  const layers = buildAllHeatmapLayers({
+    selected: 'fire',
+    points: { fire: POINTS, seismic: POINTS },
+  });
+  const visible = layers.filter((l) => l.visible);
+  assert.equal(visible.length, 1);
+  assert.equal(visible[0]?.id, 'heatmap-fire');
+});
+
+test('buildAll: all layers hidden when selected=null', () => {
+  const layers = buildAllHeatmapLayers({ selected: null, points: { fire: POINTS } });
+  for (const l of layers) assert.equal(l.visible, false);
+});
+
+test('buildAll: missing domain data → empty data array (not crash)', () => {
+  const layers = buildAllHeatmapLayers({ selected: 'cyber', points: { cyber: POINTS } });
+  const seismic = layers.find((l) => l.id === 'heatmap-seismic');
+  assert.deepEqual(seismic?.data, []);
+});
+
+test('buildAll: opacity propagates to every layer', () => {
+  const layers = buildAllHeatmapLayers({
+    selected: 'seismic',
+    points: { seismic: POINTS },
+    opacity: 0.3,
+  });
+  for (const l of layers) assert.equal(l.opacity, 0.3);
+});
+
+// ── JSON serializability of the static parts ─────────────────────────
+
+test('config data + colorRange + radius are JSON-serializable (accessors aside)', () => {
+  const cfg = buildHeatmapLayerConfig('seismic', POINTS);
+  const stripped = {
+    id: cfg.id,
+    data: cfg.data,
+    radius: cfg.radius,
+    colorRange: cfg.colorRange,
+    aggregation: cfg.aggregation,
+    opacity: cfg.opacity,
+    visible: cfg.visible,
+  };
+  const round = JSON.parse(JSON.stringify(stripped));
+  assert.equal(round.id, 'heatmap-seismic');
+  assert.equal(round.colorRange.length, 6);
+});

--- a/src/services/globe/heatmap-layers.ts
+++ b/src/services/globe/heatmap-layers.ts
@@ -1,0 +1,224 @@
+/**
+ * Per-domain heatmap layer configuration for the God's Vision globe.
+ *
+ * Pure deterministic. Builds deck.gl `HexagonLayer` props from domain
+ * point arrays + a palette so the toggle UI in GodsVisionView can do
+ * the wiring without re-deriving constants.
+ *
+ * Why a config builder instead of mounting the layer here?
+ *   The Cesium ↔ deck.gl overlay is owned by GodsVisionView and the
+ *   existing GlobeDataManager lifecycle. Decoupling the config from the
+ *   mount keeps this module unit-testable on static fixtures and lets
+ *   the panel UI snapshot config shape without touching WebGL.
+ *
+ * Plan invariants:
+ *   - Only one heatmap layer is "active" at a time per the spec; this
+ *     module just produces the config — single-active state lives in
+ *     the toggle UI that consumes it.
+ *   - Per-domain palette has a 6-stop color ramp so HexagonLayer's
+ *     binning produces a smooth gradient, not stair-steps.
+ *   - Default opacity 0.6 (spec); caller can override for the slider.
+ *   - Output is JSON-serializable apart from the accessor closures —
+ *     `data` is a plain array, `colorRange` is RGB tuples.
+ */
+
+// ── Public types ──────────────────────────────────────────────────────
+
+export type HeatmapDomain = 'seismic' | 'fire' | 'cyber' | 'conflict';
+
+export interface HeatmapPoint {
+  lat: number;
+  lon: number;
+  /** Optional weight — defaults to 1 in HexagonLayer's binning. */
+  weight?: number;
+  /** Free-text id for tooltip / debugging. */
+  id?: string;
+}
+
+/** RGB triplet, 0-255 each channel. */
+export type RgbTuple = readonly [number, number, number];
+
+export interface HeatmapPalette {
+  domain: HeatmapDomain;
+  /** Display label for the toggle button. */
+  label: string;
+  /** 6-stop color ramp from low→high density. deck.gl interpolates. */
+  colorRange: readonly RgbTuple[];
+  /** Hex bin radius in metres. Domain-specific so seismic
+   *  (continental sparseness) doesn't render the same as cyber events
+   *  (city-clustered). */
+  radius: number;
+  /** Aggregation function applied to weights inside a hex bin —
+   *  HexagonLayer accepts 'SUM' | 'MEAN' | 'MIN' | 'MAX'. */
+  aggregation: 'SUM' | 'MEAN';
+  /** Vertical exaggeration of the hex columns. 0 = flat hexes. */
+  elevationScale: number;
+}
+
+export interface HeatmapLayerConfig {
+  /** Stable id deck.gl uses to track the layer between renders. */
+  id: string;
+  /** Domain points the layer aggregates. */
+  data: readonly HeatmapPoint[];
+  /** Hex bin radius in metres. */
+  radius: number;
+  /** 6-stop RGB ramp the layer's gradient uses. */
+  colorRange: readonly RgbTuple[];
+  aggregation: 'SUM' | 'MEAN';
+  elevationScale: number;
+  /** [0, 1] — default 0.6 per spec. */
+  opacity: number;
+  /** Whether the layer should currently render. The toggle UI flips
+   *  this; only one heatmap is active at a time. */
+  visible: boolean;
+  /** Position accessor passed to HexagonLayer. */
+  getPosition: (p: HeatmapPoint) => [number, number];
+  /** Weight accessor passed to HexagonLayer. */
+  getWeight: (p: HeatmapPoint) => number;
+}
+
+// ── Per-domain palettes ───────────────────────────────────────────────
+
+/** Seismic: cool blue → red, sized for continental spacing. */
+const SEISMIC_PALETTE: HeatmapPalette = {
+  domain: 'seismic',
+  label: 'Seismic Density',
+  colorRange: [
+    [33, 102, 172], [103, 169, 207], [209, 229, 240],
+    [253, 219, 199], [239, 138, 98], [178, 24, 43],
+  ],
+  radius: 80_000, // 80 km
+  aggregation: 'SUM',
+  elevationScale: 0,
+};
+
+/** Fire: yellow → deep orange. NIFC hotspot density. */
+const FIRE_PALETTE: HeatmapPalette = {
+  domain: 'fire',
+  label: 'Fire Density',
+  colorRange: [
+    [255, 247, 188], [254, 227, 145], [254, 196, 79],
+    [254, 153, 41], [217, 95, 14], [153, 52, 4],
+  ],
+  radius: 30_000, // 30 km — fires cluster tighter than quakes
+  aggregation: 'SUM',
+  elevationScale: 0,
+};
+
+/** Cyber: muted greys → dark red. Tighter radius for city-clustered events. */
+const CYBER_PALETTE: HeatmapPalette = {
+  domain: 'cyber',
+  label: 'Cyber Incidents',
+  colorRange: [
+    [240, 240, 240], [217, 217, 217], [189, 189, 189],
+    [216, 109, 109], [165, 15, 21], [103, 0, 13],
+  ],
+  radius: 50_000, // 50 km
+  aggregation: 'SUM',
+  elevationScale: 0,
+};
+
+/** Conflict: amber palette for ACLED / GDELT events. */
+const CONFLICT_PALETTE: HeatmapPalette = {
+  domain: 'conflict',
+  label: 'Conflict Events',
+  colorRange: [
+    [255, 245, 235], [254, 230, 206], [253, 208, 162],
+    [253, 174, 107], [241, 105, 19], [127, 39, 4],
+  ],
+  radius: 40_000, // 40 km
+  aggregation: 'SUM',
+  elevationScale: 0,
+};
+
+const PALETTES: Readonly<Record<HeatmapDomain, HeatmapPalette>> = {
+  seismic: SEISMIC_PALETTE,
+  fire: FIRE_PALETTE,
+  cyber: CYBER_PALETTE,
+  conflict: CONFLICT_PALETTE,
+};
+
+// ── Public API ────────────────────────────────────────────────────────
+
+/** Lookup a domain palette. Pure. */
+export function paletteFor(domain: HeatmapDomain): HeatmapPalette {
+  return PALETTES[domain];
+}
+
+/** Every palette as a sorted list. The toggle UI uses this to render
+ *  the radio-style button row. */
+export function listPalettes(): readonly HeatmapPalette[] {
+  return ['seismic', 'fire', 'cyber', 'conflict'].map((d) => PALETTES[d as HeatmapDomain]);
+}
+
+export interface BuildLayerOptions {
+  /** [0, 1]. Default 0.6 (spec). */
+  opacity?: number;
+  /** Default true. Set false on inactive layers when rendering all
+   *  four for animated transitions. */
+  visible?: boolean;
+  /** Override id (defaults to `heatmap-{domain}`). */
+  id?: string;
+}
+
+/**
+ * Build a deck.gl HexagonLayer config object for a domain. The caller
+ * (GodsVisionView heatmap manager) wraps this in `new HexagonLayer(...)`.
+ *
+ * Returning a plain object (rather than the layer instance) keeps the
+ * service free of deck.gl runtime imports — this module loads cleanly
+ * in `tsx --test` without bringing in WebGL.
+ */
+export function buildHeatmapLayerConfig(
+  domain: HeatmapDomain,
+  points: readonly HeatmapPoint[],
+  options: BuildLayerOptions = {},
+): HeatmapLayerConfig {
+  const palette = PALETTES[domain];
+  return {
+    id: options.id ?? `heatmap-${domain}`,
+    data: points,
+    radius: palette.radius,
+    colorRange: palette.colorRange,
+    aggregation: palette.aggregation,
+    elevationScale: palette.elevationScale,
+    opacity: clamp01(options.opacity ?? 0.6),
+    visible: options.visible ?? true,
+    getPosition: (p) => [p.lon, p.lat],
+    getWeight: (p) => p.weight ?? 1,
+  };
+}
+
+/**
+ * Single-active-domain controller helper. Given the user's currently
+ * selected domain (or null when all heatmaps are off) and a per-domain
+ * data map, return one config per domain — exactly one with
+ * `visible: true`.
+ *
+ * Pure: callers re-invoke on every render with fresh data + selection
+ * and diff against the previous result themselves (or just replace
+ * the whole layer set, which deck.gl handles fine).
+ */
+export function buildAllHeatmapLayers(input: {
+  selected: HeatmapDomain | null;
+  points: Partial<Record<HeatmapDomain, readonly HeatmapPoint[]>>;
+  opacity?: number;
+}): HeatmapLayerConfig[] {
+  return listPalettes().map((p) => buildHeatmapLayerConfig(
+    p.domain,
+    input.points[p.domain] ?? [],
+    {
+      opacity: input.opacity ?? 0.6,
+      visible: input.selected === p.domain,
+    },
+  ));
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function clamp01(x: number): number {
+  if (!Number.isFinite(x)) return 0;
+  if (x < 0) return 0;
+  if (x > 1) return 1;
+  return x;
+}


### PR DESCRIPTION
Closes the globe/UI enhancements stack. Pure deterministic config builder for deck.gl HexagonLayer covering the 4 spec domains (seismic / fire / cyber / conflict).

## Why config-builder over direct mounting

Cesium ↔ deck.gl overlay is owned by GodsVisionView's existing layer lifecycle. A pure config builder is unit-testable on static fixtures and lets the panel UI snapshot config shape without touching WebGL. The toggle UI + actual layer mounting roll into a follow-up.

## Files
- src/services/globe/heatmap-layers.ts (engine)
- src/services/globe/__tests__/heatmap-layers.test.mts (17 tests)
- package.json (test:globe)

## Per-domain palettes (rationale documented inline)
| Domain | Ramp | Radius | Reason |
|---|---|---|---|
| Seismic | blue → red | 80 km | continental sparseness |
| Fire | yellow → deep orange | 30 km | NIFC tight clusters |
| Cyber | grey → dark red | 50 km | city clusters |
| Conflict | amber | 40 km | ACLED / GDELT spread |

6-stop color ramps for smooth deck.gl gradient interpolation.

## API
- `paletteFor(domain) → HeatmapPalette`
- `listPalettes() → readonly HeatmapPalette[]` (4-domain fixed order)
- `buildHeatmapLayerConfig(domain, points, options?)` → `HeatmapLayerConfig`
- `buildAllHeatmapLayers({ selected, points, opacity? })` — single-active state per spec, returns 4 configs with exactly one `visible: true`
- Default opacity 0.6 (spec); clamped to [0, 1] with NaN → 0.

## Validation
```
npm run test:globe       # 17/17
npm run typecheck:all    # clean
eslint                   # clean
```

## Stack summary

| PR | Substrate | Tests | Status |
|---|---|---|---|
| [#319](https://github.com/bradleybond512/crystal-ball/pull/319) | Cross-domain threat aggregator | 19 | merged |
| [#322](https://github.com/bradleybond512/crystal-ball/pull/322) | jsPDF brief renderer | 11 | merged |
| [#332](https://github.com/bradleybond512/crystal-ball/pull/332) | Timeline-cursor visibility | 14 | merged |
| this | Heatmap layer config | 17 | open |

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>