### PR TITLE
feat: SavedPlaces threat badges + Export Brief toolbar button

### DIFF
--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -467,6 +467,16 @@ export class EventHandlerManager implements AppModule {
  (document.getElementById('headerThemeToggle') as HTMLElement)?.click();
  });
 
+ // Toolbar overflow — Export Brief button (📄). Both desktop overflow
+ // and the web header use the same dynamic-import handler so the
+ // jsPDF + briefing modules don't bloat the initial bundle.
+ const briefHandler = (btn: HTMLElement | null) => {
+ if (!btn) return;
+ btn.addEventListener('click', () => { void exportBriefAsPdf(btn); });
+ };
+ briefHandler(document.getElementById('toolbarBriefBtn'));
+ briefHandler(document.getElementById('webBriefBtn'));
+
  // Toolbar overflow — Mode button now toggles Ghost Mode
  const toolbarModeBtn = document.getElementById('toolbarModeBtn');
  const updateModeBtn = () => {
@@ -1069,5 +1079,65 @@ export class EventHandlerManager implements AppModule {
  const panel = this.ctx.panels[key];
  panel?.toggle(config.enabled);
  });
+  }
+}
+
+// ── Export Brief PDF ─────────────────────────────────────────────────────
+// Lazy-imports jsPDF + the briefing modules so the initial bundle stays
+// lean. Generates a fresh briefing if none is cached, then triggers a
+// browser download. Works in both web and Tauri's webview — no fs
+// permission scope needed.
+async function exportBriefAsPdf(button: HTMLElement): Promise<void> {
+  const original = button.textContent;
+  const originalTitle = button.title;
+  const setBusy = (msg: string) => {
+ button.setAttribute('aria-busy', 'true');
+ button.title = msg;
+ // Briefly show a spinner glyph in place of the icon.
+ if (button.id === 'webBriefBtn') {
+ const label = button.querySelector('span');
+ if (label) label.textContent = msg;
+ } else {
+ button.textContent = '⏳';
+ }
+  };
+  const reset = () => {
+ button.removeAttribute('aria-busy');
+ button.title = originalTitle;
+ if (button.id === 'webBriefBtn') {
+ const label = button.querySelector('span');
+ if (label) label.textContent = 'Export Brief';
+ } else {
+ button.textContent = original;
+ }
+  };
+  try {
+ setBusy('Generating brief…');
+ const [briefing, brief] = await Promise.all([
+ (async () => {
+ const { getCachedBriefing, generateBriefing } = await import('@/services/intelligence-briefing');
+ const cached = getCachedBriefing();
+ if (cached) return cached;
+ return generateBriefing();
+ })(),
+ import('@/services/export/brief-pdf'),
+ ]);
+ const blob = brief.renderBriefingPdfBlob(briefing);
+ const url = URL.createObjectURL(blob);
+ const anchor = document.createElement('a');
+ anchor.href = url;
+ anchor.download = brief.briefPdfFilename(briefing);
+ document.body.append(anchor);
+ anchor.click();
+ anchor.remove();
+ // Revoke after the browser has had a chance to start the download.
+ setTimeout(() => URL.revokeObjectURL(url), 1000);
+  } catch (error) {
+ console.error('[brief] Export failed:', error);
+ // Lightweight inline notice — using window.alert keeps the wire
+ // small; a richer toast would belong in a follow-up.
+ window.alert(`Brief export failed: ${error instanceof Error ? error.message : String(error)}`);
+  } finally {
+ reset();
   }
 }

--- a/src/app/layout/html.ts
+++ b/src/app/layout/html.ts
@@ -193,6 +193,7 @@ export function buildDesktopLayout(ctx: AppContext): string {
  <button class="mac-toolbar-overflow-btn" id="toolbarSettingsBtn" title="Settings (⌘,)">⚙</button>
  <button class="mac-toolbar-overflow-btn" id="toolbarThemeBtn" title="Toggle theme">☀</button>
  <button class="mac-toolbar-overflow-btn" id="toolbarModeBtn" title="Cycle mode (⌘M)">🕊</button>
+ <button class="mac-toolbar-overflow-btn" id="toolbarBriefBtn" title="Export intelligence brief PDF">📄</button>
  </div>
  <span class="header-clock" id="headerClock" data-tauri-drag-region></span>
  <button class="search-btn" id="searchBtn"><kbd>⌘K</kbd> ${t('header.search')}</button>
@@ -248,6 +249,9 @@ export function buildWebLayout(ctx: AppContext): string {
  ${ctx.isDesktopApp ? '' : `<button class="copy-link-btn" id="copyLinkBtn">${t('header.copyLink')}</button>`}
  <button class="copy-link-btn" id="godsVisionBtn" title="God's Vision — 3D globe view (G)" style="display:inline-flex;align-items:center;gap:6px;">
  🌍 <span style="font-size:11px;">God's Vision</span>
+ </button>
+ <button class="copy-link-btn" id="webBriefBtn" title="Export intelligence brief PDF" style="display:inline-flex;align-items:center;gap:6px;">
+ 📄 <span style="font-size:11px;">Export Brief</span>
  </button>
  <button class="theme-toggle-btn" id="headerThemeToggle" title="${t('header.toggleTheme')}">
  ${buildThemeIcon()}

--- a/src/components/SavedPlacesPanel.ts
+++ b/src/components/SavedPlacesPanel.ts
@@ -2,6 +2,7 @@ import { Panel } from './Panel';
 import { escapeHtml } from '@/utils/sanitize';
 import { getSavedPlaces, subscribeSavedPlaces, type SavedPlace, type SavedPlaceTag } from '@/services/saved-places';
 import { getSavedPlaceBrief } from '@/services/place-briefs';
+import { computeDistanceKm, unifiedAlertStore, type UnifiedAlert } from '@/services/unified-alerts';
 
 interface SavedPlacesPanelOptions {
   focusPlace: (placeId: string) => void;
@@ -27,9 +28,25 @@ const PENCIL_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="11" height="1
 
 const MAX_PLACES = 20;
 
+interface PlaceThreatSummary {
+  total: number;
+  critical: number;
+  high: number;
+  medium: number;
+}
+
+const SEVERITY_COLOR: Record<UnifiedAlert['severity'], string> = {
+  critical: '#ef4444',
+  high:     '#fb923c',
+  medium:   '#fde68a',
+  low:      '#86efac',
+  info:     '#9ca3af',
+};
+
 export class SavedPlacesPanel extends Panel {
   private options: SavedPlacesPanelOptions;
   private unsubscribeSavedPlaces: (() => void) | null = null;
+  private unsubscribeAlerts: (() => void) | null = null;
   private readonly boundRefresh: () => void;
   private places: SavedPlace[] = [];
 
@@ -82,6 +99,7 @@ export class SavedPlacesPanel extends Panel {
  document.addEventListener('wm:saved-place-weather-updated', this.boundRefresh);
  document.addEventListener('wm:storm-data-updated', this.boundRefresh);
  this.unsubscribeSavedPlaces = subscribeSavedPlaces(() => this.refresh());
+ this.unsubscribeAlerts = unifiedAlertStore.subscribe(() => this.refresh());
  this.refresh();
   }
 
@@ -93,7 +111,48 @@ export class SavedPlacesPanel extends Panel {
  document.removeEventListener('wm:storm-data-updated', this.boundRefresh);
  this.unsubscribeSavedPlaces?.();
  this.unsubscribeSavedPlaces = null;
+ this.unsubscribeAlerts?.();
+ this.unsubscribeAlerts = null;
  super.destroy();
+  }
+
+  /** Count alerts whose location falls inside a saved place's radius,
+   *  grouped by severity tier. Used to render the threat badges on
+   *  each place card. */
+  private summarizeThreats(place: SavedPlace): PlaceThreatSummary {
+ const summary: PlaceThreatSummary = { total: 0, critical: 0, high: 0, medium: 0 };
+ const alerts = unifiedAlertStore.getAll();
+ for (const alert of alerts) {
+ if (!alert.location) continue;
+ if (alert.acknowledged) continue;
+ const distKm = computeDistanceKm(place.lat, place.lon, alert.location.lat, alert.location.lon);
+ if (distKm > place.radiusKm) continue;
+ summary.total += 1;
+ if (alert.severity === 'critical') summary.critical += 1;
+ else if (alert.severity === 'high') summary.high += 1;
+ else if (alert.severity === 'medium') summary.medium += 1;
+ }
+ return summary;
+  }
+
+  /** Pick the worst severity tier represented in a summary so the
+   *  badge color tracks the most-critical alert in the radius. */
+  private worstSeverity(summary: PlaceThreatSummary): UnifiedAlert['severity'] {
+ if (summary.critical > 0) return 'critical';
+ if (summary.high > 0) return 'high';
+ if (summary.medium > 0) return 'medium';
+ return 'low';
+  }
+
+  /** Render a colored severity-count badge for a place. Returns empty
+   *  string when there are no threats — saving vertical space. */
+  private renderThreatBadge(summary: PlaceThreatSummary): string {
+ if (summary.total === 0) return '';
+ const color = SEVERITY_COLOR[this.worstSeverity(summary)];
+ const tooltip = `${summary.total} alert${summary.total === 1 ? '' : 's'} in radius`
+ + (summary.critical > 0 ? ` · ${summary.critical} critical` : '')
+ + (summary.high > 0 ? ` · ${summary.high} high` : '');
+ return `<span class="watchlist-panel-chip spm-threat-chip" title="${escapeHtml(tooltip)}" style="background:${color};color:#0a0a0c;font-weight:600">⚠ ${summary.total}</span>`;
   }
 
   public refresh(): void {
@@ -128,7 +187,9 @@ export class SavedPlacesPanel extends Panel {
  const brief = getSavedPlaceBrief(place.id);
  const hasStormPosture = brief?.items.some((item) => item.kind === 'preparedness');
  const hasForecastRisk = brief?.items.some((item) => item.kind === 'forecast');
+ const threats = this.summarizeThreats(place);
  const badges = [
+ this.renderThreatBadge(threats),
  place.primary ? '<span class="watchlist-panel-chip">Primary</span>' : '',
  place.offlinePinned ? '<span class="watchlist-panel-chip">Offline</span>' : '',
  brief?.isStale ? '<span class="watchlist-panel-chip">Cached</span>' : '',


### PR DESCRIPTION
Wires two of the four follow-ups for the globe/UI substrate stack ([#319](https://github.com/bradleybond512/crystal-ball/pull/319) + [#322](https://github.com/bradleybond512/crystal-ball/pull/322)).

## What ships

### SavedPlacesPanel threat badges
- `summarizeThreats(place)` reads from `unifiedAlertStore` and filters by haversine distance against each place's `radiusKm`
- `renderThreatBadge` shows a colored ⚠ N chip — color = worst-severity tier in radius (critical → red, high → orange, medium → amber, low → green)
- Subscribes to `unifiedAlertStore.subscribe` so badges update live as alerts arrive / are acknowledged
- Skips acknowledged alerts so cleared items don't re-pollute the cards

### Export Brief toolbar button
- 📄 button in both desktop overflow row + web header (`toolbarBriefBtn` / `webBriefBtn`)
- Lazy-imports `getCachedBriefing` / `generateBriefing` + `brief-pdf` so jsPDF (~150 KB) doesn't bloat the initial bundle
- Generates a fresh briefing if none cached (LLM-backed; button shows ⏳ + 'Generating brief…' during the call)
- Renders via `renderBriefingPdfBlob` → object URL → `anchor.click()` for browser download (no Tauri fs plugin needed — works in web + Tauri webview)

## Why `unifiedAlertStore` instead of the threat-aggregator from #319

The threat-aggregator I built in [#319](https://github.com/bradleybond512/crystal-ball/pull/319) takes typed domain snapshots (seismic / wildfire / weather / infrastructure) — that requires a renderer-side data flow that aggregates from many services. `unifiedAlertStore` is the existing canonical alert sink the rest of the app already consumes; using it gets visible UI shipped now without re-architecting the data flow. The threat-aggregator stays useful for the sidecar route + future API responses where typed domain data is the input.

## Validation

```
npm run typecheck:all   # clean
eslint                  # clean
```

**Visual verification deferred** — dev server currently fails to start due to an unrelated `@luma.gl/engine` ↔ `@deck.gl/geo-layers` dep mismatch in `node_modules` (pre-existing; I didn't touch it). Will verify after that's resolved.

## Stack

| PR | Substrate / Wire | Status |
|---|---|---|
| [#319](https://github.com/bradleybond512/crystal-ball/pull/319) | threat-aggregator | merged |
| [#322](https://github.com/bradleybond512/crystal-ball/pull/322) | brief-pdf renderer | merged |
| [#332](https://github.com/bradleybond512/crystal-ball/pull/332) | timeline-cursor | merged |
| [#336](https://github.com/bradleybond512/crystal-ball/pull/336) | heatmap-layers | merged |
| this | SavedPlaces badges + brief button | open |
| next | GlobeTimeMachine wire + heatmap toggle row | pending |

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>