### PR TITLE
feat(globe): split PurpleAir into its own Air Quality layer toggle

### DIFF
--- a/src/components/GlobeDataManager.ts
+++ b/src/components/GlobeDataManager.ts
@@ -534,6 +534,7 @@ export class GlobeDataManager {
  this.registerLayer('volcanoes', () => this.loadVolcanoes());
  this.registerLayer('cyclones', () => this.loadTropicalCyclones());
  this.registerLayer('fires', () => this.loadFires());
+ this.registerLayer('airQuality', () => this.loadAirQuality());
  this.registerLayer('conflicts', () => this.loadConflicts());
  this.registerLayer('airstrikes', () => this.loadAirstrikes());
  this.registerLayer('strike-packages', () => this.loadStrikePackages());
@@ -1101,17 +1102,22 @@ export class GlobeDataManager {
  const { fetchAllFires, flattenFires, toMapFires } = await import('@/services/wildfires');
  const { fetchActivePerimeters } = await import('@/services/wildfires/fire-intel-service');
  const { clusterHotspots, findNearestPerimeter } = await import('@/services/wildfires/fire-intel-helpers');
- const { fetchPurpleAirSnapshot } = await import('@/services/airquality/purpleair-service');
 
- const [fireResult, perimeters, purpleAir] = await Promise.all([
+ const [fireResult, perimeters] = await Promise.all([
  fetchAllFires().catch(() => ({ regions: {}, totalCount: 0 })),
  fetchActivePerimeters().catch(() => []),
- fetchPurpleAirSnapshot().catch(() => ({ sensors: [], source: 'unknown' as const, fetchedAt: Date.now() })),
  ]);
 
  renderPerimeterPolygons(layer, perimeters);
  const clusters = clusterHotspots(toMapFires(flattenFires(fireResult.regions)), { gridDeg: 0.1, topN: 500 });
  renderHotspotClusters(layer, clusters, perimeters, findNearestPerimeter);
+  }
+
+  private async loadAirQuality(): Promise<void> {
+ const layer = this.layers.get('airQuality');
+ if (!layer) return;
+ const { fetchPurpleAirSnapshot } = await import('@/services/airquality/purpleair-service');
+ const purpleAir = await fetchPurpleAirSnapshot().catch(() => ({ sensors: [], source: 'unknown' as const, fetchedAt: Date.now() }));
  renderPurpleAirDots(layer, purpleAir.sensors);
   }
 

--- a/src/config/gods-vision-layers.ts
+++ b/src/config/gods-vision-layers.ts
@@ -67,7 +67,13 @@ export const DEFAULT_GODS_VISION_LAYERS: GodsVisionLayers = {
  name: 'Fires',
  category: 'intelligence',
  enabled: false,
- description: 'NASA FIRMS satellite fire detections',
+ description: 'NASA FIRMS satellite fire detections + NIFC active perimeters',
+  },
+  airQuality: {
+ name: 'Air Quality',
+ category: 'intelligence',
+ enabled: false,
+ description: 'PurpleAir community PM2.5 sensors colored by AQI band',
   },
   volcanoes: {
  name: 'Volcanoes',


### PR DESCRIPTION
## Audit finding being fixed

The full audit (see comment in #357 thread / report below) flagged that PurpleAir sensor dots are currently rendered inside `loadFires()` — they share a single toggle (`fires`) with NASA FIRMS hotspots and NIFC active perimeters. Users who want community air-quality data must enable wildfires (and inherit fire dots they may not want); finance/happy-variant users can't surface PurpleAir at all without flipping a layer named "Fires."

The three feeds were bundled for caching reasons but the fetches don't actually share data — splitting costs nothing.

## Change

- Register a new `airQuality` layer in `GlobeDataManager`.
- Move `fetchPurpleAirSnapshot` + `renderPurpleAirDots` out of `loadFires()` into a new `loadAirQuality()` method.
- `loadFires()` now fetches FIRMS + NIFC only.
- Add an `airQuality` entry to `DEFAULT_GODS_VISION_LAYERS` (intelligence category, default off) so the HUD surfaces it as an independent toggle named "Air Quality" with description "PurpleAir community PM2.5 sensors colored by AQI band."

## Verified

- `npm run typecheck:all` — clean (zero errors, both `tsconfig.json` and `tsconfig.api.json`).
- The render function (`renderPurpleAirDots`) is unchanged — only the dispatch is split.
- No behavior change for users with the Fires toggle on: they keep getting hotspots + perimeters. Air quality is now an explicit toggle, which makes the feature discoverable.

## Out of scope (other audit findings — separate PRs)

| Gap | Status |
|---|---|
| Aurora oval / subsolar / X-flare halo on globe | `globe-overlay.ts` computes descriptors; `SpaceWeatherGlobeOverlay` component referenced in comment but doesn't exist. No consumer wires the descriptors into Cesium. |
| War-risk zones (Red Sea, Hormuz, Black Sea, S. China Sea) | `WAR_RISK_ZONES` exist in `maritime-threats.ts` but no globe layer renders them. Could be tied to the `ais` layer. |
| Live AIS vessels (`/api/maritime/vessels`) | Panel-only (MaritimeIntelPanel section). Not rendered on globe or DeckGL map. |
| Outage state choropleth + RadNet dots from `infrastructure-overlay.ts` | Comment says descriptors are for "Cesium, MapLibre/DeckGL, or DOM SVG" but only the BGP banner (DOM SVG) consumes them. Choropleth and RadNet have no rendering. |
| VAAC volcanic ash polygons | Aviation intel layer renders TFRs + SIGMETs but not VAAC ash. No data source wired. |