### PR TITLE
fix(scripts): harden key backup — drop iCloud plaintext, add age/gpg engines, sidecar HMAC, --verify

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,35 @@ The user-invoked `npm run backup-keys` and `npm run restore-keys` scripts are th
 only sanctioned entry points; do not call them on the user's behalf without an
 explicit, in-turn instruction.
 
+### Backup workflow
+
+`npm run backup-keys` reads each known `crystal-ball/*` key from the keychain and
+writes a single encrypted archive to
+`~/Library/Mobile Documents/com~apple~CloudDocs/CrystalBall/keys-backup-YYYYMMDD-{engine}.enc`.
+Plaintext is never written to iCloud. The encryption engine is auto-selected:
+
+1. **age** (preferred) — ChaCha20-Poly1305 AEAD with Argon2id KDF. `brew install age`.
+2. **gpg** — AES-256 + SHA-512 S2K (65M iterations) + OpenPGP MDC.
+3. **openssl** (fallback) — AES-256-CBC + PBKDF2-HMAC-SHA256 (600,000 iters,
+   NIST SP 800-132 2023) + sidecar HMAC-SHA256 (`*.enc.hmac`) for integrity.
+
+Output filename embeds the engine so restore knows what to do
+(`-age.enc`, `-gpg.enc`, or `-openssl.enc`). Files are written with mode 600.
+
+### Restore workflow
+
+`npm run restore-keys -- /path/to/keys-backup-YYYYMMDD-engine.enc` decrypts the
+archive and writes each `KEY=value` back to the keychain (idempotent under `-U`).
+Engine is auto-detected from the filename suffix.
+
+Use `npm run restore-keys -- --verify <path>` first to decrypt the archive and
+list the contained KEY names (values are never printed) — confirms the backup
+is valid before committing to a keychain write.
+
+Integrity is verified BEFORE any keychain writes:
+- age + gpg fail decryption when the AEAD/MDC tag mismatches.
+- openssl recomputes the sidecar HMAC and aborts on mismatch.
+
 ## Project Overview
 
 - **App name**: Crystal Ball

--- a/scripts/backup-keys.sh
+++ b/scripts/backup-keys.sh
@@ -1,26 +1,30 @@
 #!/usr/bin/env bash
 # Backup Crystal Ball API keys from macOS Keychain to iCloud Drive.
 #
-# Reads each known crystal-ball/* key from the keychain (service =
-# "crystal-ball", account = key-name), writes it as a KEY=value line to
-# a temp file, and produces two artefacts in iCloud Drive:
+# Reads each known crystal-ball/* keychain entry, writes it as a
+# KEY=value line into a temp file, then encrypts the temp file with
+# the strongest available tool and stores the result in iCloud Drive.
 #
-#   1. keys-backup-YYYYMMDD.enc — AES-256-CBC encrypted (PBKDF2, salted)
-#   2. .env.local                — plaintext, suitable for the sidecar
-#                                   fallback at src-tauri/sidecar/
-#                                   env-local-loader.mjs
+# Encryption engine priority:
+#   1. age      — ChaCha20-Poly1305 AEAD, Argon2id KDF, no footgun modes
+#                 (https://age-encryption.org). brew install age.
+#   2. gpg      — AES256 + SHA512 + iterated S2K + OpenPGP MDC.
+#   3. openssl  — AES-256-CBC + PBKDF2-HMAC-SHA256 (600,000 iters,
+#                 NIST SP 800-132 2023) + sidecar HMAC-SHA256 for
+#                 integrity. Sidecar passphrase is briefly visible in
+#                 /proc / ps args during HMAC computation; on a
+#                 personal Mac this is acceptable, but install age or
+#                 gpg if that bothers you.
 #
-# The plaintext file lives behind iCloud's at-rest encryption but is
-# readable by anyone with filesystem access to this Mac. That is a
-# deliberate trade against the alternative (a keychain wipe with no
-# recovery path). If you don't want plaintext in iCloud, pass --no-plain.
+# Output filename embeds the engine so restore knows what to do:
+#   keys-backup-YYYYMMDD-{age,gpg,openssl}.enc
 #
 # Usage:
-#   scripts/backup-keys.sh [--no-plain] [--dry-run]
+#   scripts/backup-keys.sh [--dry-run]
 #
 # Exit codes:
 #   0  success (at least one key backed up)
-#   1  argument or environment error
+#   1  argument / environment / encryption error
 #   2  no keys found in keychain (nothing backed up)
 
 set -euo pipefail
@@ -36,12 +40,10 @@ KEYS=(
   GREYNOISE_API_KEY URLSCAN_API_KEY ANTHROPIC_API_KEY
 )
 
-WRITE_PLAIN=1
 DRY_RUN=0
 for arg in "$@"; do
   case "$arg" in
-    --no-plain) WRITE_PLAIN=0 ;;
-    --dry-run)  DRY_RUN=1 ;;
+    --dry-run) DRY_RUN=1 ;;
     -h|--help)
       sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
@@ -53,10 +55,23 @@ for arg in "$@"; do
   esac
 done
 
+# ── Detect encryption engine ────────────────────────────────────────
+ENGINE=""
+if command -v age >/dev/null 2>&1; then
+  ENGINE="age"
+elif command -v gpg >/dev/null 2>&1; then
+  ENGINE="gpg"
+elif command -v openssl >/dev/null 2>&1; then
+  ENGINE="openssl"
+else
+  echo "No encryption tool found. Install age (brew install age), gpg, or openssl." >&2
+  exit 1
+fi
+echo "Encryption engine: $ENGINE"
+
 ICLOUD_DIR="$HOME/Library/Mobile Documents/com~apple~CloudDocs/CrystalBall"
 DATE_TAG="$(date +%Y%m%d)"
-ENC_PATH="$ICLOUD_DIR/keys-backup-$DATE_TAG.enc"
-PLAIN_PATH="$ICLOUD_DIR/.env.local"
+ENC_PATH="$ICLOUD_DIR/keys-backup-$DATE_TAG-$ENGINE.enc"
 
 if [[ ! -d "$HOME/Library/Mobile Documents/com~apple~CloudDocs" ]]; then
   echo "iCloud Drive is not enabled on this Mac. Aborting." >&2
@@ -65,12 +80,16 @@ fi
 mkdir -p "$ICLOUD_DIR"
 
 TMP_DIR="$(mktemp -d -t crystalball-backup)"
+chmod 700 "$TMP_DIR"
 TMP_PLAIN="$TMP_DIR/keys.env"
 trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
 
+# ── Read keys from keychain ─────────────────────────────────────────
 echo "Reading ${#KEYS[@]} keys from macOS Keychain (service=crystal-ball)..."
 found=0
 missing=()
+: > "$TMP_PLAIN"
+chmod 600 "$TMP_PLAIN"
 for key in "${KEYS[@]}"; do
   if value=$(security find-generic-password -s "crystal-ball" -a "$key" -w 2>/dev/null); then
     if [[ -n "$value" ]]; then
@@ -83,6 +102,7 @@ for key in "${KEYS[@]}"; do
     missing+=("$key")
   fi
 done
+unset value
 
 echo "Found $found / ${#KEYS[@]} keys in keychain."
 if (( ${#missing[@]} > 0 )); then
@@ -96,36 +116,70 @@ fi
 
 if (( DRY_RUN == 1 )); then
   echo "[dry-run] Would write encrypted backup to: $ENC_PATH"
-  if (( WRITE_PLAIN == 1 )); then
-    echo "[dry-run] Would write plaintext .env.local to: $PLAIN_PATH"
+  if [[ "$ENGINE" == "openssl" ]]; then
+    echo "[dry-run] Would also write HMAC sidecar to:   $ENC_PATH.hmac"
   fi
   exit 0
 fi
 
-echo
-echo "Set a password to encrypt the backup. You will need it to restore."
-read -r -s -p "Password: " PW1; echo
-read -r -s -p "Confirm:  " PW2; echo
-if [[ -z "$PW1" ]]; then
-  echo "Empty password — refusing to encrypt." >&2
-  exit 1
-fi
-if [[ "$PW1" != "$PW2" ]]; then
-  echo "Passwords do not match." >&2
-  exit 1
-fi
+# ── Encrypt ─────────────────────────────────────────────────────────
+case "$ENGINE" in
+  age)
+    # age -p prompts for passphrase + confirmation interactively. Salt
+    # is per-file random (Argon2id). Wrong passphrase fails AEAD on decrypt.
+    age -p -o "$ENC_PATH" "$TMP_PLAIN"
+    ;;
+  gpg)
+    # --batch=false keeps the interactive prompt + confirmation. AES-256
+    # in CFB with OpenPGP MDC; SHA-512 S2K with iteration count 65M.
+    # --compress-algo none avoids leaking length info via compression.
+    gpg --batch=false \
+        --symmetric \
+        --cipher-algo AES256 \
+        --s2k-digest-algo SHA512 \
+        --s2k-count 65011712 \
+        --compress-algo none \
+        --output "$ENC_PATH" \
+        "$TMP_PLAIN"
+    ;;
+  openssl)
+    echo
+    echo "Set a password to encrypt the backup. You will need it to restore."
+    read -r -s -p "Password: " PW1; echo
+    read -r -s -p "Confirm:  " PW2; echo
+    if [[ -z "$PW1" ]]; then
+      echo "Empty password — refusing to encrypt." >&2
+      exit 1
+    fi
+    if [[ "$PW1" != "$PW2" ]]; then
+      echo "Passwords do not match." >&2
+      exit 1
+    fi
+    unset PW2
+    # Passphrase via stdin (-pass stdin) keeps it out of process args.
+    # PBKDF2-HMAC-SHA256 with 600,000 iterations matches NIST SP 800-132
+    # (2023). Random 8-byte salt is written into the openssl header.
+    printf '%s' "$PW1" | openssl enc -aes-256-cbc -pbkdf2 -iter 600000 -salt \
+      -in "$TMP_PLAIN" -out "$ENC_PATH" -pass stdin
+    # Sidecar HMAC-SHA256 over the ciphertext using the passphrase as key.
+    # Verified on restore BEFORE decryption so a tampered or corrupted
+    # file doesn't get fed to the decrypter. Note: the passphrase is
+    # briefly visible in process args during this command — a known
+    # openssl(1) limitation.
+    openssl dgst -sha256 -hmac "$PW1" -binary "$ENC_PATH" > "$ENC_PATH.hmac"
+    unset PW1
+    chmod 600 "$ENC_PATH.hmac"
+    ;;
+esac
 
-openssl enc -aes-256-cbc -pbkdf2 -salt \
-  -in "$TMP_PLAIN" -out "$ENC_PATH" -pass "pass:$PW1"
 chmod 600 "$ENC_PATH"
-echo "Encrypted backup → $ENC_PATH"
 
-if (( WRITE_PLAIN == 1 )); then
-  install -m 600 "$TMP_PLAIN" "$PLAIN_PATH"
-  echo "Plaintext .env.local → $PLAIN_PATH"
-  echo "  (readable by anyone with filesystem access to this Mac;"
-  echo "   protected at rest by iCloud Drive encryption only.)"
-fi
-
+# ── Summary ─────────────────────────────────────────────────────────
 echo
 echo "Done. $found keys backed up."
+echo "  Engine:  $ENGINE"
+echo "  Output:  $ENC_PATH"
+if [[ "$ENGINE" == "openssl" ]]; then
+  echo "  HMAC:    $ENC_PATH.hmac (required for restore)"
+fi
+echo "  Permissions: 600 (owner-only)"

--- a/scripts/restore-keys.sh
+++ b/scripts/restore-keys.sh
@@ -3,49 +3,151 @@
 # Keychain. Pairs with scripts/backup-keys.sh.
 #
 # Usage:
-#   scripts/restore-keys.sh <path/to/keys-backup.enc>
+#   scripts/restore-keys.sh [--verify] <path/to/keys-backup-YYYYMMDD-{age,gpg,openssl}.enc>
 #
-# Decrypts the file with a password you provide, then writes each
-# KEY=value line back to the keychain with:
-#   security add-generic-password -U -s "crystal-ball" -a KEY -w VALUE
+# The encryption engine is auto-detected from the filename suffix
+# (-age.enc / -gpg.enc / -openssl.enc).
 #
-# The -U flag updates an existing entry rather than failing — restore
-# is idempotent.
+# Integrity is checked BEFORE any keychain writes:
+#   - age + gpg use AEAD / MDC. Wrong passphrase or tampered ciphertext
+#     fails decryption with a non-zero exit and the script aborts.
+#   - openssl uses a sidecar HMAC-SHA256 file (.hmac); we recompute and
+#     compare before decrypting.
+#
+# --verify  decrypts and prints the KEY names contained in the backup
+#           without writing anything to keychain. Use this first to
+#           confirm a backup is valid before committing to a restore.
 #
 # Exit codes:
 #   0  success
-#   1  argument / file / decryption error
+#   1  argument / file / decryption / integrity / write error
 
 set -euo pipefail
 
-if (( $# != 1 )); then
-  echo "usage: $0 <path/to/keys-backup.enc>" >&2
+VERIFY_ONLY=0
+ENC_PATH=""
+for arg in "$@"; do
+  case "$arg" in
+    --verify) VERIFY_ONLY=1 ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    -*)
+      echo "unknown option: $arg" >&2
+      exit 1
+      ;;
+    *)
+      if [[ -n "$ENC_PATH" ]]; then
+        echo "more than one input file given" >&2
+        exit 1
+      fi
+      ENC_PATH="$arg"
+      ;;
+  esac
+done
+
+if [[ -z "$ENC_PATH" ]]; then
+  echo "usage: $0 [--verify] <path/to/keys-backup-YYYYMMDD-{age,gpg,openssl}.enc>" >&2
   exit 1
 fi
-
-ENC_PATH="$1"
 if [[ ! -f "$ENC_PATH" ]]; then
   echo "file not found: $ENC_PATH" >&2
   exit 1
 fi
 
+# ── Detect engine from filename suffix ──────────────────────────────
+ENGINE=""
+case "$ENC_PATH" in
+  *-age.enc)     ENGINE="age" ;;
+  *-gpg.enc)     ENGINE="gpg" ;;
+  *-openssl.enc) ENGINE="openssl" ;;
+  *)
+    echo "Cannot detect engine from filename: $ENC_PATH" >&2
+    echo "Expected suffix -age.enc, -gpg.enc, or -openssl.enc." >&2
+    exit 1
+    ;;
+esac
+if ! command -v "$ENGINE" >/dev/null 2>&1; then
+  echo "Backup uses $ENGINE but $ENGINE is not installed." >&2
+  exit 1
+fi
+echo "Encryption engine: $ENGINE"
+
 TMP_DIR="$(mktemp -d -t crystalball-restore)"
+chmod 700 "$TMP_DIR"
 TMP_PLAIN="$TMP_DIR/keys.env"
 trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
 
-echo "Decrypting $ENC_PATH..."
-read -r -s -p "Password: " PW; echo
-if [[ -z "$PW" ]]; then
-  echo "Empty password." >&2
-  exit 1
+# ── Decrypt + integrity check ───────────────────────────────────────
+case "$ENGINE" in
+  age)
+    # AEAD: wrong passphrase or tampered file fails decryption.
+    if ! age -d -o "$TMP_PLAIN" "$ENC_PATH"; then
+      echo "Integrity check failed (wrong passphrase or corrupt file)." >&2
+      exit 1
+    fi
+    ;;
+  gpg)
+    # OpenPGP MDC: tampered file fails. Wrong passphrase exits non-zero.
+    if ! gpg --decrypt --output "$TMP_PLAIN" "$ENC_PATH" 2>/dev/null; then
+      echo "Integrity check failed (wrong passphrase or corrupt file)." >&2
+      exit 1
+    fi
+    ;;
+  openssl)
+    HMAC_PATH="$ENC_PATH.hmac"
+    if [[ ! -f "$HMAC_PATH" ]]; then
+      echo "openssl backup requires sidecar HMAC at: $HMAC_PATH" >&2
+      exit 1
+    fi
+    read -r -s -p "Password: " PW; echo
+    if [[ -z "$PW" ]]; then
+      echo "Empty password." >&2
+      exit 1
+    fi
+    # Recompute HMAC over the ciphertext and compare to the sidecar.
+    # If this fails, abort BEFORE attempting decryption.
+    EXPECTED="$TMP_DIR/expected.hmac"
+    openssl dgst -sha256 -hmac "$PW" -binary "$ENC_PATH" > "$EXPECTED"
+    if ! cmp -s "$EXPECTED" "$HMAC_PATH"; then
+      echo "Integrity check failed: HMAC mismatch." >&2
+      echo "Either the passphrase is wrong or the file has been tampered with." >&2
+      exit 1
+    fi
+    rm -f "$EXPECTED"
+    # HMAC matched → passphrase is correct AND ciphertext is intact.
+    if ! printf '%s' "$PW" | openssl enc -d -aes-256-cbc -pbkdf2 -iter 600000 \
+            -in "$ENC_PATH" -out "$TMP_PLAIN" -pass stdin 2>/dev/null; then
+      # Should not happen after HMAC pass — would mean format mismatch.
+      echo "Decryption failed despite HMAC match — file format may be incompatible." >&2
+      exit 1
+    fi
+    unset PW
+    ;;
+esac
+
+chmod 600 "$TMP_PLAIN"
+
+# ── Verify mode: list key names + exit ──────────────────────────────
+if (( VERIFY_ONLY == 1 )); then
+  echo
+  echo "Backup contents (KEY names only, values not shown):"
+  count=0
+  while IFS= read -r line; do
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    key="${line%%=*}"
+    if [[ -n "$key" && "$key" != "$line" ]]; then
+      echo "  $key"
+      count=$((count + 1))
+    fi
+  done < "$TMP_PLAIN"
+  echo
+  echo "Total: $count keys. Backup integrity OK."
+  exit 0
 fi
 
-if ! openssl enc -d -aes-256-cbc -pbkdf2 \
-       -in "$ENC_PATH" -out "$TMP_PLAIN" -pass "pass:$PW" 2>/dev/null; then
-  echo "Decryption failed — wrong password or corrupt file." >&2
-  exit 1
-fi
-
+# ── Confirm + write to keychain ─────────────────────────────────────
 echo
 echo "About to write keys to the macOS Keychain (service=crystal-ball)."
 read -r -p "Proceed? [y/N] " ans


### PR DESCRIPTION
## Why
Follow-up review of the scripts shipped in #364 surfaced six concrete improvements. This PR addresses all six.

## 1. Plaintext on iCloud is gone
The `--no-plain` flag and the code that wrote `.env.local` to iCloud Drive are removed. The encrypted archive is the only iCloud artefact. The local-dev `.env.local` (project root, gitignored) is unchanged — it lives on disk only and feeds the sidecar's existing fallback path.

## 2. Encryption engines: age > gpg > openssl

Auto-detected with `command -v`. Selected engine is printed in the run header and embedded in the output filename so restore knows what to do.

| Engine | Cipher | KDF | Integrity | Notes |
|---|---|---|---|---|
| **age** (preferred) | ChaCha20-Poly1305 AEAD | Argon2id | AEAD tag | `brew install age`. No footgun modes. |
| **gpg** | AES-256 (CFB) | SHA-512 S2K, `--s2k-count 65011712` | OpenPGP MDC | `--compress-algo none` to avoid length-leak via compression. |
| **openssl** (fallback) | AES-256-CBC | PBKDF2-HMAC-SHA256, `-iter 600000` (NIST SP 800-132 2023) | Sidecar HMAC-SHA256 | Passphrase via `-pass stdin` (out of process args); HMAC `-hmac` arg has a known openssl(1) limitation, surfaced in the help banner. |

## 3. Filename embeds engine + random salt
`keys-backup-YYYYMMDD-{age,gpg,openssl}.enc`. Each engine generates its own random salt internally (Argon2id / OpenPGP / openssl `-salt`). Restore parses the suffix and rejects unknown ones.

## 4. Integrity is verified BEFORE any keychain writes
- **age + gpg**: AEAD / MDC tag mismatch fails decryption; the script aborts before reaching the keychain block.
- **openssl**: `openssl dgst -sha256 -hmac ... -binary` over the ciphertext is recomputed and compared against the `.hmac` sidecar with `cmp -s`. On mismatch the script aborts with `Integrity check failed: HMAC mismatch` before `openssl enc -d` is invoked.

## 5. New `--verify` flag on `restore-keys.sh`
`npm run restore-keys -- --verify path/to/keys-backup-…enc` decrypts, verifies integrity, and prints the contained KEY names (values are never printed). Lets you confirm a backup is intact and complete before committing to a keychain write.

## 6. Tightened file permissions + cleanup
- `mktemp -d` plus explicit `chmod 700` on the temp dir.
- `chmod 600` on the plaintext tmpfile, the encrypted output, and the openssl HMAC sidecar.
- `trap 'rm -rf "$TMP_DIR"' EXIT INT TERM` is in place on both scripts — plaintext keys never linger after a crash.
- Passphrases for openssl encrypt/decrypt come via `-pass stdin` rather than `-pass pass:$PW`, so they don't appear in process args.

## CLAUDE.md updates
The 'Backup workflow' and 'Restore workflow' sections under `## KEYCHAIN — ABSOLUTE PROHIBITION` now describe the engine ladder, the filename format, the `--verify` flag, and the integrity guarantees.

## Verification
- `bash -n` on both scripts — syntax OK.
- Help banners render cleanly for both.
- `npm run typecheck:all` — clean.
- `npm run test:sidecar` — 233/233 (env-local-loader tests unaffected).
- Manual openssl roundtrip on a fixture (no keychain touch): encrypt + HMAC succeeds; `cmp -s` rejects HMAC computed with a wrong passphrase; `cmp -s` rejects HMAC over a ciphertext with a single byte flipped at offset 20. Decrypt only runs after HMAC matches.

## What I did NOT do
- Did not run `security` commands against the keychain (the prohibition starts here, per CLAUDE.md).
- Did not test the full backup → keychain wipe → restore round-trip end-to-end. Worth a manual smoke test on a non-load-bearing key (e.g. `security add-generic-password -s 'crystal-ball' -a 'TEST_KEY' -w 'fixture'`, then back up, delete, `--verify`, then restore) before relying on the workflow.