### PR TITLE
feat(spaceweather): Cesium aurora ring + subsolar X-flare pulse + tighten banner to G4+ (PR 4/4)

### DIFF
--- a/src/components/EEWStatusBar.ts
+++ b/src/components/EEWStatusBar.ts
@@ -41,7 +41,6 @@ const COLOR_CLASSES: Record<StatusBarState['color'], string> = {
 
 const SPACEWX_CLASSES: Record<SpaceWxBannerSeverity, string> = {
   none: '',
-  g3: 'eew-bar-spacewx-g3',
   g4: 'eew-bar-spacewx-g4',
   g5: 'eew-bar-spacewx-g5',
   flare: 'eew-bar-spacewx-flare',

--- a/src/components/GlobeSpaceWeatherOverlay.ts
+++ b/src/components/GlobeSpaceWeatherOverlay.ts
@@ -1,0 +1,288 @@
+/**
+ * GlobeSpaceWeatherOverlay — Cesium entity wiring for PR 3 of the
+ * space weather stack.
+ *
+ * Consumes the descriptors produced by `globe-overlay.buildOverlayDescriptor`:
+ *   - Aurora oval ring (north + south parallels at visibility latitude)
+ *     when Kp ≥ 5, color stepped by storm level
+ *   - Pulsing point + halo at the subsolar point when an X-class flare
+ *     is active, animated via a Cesium CallbackProperty
+ *
+ * Mirrors GlobeSeismicWaves' lifecycle:
+ *   - Polls /api/spaceweather/status every 5 min
+ *   - mount / destroy reconcile a CustomDataSource on the viewer
+ *   - localStorage-backed enabled flag for HUD toggle parity
+ *   - Class is thin; the math is already in services/spaceweather/globe-overlay
+ */
+
+import {
+  CallbackProperty,
+  Cartesian3,
+  Color,
+  ColorMaterialProperty,
+  CustomDataSource,
+  type Entity,
+  HeightReference,
+  type Viewer,
+} from 'cesium';
+
+import {
+  buildOverlayDescriptor,
+  flarePulseRadiusM,
+  type AuroraRing,
+  type FlarePulse,
+  type GlobeOverlayDescriptor,
+} from '@/services/spaceweather/globe-overlay';
+import type { SpaceWxStatus } from '@/services/spaceweather/swpc-monitor';
+
+const ENDPOINT = '/api/spaceweather/status';
+const POLL_INTERVAL_MS = 5 * 60 * 1000;
+const ENABLED_KEY = 'cb:globe-space-weather-enabled';
+const DATA_SOURCE_NAME = 'space-weather-overlay';
+
+const ENTITY_IDS = {
+  auroraNorth: 'sw-aurora-north',
+  auroraSouth: 'sw-aurora-south',
+  flarePoint: 'sw-flare-point',
+  flarePulse: 'sw-flare-pulse',
+} as const;
+
+export function isSpaceWeatherOverlayEnabled(): boolean {
+  try {
+    const raw = localStorage.getItem(ENABLED_KEY);
+    if (raw === null) return true;
+    return raw === '1';
+  } catch {
+    return true;
+  }
+}
+
+export function setSpaceWeatherOverlayEnabled(value: boolean): void {
+  try {
+    localStorage.setItem(ENABLED_KEY, value ? '1' : '0');
+  } catch { /* localStorage may be unavailable */ }
+}
+
+export class GlobeSpaceWeatherOverlay {
+  private viewer: Viewer;
+  private dataSource: CustomDataSource | null = null;
+  private mounted = false;
+  private enabled = isSpaceWeatherOverlayEnabled();
+  private currentDescriptor: GlobeOverlayDescriptor = { visible: false, aurora: null, flarePulse: null };
+  private pulseStartMs: number = Date.now();
+  private entities = new Map<string, Entity>();
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(viewer: Viewer) {
+    this.viewer = viewer;
+  }
+
+  mount(): void {
+    if (this.mounted) return;
+    this.mounted = true;
+    this.dataSource = new CustomDataSource(DATA_SOURCE_NAME);
+    void this.viewer.dataSources.add(this.dataSource);
+    if (this.enabled) this.startPolling();
+  }
+
+  destroy(): void {
+    if (!this.mounted) return;
+    this.mounted = false;
+    this.stopPolling();
+    this.entities.clear();
+    this.currentDescriptor = { visible: false, aurora: null, flarePulse: null };
+    if (this.dataSource) {
+      this.viewer.dataSources.remove(this.dataSource, true);
+      this.dataSource = null;
+    }
+  }
+
+  setEnabled(value: boolean): void {
+    if (this.enabled === value) return;
+    this.enabled = value;
+    setSpaceWeatherOverlayEnabled(value);
+    if (this.mounted) {
+      if (value) {
+        this.startPolling();
+      } else {
+        this.stopPolling();
+        this.applyDescriptor({ visible: false, aurora: null, flarePulse: null });
+      }
+    }
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  // ── Polling ─────────────────────────────────────────────────────────────
+
+  private startPolling(): void {
+    if (this.pollTimer !== null) return;
+    void this.fetchAndApply();
+    this.pollTimer = setInterval(() => {
+      void this.fetchAndApply();
+    }, POLL_INTERVAL_MS);
+  }
+
+  private stopPolling(): void {
+    if (this.pollTimer !== null) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+  }
+
+  private async fetchAndApply(): Promise<void> {
+    try {
+      const res = await fetch(ENDPOINT, { headers: { Accept: 'application/json' } });
+      if (!res.ok) return;
+      const status = (await res.json()) as SpaceWxStatus;
+      this.applyStatus(status);
+    } catch { /* silent — best-effort */ }
+  }
+
+  /** Public for tests + callers that already have a SpaceWxStatus (e.g.
+   * fixture-driven panels). Builds the descriptor and reconciles entities. */
+  applyStatus(status: SpaceWxStatus | null): void {
+    this.applyDescriptor(buildOverlayDescriptor(status));
+  }
+
+  // ── Descriptor reconciliation ───────────────────────────────────────────
+
+  /** Public for tests — applies a descriptor directly. */
+  applyDescriptor(next: GlobeOverlayDescriptor): void {
+    if (!this.dataSource) return;
+    // Aurora rings
+    if (next.aurora) {
+      this.upsertAurora(next.aurora);
+    } else {
+      this.removeEntity(ENTITY_IDS.auroraNorth);
+      this.removeEntity(ENTITY_IDS.auroraSouth);
+    }
+    // Flare pulse — reset the pulse-start clock when a new flare turns on.
+    if (next.flarePulse) {
+      const wasFlaring = this.currentDescriptor.flarePulse !== null;
+      if (!wasFlaring) this.pulseStartMs = Date.now();
+      this.upsertFlarePulse(next.flarePulse);
+    } else {
+      this.removeEntity(ENTITY_IDS.flarePoint);
+      this.removeEntity(ENTITY_IDS.flarePulse);
+    }
+    this.currentDescriptor = next;
+  }
+
+  private upsertAurora(ring: AuroraRing): void {
+    if (!this.dataSource) return;
+    const cssColor = Color.fromBytes(
+      Math.round(ring.color.r * 255),
+      Math.round(ring.color.g * 255),
+      Math.round(ring.color.b * 255),
+      Math.round(ring.color.a * 255),
+    );
+    const northPositions = Cartesian3.fromDegreesArray(
+      ring.ringNorth.flatMap(([lon, lat]) => [lon, lat]),
+    );
+    const southPositions = Cartesian3.fromDegreesArray(
+      ring.ringSouth.flatMap(([lon, lat]) => [lon, lat]),
+    );
+    this.upsertPolyline(ENTITY_IDS.auroraNorth, northPositions, cssColor, ring.widthPx);
+    this.upsertPolyline(ENTITY_IDS.auroraSouth, southPositions, cssColor, ring.widthPx);
+  }
+
+  private upsertPolyline(
+    id: string,
+    positions: Cartesian3[],
+    color: Color,
+    widthPx: number,
+  ): void {
+    if (!this.dataSource) return;
+    const existing = this.entities.get(id);
+    if (existing) {
+      this.dataSource.entities.remove(existing);
+    }
+    const entity = this.dataSource.entities.add({
+      id,
+      polyline: {
+        positions,
+        width: widthPx,
+        material: new ColorMaterialProperty(color),
+        clampToGround: false,
+      },
+    });
+    this.entities.set(id, entity);
+  }
+
+  private upsertFlarePulse(pulse: FlarePulse): void {
+    if (!this.dataSource) return;
+    // Snapshot for the CallbackProperty closure — keeps the inner /
+    // outer radii stable even when the descriptor object is replaced.
+    const inner = pulse.innerRadiusM;
+    const outer = pulse.outerRadiusM;
+    const period = pulse.pulsePeriodMs;
+
+    // Subsolar focal point — small bright dot.
+    this.removeEntity(ENTITY_IDS.flarePoint);
+    const point = this.dataSource.entities.add({
+      id: ENTITY_IDS.flarePoint,
+      position: Cartesian3.fromDegrees(pulse.subsolarLonDeg, pulse.subsolarLatDeg),
+      point: {
+        pixelSize: 12,
+        color: Color.fromCssColorString('#fef3c7'),
+        outlineColor: Color.fromCssColorString('#f59e0b'),
+        outlineWidth: 2,
+        heightReference: HeightReference.CLAMP_TO_GROUND,
+      },
+    });
+    this.entities.set(ENTITY_IDS.flarePoint, point);
+
+    // Animated pulsing halo — radius oscillates inner ↔ outer over the period.
+    this.removeEntity(ENTITY_IDS.flarePulse);
+    const radius = new CallbackProperty(
+      () => flarePulseRadiusM(Date.now(), this.pulseStartMs, period, inner, outer),
+      false,
+    );
+    const haloColor = new CallbackProperty(
+      () => {
+        const r = flarePulseRadiusM(Date.now(), this.pulseStartMs, period, inner, outer);
+        const t = outer === inner ? 0 : (r - inner) / (outer - inner);
+        // Fade as the halo expands — stronger at inner, fainter at outer.
+        const alpha = 0.45 * (1 - t) + 0.1;
+        return Color.fromCssColorString('#a855f7').withAlpha(alpha);
+      },
+      false,
+    );
+    const halo = this.dataSource.entities.add({
+      id: ENTITY_IDS.flarePulse,
+      position: Cartesian3.fromDegrees(pulse.subsolarLonDeg, pulse.subsolarLatDeg),
+      ellipse: {
+        semiMinorAxis: radius,
+        semiMajorAxis: radius,
+        height: 0,
+        material: new ColorMaterialProperty(haloColor),
+        outline: false,
+      },
+    });
+    this.entities.set(ENTITY_IDS.flarePulse, halo);
+  }
+
+  private removeEntity(id: string): void {
+    if (!this.dataSource) return;
+    const entity = this.entities.get(id);
+    if (entity) {
+      this.dataSource.entities.remove(entity);
+      this.entities.delete(id);
+    }
+  }
+
+  // ── Test hooks ──────────────────────────────────────────────────────────
+
+  /** @internal */
+  __getEntityCount(): number {
+    return this.entities.size;
+  }
+
+  /** @internal */
+  __hasEntity(id: keyof typeof ENTITY_IDS): boolean {
+    return this.entities.has(ENTITY_IDS[id]);
+  }
+}

--- a/src/components/GodsVisionView.ts
+++ b/src/components/GodsVisionView.ts
@@ -16,6 +16,7 @@ import { GlobeArcs } from '@/components/gods-vision/GlobeArcs';
 import { GlobeHeatmap } from '@/components/gods-vision/GlobeHeatmap';
 import { GlobeReactorBeacons } from '@/components/GlobeReactorBeacons';
 import { GlobeSeismicWaves } from '@/components/GlobeSeismicWaves';
+import { GlobeSpaceWeatherOverlay } from '@/components/GlobeSpaceWeatherOverlay';
 import { GlobeWebcamLayer } from '@/services/webcams/webcam-globe-layer';
 import { fetchUnifiedWebcams } from '@/services/webcams/fetcher';
 import { FlyModeController } from '@/components/gods-vision/FlyMode/FlyModeController';
@@ -76,6 +77,7 @@ export class GodsVisionView {
   private fourD: Globe4DManager | null = null;
   private reactorBeacons: GlobeReactorBeacons | null = null;
   private seismicWaves: GlobeSeismicWaves | null = null;
+  private spaceWeatherOverlay: GlobeSpaceWeatherOverlay | null = null;
   private webcamLayer: GlobeWebcamLayer | null = null;
   private globePulse: GlobePulse | null = null;
   private globeArcs: GlobeArcs | null = null;
@@ -176,6 +178,8 @@ export class GodsVisionView {
  this.reactorBeacons.mount();
  this.seismicWaves = new GlobeSeismicWaves(viewer);
  this.seismicWaves.mount();
+ this.spaceWeatherOverlay = new GlobeSpaceWeatherOverlay(viewer);
+ this.spaceWeatherOverlay.mount();
  this.webcamLayer = new GlobeWebcamLayer(viewer, {
  fetchFeeds: async () => {
  const cat = await fetchUnifiedWebcams({ category: 'fire,volcano,coastal' });
@@ -401,6 +405,8 @@ export class GodsVisionView {
 
  this.seismicWaves?.destroy();
  this.seismicWaves = null;
+ this.spaceWeatherOverlay?.destroy();
+ this.spaceWeatherOverlay = null;
 
  this.hud?.destroy();
  this.hud = null;

--- a/src/services/spaceweather/__tests__/globe-overlay.test.mts
+++ b/src/services/spaceweather/__tests__/globe-overlay.test.mts
@@ -5,6 +5,7 @@ import {
   auroraColorForKp,
   buildOverlayDescriptor,
   deriveSpaceWxBanner,
+  flarePulseRadiusM,
   ringAtLatitude,
   subsolarPoint,
 } from '../globe-overlay.ts';
@@ -146,17 +147,62 @@ test('deriveSpaceWxBanner: G5 storm escalates to extreme banner', () => {
   assert.match(banner.subtitle, /Kp 9\.0/);
 });
 
-test('deriveSpaceWxBanner: G4 / G3 escalate distinctly', () => {
+test('deriveSpaceWxBanner: G4 hits the severe banner (Kp >= 8 threshold)', () => {
   const g4 = deriveSpaceWxBanner(makeStatus({
     geomag: { kp: 8, level: 'G4', auroraVisibilityLatN: 50, observedAt: '', kpMax24h: 8 },
   }));
   assert.equal(g4.severity, 'g4');
   assert.match(g4.label, /SEVERE/);
+});
+
+test('deriveSpaceWxBanner: G3 alone is below threshold and returns none', () => {
+  // Spec narrowed the banner to G4+ (Kp >= 8); G3 storms appear in the
+  // panel but no longer raise the persistent header.
   const g3 = deriveSpaceWxBanner(makeStatus({
     geomag: { kp: 7, level: 'G3', auroraVisibilityLatN: 55, observedAt: '', kpMax24h: 7 },
   }));
-  assert.equal(g3.severity, 'g3');
-  assert.match(g3.label, /STRONG/);
+  assert.equal(g3.severity, 'none');
+});
+
+// ── flarePulseRadiusM ─────────────────────────────────────────────────────
+
+test('flarePulseRadiusM oscillates between inner and outer over the period', () => {
+  const inner = 100_000;
+  const outer = 500_000;
+  const period = 1500;
+  const t0 = 1_745_000_000_000;
+  // At phase 0 (top of period) we sit at inner radius.
+  assert.equal(flarePulseRadiusM(t0, t0, period, inner, outer), inner);
+  // At half-period we sit at outer radius.
+  assert.equal(flarePulseRadiusM(t0 + period / 2, t0, period, inner, outer), outer);
+  // At full period we wrap back to inner.
+  assert.equal(flarePulseRadiusM(t0 + period, t0, period, inner, outer), inner);
+});
+
+test('flarePulseRadiusM stays within [inner, outer] for any time', () => {
+  const inner = 200_000;
+  const outer = 800_000;
+  const period = 1500;
+  for (let dt = 0; dt < period * 4; dt += 37) {
+    const r = flarePulseRadiusM(dt, 0, period, inner, outer);
+    assert.ok(r >= inner - 1e-6 && r <= outer + 1e-6, `radius ${r} out of range at dt=${dt}`);
+  }
+});
+
+test('flarePulseRadiusM falls back to inner radius when period is 0 or negative', () => {
+  assert.equal(flarePulseRadiusM(123, 0, 0, 100, 500), 100);
+  assert.equal(flarePulseRadiusM(123, 0, -1, 100, 500), 100);
+});
+
+// ── deriveSpaceWxBanner: G3 + flare fall-through (resumes the test sequence)
+
+test('deriveSpaceWxBanner: G3 + X-class flare falls through to the flare banner', () => {
+  const banner = deriveSpaceWxBanner(makeStatus({
+    geomag: { kp: 7, level: 'G3', auroraVisibilityLatN: 55, observedAt: '', kpMax24h: 7 },
+    xray: { peakFlux: 2e-4, currentFlux: 2e-4, peakClass: 'X', peakLabel: 'X2.0',
+      peakAt: '', xClassActive: true, sampleCount: 10 },
+  }));
+  assert.equal(banner.severity, 'flare');
 });
 
 test('deriveSpaceWxBanner: G2 storm + X-class flare prefers the flare banner', () => {

--- a/src/services/spaceweather/globe-overlay.ts
+++ b/src/services/spaceweather/globe-overlay.ts
@@ -127,6 +127,28 @@ function buildAuroraRing(status: SpaceWxStatus): AuroraRing | null {
   };
 }
 
+/**
+ * Pulse animation phase — radius linearly oscillates between inner and
+ * outer over `periodMs`, hitting the outer radius at the half-period and
+ * returning to inner at the period boundary. Used by the Cesium overlay
+ * to drive the subsolar X-flare pulse via a CallbackProperty without
+ * keeping per-tick state.
+ */
+export function flarePulseRadiusM(
+  nowMs: number,
+  startMs: number,
+  periodMs: number,
+  innerRadiusM: number,
+  outerRadiusM: number,
+): number {
+  if (!Number.isFinite(periodMs) || periodMs <= 0) return innerRadiusM;
+  const elapsed = ((nowMs - startMs) % periodMs + periodMs) % periodMs;
+  const phase = elapsed / periodMs; // 0..1
+  // Triangle wave: 0 → 1 → 0 across the period.
+  const tri = phase < 0.5 ? phase * 2 : (1 - phase) * 2;
+  return innerRadiusM + (outerRadiusM - innerRadiusM) * tri;
+}
+
 function buildFlarePulse(status: SpaceWxStatus, nowMs: number): FlarePulse | null {
   if (!status.xray?.xClassActive) return null;
   const point = subsolarPoint(nowMs);
@@ -141,7 +163,7 @@ function buildFlarePulse(status: SpaceWxStatus, nowMs: number): FlarePulse | nul
 
 // ── Status banner integration ────────────────────────────────────────────
 
-export type SpaceWxBannerSeverity = 'none' | 'g3' | 'g4' | 'g5' | 'flare';
+export type SpaceWxBannerSeverity = 'none' | 'g4' | 'g5' | 'flare';
 
 export interface SpaceWxBanner {
   severity: SpaceWxBannerSeverity;
@@ -151,11 +173,11 @@ export interface SpaceWxBanner {
   subtitle: string;
 }
 
-/** Map a SpaceWxStatus into the EEWStatusBar banner. Banner shows for
- * G3+ geomagnetic storms or active X-class flares — the user spec
- * required "G4+ storm warnings", we widen to G3 to match the usual
- * SWPC subscriber threshold. Returns severity 'none' when nothing
- * warrants surfacing on the header. */
+/** Map a SpaceWxStatus into the EEWStatusBar banner. Per the spec the
+ * banner only fires for G4+ geomagnetic storms (Kp ≥ 8) — lower-level
+ * storms still surface in the SpaceWeatherPanel itself. An active
+ * X-class flare with no qualifying storm falls through to the flare
+ * banner. Returns severity 'none' otherwise. */
 export function deriveSpaceWxBanner(status: SpaceWxStatus | null): SpaceWxBanner {
   if (!status) return { severity: 'none', label: '', subtitle: '' };
   const level = status.geomag?.level ?? 'G0';
@@ -175,14 +197,6 @@ export function deriveSpaceWxBanner(status: SpaceWxStatus | null): SpaceWxBanner
       label: 'GEOMAGNETIC G4 — SEVERE STORM',
       subtitle: kp === null ? 'grid + GPS + HF degraded'
                             : `Kp ${kp.toFixed(1)} · grid + GPS + HF degraded`,
-    };
-  }
-  if (level === 'G3') {
-    return {
-      severity: 'g3',
-      label: 'GEOMAGNETIC G3 — STRONG STORM',
-      subtitle: kp === null ? 'GPS / HF impacts possible'
-                            : `Kp ${kp.toFixed(1)} · GPS / HF impacts possible`,
     };
   }
   if (xray?.xClassActive) {

--- a/src/styles/eew-status-bar.css
+++ b/src/styles/eew-status-bar.css
@@ -72,14 +72,16 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.eew-bar-spacewx-g3    { background: rgba(234, 88, 12, 0.85);  color: #fff7ed; }
-.eew-bar-spacewx-g4    { background: rgba(220, 38, 38, 0.92);  color: #fef2f2; }
+/* G4+ uses the spec-mandated purple; G5 deepens it with a pulse to match
+ * the seismic TIER_5 EXTREME visual treatment. G3 storms no longer
+ * surface in the persistent header (panel-only). */
+.eew-bar-spacewx-g4    { background: rgba(124, 58, 237, 0.92);  color: #f5f3ff; }
 .eew-bar-spacewx-g5    {
-  background: rgba(159, 18, 57, 0.95);
+  background: rgba(91, 33, 182, 0.95);
   color: #ffffff;
   animation: eew-bar-crimson-pulse 2.4s ease-in-out infinite;
 }
-.eew-bar-spacewx-flare { background: rgba(124, 58, 237, 0.85); color: #f5f3ff; }
+.eew-bar-spacewx-flare { background: rgba(168, 85, 247, 0.85); color: #f5f3ff; }
 
 /* Tier color schemes — outer container background + text */
 .eew-bar-gray    { background: rgba(40, 44, 52, 0.92);  color: #cbd5e1; }


### PR DESCRIPTION
Stacks on #337. Closes the deferred Cesium-entity wiring (drawing the aurora ring + subsolar flare pulse on \`GodsVisionView\`) and tightens the status-bar banner to the spec-mandated G4+ threshold (Kp ≥ 8).

## What lands

### \`src/components/GlobeSpaceWeatherOverlay.ts\` (new)
- Layer mounted on the God's Eye Cesium viewer alongside \`GlobeSeismicWaves\`, mirroring its lifecycle and localStorage-backed enable flag
- Polls \`/api/spaceweather/status\` every 5 min, runs the result through \`buildOverlayDescriptor\`, reconciles entities on a \`CustomDataSource\`
- **Aurora oval**: two polylines (north + south parallels) at the visibility latitude, color stepped by Kp band (green at G1–G2, violet at G3, deep purple at G4–G5), width 2–4 px
- **X-flare pulse**: bright dot at the subsolar point + animated halo ellipse driven by a \`CallbackProperty\` and the new pure helper \`flarePulseRadiusM\` (triangle-wave between inner and outer over the period)

### Banner tightening (G3+ → G4+)
- \`SpaceWxBannerSeverity\` narrowed: \`'g3'\` removed; only \`none\` / \`g4\` / \`g5\` / \`flare\` remain
- \`deriveSpaceWxBanner\` drops the G3 case — G3 storms surface in the panel only; banner is reserved for G4+ per spec
- G3 + active X-class flare now falls through to the flare banner rather than being masked
- CSS swaps G4/G5/flare to the spec-mandated purple shades (G4 violet, G5 deep purple + crimson-pulse, flare bright violet)

### \`flarePulseRadiusM\` helper (in \`globe-overlay.ts\`)
- Pure triangle-wave animation phase: \`(now, start, period, inner, outer)\` → radius
- Keeps the Cesium \`CallbackProperty\` stateless

## Tests
- 3 new \`flarePulseRadiusM\` tests (period boundary, in-range, zero/negative-period fallback)
- Existing \`G4/G3 escalate distinctly\` test replaced by 3: \`G4 fires\`, \`G3 alone returns none\`, \`G3 + flare falls through to flare banner\`
- 21 globe-overlay + 17 swpc-monitor + 10 sidecar parity = **48 / 48 green**

## Verification
- \`npm run typecheck:all\` clean
- \`npm run test:spaceweather\` 48/48
- \`npm run test:panels:smoke\` no new failures (\`space-weather\` panel unchanged from #337's baseline)

## PR ordering
Targeted at \`claude/space-weather-pr-3\` so it stacks on #337. Once #337 merges, GitHub will auto-retarget this PR to \`main\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)