### PR TITLE
feat: globe timeline sync + heatmap toggle row

### DIFF
--- a/src/components/GodsVisionView.ts
+++ b/src/components/GodsVisionView.ts
@@ -31,6 +31,8 @@ import { GlobeSatellites } from '@/components/gods-vision/GlobeSatellites';
 import { GlobeMiniMap } from '@/components/gods-vision/GlobeMiniMap';
 import { GlobeAudio } from '@/components/gods-vision/GlobeAudio';
 import { GlobeAlertClusters } from '@/components/gods-vision/GlobeAlertClusters';
+import { GlobeTimelineSync } from '@/components/gods-vision/GlobeTimelineSync';
+import { GlobeHeatmapToggle } from '@/components/gods-vision/GlobeHeatmapToggle';
 import { StreetTileManager } from '@/services/street-tiles';
 import { GpsTracker, type GpsPosition } from '@/services/gps-tracker';
 import { computeRoute, type RouteResult, type RouteCoord } from '@/services/routing-engine';
@@ -72,6 +74,8 @@ export class GodsVisionView {
   private dataManager: GlobeDataManager | null = null;
   private hud: GlobeHUD | null = null;
   private timeMachine: GlobeTimeMachine | null = null;
+  private timelineSync: GlobeTimelineSync | null = null;
+  private heatmapToggle: GlobeHeatmapToggle | null = null;
   private autoFollow: AutoFollowEngine | null = null;
   private fourD: Globe4DManager | null = null;
   private reactorBeacons: GlobeReactorBeacons | null = null;
@@ -222,7 +226,23 @@ export class GodsVisionView {
  if (viewer && this.dataManager) {
  this.timeMachine = new GlobeTimeMachine(viewer, this.dataManager, this.container);
  this.timeMachine.mount();
+
+ // Bridge cursor → timeline-cursor visibility helper. Renders a
+ // small "N events @ cursor" badge above the scrubber + dispatches
+ // `wm:globe-timeline-cursor` events for layer managers to react.
+ this.timelineSync = new GlobeTimelineSync(this.timeMachine, this.container);
+ this.timelineSync.mount();
+ this.cleanupHandlers.push(() => { this.timelineSync?.destroy(); this.timelineSync = null; });
  }
+
+ // Per-domain heatmap toggle row (seismic / fire / cyber / conflict).
+ // The toggle owns selection + opacity state and dispatches
+ // `wm:globe-heatmap-changed` with deck.gl HexagonLayer configs;
+ // the deck.gl-on-Cesium overlay that consumes those configs is a
+ // follow-up. Visible UI lands now so users see the controls.
+ this.heatmapToggle = new GlobeHeatmapToggle(this.container);
+ this.heatmapToggle.mount();
+ this.cleanupHandlers.push(() => { this.heatmapToggle?.destroy(); this.heatmapToggle = null; });
 
  // Geocode search bar
  if (viewer) {

--- a/src/components/gods-vision/GlobeHeatmapToggle.ts
+++ b/src/components/gods-vision/GlobeHeatmapToggle.ts
@@ -1,0 +1,170 @@
+/**
+ * GlobeHeatmapToggle
+ * -----------------
+ * Toggle row + opacity slider for the per-domain heatmap layers built
+ * by `services/globe/heatmap-layers.ts` (PR #336).
+ *
+ * Mounts a 4-button radio row (Seismic / Fire / Cyber / Conflict) plus
+ * an opacity slider into the GodsVisionView container. Selection state
+ * is local; on change, dispatches `wm:globe-heatmap-changed` so the
+ * deck.gl-on-Cesium overlay (follow-up) can pick up the active config
+ * and (re-)render the layer.
+ *
+ * Decoupling the UI from the renderer keeps this component testable
+ * without WebGL — the pure config builder + this UI talk via a typed
+ * event payload, not a direct deck.gl handle.
+ */
+
+import {
+  buildAllHeatmapLayers,
+  listPalettes,
+  type HeatmapDomain,
+  type HeatmapLayerConfig,
+  type HeatmapPoint,
+} from '@/services/globe/heatmap-layers';
+
+export interface HeatmapState {
+  selected: HeatmapDomain | null;
+  opacity: number;
+  /** Per-domain point arrays the renderer should consume. The toggle
+   *  doesn't fetch data; callers feed it via `setPoints()`. */
+  points: Partial<Record<HeatmapDomain, readonly HeatmapPoint[]>>;
+}
+
+export interface GlobeHeatmapChangedEvent extends CustomEvent {
+  detail: { state: HeatmapState; configs: HeatmapLayerConfig[] };
+}
+
+const CHANGED_EVENT = 'wm:globe-heatmap-changed';
+const DEFAULT_OPACITY = 0.6;
+
+export class GlobeHeatmapToggle {
+  private container: HTMLElement;
+  private root: HTMLDivElement | null = null;
+  private buttons = new Map<HeatmapDomain, HTMLButtonElement>();
+  private state: HeatmapState = {
+    selected: null,
+    opacity: DEFAULT_OPACITY,
+    points: {},
+  };
+
+  constructor(container: HTMLElement) {
+    this.container = container;
+  }
+
+  mount(): void {
+    const root = document.createElement('div');
+    root.className = 'globe-heatmap-toggle';
+    root.style.cssText = [
+      'position:absolute',
+      'top:88px',
+      'right:12px',
+      'display:flex',
+      'flex-direction:column',
+      'gap:6px',
+      'padding:8px 10px',
+      'border-radius:8px',
+      'background:rgba(0,0,0,0.55)',
+      'backdrop-filter:blur(10px)',
+      'color:#fff',
+      'font:11px/1.2 -apple-system,BlinkMacSystemFont,sans-serif',
+      'z-index:8',
+      'min-width:140px',
+    ].join(';');
+
+    const header = document.createElement('div');
+    header.style.cssText = 'opacity:0.7;letter-spacing:0.05em;text-transform:uppercase;font-size:9px;';
+    header.textContent = 'Heatmap';
+    root.append(header);
+
+    const row = document.createElement('div');
+    row.style.cssText = 'display:flex;flex-wrap:wrap;gap:4px;';
+    for (const palette of listPalettes()) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.dataset.domain = palette.domain;
+      btn.textContent = palette.label.replace(/ Density$| Incidents$| Events$/, '');
+      btn.style.cssText = [
+        'padding:3px 7px',
+        'border-radius:6px',
+        'border:1px solid rgba(255,255,255,0.15)',
+        'background:transparent',
+        'color:#fff',
+        'cursor:pointer',
+        'font-size:10px',
+      ].join(';');
+      btn.addEventListener('click', () => this.toggle(palette.domain));
+      this.buttons.set(palette.domain, btn);
+      row.append(btn);
+    }
+    root.append(row);
+
+    const sliderLabel = document.createElement('label');
+    sliderLabel.style.cssText = 'display:flex;align-items:center;gap:6px;font-size:10px;opacity:0.85;';
+    sliderLabel.append('Opacity ');
+    const slider = document.createElement('input');
+    slider.type = 'range';
+    slider.min = '0';
+    slider.max = '100';
+    slider.value = String(Math.round(DEFAULT_OPACITY * 100));
+    slider.style.cssText = 'flex:1;accent-color:#3b82f6;';
+    slider.addEventListener('input', () => {
+      this.state.opacity = Number(slider.value) / 100;
+      this.emit();
+    });
+    sliderLabel.append(slider);
+    root.append(sliderLabel);
+
+    this.container.append(root);
+    this.root = root;
+    this.repaintButtons();
+  }
+
+  destroy(): void {
+    this.root?.remove();
+    this.root = null;
+    this.buttons.clear();
+  }
+
+  /** Update the underlying point data for one or more domains. The
+   *  renderer should call this whenever its data sources tick. */
+  setPoints(points: Partial<Record<HeatmapDomain, readonly HeatmapPoint[]>>): void {
+    this.state.points = { ...this.state.points, ...points };
+    this.emit();
+  }
+
+  /** Public accessor for tests + downstream consumers. */
+  getState(): HeatmapState {
+    return { ...this.state, points: { ...this.state.points } };
+  }
+
+  /** Toggle a domain. Clicking the active domain turns it off (matches
+   *  the "single active at a time" rule from the spec). */
+  private toggle(domain: HeatmapDomain): void {
+    this.state.selected = this.state.selected === domain ? null : domain;
+    this.repaintButtons();
+    this.emit();
+  }
+
+  private repaintButtons(): void {
+    for (const [domain, btn] of this.buttons) {
+      const active = this.state.selected === domain;
+      btn.style.background = active ? 'rgba(59,130,246,0.35)' : 'transparent';
+      btn.style.borderColor = active ? '#3b82f6' : 'rgba(255,255,255,0.15)';
+      btn.style.fontWeight = active ? '600' : '400';
+    }
+  }
+
+  private emit(): void {
+    const configs = buildAllHeatmapLayers({
+      selected: this.state.selected,
+      points: this.state.points,
+      opacity: this.state.opacity,
+    });
+    document.dispatchEvent(new CustomEvent(CHANGED_EVENT, {
+      detail: { state: this.getState(), configs },
+    }));
+  }
+}
+
+export const GLOBE_HEATMAP_CHANGED_EVENT = CHANGED_EVENT;

--- a/src/components/gods-vision/GlobeTimelineSync.ts
+++ b/src/components/gods-vision/GlobeTimelineSync.ts
@@ -1,0 +1,114 @@
+/**
+ * GlobeTimelineSync
+ * ----------------
+ * Bridge between the existing GlobeTimeMachine (cursor controller) and
+ * the timeline-cursor visibility helper from PR #332. Subscribes to
+ * the time-machine's onTimeChange callback, computes which TimelineEvents
+ * are "visible at the cursor" via `visibleAt()`, and broadcasts the
+ * result to the rest of the app via a custom DOM event.
+ *
+ * Also renders a tiny "N events @ cursor" badge near the time-machine
+ * bar so users get immediate visual feedback that the cursor is doing
+ * something. Anything else that wants to fade/dim entities can listen
+ * for `wm:globe-timeline-cursor` and react.
+ *
+ * The deeper integration (entity opacity changes inside GlobeDataManager)
+ * is intentionally NOT in this component — that's a per-layer concern
+ * and lands in a follow-up after each layer manager picks the visibility
+ * model that suits it.
+ */
+
+import type { GlobeTimeMachine } from '@/components/GlobeTimeMachine';
+import { getEventsInWindow } from '@/services/timeline-scrubber';
+import {
+  countByType,
+  visibleAt,
+  type VisibleTimelineEvent,
+} from '@/services/playback/timeline-cursor';
+
+/** Event detail dispatched on `document` whenever the cursor changes
+ *  and the visible-event set is recomputed. */
+export interface GlobeTimelineCursorEvent extends CustomEvent {
+  detail: {
+    /** ms epoch of the time-machine cursor. */
+    cursorMs: number;
+    visible: VisibleTimelineEvent[];
+    countsByType: ReturnType<typeof countByType>;
+  };
+}
+
+const CURSOR_EVENT = 'wm:globe-timeline-cursor';
+/** How far back to look for events around the cursor. Matches
+ *  timeline-cursor's default window (6 h). */
+const CURSOR_WINDOW_MS = 6 * 60 * 60 * 1000;
+
+export class GlobeTimelineSync {
+  private timeMachine: GlobeTimeMachine;
+  private container: HTMLElement;
+  private badge: HTMLDivElement | null = null;
+  private unsubscribe: (() => void) | null = null;
+
+  constructor(timeMachine: GlobeTimeMachine, container: HTMLElement) {
+    this.timeMachine = timeMachine;
+    this.container = container;
+  }
+
+  mount(): void {
+    const badge = document.createElement('div');
+    badge.className = 'globe-timeline-sync-badge';
+    badge.style.cssText = [
+      'position:absolute',
+      'bottom:46px',
+      'left:50%',
+      'transform:translateX(-50%)',
+      'padding:4px 8px',
+      'border-radius:10px',
+      'background:rgba(0,0,0,0.55)',
+      'color:#fff',
+      'font:11px/1.2 ui-monospace,Menlo,monospace',
+      'pointer-events:none',
+      'z-index:8',
+      'opacity:0',
+      'transition:opacity 0.2s',
+    ].join(';');
+    this.container.append(badge);
+    this.badge = badge;
+
+    // Initial paint at "now" so we don't sit at "0 events" on mount.
+    this.handleTimeChange(Date.now());
+
+    this.unsubscribe = this.timeMachine.onTimeChange((ms) => this.handleTimeChange(ms));
+  }
+
+  destroy(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.badge?.remove();
+    this.badge = null;
+  }
+
+  private handleTimeChange(cursorMs: number): void {
+    // Pull the lookback window of timeline events ending at the cursor.
+    const startMs = cursorMs - CURSOR_WINDOW_MS;
+    const allEvents = getEventsInWindow(startMs, cursorMs);
+    const visible = visibleAt(allEvents, { currentMs: cursorMs, windowMs: CURSOR_WINDOW_MS });
+    const counts = countByType(visible);
+
+    // Update the inline badge — only show when ≥1 event is visible.
+    if (this.badge) {
+      if (visible.length > 0) {
+        this.badge.textContent = `${visible.length} event${visible.length === 1 ? '' : 's'} @ cursor`;
+        this.badge.style.opacity = '1';
+      } else {
+        this.badge.style.opacity = '0';
+      }
+    }
+
+    // Broadcast for any layer manager that wants to react.
+    document.dispatchEvent(new CustomEvent(CURSOR_EVENT, {
+      detail: { cursorMs, visible, countsByType: counts },
+    }));
+  }
+}
+
+export const GLOBE_TIMELINE_CURSOR_EVENT = CURSOR_EVENT;


### PR DESCRIPTION
Wires the remaining two follow-ups for the globe/UI substrate stack: timeline-cursor visibility ([#332](https://github.com/bradleybond512/crystal-ball/pull/332)) and per-domain heatmap configs ([#336](https://github.com/bradleybond512/crystal-ball/pull/336)).

## What ships

### `GlobeTimelineSync`
- Bridges GlobeTimeMachine's `onTimeChange` callback to the `visibleAt` / `countByType` helpers from #332
- Renders a small floating 'N events @ cursor' badge above the scrubber so the cursor's effect is immediately visible
- Dispatches `wm:globe-timeline-cursor` with `{ cursorMs, visible, countsByType }` so any layer manager can react (per-layer entity-opacity wiring lands in a follow-up — each manager picks the visibility model that suits it)
- Initial paint at `Date.now()` so the badge doesn't sit at zero on mount

### `GlobeHeatmapToggle`
- Floating toolbar (top-right of the globe) with 4-button radio row (Seismic / Fire / Cyber / Conflict) + opacity slider
- Single-active-at-a-time selection per spec; clicking the active domain turns it off
- Owns local `HeatmapState` ({ selected, opacity, per-domain points })
- `setPoints(partial)` lets callers feed live data without re-fetching inside the toggle
- Dispatches `wm:globe-heatmap-changed` with `{ state, configs }` where configs come from `buildAllHeatmapLayers` — exactly one config has `visible:true`. The deck.gl-on-Cesium overlay that mounts those configs is a follow-up; UI ships now so users see the controls.

### `GodsVisionView`
- Mounts both right after `timeMachine.mount()` with matching `cleanupHandlers` entries

## Why event-bus instead of direct wiring

Each existing layer manager has its own model for entity visibility — some rely on Cesium primitives, some on canvas overlays, some on data-source filtering. A single direct integration would require touching all of them in one PR. The event bus pattern lets each layer manager opt in independently in a follow-up that suits its model.

## Validation
```
npm run typecheck:all   # clean
eslint                  # clean
```

**Visual verification deferred** — dev server currently fails to start due to an unrelated `@luma.gl/engine` ↔ `@deck.gl/geo-layers` dep mismatch in `node_modules` (pre-existing; I didn't touch it).

## Stack closeout

| PR | Layer | Status |
|---|---|---|
| [#319](https://github.com/bradleybond512/crystal-ball/pull/319) | threat-aggregator | merged |
| [#322](https://github.com/bradleybond512/crystal-ball/pull/322) | brief-pdf renderer | merged |
| [#332](https://github.com/bradleybond512/crystal-ball/pull/332) | timeline-cursor | merged |
| [#336](https://github.com/bradleybond512/crystal-ball/pull/336) | heatmap-layers | merged |
| [#349](https://github.com/bradleybond512/crystal-ball/pull/349) | SavedPlaces badges + brief button | open |
| this | Globe timeline sync + heatmap toggle | open |

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>