### PR TITLE
feat(globe): wire space-weather + war-risk + infrastructure overlays

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "test:e2e:finance": "cross-env VITE_VARIANT=finance playwright test",
     "test:e2e:runtime": "cross-env VITE_VARIANT=full playwright test e2e/runtime-fetch.spec.ts",
     "test:e2e": "npm run test:e2e:runtime && npm run test:e2e:full && npm run test:e2e:tech && npm run test:e2e:finance",
+    "test:globe-overlay": "tsx --test src/services/globe/__tests__/overlay-helpers.test.mts",
     "test:data": "tsx --test tests/*.test.mjs tests/*.test.mts",
     "test:reasoning": "tsx --test src/services/__tests__/hypothesis-dedupe.test.mts src/services/__tests__/hypothesis-entities.test.mts src/services/__tests__/hypothesis-feedback.test.mts src/services/__tests__/pressure-baselines.test.mts src/services/__tests__/llm-budget.test.mts src/services/__tests__/action-memory.test.mts",
     "test:settings": "tsx --test src/services/__tests__/key-categories.test.mts src/services/__tests__/key-feature-index.test.mts src/services/__tests__/key-shape-registry.test.mts src/services/__tests__/wizard-state.test.mts",

--- a/src/components/GlobeDataManager.ts
+++ b/src/components/GlobeDataManager.ts
@@ -1,4 +1,5 @@
 import {
+  CallbackProperty,
   Cartesian3,
   Cartographic,
   Color,
@@ -16,6 +17,7 @@ import {
   JulianDate,
   Math as CesiumMath,
   Ellipsoid,
+  Rectangle,
   UrlTemplateImageryProvider,
   type ImageryLayer,
   PointPrimitiveCollection,
@@ -373,6 +375,13 @@ function purpleAirDotSize(pm25: number): number {
   return 8;
 }
 
+function radnetDescription(hot: { name: string; cpm: number; severity: string; state: string | null }): string {
+  const head = `<b>RadNet ${escapeHtml(hot.name)}</b>`;
+  const body = `${hot.cpm.toFixed(1)} CPM (${hot.severity})`;
+  const tail = hot.state ? ` · ${hot.state}` : '';
+  return `${head}<br/>${body}${tail}`;
+}
+
 function cyberColor(severity: string): Color {
   if (severity === 'critical') return C.cyberCritical;
   if (severity === 'high') return C.cyberHigh;
@@ -535,6 +544,9 @@ export class GlobeDataManager {
  this.registerLayer('cyclones', () => this.loadTropicalCyclones());
  this.registerLayer('fires', () => this.loadFires());
  this.registerLayer('airQuality', () => this.loadAirQuality());
+ this.registerLayer('spaceWeather', () => this.loadSpaceWeatherOverlay());
+ this.registerLayer('warRiskZones', () => this.loadWarRiskZones());
+ this.registerLayer('infrastructure', () => this.loadInfrastructureOverlay());
  this.registerLayer('conflicts', () => this.loadConflicts());
  this.registerLayer('airstrikes', () => this.loadAirstrikes());
  this.registerLayer('strike-packages', () => this.loadStrikePackages());
@@ -1119,6 +1131,92 @@ export class GlobeDataManager {
  const { fetchPurpleAirSnapshot } = await import('@/services/airquality/purpleair-service');
  const purpleAir = await fetchPurpleAirSnapshot().catch(() => ({ sensors: [], source: 'unknown' as const, fetchedAt: Date.now() }));
  renderPurpleAirDots(layer, purpleAir.sensors);
+  }
+
+  private async loadSpaceWeatherOverlay(): Promise<void> {
+ const layer = this.layers.get('spaceWeather');
+ if (!layer) return;
+ const { fetchSpaceWxStatus, renderSpaceWeatherDescriptor, buildOverlayDescriptor } =
+ await import('./globe/SpaceWeatherGlobeOverlay');
+ const status = await fetchSpaceWxStatus();
+ if (!status) return;
+ renderSpaceWeatherDescriptor(layer, buildOverlayDescriptor(status));
+  }
+
+  private async loadWarRiskZones(): Promise<void> {
+ const layer = this.layers.get('warRiskZones');
+ if (!layer) return;
+ const { WAR_RISK_ZONES } = await import('@/services/maritime/maritime-threats');
+ const { warZoneColors } = await import('@/services/globe/overlay-helpers');
+
+ for (const zone of WAR_RISK_ZONES) {
+ const palette = warZoneColors(zone.threatCategory);
+ const fill = Color.fromCssColorString(palette.fillHex).withAlpha(palette.fillAlpha);
+ const outline = Color.fromCssColorString(palette.outlineHex);
+ layer.source.entities.add({
+ position: Cartesian3.fromDegrees(zone.centerLon, zone.centerLat),
+ ellipse: {
+ semiMajorAxis: zone.radiusKm * 1000,
+ semiMinorAxis: zone.radiusKm * 1000,
+ material: new ColorMaterialProperty(fill),
+ outline: true,
+ outlineColor: outline,
+ outlineWidth: 2,
+ heightReference: HeightReference.CLAMP_TO_GROUND,
+ },
+ name: `war-risk-${zone.id}`,
+ description: `<b>${escapeHtml(zone.name)}</b><br/>${escapeHtml(zone.rationale)}<br/>Effective: ${zone.effectiveFrom}`,
+ });
+ }
+  }
+
+  private async loadInfrastructureOverlay(): Promise<void> {
+ const layer = this.layers.get('infrastructure');
+ if (!layer) return;
+ const [{ fetchOutages, fetchRadiation }, { outagesToStateOverlay, radiationToHotspots }, { outageRectExtent, radnetPulsePixelSize }] = await Promise.all([
+ import('@/services/infrastructure/grid-intelligence-loader'),
+ import('@/services/infrastructure/infrastructure-overlay'),
+ import('@/services/globe/overlay-helpers'),
+ ]);
+ const [outages, radiation] = await Promise.all([fetchOutages(), fetchRadiation()]);
+
+ for (const row of outagesToStateOverlay(outages)) {
+ const ext = outageRectExtent(row.lat, row.lon, row.severity);
+ const fill = Color.fromCssColorString(row.fillColorHex).withAlpha(row.fillOpacity);
+ const outline = Color.fromCssColorString(row.fillColorHex);
+ layer.source.entities.add({
+ rectangle: {
+ coordinates: Rectangle.fromDegrees(ext.west, ext.south, ext.east, ext.north),
+ material: new ColorMaterialProperty(fill),
+ outline: true,
+ outlineColor: outline,
+ outlineWidth: 1,
+ heightReference: HeightReference.CLAMP_TO_GROUND,
+ },
+ name: `outage-${row.state}`,
+ description: `<b>${escapeHtml(row.state)} — ${row.severity}</b><br/>${row.customersAffected.toLocaleString()} customers affected across ${row.countyCount} counties`,
+ });
+ }
+
+ for (const hot of radiationToHotspots(radiation)) {
+ const startMs = Date.now();
+ const periodMs = hot.pulsePeriodMs;
+ const pulseColor = Color.fromCssColorString(hot.pulseColorHex);
+ const pixelSize = new CallbackProperty(() => radnetPulsePixelSize(Date.now() - startMs, periodMs), false);
+ layer.source.entities.add({
+ position: Cartesian3.fromDegrees(hot.lon, hot.lat),
+ point: {
+ color: pulseColor,
+ outlineColor: Color.BLACK,
+ outlineWidth: 1,
+ pixelSize,
+ heightReference: HeightReference.CLAMP_TO_GROUND,
+ scaleByDistance: new NearFarScalar(1e4, 1.4, 1e7, 0.4),
+ },
+ name: `radnet-${hot.name}`,
+ description: radnetDescription(hot),
+ });
+ }
   }
 
   private async loadConflicts(): Promise<void> {

--- a/src/components/globe/SpaceWeatherGlobeOverlay.ts
+++ b/src/components/globe/SpaceWeatherGlobeOverlay.ts
@@ -1,0 +1,120 @@
+/**
+ * Cesium globe overlay for space-weather state.
+ *
+ * Consumes the pure descriptors from `services/spaceweather/globe-overlay.ts`
+ * and paints them onto a CustomDataSource:
+ *   - Aurora oval as a polyline ring at the visibility latitude (north +
+ *     mirrored south), clamped to ground.
+ *   - Subsolar X-flare halo as a CallbackProperty-driven ellipse — the
+ *     radius triangle-waves between innerRadiusM and outerRadiusM each
+ *     pulsePeriodMs.
+ *
+ * The G3+ banner is NOT this component's job — `EEWStatusBar` already
+ * consumes `deriveSpaceWxBanner` via `status-bar-poller`.
+ */
+
+import {
+  CallbackProperty,
+  Cartesian3,
+  Color,
+  ColorMaterialProperty,
+  type CustomDataSource,
+  HeightReference,
+} from 'cesium';
+
+import {
+  
+  flarePulseRadiusAt,
+  type GlobeOverlayDescriptor,
+} from '@/services/spaceweather/globe-overlay';
+import type { SpaceWxStatus } from '@/services/spaceweather/swpc-monitor';
+import { getApiBaseUrl } from '@/services/runtime';
+
+const FLARE_PULSE_COLOR = '#ffaa00';
+
+export interface SpaceWeatherLayerLike {
+  source: CustomDataSource;
+}
+
+export async function fetchSpaceWxStatus(
+  signal?: AbortSignal,
+): Promise<SpaceWxStatus | null> {
+  try {
+    const r = await fetch(`${getApiBaseUrl()}/api/spaceweather/status`, {
+      signal,
+      headers: { Accept: 'application/json' },
+    });
+    if (!r.ok) return null;
+    return await r.json() as SpaceWxStatus;
+  } catch {
+    return null;
+  }
+}
+
+export function renderSpaceWeatherDescriptor(
+  layer: SpaceWeatherLayerLike,
+  descriptor: GlobeOverlayDescriptor,
+  nowFn: () => number = Date.now,
+): void {
+  if (!descriptor.visible) return;
+
+  if (descriptor.aurora) {
+    const a = descriptor.aurora;
+    const lineColor = new Color(a.color.r, a.color.g, a.color.b, a.color.a);
+    const material = new ColorMaterialProperty(lineColor);
+
+    layer.source.entities.add({
+      polyline: {
+        positions: ringToCartesian(a.ringNorth),
+        width: a.widthPx,
+        material,
+        clampToGround: true,
+      },
+      name: `aurora-ring-north-lat${a.latN.toFixed(0)}`,
+    });
+
+    layer.source.entities.add({
+      polyline: {
+        positions: ringToCartesian(a.ringSouth),
+        width: a.widthPx,
+        material,
+        clampToGround: true,
+      },
+      name: `aurora-ring-south-lat${a.latS.toFixed(0)}`,
+    });
+  }
+
+  if (descriptor.flarePulse) {
+    const pulse = descriptor.flarePulse;
+    const startMs = nowFn();
+    const radiusCallback = new CallbackProperty(
+      () => flarePulseRadiusAt(nowFn() - startMs, pulse),
+      false,
+    );
+    const fill = Color.fromCssColorString(FLARE_PULSE_COLOR).withAlpha(0.35);
+    const outline = Color.fromCssColorString(FLARE_PULSE_COLOR);
+
+    layer.source.entities.add({
+      position: Cartesian3.fromDegrees(pulse.subsolarLonDeg, pulse.subsolarLatDeg),
+      ellipse: {
+        semiMajorAxis: radiusCallback,
+        semiMinorAxis: radiusCallback,
+        material: new ColorMaterialProperty(fill),
+        outline: true,
+        outlineColor: outline,
+        heightReference: HeightReference.CLAMP_TO_GROUND,
+      },
+      name: 'flare-pulse-subsolar',
+    });
+  }
+}
+
+function ringToCartesian(ring: readonly [number, number][]): Cartesian3[] {
+  const flat: number[] = [];
+  for (const [lon, lat] of ring) flat.push(lon, lat);
+  return Cartesian3.fromDegreesArray(flat);
+}
+
+
+
+export {buildOverlayDescriptor} from '@/services/spaceweather/globe-overlay';

--- a/src/config/gods-vision-layers.ts
+++ b/src/config/gods-vision-layers.ts
@@ -117,6 +117,24 @@ export const DEFAULT_GODS_VISION_LAYERS: GodsVisionLayers = {
  enabled: true,
  description: 'Satellite imagery change detection at watched locations',
   },
+  spaceWeather: {
+ name: 'Space Wx',
+ category: 'intelligence',
+ enabled: false,
+ description: 'Aurora oval (Kp ≥ 5) + pulsing subsolar X-flare halo',
+  },
+  warRiskZones: {
+ name: 'War Risk',
+ category: 'intelligence',
+ enabled: false,
+ description: 'Lloyd-style war-risk maritime zones — Red Sea, Hormuz, Black Sea, Gulf of Guinea',
+  },
+  infrastructure: {
+ name: 'Infra Outage',
+ category: 'intelligence',
+ enabled: false,
+ description: 'US grid outages by state (severity-colored) + RadNet stations pulsing above threshold',
+  },
   // ── Static Geo Layers ──
   bases: {
  name: 'Mil. Bases',

--- a/src/services/globe/__tests__/overlay-helpers.test.mts
+++ b/src/services/globe/__tests__/overlay-helpers.test.mts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  outageRectExtent,
+  radnetPulsePixelSize,
+  warZoneColors,
+} from '../overlay-helpers.ts';
+
+// ── warZoneColors ────────────────────────────────────────────────────
+
+test('warZoneColors: each threat category maps to a distinct outline', () => {
+  const categories = ['state_conflict', 'missile_drone', 'piracy', 'mixed'] as const;
+  const seen = new Set<string>();
+  for (const cat of categories) {
+    const c = warZoneColors(cat);
+    assert.match(c.outlineHex, /^#[0-9a-f]{6}$/i, `${cat} outline must be a hex`);
+    assert.ok(c.fillAlpha > 0 && c.fillAlpha < 1, `${cat} alpha in (0,1)`);
+    seen.add(c.outlineHex);
+  }
+  assert.equal(seen.size, categories.length, 'each category must map to its own outline color');
+});
+
+// ── outageRectExtent ─────────────────────────────────────────────────
+
+test('outageRectExtent: extreme severity is wider than elevated', () => {
+  const elev = outageRectExtent(40, -100, 'elevated');
+  const ext  = outageRectExtent(40, -100, 'extreme');
+  const elevW = elev.east - elev.west;
+  const extW  = ext.east  - ext.west;
+  assert.ok(extW > elevW, `extreme width ${extW} must exceed elevated width ${elevW}`);
+});
+
+test('outageRectExtent: rectangle is centered on the centroid', () => {
+  const r = outageRectExtent(40, -100, 'major');
+  assert.equal((r.east + r.west) / 2, -100);
+  assert.equal((r.north + r.south) / 2, 40);
+});
+
+test('outageRectExtent: normal severity collapses to a zero-extent rect', () => {
+  const r = outageRectExtent(40, -100, 'normal');
+  assert.equal(r.east - r.west, 0);
+  assert.equal(r.north - r.south, 0);
+});
+
+// ── radnetPulsePixelSize ─────────────────────────────────────────────
+
+test('radnetPulsePixelSize: phase 0 returns minPx', () => {
+  assert.equal(radnetPulsePixelSize(0, 1000, 8, 22), 8);
+});
+
+test('radnetPulsePixelSize: phase 0.5 returns maxPx', () => {
+  assert.equal(radnetPulsePixelSize(500, 1000, 8, 22), 22);
+});
+
+test('radnetPulsePixelSize: phase 0.25 is halfway up', () => {
+  assert.equal(radnetPulsePixelSize(250, 1000, 8, 22), 15);
+});
+
+test('radnetPulsePixelSize: zero period returns midpoint without dividing by zero', () => {
+  const r = radnetPulsePixelSize(123, 0, 8, 22);
+  assert.ok(Number.isFinite(r));
+  assert.equal(r, 15);
+});

--- a/src/services/globe/overlay-helpers.ts
+++ b/src/services/globe/overlay-helpers.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure helpers for the war-risk-zone and infrastructure-overlay globe
+ * layers. No DOM, no fetch, no Cesium — testable with static inputs.
+ */
+
+import type { Severity } from '@/services/infrastructure/grid-monitor';
+import type { WarRiskZone } from '@/services/maritime/maritime-threats';
+
+export interface WarZoneColors {
+  outlineHex: string;
+  fillHex: string;
+  fillAlpha: number;
+}
+
+const WAR_ZONE_PALETTE: Readonly<Record<WarRiskZone['threatCategory'], WarZoneColors>> = {
+  state_conflict: { outlineHex: '#dc2626', fillHex: '#dc2626', fillAlpha: 0.18 },
+  missile_drone:  { outlineHex: '#a855f7', fillHex: '#a855f7', fillAlpha: 0.18 },
+  piracy:         { outlineHex: '#f97316', fillHex: '#f97316', fillAlpha: 0.18 },
+  mixed:          { outlineHex: '#facc15', fillHex: '#facc15', fillAlpha: 0.18 },
+};
+
+export function warZoneColors(category: WarRiskZone['threatCategory']): WarZoneColors {
+  return WAR_ZONE_PALETTE[category];
+}
+
+export interface OutageRectExtent {
+  west: number;
+  south: number;
+  east: number;
+  north: number;
+}
+
+const SEVERITY_HALF_WIDTH_DEG: Readonly<Record<Severity, number>> = {
+  normal: 0,
+  elevated: 1.6,
+  high: 2,
+  major: 2.4,
+  extreme: 2.8,
+};
+
+const SEVERITY_HALF_HEIGHT_DEG: Readonly<Record<Severity, number>> = {
+  normal: 0,
+  elevated: 1.2,
+  high: 1.5,
+  major: 1.8,
+  extreme: 2.1,
+};
+
+/**
+ * Axis-aligned rectangle centered on (lat, lon) sized by severity.
+ * The on-screen footprint is a stylized choropleth tile — actual state
+ * GeoJSON would inflate the bundle and isn't required to communicate
+ * "this state is in trouble."
+ */
+export function outageRectExtent(lat: number, lon: number, severity: Severity): OutageRectExtent {
+  const halfW = SEVERITY_HALF_WIDTH_DEG[severity];
+  const halfH = SEVERITY_HALF_HEIGHT_DEG[severity];
+  return {
+    west: lon - halfW,
+    south: lat - halfH,
+    east: lon + halfW,
+    north: lat + halfH,
+  };
+}
+
+/**
+ * Pulse pixelSize for RadNet dots. Same triangle-wave shape as the
+ * X-flare halo but in pixels rather than metres.
+ */
+export function radnetPulsePixelSize(
+  elapsedMs: number,
+  pulsePeriodMs: number,
+  minPx = 8,
+  maxPx = 22,
+): number {
+  if (pulsePeriodMs <= 0) return (minPx + maxPx) / 2;
+  const period = pulsePeriodMs;
+  const norm = ((elapsedMs % period) + period) % period;
+  const phase = norm / period;
+  const tri = phase < 0.5 ? phase * 2 : 2 - phase * 2;
+  return minPx + (maxPx - minPx) * tri;
+}

--- a/src/services/infrastructure/grid-intelligence-loader.ts
+++ b/src/services/infrastructure/grid-intelligence-loader.ts
@@ -167,7 +167,7 @@ async function fetchGrid(): Promise<GridSnapshot | null> {
   return buildGridSnapshot(rows, Date.now());
 }
 
-async function fetchOutages(): Promise<OutageSummary | null> {
+export async function fetchOutages(): Promise<OutageSummary | null> {
   const data = await fetchJson('/api/infrastructure/outages');
   if (!data) return null;
   const entities = Array.isArray((data as { entities?: unknown }).entities) ? (data as { entities: unknown[] }).entities : [];
@@ -181,7 +181,7 @@ async function fetchBgp(): Promise<BgpSummary | null> {
   return buildBgpSummary(events as Parameters<typeof buildBgpSummary>[0], Date.now());
 }
 
-async function fetchRadiation(): Promise<RadSummary | null> {
+export async function fetchRadiation(): Promise<RadSummary | null> {
   const data = await fetchJson('/api/infrastructure/radiation');
   if (!data) return null;
   const stations = Array.isArray((data as { stations?: unknown }).stations) ? (data as { stations: unknown[] }).stations : [];

--- a/src/services/spaceweather/__tests__/globe-overlay.test.mts
+++ b/src/services/spaceweather/__tests__/globe-overlay.test.mts
@@ -5,6 +5,7 @@ import {
   auroraColorForKp,
   buildOverlayDescriptor,
   deriveSpaceWxBanner,
+  flarePulseRadiusAt,
   ringAtLatitude,
   subsolarPoint,
 } from '../globe-overlay.ts';
@@ -174,4 +175,33 @@ test('deriveSpaceWxBanner: G1/G2 alone returns none', () => {
     geomag: { kp: 5, level: 'G1', auroraVisibilityLatN: 60, observedAt: '', kpMax24h: 5 },
   }));
   assert.equal(banner.severity, 'none');
+});
+
+const PULSE = { subsolarLonDeg: 0, subsolarLatDeg: 0, pulsePeriodMs: 1000, innerRadiusM: 100, outerRadiusM: 500 };
+
+test('flarePulseRadiusAt: phase 0 sits at innerRadius', () => {
+  assert.equal(flarePulseRadiusAt(0, PULSE), 100);
+});
+
+test('flarePulseRadiusAt: phase 0.5 sits at outerRadius', () => {
+  assert.equal(flarePulseRadiusAt(500, PULSE), 500);
+});
+
+test('flarePulseRadiusAt: phase 0.25 is halfway up the ramp', () => {
+  assert.equal(flarePulseRadiusAt(250, PULSE), 300);
+});
+
+test('flarePulseRadiusAt: phase 0.75 is halfway down the ramp', () => {
+  assert.equal(flarePulseRadiusAt(750, PULSE), 300);
+});
+
+test('flarePulseRadiusAt: wraps cleanly across multiple periods', () => {
+  assert.equal(flarePulseRadiusAt(2500, PULSE), flarePulseRadiusAt(500, PULSE));
+});
+
+test('flarePulseRadiusAt: tolerates zero-period pulse without dividing by zero', () => {
+  const degenerate = { ...PULSE, pulsePeriodMs: 0 };
+  const r = flarePulseRadiusAt(123, degenerate);
+  assert.ok(Number.isFinite(r), 'radius must be finite');
+  assert.ok(r >= PULSE.innerRadiusM && r <= PULSE.outerRadiusM, 'radius must stay in bounds');
 });

--- a/src/services/spaceweather/globe-overlay.ts
+++ b/src/services/spaceweather/globe-overlay.ts
@@ -195,5 +195,20 @@ export function deriveSpaceWxBanner(status: SpaceWxStatus | null): SpaceWxBanner
   return { severity: 'none', label: '', subtitle: '' };
 }
 
+/**
+ * Triangle-wave pulse radius for the subsolar X-flare halo. Phase ramps
+ * 0→1 over the first half of `pulsePeriodMs`, then 1→0 over the second
+ * half, mapping linearly between `innerRadiusM` and `outerRadiusM`. The
+ * Cesium `CallbackProperty` driving the entity sample-evaluates this on
+ * each frame.
+ */
+export function flarePulseRadiusAt(elapsedMs: number, pulse: FlarePulse): number {
+  const period = Math.max(1, pulse.pulsePeriodMs);
+  const norm = ((elapsedMs % period) + period) % period; // safe under negative elapsed
+  const phase = norm / period; // 0..1
+  const tri = phase < 0.5 ? phase * 2 : 2 - phase * 2; // 0..1..0
+  return pulse.innerRadiusM + (pulse.outerRadiusM - pulse.innerRadiusM) * tri;
+}
+
 // Useful fixed values from J2000 epoch — exported for test stability checks.
 export const _internal = { J2000_MS };


### PR DESCRIPTION
## What this PR does

Wires three globe layers that the audit flagged as having descriptors / data already on disk but no Cesium consumer.

### 1. `SpaceWeatherGlobeOverlay` (new file: `src/components/globe/SpaceWeatherGlobeOverlay.ts`)
The comment in `src/services/spaceweather/globe-overlay.ts` referenced this component as the consumer of `AuroraRing` + `FlarePulse` descriptors — but the component never existed.

- `fetchSpaceWxStatus()` pulls `/api/spaceweather/status`.
- Aurora oval rendered as ground-clamped polylines at the visibility latitude (northern + mirrored southern ring). Color/width come from the descriptor — green at G1/G2, violet at G3, deep purple at G4/G5.
- Subsolar X-flare halo rendered as a Cesium ellipse whose `semiMajorAxis`/`semiMinorAxis` are `CallbackProperty`-driven; radius triangle-waves between `innerRadiusM` and `outerRadiusM` over `pulsePeriodMs`.
- **G3+ banner already wired** — `deriveSpaceWxBanner` + `EEWStatusBar.setSpaceWeatherStatus` already hand off via `status-bar-poller` in `panel-layout.ts`. No new banner work.

### 2. War-risk zones (`loadWarRiskZones` in `GlobeDataManager`)
`WAR_RISK_ZONES` (Red Sea, Hormuz, Black Sea, Gulf of Guinea) were only used for AIS proximity scoring — no globe layer rendered them.

- Each zone rendered as a Cesium ellipse sized to its radius, clamped to ground.
- Color palette per `threatCategory` (red/purple/orange/yellow) lives in `src/services/globe/overlay-helpers.ts` so it stays testable without Cesium.
- New independent `warRiskZones` HUD toggle (does not pollute the existing `ais` toggle, per audit recommendation).

### 3. Infrastructure overlay (`loadInfrastructureOverlay`)
`outagesToStateOverlay` + `radiationToHotspots` produced descriptors only the BGP banner consumed.

- Calls the same `/api/infrastructure/outages` + `/api/infrastructure/radiation` endpoints already polled by `grid-intelligence-loader`. `fetchOutages` and `fetchRadiation` are now exported so the globe layer reuses the parsers without duplicating logic.
- Each non-normal state from `outagesToStateOverlay` renders as a severity-sized Cesium rectangle around the state centroid (axis-aligned; `SEVERITY_HALF_WIDTH/HEIGHT_DEG` ladder in `overlay-helpers`).
- Each elevated RadNet station from `radiationToHotspots` renders as a `CallbackProperty`-driven point that pulses its `pixelSize` 8 px ↔ 22 px on a period that scales with severity.

## Layer registration
Three new keys in `gods-vision-layers.ts` (HUD toggles): `spaceWeather`, `warRiskZones`, `infrastructure`. All default off (intelligence category).

## Tests
- `npm run test:spaceweather` — **22/22** (was 16, +6 `flarePulseRadiusAt` cases covering both ramp halves, period wrap, zero-period guard).
- `npm run test:globe-overlay` — **8/8** new (warZoneColors palette distinctness, outageRectExtent severity scaling + centering + normal-collapse, radnetPulsePixelSize symmetry + zero-period guard).
- `npm run test:globe` — 17/17 unchanged.
- `npm run typecheck:all` — clean.

## Verification scope
This change exercises Cesium `Entity` / `CallbackProperty` rendering inside the Tauri webview. The Vite browser preview can't run it (no Cesium Ion token, no Tauri runtime). Verification is via the typed pure-helper test suites; the rendering wiring is small and matches the patterns already used by `loadFires`, `loadWeatherHazards`, and `loadAviationIntel`. End-to-end visual verification needs a desktop build install.