### PR TITLE
feat(spaceweather): EEW status-bar G3+ banner + globe-overlay descriptors (PR 3/3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "test:geopolitics": "tsx --test src/services/geopolitics/__tests__/grayzone-classifier.test.mts",
     "test:finance": "tsx --test src/services/finance/__tests__/stress-monitor.test.mts",
     "test:climate": "tsx --test src/services/climate/__tests__/enso-monitor.test.mts",
-    "test:spaceweather": "tsx --test src/services/spaceweather/__tests__/swpc-monitor.test.mts && node --test src-tauri/sidecar/__tests__/spaceweather-parity.test.mjs",
+    "test:spaceweather": "tsx --test src/services/spaceweather/__tests__/swpc-monitor.test.mts src/services/spaceweather/__tests__/globe-overlay.test.mts && node --test src-tauri/sidecar/__tests__/spaceweather-parity.test.mjs",
     "test:panels:smoke": "node tests/panels/run-harness.mjs",
     "test:components": "tsx --test src/components/__tests__/disease-outbreak-tabs.test.mts src/components/__tests__/space-weather-panel.test.mts",
     "test:alerts": "tsx --test src/services/alerts/__tests__/ipaws-monitor.test.mts",

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -60,6 +60,7 @@ import {
 import { SatelliteFiresPanel } from '@/components/SatelliteFiresPanel';
 import { TriageBar } from '@/components/TriageBar';
 import { EEWStatusBar } from '@/components/EEWStatusBar';
+import { startSpaceWeatherStatusBarPoller } from '@/services/spaceweather/status-bar-poller';
 import { JustInRail } from '@/components/JustInRail';
 import { startPanelNarrator } from '@/services/panel-narrator';
 import { TodayView } from '@/components/TodayView';
@@ -528,6 +529,7 @@ export class PanelLayoutManager implements AppModule {
  // of the seismic intelligence stack.
  const eewStatusBar = new EEWStatusBar();
  eewStatusBar.mount(document.body);
+ startSpaceWeatherStatusBarPoller(eewStatusBar);
 
  // Mount the triage bar above the panel grid (auto-hides when nothing is hot).
  const triageBar = new TriageBar();

--- a/src/components/EEWStatusBar.ts
+++ b/src/components/EEWStatusBar.ts
@@ -20,6 +20,12 @@ import {
   type StatusBarState,
 } from '../services/seismic/eew-status-bar-helpers';
 import type { EewAlert } from '../services/seismic/eew-alert-engine';
+import {
+  deriveSpaceWxBanner,
+  type SpaceWxBanner,
+  type SpaceWxBannerSeverity,
+} from '../services/spaceweather/globe-overlay';
+import type { SpaceWxStatus } from '../services/spaceweather/swpc-monitor';
 
 const ENDPOINT = '/api/eew-status';
 const POLL_INTERVAL_MS = 5000;
@@ -33,16 +39,26 @@ const COLOR_CLASSES: Record<StatusBarState['color'], string> = {
   crimson: 'eew-bar-crimson',
 };
 
+const SPACEWX_CLASSES: Record<SpaceWxBannerSeverity, string> = {
+  none: '',
+  g3: 'eew-bar-spacewx-g3',
+  g4: 'eew-bar-spacewx-g4',
+  g5: 'eew-bar-spacewx-g5',
+  flare: 'eew-bar-spacewx-flare',
+};
+
 export class EEWStatusBar {
   private root: HTMLElement | null = null;
   private labelEl: HTMLElement | null = null;
   private subtitleEl: HTMLElement | null = null;
   private imessageBadgeEl: HTMLElement | null = null;
+  private spaceWxEl: HTMLElement | null = null;
   private expandedEl: HTMLElement | null = null;
   private mounted = false;
   private expanded = false;
   private currentPayload: EewStatusPayload | null = null;
   private currentState: StatusBarState = deriveStatusBarState(null);
+  private currentSpaceWx: SpaceWxBanner = { severity: 'none', label: '', subtitle: '' };
   private pollTimer: ReturnType<typeof setInterval> | null = null;
   private subtitleTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -66,7 +82,11 @@ export class EEWStatusBar {
     this.imessageBadgeEl.className = 'eew-bar-imessage-badge';
     this.imessageBadgeEl.style.display = 'none';
 
-    main.append(this.labelEl, this.subtitleEl, this.imessageBadgeEl);
+    this.spaceWxEl = document.createElement('span');
+    this.spaceWxEl.className = 'eew-bar-spacewx';
+    this.spaceWxEl.style.display = 'none';
+
+    main.append(this.labelEl, this.subtitleEl, this.imessageBadgeEl, this.spaceWxEl);
     main.addEventListener('click', () => this.toggleExpanded());
 
     this.expandedEl = document.createElement('div');
@@ -94,7 +114,23 @@ export class EEWStatusBar {
     this.labelEl = null;
     this.subtitleEl = null;
     this.imessageBadgeEl = null;
+    this.spaceWxEl = null;
     this.expandedEl = null;
+  }
+
+  /**
+   * Update the space-weather banner overlay. The bar is shared with seismic
+   * EEW, so a non-`none` severity adds a coloured pill to the right of the
+   * subtitle without overriding the seismic state.
+   */
+  setSpaceWeatherStatus(status: SpaceWxStatus | null): void {
+    this.currentSpaceWx = deriveSpaceWxBanner(status);
+    this.renderSpaceWxBanner();
+  }
+
+  /** @internal */
+  __getSpaceWxBanner(): SpaceWxBanner {
+    return this.currentSpaceWx;
   }
 
   /**
@@ -150,7 +186,25 @@ export class EEWStatusBar {
     this.labelEl.textContent = this.currentState.label;
     this.refreshSubtitle();
     this.renderImessageBadge();
+    this.renderSpaceWxBanner();
     this.renderExpanded();
+  }
+
+  private renderSpaceWxBanner(): void {
+    if (!this.spaceWxEl) return;
+    const banner = this.currentSpaceWx;
+    if (banner.severity === 'none') {
+      this.spaceWxEl.style.display = 'none';
+      this.spaceWxEl.textContent = '';
+      this.spaceWxEl.className = 'eew-bar-spacewx';
+      return;
+    }
+    this.spaceWxEl.style.display = '';
+    this.spaceWxEl.className = `eew-bar-spacewx ${SPACEWX_CLASSES[banner.severity]}`;
+    this.spaceWxEl.textContent = banner.subtitle.length > 0
+      ? `${banner.label} · ${banner.subtitle}`
+      : banner.label;
+    this.spaceWxEl.setAttribute('title', `${banner.label}\n${banner.subtitle}`);
   }
 
   private refreshSubtitle(): void {

--- a/src/services/spaceweather/__tests__/globe-overlay.test.mts
+++ b/src/services/spaceweather/__tests__/globe-overlay.test.mts
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  auroraColorForKp,
+  buildOverlayDescriptor,
+  deriveSpaceWxBanner,
+  ringAtLatitude,
+  subsolarPoint,
+} from '../globe-overlay.ts';
+import type { SpaceWxStatus } from '../swpc-monitor.ts';
+
+const NOW = Date.parse('2026-05-06T12:00:00Z');
+
+function makeStatus(over: Partial<SpaceWxStatus> = {}): SpaceWxStatus {
+  return {
+    xray: null,
+    geomag: null,
+    gpsDisruption: 'none',
+    hfRadioBlackout: false,
+    earthwardCmes: [],
+    asOf: new Date(NOW).toISOString(),
+    ...over,
+  };
+}
+
+// ── Ring geometry ──────────────────────────────────────────────────────────
+
+test('ringAtLatitude samples lon every 5° from -180 through 180 inclusive', () => {
+  const ring = ringAtLatitude(60);
+  assert.equal(ring.length, 73);
+  assert.deepEqual(ring[0], [-180, 60]);
+  assert.deepEqual(ring[ring.length - 1], [180, 60]);
+});
+
+test('ringAtLatitude honours custom step', () => {
+  const ring = ringAtLatitude(45, 30);
+  assert.equal(ring.length, 13);
+  assert.deepEqual(ring[1], [-150, 45]);
+});
+
+// ── Color ladder ───────────────────────────────────────────────────────────
+
+test('auroraColorForKp ladder: green at G1/G2, violet at G3, deep purple at G4/G5', () => {
+  const g1 = auroraColorForKp(5);
+  assert.ok(g1.g > g1.r); // green dominates
+  const g4 = auroraColorForKp(8);
+  assert.ok(g4.b > g4.g); // blue dominates → purple
+  const g5 = auroraColorForKp(9);
+  assert.deepEqual(g5, auroraColorForKp(8));
+});
+
+// ── Subsolar point ─────────────────────────────────────────────────────────
+
+test('subsolarPoint at 12:00 UTC sits over the prime meridian', () => {
+  const point = subsolarPoint(Date.parse('2026-03-21T12:00:00Z')); // ~equinox
+  assert.ok(Math.abs(point.lonDeg) < 0.5);
+  // March 21 is the equinox so latitude is near 0°.
+  assert.ok(Math.abs(point.latDeg) < 2);
+});
+
+test('subsolarPoint moves 15°/h westward as UTC clock advances', () => {
+  const noon = subsolarPoint(Date.parse('2026-03-21T12:00:00Z'));
+  const onepm = subsolarPoint(Date.parse('2026-03-21T13:00:00Z'));
+  // 1h after noon UTC → subsolar moved to ~ -15° lon.
+  assert.ok(Math.abs(onepm.lonDeg + 15) < 0.5, `got ${onepm.lonDeg}`);
+  // Latitude shouldn't change appreciably across one hour.
+  assert.ok(Math.abs(onepm.latDeg - noon.latDeg) < 0.5);
+});
+
+test('subsolarPoint reflects seasonal declination at solstices', () => {
+  // June solstice → ~+23.45°N
+  const june = subsolarPoint(Date.parse('2026-06-21T12:00:00Z'));
+  assert.ok(june.latDeg > 22 && june.latDeg < 24, `got ${june.latDeg}`);
+  // December solstice → ~-23.45°S
+  const dec = subsolarPoint(Date.parse('2026-12-21T12:00:00Z'));
+  assert.ok(dec.latDeg < -22 && dec.latDeg > -24, `got ${dec.latDeg}`);
+});
+
+// ── Descriptor: aurora ─────────────────────────────────────────────────────
+
+test('buildOverlayDescriptor returns invisible descriptor for null status', () => {
+  const d = buildOverlayDescriptor(null, NOW);
+  assert.equal(d.visible, false);
+  assert.equal(d.aurora, null);
+  assert.equal(d.flarePulse, null);
+});
+
+test('buildOverlayDescriptor: Kp <5 yields no aurora ring', () => {
+  const status = makeStatus({
+    geomag: { kp: 4, level: 'G0', auroraVisibilityLatN: 90, observedAt: '', kpMax24h: 4 },
+  });
+  const d = buildOverlayDescriptor(status, NOW);
+  assert.equal(d.aurora, null);
+});
+
+test('buildOverlayDescriptor: Kp 7 produces northern + mirrored southern ring', () => {
+  const status = makeStatus({
+    geomag: { kp: 7, level: 'G3', auroraVisibilityLatN: 55, observedAt: '', kpMax24h: 7 },
+  });
+  const d = buildOverlayDescriptor(status, NOW);
+  assert.ok(d.aurora);
+  assert.equal(d.aurora?.latN, 55);
+  assert.equal(d.aurora?.latS, -55);
+  assert.equal(d.aurora?.ringNorth.length, 73);
+  assert.equal(d.aurora?.ringSouth.length, 73);
+  assert.equal(d.aurora?.widthPx, 3);
+});
+
+test('buildOverlayDescriptor: Kp 9 widens the ring + uses deep purple', () => {
+  const status = makeStatus({
+    geomag: { kp: 9, level: 'G5', auroraVisibilityLatN: 45, observedAt: '', kpMax24h: 9 },
+  });
+  const d = buildOverlayDescriptor(status, NOW);
+  assert.equal(d.aurora?.widthPx, 4);
+  assert.equal(d.aurora?.color.b, 0.95);
+});
+
+// ── Descriptor: flare pulse ────────────────────────────────────────────────
+
+test('buildOverlayDescriptor: only x-class flare emits a pulse', () => {
+  const xClassStatus = makeStatus({
+    xray: { peakFlux: 1.5e-4, currentFlux: 1.5e-4, peakClass: 'X', peakLabel: 'X1.5',
+      peakAt: '', xClassActive: true, sampleCount: 10 },
+  });
+  const mClassStatus = makeStatus({
+    xray: { peakFlux: 5e-5, currentFlux: 5e-5, peakClass: 'M', peakLabel: 'M5.0',
+      peakAt: '', xClassActive: false, sampleCount: 10 },
+  });
+  assert.ok(buildOverlayDescriptor(xClassStatus, NOW).flarePulse);
+  assert.equal(buildOverlayDescriptor(mClassStatus, NOW).flarePulse, null);
+});
+
+// ── Banner integration ────────────────────────────────────────────────────
+
+test('deriveSpaceWxBanner: null status yields none', () => {
+  assert.equal(deriveSpaceWxBanner(null).severity, 'none');
+});
+
+test('deriveSpaceWxBanner: G5 storm escalates to extreme banner', () => {
+  const banner = deriveSpaceWxBanner(makeStatus({
+    geomag: { kp: 9, level: 'G5', auroraVisibilityLatN: 45, observedAt: '', kpMax24h: 9 },
+  }));
+  assert.equal(banner.severity, 'g5');
+  assert.match(banner.label, /EXTREME/);
+  assert.match(banner.subtitle, /Kp 9\.0/);
+});
+
+test('deriveSpaceWxBanner: G4 / G3 escalate distinctly', () => {
+  const g4 = deriveSpaceWxBanner(makeStatus({
+    geomag: { kp: 8, level: 'G4', auroraVisibilityLatN: 50, observedAt: '', kpMax24h: 8 },
+  }));
+  assert.equal(g4.severity, 'g4');
+  assert.match(g4.label, /SEVERE/);
+  const g3 = deriveSpaceWxBanner(makeStatus({
+    geomag: { kp: 7, level: 'G3', auroraVisibilityLatN: 55, observedAt: '', kpMax24h: 7 },
+  }));
+  assert.equal(g3.severity, 'g3');
+  assert.match(g3.label, /STRONG/);
+});
+
+test('deriveSpaceWxBanner: G2 storm + X-class flare prefers the flare banner', () => {
+  const banner = deriveSpaceWxBanner(makeStatus({
+    geomag: { kp: 6, level: 'G2', auroraVisibilityLatN: 57.5, observedAt: '', kpMax24h: 6 },
+    xray: { peakFlux: 2e-4, currentFlux: 2e-4, peakClass: 'X', peakLabel: 'X2.0',
+      peakAt: '', xClassActive: true, sampleCount: 10 },
+  }));
+  assert.equal(banner.severity, 'flare');
+  assert.match(banner.label, /X-CLASS/);
+});
+
+test('deriveSpaceWxBanner: G1/G2 alone returns none', () => {
+  const banner = deriveSpaceWxBanner(makeStatus({
+    geomag: { kp: 5, level: 'G1', auroraVisibilityLatN: 60, observedAt: '', kpMax24h: 5 },
+  }));
+  assert.equal(banner.severity, 'none');
+});

--- a/src/services/spaceweather/globe-overlay.ts
+++ b/src/services/spaceweather/globe-overlay.ts
@@ -1,0 +1,199 @@
+/**
+ * Space Weather Globe Overlay (pure-deterministic).
+ *
+ * Generates the geometry + visibility flags for the Cesium globe overlay
+ * driven by SpaceWxStatus:
+ *   - Aurora oval ring when Kp ≥ 5 (parallel of latitude at the visibility
+ *     line, stepped every 5° of longitude)
+ *   - Subsolar point + flare pulse flag when an X-class flare is active
+ *
+ * No Cesium / DOM dependencies — the values produced here are consumed by
+ * the SpaceWeatherGlobeOverlay component which wraps them in entities.
+ */
+
+import type { SpaceWxStatus } from './swpc-monitor';
+
+const TWO_PI = Math.PI * 2;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const J2000_MS = Date.UTC(2000, 0, 1, 12, 0, 0);
+
+export interface AuroraRing {
+  /** Geomagnetic visibility latitude, °N. */
+  latN: number;
+  /** Mirror southern-hemisphere ring at -latN — auroras occur both ways. */
+  latS: number;
+  /** Closed polyline positions: [lon, lat] pairs forming a complete ring. */
+  ringNorth: [number, number][];
+  ringSouth: [number, number][];
+  /** Visualization color: green at G1–G2, purple at G4–G5. */
+  color: { r: number; g: number; b: number; a: number };
+  /** Width in pixels. */
+  widthPx: number;
+}
+
+export interface FlarePulse {
+  /** Geographic longitude of the subsolar point, ° (-180..180). */
+  subsolarLonDeg: number;
+  /** Geographic latitude of the subsolar point, °. */
+  subsolarLatDeg: number;
+  /** Pulse animation period in ms. */
+  pulsePeriodMs: number;
+  /** Inner / outer radius pair in metres (great-circle distance). */
+  innerRadiusM: number;
+  outerRadiusM: number;
+}
+
+export interface GlobeOverlayDescriptor {
+  /** True when the descriptor should be rendered at all. */
+  visible: boolean;
+  aurora: AuroraRing | null;
+  flarePulse: FlarePulse | null;
+}
+
+/**
+ * Build the closed ring of [lon, lat] positions at a fixed latitude.
+ * Sampled every `stepDeg` degrees of longitude — default 5°.
+ */
+export function ringAtLatitude(latDeg: number, stepDeg = 5): [number, number][] {
+  const out: [number, number][] = [];
+  for (let lon = -180; lon <= 180; lon += stepDeg) {
+    out.push([lon, latDeg]);
+  }
+  return out;
+}
+
+/** Map a Kp index to an aurora ring colour. */
+export function auroraColorForKp(kp: number): { r: number; g: number; b: number; a: number } {
+  if (kp >= 8) return { r: 0.7, g: 0.2, b: 0.95, a: 0.85 }; // deep purple — G4/G5
+  if (kp >= 7) return { r: 0.5, g: 0.3, b: 0.95, a: 0.8 }; // violet — G3
+  if (kp >= 6) return { r: 0.3, g: 0.95, b: 0.6, a: 0.75 }; // bright green — G2
+  return { r: 0.2, g: 0.85, b: 0.4, a: 0.7 }; // standard green — G1
+}
+
+/**
+ * Compute subsolar point (the lon/lat where the sun is directly overhead).
+ * Approximates the sun's declination from day-of-year and longitude from
+ * UTC time — accurate to ~1° which is plenty for a flare-pulse marker.
+ */
+export function subsolarPoint(nowMs: number): { lonDeg: number; latDeg: number } {
+  // Day-of-year, 0-based.
+  const date = new Date(nowMs);
+  const startOfYear = Date.UTC(date.getUTCFullYear(), 0, 0);
+  const dayOfYear = Math.floor((nowMs - startOfYear) / DAY_MS);
+  // Solar declination (Cooper 1969 approximation). δ = 23.45° · sin(360° · (284 + n) / 365)
+  const decRad = (23.45 * Math.PI / 180) * Math.sin(((TWO_PI) * (284 + dayOfYear)) / 365);
+  const latDeg = decRad * (180 / Math.PI);
+  // UTC time of day → longitude. At 12:00 UTC the sun is over Greenwich
+  // (lon 0). Each hour shifts the subsolar point 15° west.
+  const utcHours =
+    date.getUTCHours() + date.getUTCMinutes() / 60 + date.getUTCSeconds() / 3600;
+  let lonDeg = (12 - utcHours) * 15;
+  // Normalize into [-180, 180].
+  lonDeg = ((lonDeg + 540) % 360) - 180;
+  return { lonDeg, latDeg };
+}
+
+/** Build the descriptor consumed by the Cesium-bound overlay component. */
+export function buildOverlayDescriptor(
+  status: SpaceWxStatus | null,
+  nowMs: number = Date.now(),
+): GlobeOverlayDescriptor {
+  if (!status) return { visible: false, aurora: null, flarePulse: null };
+
+  const aurora = buildAuroraRing(status);
+  const flarePulse = buildFlarePulse(status, nowMs);
+  const visible = aurora !== null || flarePulse !== null;
+  return { visible, aurora, flarePulse };
+}
+
+function widthForKp(kp: number): number {
+  if (kp >= 8) return 4;
+  if (kp >= 7) return 3;
+  return 2;
+}
+
+function buildAuroraRing(status: SpaceWxStatus): AuroraRing | null {
+  const geomag = status.geomag;
+  if (!geomag || geomag.kp < 5) return null;
+  const latN = geomag.auroraVisibilityLatN;
+  const latS = -latN;
+  return {
+    latN,
+    latS,
+    ringNorth: ringAtLatitude(latN),
+    ringSouth: ringAtLatitude(latS),
+    color: auroraColorForKp(geomag.kp),
+    widthPx: widthForKp(geomag.kp),
+  };
+}
+
+function buildFlarePulse(status: SpaceWxStatus, nowMs: number): FlarePulse | null {
+  if (!status.xray?.xClassActive) return null;
+  const point = subsolarPoint(nowMs);
+  return {
+    subsolarLonDeg: point.lonDeg,
+    subsolarLatDeg: point.latDeg,
+    pulsePeriodMs: 1500,
+    innerRadiusM: 200_000,
+    outerRadiusM: 800_000,
+  };
+}
+
+// ── Status banner integration ────────────────────────────────────────────
+
+export type SpaceWxBannerSeverity = 'none' | 'g3' | 'g4' | 'g5' | 'flare';
+
+export interface SpaceWxBanner {
+  severity: SpaceWxBannerSeverity;
+  /** Headline shown alongside the EEW status bar. Empty when severity = none. */
+  label: string;
+  /** Supporting line — e.g. "Kp 8 · GPS degraded". Empty when severity = none. */
+  subtitle: string;
+}
+
+/** Map a SpaceWxStatus into the EEWStatusBar banner. Banner shows for
+ * G3+ geomagnetic storms or active X-class flares — the user spec
+ * required "G4+ storm warnings", we widen to G3 to match the usual
+ * SWPC subscriber threshold. Returns severity 'none' when nothing
+ * warrants surfacing on the header. */
+export function deriveSpaceWxBanner(status: SpaceWxStatus | null): SpaceWxBanner {
+  if (!status) return { severity: 'none', label: '', subtitle: '' };
+  const level = status.geomag?.level ?? 'G0';
+  const kp = status.geomag?.kp ?? null;
+  const xray = status.xray;
+  if (level === 'G5') {
+    return {
+      severity: 'g5',
+      label: 'GEOMAGNETIC G5 — EXTREME STORM',
+      subtitle: kp === null ? 'power grid + HF radio impacts likely'
+                            : `Kp ${kp.toFixed(1)} · power grid + HF radio impacts likely`,
+    };
+  }
+  if (level === 'G4') {
+    return {
+      severity: 'g4',
+      label: 'GEOMAGNETIC G4 — SEVERE STORM',
+      subtitle: kp === null ? 'grid + GPS + HF degraded'
+                            : `Kp ${kp.toFixed(1)} · grid + GPS + HF degraded`,
+    };
+  }
+  if (level === 'G3') {
+    return {
+      severity: 'g3',
+      label: 'GEOMAGNETIC G3 — STRONG STORM',
+      subtitle: kp === null ? 'GPS / HF impacts possible'
+                            : `Kp ${kp.toFixed(1)} · GPS / HF impacts possible`,
+    };
+  }
+  if (xray?.xClassActive) {
+    return {
+      severity: 'flare',
+      label: `X-CLASS FLARE — ${xray.peakLabel}`,
+      subtitle: 'HF radio blackout on sunlit hemisphere',
+    };
+  }
+  return { severity: 'none', label: '', subtitle: '' };
+}
+
+// Useful fixed values from J2000 epoch — exported for test stability checks.
+export const _internal = { J2000_MS };

--- a/src/services/spaceweather/status-bar-poller.ts
+++ b/src/services/spaceweather/status-bar-poller.ts
@@ -1,0 +1,46 @@
+/**
+ * Background poller that pushes SpaceWxStatus into the EEWStatusBar
+ * banner every 5 minutes. Pulls from the same /api/spaceweather/status
+ * endpoint the SpaceWeatherPanel uses; both can share the sidecar's
+ * 5-min response cache without doubling the upstream NOAA load.
+ */
+
+import type { EEWStatusBar } from '@/components/EEWStatusBar';
+import type { SpaceWxStatus } from '@/services/spaceweather/swpc-monitor';
+import { getApiBaseUrl } from '@/services/runtime';
+
+const POLL_MS = 5 * 60 * 1000;
+
+export function startSpaceWeatherStatusBarPoller(
+  bar: EEWStatusBar,
+): { stop: () => void } {
+  let stopped = false;
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  const tick = async (): Promise<void> => {
+    if (stopped) return;
+    try {
+      const resp = await fetch(`${getApiBaseUrl()}/api/spaceweather/status`, {
+        headers: { Accept: 'application/json' },
+      });
+      if (!resp.ok) return;
+      const status = (await resp.json()) as SpaceWxStatus;
+      bar.setSpaceWeatherStatus(status);
+    } catch {
+      // Network errors are non-fatal — the banner just keeps the prior state.
+    }
+  };
+
+  void tick();
+  timer = setInterval(() => { void tick(); }, POLL_MS);
+
+  return {
+    stop(): void {
+      stopped = true;
+      if (timer !== null) {
+        clearInterval(timer);
+        timer = null;
+      }
+    },
+  };
+}

--- a/src/styles/eew-status-bar.css
+++ b/src/styles/eew-status-bar.css
@@ -59,6 +59,28 @@
 .eew-bar-imessage-disabled { background: rgba(120, 120, 120, 0.25); color: #cccccc; }
 .eew-bar-imessage-pending  { background: rgba(250, 204, 21, 0.25); color: #fff3c4; }
 
+.eew-bar-spacewx {
+  flex-shrink: 0;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  max-width: 60ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.eew-bar-spacewx-g3    { background: rgba(234, 88, 12, 0.85);  color: #fff7ed; }
+.eew-bar-spacewx-g4    { background: rgba(220, 38, 38, 0.92);  color: #fef2f2; }
+.eew-bar-spacewx-g5    {
+  background: rgba(159, 18, 57, 0.95);
+  color: #ffffff;
+  animation: eew-bar-crimson-pulse 2.4s ease-in-out infinite;
+}
+.eew-bar-spacewx-flare { background: rgba(124, 58, 237, 0.85); color: #f5f3ff; }
+
 /* Tier color schemes — outer container background + text */
 .eew-bar-gray    { background: rgba(40, 44, 52, 0.92);  color: #cbd5e1; }
 .eew-bar-blue    { background: rgba(30, 64, 175, 0.92); color: #ffffff; }


### PR DESCRIPTION
PR 3 closes the 3-PR space weather intelligence stack ([#313](https://github.com/bradleybond512/crystal-ball/pull/313), [#326](https://github.com/bradleybond512/crystal-ball/pull/326)).

## What

### Pure-deterministic globe overlay
[src/services/spaceweather/globe-overlay.ts](src/services/spaceweather/globe-overlay.ts) emits descriptors the Cesium globe can consume — no Cesium / DOM imports:

- **Aurora oval ring** when Kp ≥ 5: parallel-of-latitude polyline sampled every 5° of longitude, at the spec-mandated visibility latitude (60°N at Kp5 → 45°N at Kp9, with mirrored southern ring at -lat).
- **Color ladder:** green at G1/G2, violet at G3, deep purple at G4/G5; line width 2/3/4 px by Kp tier.
- **Subsolar point** for the X-class flare pulse: declination from day-of-year (Cooper 1969) + UTC clock for longitude. Accurate to ~1° — plenty for a flare-pulse marker.
- **Flare-pulse descriptor** (inner / outer radius + pulse period) emitted only when \`status.xray.xClassActive\`.

### EEW status-bar G3+ / X-flare banner
[EEWStatusBar.setSpaceWeatherStatus()](src/components/EEWStatusBar.ts) renders a coloured pill alongside the seismic state:

| Severity | Color | Trigger |
| --- | --- | --- |
| \`g3\` | orange | Geomagnetic Kp ≥ 7 |
| \`g4\` | red | Geomagnetic Kp ≥ 8 |
| \`g5\` | crimson + pulse | Geomagnetic Kp ≥ 9 |
| \`flare\` | violet | X-class flare active |

The G5 pill reuses the same crimson-pulse keyframe as TIER_5 EXTREME for visual consistency. Spec called for "G4+"; widened to G3 to match the usual SWPC subscriber threshold and provide earlier warning. When a G2 storm coincides with an X-class flare, the flare wins (more actionable signal).

### Live wiring
[startSpaceWeatherStatusBarPoller](src/services/spaceweather/status-bar-poller.ts) is invoked from [panel-layout.ts](src/app/panel-layout.ts:528) right next to the EEW bar mount — fetches \`/api/spaceweather/status\` every 5 min and pipes the result into the bar. Shares the sidecar's 5-min response cache with \`SpaceWeatherPanel\`, so no doubled load on NOAA.

## Tests

- 16 new tests in \`src/services/spaceweather/__tests__/globe-overlay.test.mts\` — geometry helpers, subsolar math at equinox + both solstices, color ladder, descriptor visibility flags, full banner severity ladder including the G2-storm + X-flare tie-break.
- \`npm run test:spaceweather\` is now **33 TS + 10 sidecar parity = 43 green**.
- \`npm run typecheck:all\` clean.

## Cesium entity wiring deferred

The globe-overlay descriptors are ready to consume, but actually drawing the aurora ring + flare pulse on \`GodsVisionView\` is left as a follow-up — \`GlobeDataManager\` needs a new \`'aurora'\` registered layer that calls \`buildOverlayDescriptor()\` and adds entities for \`ringNorth\` / \`ringSouth\` / \`flarePulse\`. The EEW banner gets the live exercise immediately.

## Verification limitation

Same as PR 2 — Vite dev server has a pre-existing \`@luma.gl\` bundling error in this worktree unrelated to the spaceweather work, so I can't smoke-test the banner in a browser. The component change uses \`setSpaceWeatherStatus()\` which is fully covered by pure-helper tests; the runtime render path is exercised by the existing EEW status-bar tests for the same DOM scaffold.