### PR TITLE
fix(sidecar): wildfire/purpleair/EIA endpoint upstream failures

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -7811,7 +7811,7 @@ async function dispatch(requestUrl, req, routes, context) {
   if (requestUrl.pathname === '/api/wildfire/incidents') {
  try {
  const resp = await fetchWithTimeout(
- 'https://inciweb.wildfire.gov/feeds/rss/incidents/',
+ 'https://inciweb.wildfire.gov/incidents/rss.xml',
  { headers: { 'User-Agent': CHROME_UA, Accept: 'application/rss+xml,application/xml,text/xml' } },
  15_000,
  );
@@ -7856,9 +7856,15 @@ async function dispatch(requestUrl, req, routes, context) {
   // are kept upstream-side; the renderer applies confidence + AQI scoring.
   if (requestUrl.pathname === '/api/airquality/purpleair') {
  const apiKey = process.env.PURPLEAIR_API_KEY;
+ if (!apiKey) {
+ return json({
+ sensors: [],
+ keyMissing: true,
+ error: 'PURPLEAIR_API_KEY required — public www.purpleair.com/json endpoint is no longer served',
+ }, 503);
+ }
  const fields = 'sensor_index,pm2.5,latitude,longitude,location_type,confidence,name,last_seen';
  try {
- if (apiKey) {
  const url = `https://api.purpleair.com/v1/sensors?fields=${encodeURIComponent(fields)}&location_type=0`;
  const resp = await fetchWithTimeout(url, {
  headers: {
@@ -7867,20 +7873,10 @@ async function dispatch(requestUrl, req, routes, context) {
  'User-Agent': CHROME_UA,
  },
  }, 20_000);
- if (resp.ok) {
+ if (!resp.ok) return json({ sensors: [], error: `purpleair upstream ${resp.status}` }, 502);
  const payload = await resp.json();
  const sensors = sidecarParseV1Sensors(payload);
  return json({ sensors, source: 'v1', fetchedAt: Date.now() });
- }
- // Fall through to the public endpoint if the v1 call fails.
- }
- const fallbackResp = await fetchWithTimeout('https://www.purpleair.com/json', {
- headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
- }, 20_000);
- if (!fallbackResp.ok) return json({ sensors: [], error: `purpleair upstream ${fallbackResp.status}` }, 502);
- const payload = await fallbackResp.json();
- const sensors = sidecarParsePublicJson(payload);
- return json({ sensors, source: 'public', fetchedAt: Date.now() });
  } catch (error) {
  return json({ sensors: [], error: String(error.message ?? error) }, 500);
  }
@@ -9683,11 +9679,13 @@ async function dispatch(requestUrl, req, routes, context) {
 
   // ── Power Grid (EIA electricity RTO demand/capacity) ──────────────
   if (requestUrl.pathname === '/api/power-grid') {
+ const eiaKey = process.env.EIA_API_KEY;
+ if (!eiaKey) return json({ regions: [], keyMissing: true, error: 'EIA_API_KEY required' }, 503);
  const cached = getCached('power-grid', 15 * 60 * 1000);
  if (cached) return json(cached);
  try {
  // EIA Open Data API — Real-Time Operating grid demand by region
- const eiaUrl = 'https://api.eia.gov/v2/electricity/rto/region-data/data/?frequency=hourly&data[0]=value&facets[type][]=D&facets[type][]=NG&length=200&sort[0][column]=period&sort[0][direction]=desc';
+ const eiaUrl = `https://api.eia.gov/v2/electricity/rto/region-data/data/?api_key=${encodeURIComponent(eiaKey)}&frequency=hourly&data[0]=value&facets[type][]=D&facets[type][]=NG&length=200&sort[0][column]=period&sort[0][direction]=desc`;
  const r = await fetchWithTimeout(eiaUrl, { headers: { 'User-Agent': CHROME_UA } }, 15000);
  if (!r.ok) throw new Error(`EIA HTTP ${r.status}`);
  const raw = await r.json();
@@ -9726,13 +9724,14 @@ async function dispatch(requestUrl, req, routes, context) {
 
   // ── Grid Alerts (NERC public alerts RSS) ────────────────────────
   if (requestUrl.pathname === '/api/grid-alerts') {
+ const eiaKey = process.env.EIA_API_KEY;
+ if (!eiaKey) return json({ alerts: [], keyMissing: true, error: 'EIA_API_KEY required' }, 503);
  const cached = getCached('grid-alerts', 15 * 60 * 1000);
  if (cached) return json(cached);
  try {
- const rssUrl = 'https://www.nerc.com/pa/rrm/bpsa/Pages/Alerts.aspx';
  // NERC does not have a clean RSS; fall back to EIA system alerts or return empty
  // Try EIA grid emergency data as a proxy
- const eiaAlertUrl = 'https://api.eia.gov/v2/electricity/rto/region-data/data/?frequency=hourly&data[0]=value&facets[type][]=D&length=50&sort[0][column]=period&sort[0][direction]=desc';
+ const eiaAlertUrl = `https://api.eia.gov/v2/electricity/rto/region-data/data/?api_key=${encodeURIComponent(eiaKey)}&frequency=hourly&data[0]=value&facets[type][]=D&length=50&sort[0][column]=period&sort[0][direction]=desc`;
  const r = await fetchWithTimeout(eiaAlertUrl, { headers: { 'User-Agent': CHROME_UA } }, 12000);
  if (!r.ok) throw new Error(`EIA alerts HTTP ${r.status}`);
  const raw = await r.json();


### PR DESCRIPTION
## Smoke-test failures surfaced on v2.12.0

Three sidecar endpoints were 502'ing in a fresh smoke-test run against the v2.12.0 build. None are panel-side issues — all three are sidecar bugs.

### `/api/wildfire/incidents` — InciWeb RSS path moved
Old path `/feeds/rss/incidents/` returns 404. The current feed is at `/incidents/rss.xml` (verified 200 `application/rss+xml` with current incidents).

### `/api/airquality/purpleair` — public `/json` endpoint is gone
`https://www.purpleair.com/json` now 302s to an over-quota App Engine page and is no longer served. The handler's silent fallback to it produced a misleading `purpleair upstream 302` error. Drop the dead fallback; without `PURPLEAIR_API_KEY` return 503 `keyMissing:true` so the panel can render a setup hint instead of a fake upstream error.

### `/api/power-grid` + `/api/grid-alerts` — EIA called without api_key
Both handlers called the EIA v2 API without the `api_key` query parameter, which is why EIA returned 403 (`EIA HTTP 403`). Read `EIA_API_KEY` (already a supported key in the keychain), include it in the URL, and return 503 `keyMissing:true` when absent — matching the existing pattern in `/api/fuel-prices`.

## Verified

- `npm run typecheck:all` — clean
- `npm run test:sidecar` — 216/216 pass
- Hot-swapped fixed sidecar into the installed bundle and re-curled all four endpoints:
  - `/api/wildfire/incidents` 502 → **200** with real RSS
  - `/api/airquality/purpleair` 502 → **503** `keyMissing:true`
  - `/api/power-grid` 502 → **503** `keyMissing:true`
  - `/api/grid-alerts` 502 → **503** `keyMissing:true`

## Out of scope (surfaced, not fixed here)

- Tauri app launch hang on the macOS keychain dance — runtime issue, not a sidecar bug. The synchronous `SecretsCache::load_from_keychain()` runs before `setup()`, so `desktop.log` stays empty when the user hasn't approved keychain prompts. Worth a separate PR to move keychain load off the main thread.
- 4 endpoints (`/api/seismic/recent`, `/api/aviation/notams`, `/api/otx-intel`, `/api/synthesis/correlations`) return the by-design degraded fallback because no inline route exists — see the comment block above `buildDegradedResponse`.