### PR TITLE
feat(wildfires): NIFC perimeters + 0.1° clusters on globe + fire-trigger event [PR 3/3]

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -567,6 +567,7 @@ export class DataLoaderManager implements AppModule {
  if (SITE_VARIANT === 'full') tasks.push({ name: 'federalRegister', task: () => runGuarded('federalRegister', () => this.loadFederalRegister()) });
  if (SITE_VARIANT === 'full') tasks.push({ name: 'airQuality', task: () => runGuarded('airQuality', () => this.loadAirQuality()) });
  if (SITE_VARIANT === 'full') tasks.push({ name: 'wildfireIncidents', task: () => runGuarded('wildfireIncidents', () => this.loadWildfireIncidents()) });
+ if (SITE_VARIANT === 'full') tasks.push({ name: 'wildfireIntel', task: () => runGuarded('wildfireIntel', () => this.loadWildfireIntel()) });
  if (SITE_VARIANT === 'full') tasks.push({ name: 'hazmatIncidents', task: () => runGuarded('hazmatIncidents', () => this.loadHazmatIncidents()) });
  if (SITE_VARIANT === 'full') tasks.push({ name: 'oilSpills', task: () => runGuarded('oilSpills', () => this.loadOilSpills()) });
  if (SITE_VARIANT === 'full') tasks.push({ name: 'gdacsAlerts', task: () => runGuarded('gdacsAlerts', () => this.loadGDACSAlerts()) });
@@ -1946,6 +1947,7 @@ export class DataLoaderManager implements AppModule {
   // in as a callback rather than importing it from the loader module.
   async loadAirQuality(): Promise<void> { return hazardLoaders.loadAirQuality(this.ctx, () => void this.evaluateCompoundThreats()); }
   async loadWildfireIncidents(): Promise<void> { return hazardLoaders.loadWildfireIncidents(this.ctx, () => void this.evaluateCompoundThreats()); }
+  async loadWildfireIntel(): Promise<void> { return hazardLoaders.loadWildfireIntel(this.ctx); }
   async loadHazmatIncidents(): Promise<void> { return hazardLoaders.loadHazmatIncidents(this.ctx, () => void this.evaluateCompoundThreats()); }
   async loadOilSpills(): Promise<void> { return hazardLoaders.loadOilSpills(this.ctx); }
 

--- a/src/app/loaders/hazards.ts
+++ b/src/app/loaders/hazards.ts
@@ -18,6 +18,9 @@ import type { WildfireIncidentsPanel } from '@/components/WildfireIncidentsPanel
 import type { HazmatIncidentsPanel } from '@/components/HazmatIncidentsPanel';
 import type { OilSpillPanel } from '@/components/OilSpillPanel';
 import type { HazardAlertsPanel } from '@/components/HazardAlertsPanel';
+import type { WildfireIntelPanel } from '@/components/WildfireIntelPanel';
+import { fetchFireIntelSnapshot } from '@/services/wildfires/fire-intel-service';
+import { getSavedPlaces } from '@/services/saved-places';
 
 export async function loadAirQuality(ctx: AppContext, triggerCompoundEval: () => void): Promise<void> {
   try {
@@ -44,6 +47,20 @@ export async function loadWildfireIncidents(ctx: AppContext, triggerCompoundEval
  // eslint-disable-next-line no-console
  console.warn('[wildfire-incidents] fetch failed', error);
  (ctx.panels['wildfire-incidents'] as WildfireIncidentsPanel | undefined)?.update([]);
+  }
+}
+
+export async function loadWildfireIntel(ctx: AppContext): Promise<void> {
+  const panel = ctx.panels['wildfire-intel'] as WildfireIntelPanel | undefined;
+  if (!panel) return;
+  try {
+ const places = getSavedPlaces();
+ const snapshot = await fetchFireIntelSnapshot(places);
+ panel.update(snapshot);
+  } catch (error) {
+ // eslint-disable-next-line no-console
+ console.warn('[wildfire-intel] fetch failed', error);
+ panel.showUpstreamUnavailable(error instanceof Error ? error.message : String(error));
   }
 }
 

--- a/src/app/loaders/hazards.ts
+++ b/src/app/loaders/hazards.ts
@@ -57,11 +57,35 @@ export async function loadWildfireIntel(ctx: AppContext): Promise<void> {
  const places = getSavedPlaces();
  const snapshot = await fetchFireIntelSnapshot(places);
  panel.update(snapshot);
+ emitFireTriggerEvent(snapshot);
   } catch (error) {
  // eslint-disable-next-line no-console
  console.warn('[wildfire-intel] fetch failed', error);
  panel.showUpstreamUnavailable(error instanceof Error ? error.message : String(error));
   }
+}
+
+/**
+ * Emit a `wildfire:fire-trigger` CustomEvent for the top-3 threat-ranked
+ * incidents that have lat/lon. Webcam aggregators (or other consumers)
+ * can listen and call evaluateFireTrigger() against their spatial index.
+ * Skipped silently when nothing has coordinates.
+ */
+function emitFireTriggerEvent(snapshot: { rankedThreats: { incident: { id: string; lat: number | null; lon: number | null; name: string; updatedAt: Date } }[] }): void {
+  if (typeof globalThis === 'undefined' || typeof CustomEvent === 'undefined') return;
+  const inputs = snapshot.rankedThreats
+ .slice(0, 3)
+ .map(t => t.incident)
+ .filter(inc => inc.lat !== null && inc.lon !== null)
+ .map(inc => ({
+ id: inc.id,
+ lat: inc.lat as number,
+ lon: inc.lon as number,
+ name: inc.name,
+ detectedAt: inc.updatedAt.getTime(),
+ }));
+  if (inputs.length === 0) return;
+  globalThis.dispatchEvent(new CustomEvent('wildfire:fire-trigger', { detail: { incidents: inputs } }));
 }
 
 export async function loadHazmatIncidents(ctx: AppContext, triggerCompoundEval: () => void): Promise<void> {

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -146,6 +146,7 @@ import { OpenSanctionsPanel } from '@/components/OpenSanctionsPanel';
 import { EdgarFilingsPanel } from '@/components/EdgarFilingsPanel';
 import { AirQualityPanel } from '@/components/AirQualityPanel';
 import { WildfireIncidentsPanel } from '@/components/WildfireIncidentsPanel';
+import { WildfireIntelPanel } from '@/components/WildfireIntelPanel';
 import { HazmatIncidentsPanel } from '@/components/HazmatIncidentsPanel';
 import { OilSpillPanel } from '@/components/OilSpillPanel';
 import { HazardAlertsPanel } from '@/components/HazardAlertsPanel';
@@ -997,6 +998,9 @@ export class PanelLayoutManager implements AppModule {
 
  const wildfireIncidentsPanel = new WildfireIncidentsPanel();
  this.ctx.panels['wildfire-incidents'] = wildfireIncidentsPanel;
+
+ const wildfireIntelPanel = new WildfireIntelPanel();
+ this.ctx.panels['wildfire-intel'] = wildfireIntelPanel;
 
  const hazmatIncidentsPanel = new HazmatIncidentsPanel();
  this.ctx.panels['hazmat-incidents'] = hazmatIncidentsPanel;

--- a/src/components/GlobeDataManager.ts
+++ b/src/components/GlobeDataManager.ts
@@ -22,9 +22,11 @@ import {
   PolylineCollection,
   HeadingPitchRoll,
   Transforms,
+  PolygonGraphics,
 } from 'cesium';
 
 import { applyClustering } from '@/components/globeClustering';
+import { escapeHtml } from '@/utils/sanitize';
 import { modelLoader } from '@/services/model-loader';
 import { BuildingTileManager } from '@/services/building-tiles';
 import { fetchSatelliteCatalog, filterNotable, type SatelliteTLE } from '@/services/satellite-catalog';
@@ -219,16 +221,110 @@ function cycloneScale(isCat5: boolean, isCat3Plus: boolean, isCat1Plus: boolean)
   return 0.35;
 }
 
-function fireColor(confidence: string): Color {
-  if (confidence === 'FIRE_CONFIDENCE_HIGH') return C.fireHigh;
-  if (confidence === 'FIRE_CONFIDENCE_NOMINAL') return C.fireNominal;
-  return C.fireLow;
+interface PerimeterLike {
+  name: string;
+  acres: number | null;
+  containmentPct: number | null;
+  state: string | null;
+  lat: number;
+  lon: number;
+  geometry: { type: 'Polygon' | 'MultiPolygon'; coordinates: number[][][] | number[][][][] } | null;
 }
 
-function fireScale(confidence: string): number {
-  if (confidence === 'FIRE_CONFIDENCE_HIGH') return 0.3;
-  if (confidence === 'FIRE_CONFIDENCE_NOMINAL') return 0.22;
-  return 0.16;
+function renderPerimeterPolygons(layer: GlobeLayer, perimeters: PerimeterLike[]): void {
+  for (const p of perimeters) {
+    if (!p.geometry) continue;
+    const rings = p.geometry.type === 'Polygon'
+      ? [p.geometry.coordinates as number[][][]]
+      : (p.geometry.coordinates as number[][][][]);
+    for (const polygon of rings) {
+      addPerimeterEntity(layer, p, polygon[0]);
+    }
+  }
+}
+
+function addPerimeterEntity(layer: GlobeLayer, p: PerimeterLike, outerRing: number[][] | undefined): void {
+  const positions = polygonRingToCartesian(outerRing);
+  if (positions.length < 3) return;
+  const cont = p.containmentPct === null ? '—' : `${Math.round(p.containmentPct)}%`;
+  const acresStr = p.acres === null ? '—' : p.acres.toLocaleString();
+  const stateStr = p.state ?? '—';
+  layer.source.entities.add({
+    polygon: new PolygonGraphics({
+      hierarchy: new PolygonHierarchy(positions),
+      material: C.fireHigh.withAlpha(0.12),
+      outline: true,
+      outlineColor: C.fireHigh.withAlpha(0.85),
+      heightReference: HeightReference.CLAMP_TO_GROUND,
+    }),
+    description: `<b>${escapeHtml(p.name)}</b><br/>State: ${escapeHtml(stateStr)}<br/>Acres: ${acresStr}<br/>Containment: ${cont}`,
+  });
+}
+
+function polygonRingToCartesian(outerRing: number[][] | undefined): Cartesian3[] {
+  if (!outerRing || outerRing.length < 3) return [];
+  const positions: Cartesian3[] = [];
+  for (const pt of outerRing) {
+    const px = pt[0];
+    const py = pt[1];
+    if (px === undefined || py === undefined) continue;
+    if (!Number.isFinite(px) || !Number.isFinite(py)) continue;
+    positions.push(Cartesian3.fromDegrees(px, py));
+  }
+  return positions;
+}
+
+interface ClusterLike {
+  lat: number;
+  lon: number;
+  fireCount: number;
+  totalFrp: number;
+  maxBrightness: number;
+  highConfidence: boolean;
+  region: string;
+}
+
+function renderHotspotClusters(
+  layer: GlobeLayer,
+  clusters: ClusterLike[],
+  perimeters: PerimeterLike[],
+  findNearest: (lat: number, lon: number, perims: PerimeterLike[], maxKm: number) => { perimeter: PerimeterLike; distanceKm: number } | null,
+): void {
+  for (const c of clusters) {
+    const color = c.highConfidence ? C.fireHigh : C.fireNominal;
+    const scale = c.highConfidence ? 0.65 : 0.5;
+    const nearest = findNearest(c.lat, c.lon, perimeters, 50);
+    const nearestNote = nearest
+      ? `<br/><i>Near: ${escapeHtml(nearest.perimeter.name)} (${nearest.distanceKm.toFixed(1)} km)</i>`
+      : '';
+    const fireEntity = layer.source.entities.add({
+      position: Cartesian3.fromDegrees(c.lon, c.lat),
+      billboard: {
+        image: ICON_FIRE,
+        color,
+        scale,
+        heightReference: HeightReference.CLAMP_TO_GROUND,
+        scaleByDistance: new NearFarScalar(1e4, 1.2, 1e7, 0.15),
+        verticalOrigin: VerticalOrigin.CENTER,
+        horizontalOrigin: HorizontalOrigin.CENTER,
+      },
+      label: c.totalFrp >= 50 ? {
+        text: `${c.fireCount}× ${c.totalFrp.toFixed(0)}MW`,
+        font: '10px monospace',
+        fillColor: color,
+        outlineColor: Color.BLACK,
+        outlineWidth: 2,
+        style: 2,
+        pixelOffset: LABEL_OFFSET_SM,
+        horizontalOrigin: HorizontalOrigin.CENTER,
+        verticalOrigin: VerticalOrigin.BOTTOM,
+        scaleByDistance: new NearFarScalar(1e5, 1, 1.5e7, 0.4),
+        distanceDisplayCondition: new DistanceDisplayCondition(0, 8e6),
+      } : undefined,
+      description: `<b>FIRMS hotspot cluster</b><br/>Pixels: ${c.fireCount}<br/>Total FRP: ${c.totalFrp.toFixed(1)} MW<br/>Max brightness: ${c.maxBrightness.toFixed(0)} K<br/>Confidence: ${c.highConfidence ? 'high' : 'nominal'}<br/>Region: ${escapeHtml(c.region)}${nearestNote}`,
+    });
+    setEntityTimestamp(fireEntity, new Date());
+  }
 }
 
 function cyberColor(severity: string): Color {
@@ -955,50 +1051,18 @@ export class GlobeDataManager {
  const layer = this.layers.get('fires');
  if (!layer) return;
 
- const { fetchAllFires, flattenFires } = await import('@/services/wildfires');
- const result = await fetchAllFires();
- const fires = flattenFires(result.regions);
+ const { fetchAllFires, flattenFires, toMapFires } = await import('@/services/wildfires');
+ const { fetchActivePerimeters } = await import('@/services/wildfires/fire-intel-service');
+ const { clusterHotspots, findNearestPerimeter } = await import('@/services/wildfires/fire-intel-helpers');
 
- for (const f of fires) {
- const lat = f.location?.latitude;
- const lon = f.location?.longitude;
- if (lat == null || lon == null) continue;
- // Only show significant fires to avoid flooding the globe
- if (f.frp < 10) continue;
+ const [fireResult, perimeters] = await Promise.all([
+ fetchAllFires().catch(() => ({ regions: {}, totalCount: 0 })),
+ fetchActivePerimeters().catch(() => []),
+ ]);
 
- const color = fireColor(f.confidence ?? '');
- const scale = fireScale(f.confidence ?? '') * 0.7;
-
- const fireEntity = layer.source.entities.add({
- position: Cartesian3.fromDegrees(lon, lat),
- billboard: {
- image: ICON_FIRE,
- color,
- scale,
- heightReference: HeightReference.CLAMP_TO_GROUND,
- scaleByDistance: new NearFarScalar(1e4, 1.2, 1e7, 0.15),
- verticalOrigin: VerticalOrigin.CENTER,
- horizontalOrigin: HorizontalOrigin.CENTER,
- },
- label: f.frp >= 50 ? {
- text: `Fire ${f.frp.toFixed(0)}MW`,
- font: '10px monospace',
- fillColor: color,
- outlineColor: Color.BLACK,
- outlineWidth: 2,
- style: 2,
- pixelOffset: LABEL_OFFSET_SM,
- horizontalOrigin: HorizontalOrigin.CENTER,
- verticalOrigin: VerticalOrigin.BOTTOM,
- scaleByDistance: new NearFarScalar(1e5, 1, 1.5e7, 0.4),
- distanceDisplayCondition: new DistanceDisplayCondition(0, 8e6),
- } : undefined,
- description: `Fire — FRP: ${f.frp.toFixed(1)} MW | Brightness: ${f.brightness.toFixed(0)} | ${f.region}`,
- });
- if (f.detectedAt) {
- setEntityTimestamp(fireEntity, new Date(f.detectedAt));
- }
- }
+ renderPerimeterPolygons(layer, perimeters);
+ const clusters = clusterHotspots(toMapFires(flattenFires(fireResult.regions)), { gridDeg: 0.1, topN: 500 });
+ renderHotspotClusters(layer, clusters, perimeters, findNearestPerimeter);
   }
 
   private async loadConflicts(): Promise<void> {

--- a/src/components/WildfireIntelPanel.ts
+++ b/src/components/WildfireIntelPanel.ts
@@ -1,0 +1,225 @@
+/**
+ * Wildfire Intel — unified panel that joins satellite hotspots, NIFC fire
+ * perimeters, InciWeb incidents, and EPA AirNow AQI for the user's saved
+ * places. Reads from `fetchFireIntelSnapshot()` in fire-intel-service.ts.
+ *
+ * Highest-threat fires are sorted by acreage × (1 - containment%).
+ */
+import { Panel } from './Panel';
+import { escapeHtml } from '@/utils/sanitize';
+import type {
+  FireIntelSnapshot,
+  ActiveFirePerimeter,
+  AirNowAqi,
+} from '@/services/wildfires/fire-intel-service';
+import type { AqiCategory } from '@/services/wildfires/fire-intel-helpers';
+import type { RankedThreat } from '@/services/wildfires/fire-intel-helpers';
+
+const TOP_THREATS_LIMIT = 10;
+const PERIMETER_LIST_LIMIT = 12;
+
+const AQI_LABELS: Record<AqiCategory, string> = {
+  good: 'Good',
+  moderate: 'Moderate',
+  sensitive: 'Sensitive',
+  unhealthy: 'Unhealthy',
+  very_unhealthy: 'Very Unhealthy',
+  hazardous: 'Hazardous',
+  unknown: 'Unknown',
+};
+
+const AQI_BADGE_COLORS: Record<AqiCategory, string> = {
+  good: '#4caf50',
+  moderate: '#ffeb3b',
+  sensitive: '#ff9800',
+  unhealthy: '#f44336',
+  very_unhealthy: '#9c27b0',
+  hazardous: '#7e0023',
+  unknown: '#616161',
+};
+
+export class WildfireIntelPanel extends Panel {
+  private snapshot: FireIntelSnapshot | null = null;
+
+  constructor() {
+    super({
+      id: 'wildfire-intel',
+      title: 'Wildfire Intel',
+      showCount: true,
+      trackActivity: true,
+      infoTooltip:
+        'Unified wildfire view: NASA FIRMS hotspots (clustered to 0.1° cells) · NIFC active fire perimeters · InciWeb incidents ranked by threat · EPA AirNow AQI for saved places. Refreshes every 15 min.',
+    });
+    this.showLoading('Joining FIRMS, NIFC, InciWeb, and AirNow…');
+  }
+
+  public update(snapshot: FireIntelSnapshot): void {
+    this.snapshot = snapshot;
+    this.setCount(snapshot.rankedThreats.length);
+    this.render();
+  }
+
+  public showUpstreamUnavailable(reason: string): void {
+    this.setContent(
+      `<div class="panel-empty">Wildfire intel sources unavailable${escapeHtml(reason ? ': ' + reason : '')}.<br/>` +
+        `Sources: NASA FIRMS · NIFC · InciWeb · EPA AirNow — will retry on the next 15-min refresh.</div>`,
+    );
+    this.setCount(0);
+  }
+
+  private render(): void {
+    if (!this.snapshot) return;
+    const snap = this.snapshot;
+    const top = snap.rankedThreats.slice(0, TOP_THREATS_LIMIT);
+    const totalHotspots = snap.hotspotClusters.reduce((s, c) => s + c.fireCount, 0);
+    const highConfClusters = snap.hotspotClusters.filter(c => c.highConfidence).length;
+
+    const aqi = renderAqiSection(snap.aqi);
+    const summary = renderSummaryRow({
+      totalHotspots,
+      hotspotClusters: snap.hotspotClusters.length,
+      highConfClusters,
+      perimeters: snap.perimeters.length,
+      perimeterAcres: snap.perimeters.reduce((s, p) => s + (p.acres ?? 0), 0),
+    });
+    const topThreats = renderTopThreats(top);
+    const perimeterList = renderPerimeterList(snap.perimeters.slice(0, PERIMETER_LIST_LIMIT));
+    const updatedAgo = timeAgo(snap.fetchedAt);
+
+    this.setContent(`
+<div class="wf-intel-panel">
+  ${aqi}
+  ${summary}
+  ${topThreats}
+  ${perimeterList}
+  <div class="fires-footer">
+    <span class="fires-source">FIRMS · NIFC WFIGS · InciWeb · EPA AirNow</span>
+    <span class="fires-updated">Updated ${escapeHtml(updatedAgo)}</span>
+  </div>
+</div>`);
+  }
+}
+
+// ── Sub-renderers ────────────────────────────────────────────────────────
+
+function renderAqiSection(aqi: AirNowAqi[]): string {
+  if (aqi.length === 0) {
+    return '<div class="wf-aqi-empty" style="opacity:0.7;font-size:12px;margin-bottom:8px">' +
+      'Add a saved place + AIRNOW_API_KEY to see local air quality.</div>';
+  }
+  const rows = aqi.map(r => {
+    const color = AQI_BADGE_COLORS[r.category];
+    const label = AQI_LABELS[r.category];
+    const value = r.aqi === null ? '—' : String(r.aqi);
+    const param = r.parameter ? ` (${escapeHtml(r.parameter)})` : '';
+    return `<div class="wf-aqi-row" style="display:flex;align-items:center;gap:8px;padding:3px 0">
+      <span class="aq-badge" style="display:inline-block;min-width:36px;text-align:center;padding:2px 6px;background:${color};color:#fff;border-radius:4px;font-weight:600">${escapeHtml(value)}</span>
+      <span style="flex:1">${escapeHtml(r.placeName)}</span>
+      <span style="opacity:0.75">${escapeHtml(label)}${param}</span>
+    </div>`;
+  }).join('');
+  return `<div class="wf-aqi-section" style="margin-bottom:10px">
+    <div style="font-weight:600;font-size:12px;margin-bottom:4px;opacity:0.85">Air Quality (saved places)</div>
+    ${rows}
+  </div>`;
+}
+
+function renderSummaryRow(opts: {
+  totalHotspots: number;
+  hotspotClusters: number;
+  highConfClusters: number;
+  perimeters: number;
+  perimeterAcres: number;
+}): string {
+  const acresStr = opts.perimeterAcres >= 1000
+    ? `${(opts.perimeterAcres / 1000).toFixed(1)}k`
+    : Math.round(opts.perimeterAcres).toLocaleString();
+  return `<div class="wf-summary" style="display:flex;gap:12px;flex-wrap:wrap;padding:6px 0;border-top:1px solid rgba(255,255,255,0.08);border-bottom:1px solid rgba(255,255,255,0.08);margin-bottom:8px">
+    <span><b>${opts.totalHotspots.toLocaleString()}</b> hotspots</span>
+    <span>·</span>
+    <span><b>${opts.hotspotClusters}</b> clusters</span>
+    <span>(${opts.highConfClusters} high-conf)</span>
+    <span>·</span>
+    <span><b>${opts.perimeters}</b> NIFC perimeters</span>
+    <span>(${acresStr} acres)</span>
+  </div>`;
+}
+
+function renderTopThreats(top: RankedThreat[]): string {
+  if (top.length === 0) {
+    return '<div class="panel-empty">No active threat-ranked incidents.</div>';
+  }
+  const rows = top.map((t, idx) => {
+    const inc = t.incident;
+    const severityClass = severityClassFor(idx);
+    const acres = inc.acresBurned === null ? '—' : inc.acresBurned.toLocaleString();
+    const cont = inc.percentContained === null ? '—' : `${inc.percentContained}%`;
+    const evac = evacBadgeFor(inc.evacuationOrders, inc.evacuationWarnings);
+    return `<tr class="${severityClass}">
+      <td>${evac}</td>
+      <td>${escapeHtml(inc.name.length > 40 ? inc.name.slice(0, 38) + '…' : inc.name)}</td>
+      <td>${escapeHtml(inc.state)}</td>
+      <td style="text-align:right">${acres}</td>
+      <td>${cont}</td>
+      <td style="text-align:right;opacity:0.75">${formatThreat(t.threatScore)}</td>
+    </tr>`;
+  }).join('');
+  return `<div style="margin-bottom:8px">
+    <div style="font-weight:600;font-size:12px;margin-bottom:4px;opacity:0.85">Highest-threat incidents (acres × uncontained)</div>
+    <table class="eq-table">
+      <thead>
+        <tr><th></th><th>Incident</th><th>State</th><th style="text-align:right">Acres</th><th>Cont.</th><th style="text-align:right">Threat</th></tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>
+  </div>`;
+}
+
+function renderPerimeterList(perimeters: ActiveFirePerimeter[]): string {
+  if (perimeters.length === 0) return '';
+  const rows = perimeters.map(p => {
+    const acres = p.acres === null ? '—' : p.acres.toLocaleString();
+    const cont = p.containmentPct === null ? '—' : `${Math.round(p.containmentPct)}%`;
+    const state = p.state ?? '—';
+    return `<tr>
+      <td>${escapeHtml(p.name.length > 36 ? p.name.slice(0, 34) + '…' : p.name)}</td>
+      <td>${escapeHtml(state)}</td>
+      <td style="text-align:right">${acres}</td>
+      <td>${cont}</td>
+    </tr>`;
+  }).join('');
+  return `<div>
+    <div style="font-weight:600;font-size:12px;margin-bottom:4px;opacity:0.85">NIFC active perimeters</div>
+    <table class="eq-table">
+      <thead><tr><th>Incident</th><th>State</th><th style="text-align:right">Acres</th><th>Cont.</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table>
+  </div>`;
+}
+
+function severityClassFor(idx: number): string {
+  if (idx === 0) return 'eq-major';
+  if (idx <= 2) return 'eq-strong';
+  return 'eq-moderate';
+}
+
+function evacBadgeFor(orders: boolean, warnings: boolean): string {
+  if (orders) return '<span class="sev-badge" style="background:var(--semantic-critical)">EVAC</span>';
+  if (warnings) return '<span class="sev-badge" style="background:var(--semantic-high)">WARN</span>';
+  return '';
+}
+
+function formatThreat(score: number): string {
+  if (score === 0) return '—';
+  if (score >= 1000) return `${(score / 1000).toFixed(1)}k`;
+  return Math.round(score).toLocaleString();
+}
+
+function timeAgo(ts: number): string {
+  const secs = Math.floor((Date.now() - ts) / 1000);
+  if (secs < 60) return 'just now';
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  return `${hrs}h ago`;
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -92,6 +92,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'humanitarian-crisis': { name: 'Humanitarian Crises', enabled: true, priority: 2 },
   'air-quality': { name: 'Air Quality', enabled: true, priority: 2 },
   'wildfire-incidents': { name: 'Wildfires (InciWeb)', enabled: true, priority: 2 },
+  'wildfire-intel': { name: 'Wildfire Intel', enabled: true, priority: 1 },
   'hazmat-incidents': { name: 'Hazmat Incidents', enabled: true, priority: 2 },
   'oil-spill': { name: 'Oil & Chemical Spills', enabled: true, priority: 2 },
   'hazard-alerts': { name: 'Hazard Alerts — Near Me', enabled: true, priority: 1 },
@@ -991,7 +992,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   hazards: {
  labelKey: 'header.panelCatHazards',
 
- panelKeys: ['satellite-fires', 'earthquakes', 'emsc-seismic', 'gdacs-alerts', 'volcano-alerts', 'nws-alerts', 'faa-weather-cams', 'tsunami-alerts', 'tropical-cyclones', 'climate', 'wildfire-incidents', 'hazmat-incidents', 'oil-spill', 'fcdo-warnings', 'dfat-warnings', 'gac-warnings', 'avalanche-hazard', 'wildfire-smoke', 'spc-mesoscale', 'amtrak-alerts', 'habsos', 'global-weather', 'extended-forecast', 'tide-predictions', 'pollen', 'weather-radar'],
+ panelKeys: ['wildfire-intel', 'satellite-fires', 'earthquakes', 'emsc-seismic', 'gdacs-alerts', 'volcano-alerts', 'nws-alerts', 'faa-weather-cams', 'tsunami-alerts', 'tropical-cyclones', 'climate', 'wildfire-incidents', 'hazmat-incidents', 'oil-spill', 'fcdo-warnings', 'dfat-warnings', 'gac-warnings', 'avalanche-hazard', 'wildfire-smoke', 'spc-mesoscale', 'amtrak-alerts', 'habsos', 'global-weather', 'extended-forecast', 'tide-predictions', 'pollen', 'weather-radar'],
  variants: ['full'],
   },
   healthEnv: {

--- a/src/services/__tests__/fire-intel-service.test.mts
+++ b/src/services/__tests__/fire-intel-service.test.mts
@@ -5,6 +5,7 @@ import {
   clusterHotspots,
   rankIncidentsByThreat,
   categorizeAqi,
+  findNearestPerimeter,
 } from '../wildfires/fire-intel-helpers.ts';
 import type { MapFire } from '../wildfires/index.ts';
 import type { IncidentReport } from '../inciweb.ts';
@@ -151,4 +152,38 @@ test('categorizeAqi: thresholds map per EPA US AQI scale', () => {
 test('categorizeAqi: NaN / Infinity → unknown', () => {
   assert.equal(categorizeAqi(Number.NaN), 'unknown');
   assert.equal(categorizeAqi(Number.POSITIVE_INFINITY), 'unknown');
+});
+
+// ── findNearestPerimeter ─────────────────────────────────────────────────
+
+test('findNearestPerimeter: empty list → null', () => {
+  assert.equal(findNearestPerimeter(34, -118, [], 50), null);
+});
+
+test('findNearestPerimeter: returns nearest within range', () => {
+  const perimeters = [
+    { lat: 34.10, lon: -118.20, id: 'A' },
+    { lat: 34.50, lon: -118.50, id: 'B' },
+    { lat: 40.00, lon: -100.00, id: 'C' },
+  ];
+  // Hotspot at LA → A is closest (~few km), B ~50+km, C far away
+  const r = findNearestPerimeter(34.10, -118.21, perimeters, 50);
+  assert.ok(r);
+  assert.equal(r.perimeter.id, 'A');
+  assert.ok(r.distanceKm < 5);
+});
+
+test('findNearestPerimeter: returns null when nothing within maxKm', () => {
+  const perimeters = [{ lat: 40, lon: -100, id: 'far' }];
+  assert.equal(findNearestPerimeter(34, -118, perimeters, 50), null);
+});
+
+test('findNearestPerimeter: ignores NaN coordinates', () => {
+  const perimeters = [
+    { lat: Number.NaN, lon: -118, id: 'broken' },
+    { lat: 34.10, lon: -118.20, id: 'A' },
+  ];
+  const r = findNearestPerimeter(34.10, -118.21, perimeters, 50);
+  assert.ok(r);
+  assert.equal(r.perimeter.id, 'A');
 });

--- a/src/services/wildfires/fire-intel-helpers.ts
+++ b/src/services/wildfires/fire-intel-helpers.ts
@@ -94,6 +94,39 @@ export function rankIncidentsByThreat(incidents: IncidentReport[]): RankedThreat
     .sort((a, b) => b.threatScore - a.threatScore);
 }
 
+/**
+ * Find the perimeter whose centroid is closest to (lat, lon), if any are
+ * within `maxKm`. Returns `null` when nothing is in range. Pure: takes the
+ * centroid lat/lon already exposed on the perimeter snapshot.
+ */
+export function findNearestPerimeter<T extends { lat: number; lon: number }>(
+  lat: number,
+  lon: number,
+  perimeters: T[],
+  maxKm: number,
+): { perimeter: T; distanceKm: number } | null {
+  if (perimeters.length === 0) return null;
+  let best: { perimeter: T; distanceKm: number } | null = null;
+  for (const p of perimeters) {
+    if (!Number.isFinite(p.lat) || !Number.isFinite(p.lon)) continue;
+    const d = haversineKm(lat, lon, p.lat, p.lon);
+    if (d > maxKm) continue;
+    if (!best || d < best.distanceKm) best = { perimeter: p, distanceKm: d };
+  }
+  return best;
+}
+
+function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const R = 6371;
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return 2 * R * Math.asin(Math.min(1, Math.sqrt(a)));
+}
+
 export function categorizeAqi(aqi: number | null): AqiCategory {
   if (aqi === null || !Number.isFinite(aqi)) return 'unknown';
   if (aqi <= 50) return 'good';


### PR DESCRIPTION
**PR 3 of 3 in the wildfire intelligence stack. Stacks on [#342](https://github.com/bradleybond512/crystal-ball/pull/342) → [#327](https://github.com/bradleybond512/crystal-ball/pull/327).**

## What

Replaces the per-pixel FIRMS render on the Cesium globe with the **0.1° clustered top-500** from PR 1, and adds **NIFC active fire perimeters** as red outlined polygons.

When a hotspot cluster's centroid is within **50 km** of a NIFC perimeter, the click description on the globe includes the perimeter name + distance — answering 'is that hotspot the X fire?' inline.

## Globe layer changes

| Before | After |
|--------|-------|
| Every FIRMS pixel rendered (filtered by FRP > 10) | Top 500 clusters by total FRP, 0.1° grid |
| Single hotspot label `Fire 12MW` | Cluster label `23× 145MW` (pixel count × total FRP) |
| 3-tier color (high/nominal/low) | 2-tier (high/nominal); low rolls into nominal in cluster |
| No perimeter context | NIFC polygons + nearest-perimeter note on hotspot click |

The renderer is split into two pure helpers (`renderPerimeterPolygons`, `renderHotspotClusters`) so `loadFires()` stays under the cognitive-complexity ceiling.

## New helper: `findNearestPerimeter()`

Pure function in `fire-intel-helpers.ts`. Returns the closest perimeter within `maxKm` (or null), using haversine over the perimeter centroid. **4 new unit tests** added.

## Webcam fire-trigger wire-up

`loadWildfireIntel` emits a `'wildfire:fire-trigger'` CustomEvent on `globalThis` with the top-3 threat-ranked incidents that have lat/lon. Webcam aggregators (or any other consumer) subscribe and call `evaluateFireTrigger()` from `webcams/webcam-event-triggers.ts` against their spatial index.

**Why an event, not a direct call:** the webcam aggregator + spatial index doesn't yet have a wired loader chain in `src/app/` (the aggregator exists in `src/services/webcams/` but loaders don't construct an index on startup). An event lets that wire-up land independently without coupling this PR to webcam-feed bootstrapping.

## Tests

```
npm run test:wildfire    # 20/20 pass (16 from PR 1 + 4 new findNearestPerimeter cases)
npm run typecheck:all    # zero errors
```

## Stacking

Depends on #342 (panel) → #327 (orchestrator). Once both merge, this PR auto-rebases.

## Out of scope (intentional, with rationale)

- **Constructing a webcam spatial index in app loaders** — that's a separate webcam-feed plumbing change. Deferred so this PR stays focused on wildfire.
- **Click-to-zoom-to-incident** — current click description already includes the linked perimeter name; explicit zoom button can land later.
- **Per-pixel render fallback** — clustering is strictly better for the 50k+ global FIRMS pixel firehose. If someone wants pixel-level on a small region, that's a separate map-view feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)