### PR TITLE
feat: Cesium-native globe heatmap renderer + timeline-cursor entity opacity

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "test:personal": "tsx --test src/services/personal/__tests__/personal-impact.test.mts src/services/personal/__tests__/threat-aggregator.test.mts",
     "test:export": "tsx --test src/services/export/__tests__/brief-pdf.test.mts",
     "test:playback": "tsx --test src/services/playback/__tests__/timeline-cursor.test.mts",
-    "test:globe": "tsx --test src/services/globe/__tests__/heatmap-layers.test.mts",
+    "test:globe": "tsx --test src/services/globe/__tests__/heatmap-layers.test.mts src/components/globe/__tests__/heatmap-grid.test.mts src/components/globe/__tests__/cursor-opacity.test.mts src/components/globe/__tests__/GlobeHeatmapRenderer.test.mts",
     "test:adsb": "tsx --test src/services/adsb/__tests__/adsb-aggregate.test.mts",
     "test:synthesis": "tsx --test src/services/synthesis/__tests__/signal-watch.test.mts",
     "test:bio": "tsx --test src/services/biosurveillance/__tests__/cdc-ari.test.mts",

--- a/src/components/GlobeDataManager.ts
+++ b/src/components/GlobeDataManager.ts
@@ -29,6 +29,8 @@ import {
 } from 'cesium';
 
 import { applyClustering } from '@/components/globeClustering';
+import { GlobeHeatmapRenderer } from '@/components/globe/GlobeHeatmapRenderer';
+import { coerceTimestampMs, opacityForEntity } from '@/components/globe/cursor-opacity';
 import { escapeHtml } from '@/utils/sanitize';
 import { modelLoader } from '@/services/model-loader';
 import { BuildingTileManager } from '@/services/building-tiles';
@@ -424,6 +426,51 @@ function setEntityTimestamp(entity: import('cesium').Entity, when: Date): void {
   entity.properties.addProperty('timestamp', new ConstantProperty(when));
 }
 
+/** Read an entity's `timestamp` property and coerce to ms epoch.
+ *  Returns null when no timestamp is set. Used by cursor-window
+ *  opacity. Exported for tests. */
+export function readEntityTimestampMs(entity: import('cesium').Entity): number | null {
+  const props = entity.properties;
+  if (!props) return null;
+  // PropertyBag.getValue takes a JulianDate; pass a fresh one — the
+  // timestamp is stored as a ConstantProperty so the time arg is
+  // ignored, but the API requires it.
+  const v = props.getValue(JulianDate.now()) as { timestamp?: unknown } | undefined;
+  return coerceTimestampMs(v?.timestamp);
+}
+
+/** Apply an alpha multiplier to whatever color-bearing graphic an
+ *  entity carries (point / billboard / rectangle / polygon / polyline).
+ *  Reads the current color, swaps alpha, writes back. Cesium's
+ *  `Color.withAlpha()` returns a fresh instance so we don't mutate
+ *  shared color objects. */
+export function applyEntityAlpha(entity: import('cesium').Entity, alpha: number): void {
+  const a = Math.max(0, Math.min(1, alpha));
+  const now = JulianDate.now();
+  const setColorWithAlpha = (
+    holder: { color?: import('cesium').Property } | undefined | null,
+    setter: (next: ConstantProperty) => void,
+  ): void => {
+    if (!holder?.color) return;
+    const raw: unknown = holder.color.getValue(now);
+    if (raw instanceof Color) setter(new ConstantProperty(raw.withAlpha(a)));
+  };
+  setColorWithAlpha(entity.point, (p) => { entity.point!.color = p; });
+  setColorWithAlpha(entity.billboard, (p) => { entity.billboard!.color = p; });
+  if (entity.rectangle?.material instanceof ColorMaterialProperty) {
+    const mat = entity.rectangle.material;
+    setColorWithAlpha({ color: mat.color }, (p) => { mat.color = p; });
+  }
+  if (entity.polygon?.material instanceof ColorMaterialProperty) {
+    const mat = entity.polygon.material;
+    setColorWithAlpha({ color: mat.color }, (p) => { mat.color = p; });
+  }
+  if (entity.polyline?.material instanceof ColorMaterialProperty) {
+    const mat = entity.polyline.material;
+    setColorWithAlpha({ color: mat.color }, (p) => { mat.color = p; });
+  }
+}
+
 interface GlobeLayer {
   source: CustomDataSource;
   load: () => void | Promise<void>;
@@ -526,6 +573,8 @@ export class GlobeDataManager {
   private unsubPositions: (() => void) | null = null;
   private cameraMoveSub: (() => void) | null = null;
   private maritimeVesselsTimer: ReturnType<typeof setInterval> | null = null;
+  private heatmapRenderer: GlobeHeatmapRenderer | null = null;
+  private cursorListener: ((event: Event) => void) | null = null;
   private aftershockForecasts = new Map<string, AftershockForecast>();
   private cycloneCones = new Map<string, ForecastCone>();
   // Persists across loadTropicalCyclones() calls so we can derive an actual
@@ -596,6 +645,44 @@ export class GlobeDataManager {
  if (!DEFERRED_LAYER_ALTITUDE[name]) void this.loadLayer(name);
  }
  this.setupDeferredLayerLoading();
+
+ // Heatmap renderer self-manages via the wm:globe-heatmap-changed event bus.
+ this.heatmapRenderer = new GlobeHeatmapRenderer(this.viewer);
+ this.heatmapRenderer.mount();
+
+ // Timeline cursor → entity opacity wiring. Fades out-of-window
+ // entities to 0.3 alpha so playback visibly affects the globe.
+ this.cursorListener = (event) => this.handleCursorChange(event);
+ document.addEventListener('wm:globe-timeline-cursor', this.cursorListener);
+  }
+
+  /** Apply cursor-window opacity to every time-stamped entity in
+   *  every loaded data source. Called from the cursor event listener.
+   *  Public so tests can drive it without dispatching DOM events. */
+  applyCursorOpacity(cursorMs: number): { faded: number; full: number; timeless: number } {
+ const result = { faded: 0, full: 0, timeless: 0 };
+ for (const [, layer] of this.layers) {
+ for (const entity of layer.source.entities.values) {
+ const ts = readEntityTimestampMs(entity);
+ if (ts === null) {
+ result.timeless += 1;
+ // Timeless entities are never faded — leave them alone.
+ continue;
+ }
+ const alpha = opacityForEntity(ts, cursorMs);
+ applyEntityAlpha(entity, alpha);
+ if (alpha < 1) result.faded += 1;
+ else result.full += 1;
+ }
+ }
+ return result;
+  }
+
+  private handleCursorChange(event: Event): void {
+ const detail = (event as CustomEvent<{ cursorMs?: unknown }>).detail;
+ const ms = Number(detail?.cursorMs);
+ if (!Number.isFinite(ms)) return;
+ this.applyCursorOpacity(ms);
   }
 
   private checkDeferredLayers = (): void => {
@@ -2489,6 +2576,12 @@ ${pkg.composition.map(u => u.type + ' x' + String(u.count)).join(', ')}`,
   }
 
   destroy(): void {
+ if (this.cursorListener) {
+ document.removeEventListener('wm:globe-timeline-cursor', this.cursorListener);
+ this.cursorListener = null;
+ }
+ this.heatmapRenderer?.destroy();
+ this.heatmapRenderer = null;
  this.cameraMoveSub?.();
  this.cameraMoveSub = null;
  for (const [, layer] of this.layers) {

--- a/src/components/globe/GlobeHeatmapRenderer.ts
+++ b/src/components/globe/GlobeHeatmapRenderer.ts
@@ -1,0 +1,266 @@
+/**
+ * GlobeHeatmapRenderer
+ * --------------------
+ * Cesium-native renderer for the per-domain heatmap toggle.
+ *
+ * Listens for the `wm:globe-heatmap-changed` CustomEvent dispatched by
+ * GlobeHeatmapToggle, fetches the relevant sidecar data for the active
+ * domain, bins it into a 1°×1° grid via `heatmap-grid.ts`, and draws
+ * each non-empty cell as a translucent rectangle entity in a dedicated
+ * CustomDataSource.
+ *
+ * Why CustomDataSource of rectangle entities (not GroundPrimitive)?
+ *   GroundPrimitive draws on the terrain depth buffer but is harder
+ *   to update incrementally and harder to test. Entity rectangles use
+ *   the same render path as the rest of GlobeDataManager's overlays
+ *   (see loadInfrastructureOverlay) and clear cleanly via
+ *   `entities.removeAll()`. This matches the spec's "GroundPrimitive
+ *   colored rectangles" intent (terrain-clamped, color-mapped) at the
+ *   layer the rest of the codebase already uses.
+ *
+ * Pure-logic layer (binning + colors + domain mapping) lives in
+ * `heatmap-grid.ts` and is unit-tested in isolation; this file is the
+ * Cesium glue + fetch orchestration.
+ *
+ * Plan invariants:
+ *   - Self-managed via the event bus — instantiate once, no manual
+ *     `setDomain()` calls needed.
+ *   - Clearing: every domain change clears the previous data source
+ *     before fetching new data, so toggling A → B → null leaves no
+ *     stale cells on screen.
+ *   - Race-safe: an in-flight fetch for an old domain can't overwrite
+ *     a newer one — the renderer pins the requested domain on each
+ *     fetch and bails when it changes mid-flight.
+ *   - Fetch failure paints nothing for the active domain (no half-state).
+ */
+
+import {
+  Color,
+  ColorMaterialProperty,
+  ConstantProperty,
+  CustomDataSource,
+  Rectangle,
+  type Viewer,
+} from 'cesium';
+import { getApiBaseUrl } from '@/services/runtime';
+import {
+  buildColoredCells,
+  type ColoredHeatmapCell,
+  type HeatmapDomain,
+  type HeatmapPoint,
+  type RgbaColor,
+} from './heatmap-grid';
+
+const DATA_SOURCE_NAME = 'globe-heatmap';
+const CHANGED_EVENT = 'wm:globe-heatmap-changed';
+
+/**
+ * The toggle UI uses a wider/older domain set (`fire`, `cyber`,
+ * `conflict`) inherited from the deck.gl config builder; this renderer
+ * uses the spec-defined set (`seismic` / `wildfire` / `weather` /
+ * `infrastructure`). Map between them so existing toggle dispatches
+ * land cleanly without coordinating a second UI change.
+ *
+ * Anything not in this map → `null` (no render, clear). When the
+ * toggle is later extended to dispatch `weather` + `infrastructure`
+ * directly, those pass through unchanged.
+ */
+export function mapToggleDomain(raw: string | null | undefined): HeatmapDomain | null {
+  if (!raw) return null;
+  switch (raw) {
+    case 'seismic':         { return 'seismic'; }
+    case 'fire':
+    case 'wildfire':        { return 'wildfire'; }
+    case 'weather':         { return 'weather'; }
+    case 'infrastructure':  { return 'infrastructure'; }
+    default:                { return null; }
+  }
+}
+
+/** Adapter shape the renderer accepts from each sidecar endpoint.
+ *  Each domain has its own raw shape; the per-domain extractor
+ *  normalises to `HeatmapPoint[]`. */
+type SidecarFetcher = (baseUrl: string, signal: AbortSignal) => Promise<HeatmapPoint[]>;
+
+/** Per-domain endpoint + extractor. Keeping these as plain functions
+ *  (instead of a constant config object) lets tests pass mock
+ *  fetchers via the constructor's `fetchers` override. */
+const DEFAULT_FETCHERS: Record<HeatmapDomain, SidecarFetcher> = {
+  seismic: async (baseUrl, signal) => {
+    const res = await fetch(`${baseUrl}/api/earthquakes`, { signal });
+    if (!res.ok) return [];
+    const body = await res.json() as { earthquakes?: { magnitude?: unknown; location?: { latitude?: unknown; longitude?: unknown } }[] };
+    const out: HeatmapPoint[] = [];
+    for (const q of body.earthquakes ?? []) {
+      const lat = Number(q?.location?.latitude);
+      const lon = Number(q?.location?.longitude);
+      const mag = Number(q?.magnitude);
+      if (Number.isFinite(lat) && Number.isFinite(lon) && Number.isFinite(mag)) {
+        out.push({ lat, lon, intensity: mag });
+      }
+    }
+    return out;
+  },
+  wildfire: async (baseUrl, signal) => {
+    const res = await fetch(`${baseUrl}/api/nasa-firms`, { signal });
+    if (!res.ok) return [];
+    const body = await res.json() as { fires?: { latitude?: unknown; longitude?: unknown; frp?: unknown }[]; hotspots?: { latitude?: unknown; longitude?: unknown; frp?: unknown }[] };
+    const rows = body.fires ?? body.hotspots ?? [];
+    const out: HeatmapPoint[] = [];
+    for (const r of rows) {
+      const lat = Number(r?.latitude);
+      const lon = Number(r?.longitude);
+      const frp = Number(r?.frp);
+      if (Number.isFinite(lat) && Number.isFinite(lon)) {
+        out.push({ lat, lon, intensity: Number.isFinite(frp) ? frp : 1 });
+      }
+    }
+    return out;
+  },
+  weather: async (baseUrl, signal) => {
+    const res = await fetch(`${baseUrl}/api/nws-alerts`, { signal });
+    if (!res.ok) return [];
+    const body = await res.json() as { alerts?: { lat?: unknown; lon?: unknown; latitude?: unknown; longitude?: unknown }[] };
+    const out: HeatmapPoint[] = [];
+    for (const a of body.alerts ?? []) {
+      const lat = Number(a?.lat ?? a?.latitude);
+      const lon = Number(a?.lon ?? a?.longitude);
+      if (Number.isFinite(lat) && Number.isFinite(lon)) {
+        out.push({ lat, lon, intensity: 1 });
+      }
+    }
+    return out;
+  },
+  infrastructure: async (baseUrl, signal) => {
+    const res = await fetch(`${baseUrl}/api/infrastructure/outages`, { signal });
+    if (!res.ok) return [];
+    const body = await res.json() as { outages?: { lat?: unknown; lon?: unknown; latitude?: unknown; longitude?: unknown; customers?: unknown }[] };
+    const out: HeatmapPoint[] = [];
+    for (const o of body.outages ?? []) {
+      const lat = Number(o?.lat ?? o?.latitude);
+      const lon = Number(o?.lon ?? o?.longitude);
+      if (Number.isFinite(lat) && Number.isFinite(lon)) {
+        out.push({ lat, lon, intensity: 1 });
+      }
+    }
+    return out;
+  },
+};
+
+export interface GlobeHeatmapRendererOptions {
+  /** Override fetchers for tests. */
+  fetchers?: Partial<Record<HeatmapDomain, SidecarFetcher>>;
+  /** Override the base URL resolver (defaults to `getApiBaseUrl()`). */
+  baseUrl?: () => string;
+}
+
+export class GlobeHeatmapRenderer {
+  private viewer: Viewer;
+  private dataSource: CustomDataSource;
+  private fetchers: Record<HeatmapDomain, SidecarFetcher>;
+  private baseUrlFn: () => string;
+  private activeDomain: HeatmapDomain | null = null;
+  private activeAbort: AbortController | null = null;
+  private boundHandler: ((event: Event) => void) | null = null;
+
+  constructor(viewer: Viewer, options: GlobeHeatmapRendererOptions = {}) {
+    this.viewer = viewer;
+    this.fetchers = { ...DEFAULT_FETCHERS, ...options.fetchers };
+    this.baseUrlFn = options.baseUrl ?? getApiBaseUrl;
+    this.dataSource = new CustomDataSource(DATA_SOURCE_NAME);
+  }
+
+  /** Subscribe to the event bus and attach the data source. Call once
+   *  after construction. */
+  mount(): void {
+    if (this.boundHandler) return;
+    void this.viewer.dataSources.add(this.dataSource);
+    this.boundHandler = (event) => this.handleChanged(event);
+    document.addEventListener(CHANGED_EVENT, this.boundHandler);
+  }
+
+  destroy(): void {
+    if (this.boundHandler) {
+      document.removeEventListener(CHANGED_EVENT, this.boundHandler);
+      this.boundHandler = null;
+    }
+    this.activeAbort?.abort();
+    this.activeAbort = null;
+    this.dataSource.entities.removeAll();
+    this.viewer.dataSources.remove(this.dataSource, true);
+  }
+
+  /** Programmatic entry point — same path as the event handler. Used
+   *  by tests + as a fallback when the event bus isn't available. */
+  async setDomain(domain: HeatmapDomain | null): Promise<void> {
+    this.activeAbort?.abort();
+    this.activeAbort = null;
+    this.activeDomain = domain;
+    this.clear();
+    if (domain === null) return;
+    await this.fetchAndRender(domain);
+  }
+
+  /** Public for tests. Clears the data source. */
+  clear(): void {
+    this.dataSource.entities.removeAll();
+  }
+
+  /** Public for tests. Returns the count of currently-rendered cells. */
+  cellCount(): number {
+    return this.dataSource.entities.values.length;
+  }
+
+  /** Public for tests. Returns the active domain, or null. */
+  getActiveDomain(): HeatmapDomain | null {
+    return this.activeDomain;
+  }
+
+  // ── Internal ──────────────────────────────────────────────────────
+
+  private handleChanged(event: Event): void {
+    const detail = (event as CustomEvent<{ state?: { selected?: string | null } }>).detail;
+    const raw = detail?.state?.selected ?? null;
+    const mapped = mapToggleDomain(raw);
+    void this.setDomain(mapped);
+  }
+
+  private async fetchAndRender(domain: HeatmapDomain): Promise<void> {
+    const controller = new AbortController();
+    this.activeAbort = controller;
+    const fetcher = this.fetchers[domain];
+    let points: readonly HeatmapPoint[] = [];
+    try {
+      points = await fetcher(this.baseUrlFn(), controller.signal);
+    } catch (error) {
+      if ((error as { name?: string })?.name === 'AbortError') return;
+      // eslint-disable-next-line no-console -- diagnostic only; renderer falls through to no-op
+      console.warn(`[GlobeHeatmapRenderer] fetch failed for ${domain}:`, error);
+      return;
+    }
+    // Race guard — if a newer domain change came in while we were
+    // awaiting, drop this result on the floor.
+    if (this.activeDomain !== domain) return;
+    this.renderCells(buildColoredCells(domain, points));
+  }
+
+  private renderCells(cells: readonly ColoredHeatmapCell[]): void {
+    this.dataSource.entities.removeAll();
+    for (const cell of cells) {
+      this.dataSource.entities.add({
+        rectangle: {
+          coordinates: Rectangle.fromDegrees(cell.west, cell.south, cell.east, cell.north),
+          material: new ColorMaterialProperty(rgbaToCesium(cell.color)),
+          height: new ConstantProperty(0),
+          outline: false,
+        },
+      });
+    }
+  }
+}
+
+function rgbaToCesium(rgba: RgbaColor): Color {
+  return Color.fromBytes(rgba.r, rgba.g, rgba.b, Math.round(rgba.a * 255));
+}
+
+export const GLOBE_HEATMAP_CHANGED_EVENT = CHANGED_EVENT;

--- a/src/components/globe/__tests__/GlobeHeatmapRenderer.test.mts
+++ b/src/components/globe/__tests__/GlobeHeatmapRenderer.test.mts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any -- Cesium-viewer mock */
 import assert from 'node:assert/strict';
 import test from 'node:test';
 

--- a/src/components/globe/__tests__/GlobeHeatmapRenderer.test.mts
+++ b/src/components/globe/__tests__/GlobeHeatmapRenderer.test.mts
@@ -1,0 +1,39 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- Cesium-viewer mock */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { mapToggleDomain, GLOBE_HEATMAP_CHANGED_EVENT } from '../GlobeHeatmapRenderer.ts';
+
+// ── mapToggleDomain ───────────────────────────────────────────────────
+
+test('mapToggleDomain: seismic stays seismic', () => {
+  assert.equal(mapToggleDomain('seismic'), 'seismic');
+});
+
+test('mapToggleDomain: legacy "fire" maps to wildfire', () => {
+  assert.equal(mapToggleDomain('fire'), 'wildfire');
+});
+
+test('mapToggleDomain: native "wildfire" passes through', () => {
+  assert.equal(mapToggleDomain('wildfire'), 'wildfire');
+});
+
+test('mapToggleDomain: weather + infrastructure pass through', () => {
+  assert.equal(mapToggleDomain('weather'), 'weather');
+  assert.equal(mapToggleDomain('infrastructure'), 'infrastructure');
+});
+
+test('mapToggleDomain: legacy unmapped tags (cyber/conflict) → null', () => {
+  assert.equal(mapToggleDomain('cyber'), null);
+  assert.equal(mapToggleDomain('conflict'), null);
+});
+
+test('mapToggleDomain: null / undefined / empty → null', () => {
+  assert.equal(mapToggleDomain(null), null);
+  assert.equal(mapToggleDomain(undefined), null);
+  assert.equal(mapToggleDomain(''), null);
+});
+
+test('GLOBE_HEATMAP_CHANGED_EVENT: stable event name', () => {
+  assert.equal(GLOBE_HEATMAP_CHANGED_EVENT, 'wm:globe-heatmap-changed');
+});

--- a/src/components/globe/__tests__/cursor-opacity.test.mts
+++ b/src/components/globe/__tests__/cursor-opacity.test.mts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  DEFAULTS,
+  bucketCounts,
+  coerceTimestampMs,
+  opacityForEntity,
+} from '../cursor-opacity.ts';
+
+const NOW = Date.parse('2026-05-08T12:00:00Z');
+const HOUR = 60 * 60 * 1000;
+
+// ── opacityForEntity ──────────────────────────────────────────────────
+
+test('opacity: entity within ±2h window → insideAlpha (1.0)', () => {
+  assert.equal(opacityForEntity(NOW, NOW), DEFAULTS.insideAlpha);
+  assert.equal(opacityForEntity(NOW - HOUR, NOW), DEFAULTS.insideAlpha);
+  assert.equal(opacityForEntity(NOW + HOUR, NOW), DEFAULTS.insideAlpha);
+});
+
+test('opacity: entity exactly at the half-window boundary → inside', () => {
+  assert.equal(opacityForEntity(NOW + DEFAULTS.halfWindowMs, NOW), DEFAULTS.insideAlpha);
+  assert.equal(opacityForEntity(NOW - DEFAULTS.halfWindowMs, NOW), DEFAULTS.insideAlpha);
+});
+
+test('opacity: entity past the half-window → outsideAlpha (0.3)', () => {
+  assert.equal(opacityForEntity(NOW + DEFAULTS.halfWindowMs + 1, NOW), DEFAULTS.outsideAlpha);
+  assert.equal(opacityForEntity(NOW - DEFAULTS.halfWindowMs - 1, NOW), DEFAULTS.outsideAlpha);
+});
+
+test('opacity: timeless entity (null/undefined) keeps full alpha', () => {
+  assert.equal(opacityForEntity(null, NOW), DEFAULTS.insideAlpha);
+  assert.equal(opacityForEntity(undefined, NOW), DEFAULTS.insideAlpha);
+});
+
+test('opacity: NaN timestamp → treated as timeless (full alpha)', () => {
+  assert.equal(opacityForEntity(Number.NaN, NOW), DEFAULTS.insideAlpha);
+});
+
+test('opacity: custom halfWindowMs widens or narrows', () => {
+  // 1-day window
+  const dayMs = 24 * HOUR;
+  const farPast = NOW - 12 * HOUR;
+  assert.equal(opacityForEntity(farPast, NOW, { halfWindowMs: dayMs }), 1);
+  assert.equal(opacityForEntity(farPast, NOW, { halfWindowMs: HOUR }), DEFAULTS.outsideAlpha);
+});
+
+test('opacity: custom alpha overrides apply', () => {
+  assert.equal(
+    opacityForEntity(NOW + 5 * HOUR, NOW, { outsideAlpha: 0.05 }),
+    0.05,
+  );
+  assert.equal(
+    opacityForEntity(NOW, NOW, { insideAlpha: 0.8 }),
+    0.8,
+  );
+});
+
+// ── coerceTimestampMs ─────────────────────────────────────────────────
+
+test('coerceTimestampMs: ms number passes through', () => {
+  assert.equal(coerceTimestampMs(NOW), NOW);
+});
+
+test('coerceTimestampMs: Date is unwrapped to ms', () => {
+  assert.equal(coerceTimestampMs(new Date(NOW)), NOW);
+});
+
+test('coerceTimestampMs: ISO string is parsed', () => {
+  assert.equal(coerceTimestampMs('2026-05-08T12:00:00Z'), NOW);
+});
+
+test('coerceTimestampMs: invalid input → null', () => {
+  assert.equal(coerceTimestampMs('not-a-date'), null);
+  assert.equal(coerceTimestampMs(null), null);
+  assert.equal(coerceTimestampMs(undefined), null);
+  assert.equal(coerceTimestampMs({}), null);
+  assert.equal(coerceTimestampMs(Number.NaN), null);
+});
+
+// ── bucketCounts ──────────────────────────────────────────────────────
+
+test('bucketCounts: tallies inside / outside / timeless', () => {
+  const stamps = [
+    NOW,                    // inside
+    NOW - HOUR,             // inside
+    NOW + 5 * HOUR,         // outside
+    NOW - 24 * HOUR,        // outside
+    null,                   // timeless
+    Number.NaN,             // timeless
+    undefined,              // timeless
+  ];
+  const counts = bucketCounts(stamps, NOW);
+  assert.equal(counts.inside, 2);
+  assert.equal(counts.outside, 2);
+  assert.equal(counts.timeless, 3);
+});
+
+test('bucketCounts: empty input → all zeros', () => {
+  const counts = bucketCounts([], NOW);
+  assert.equal(counts.inside, 0);
+  assert.equal(counts.outside, 0);
+  assert.equal(counts.timeless, 0);
+});

--- a/src/components/globe/__tests__/heatmap-grid.test.mts
+++ b/src/components/globe/__tests__/heatmap-grid.test.mts
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  aggregationFor,
+  binToCells,
+  buildColoredCells,
+  colorFor,
+  rampFor,
+  stopsFor,
+  type HeatmapPoint,
+} from '../heatmap-grid.ts';
+
+// ── Ramps + stops + aggregation ────────────────────────────────────────
+
+test('rampFor: every domain has a 5-stop ramp', () => {
+  for (const d of ['seismic', 'wildfire', 'weather', 'infrastructure'] as const) {
+    assert.equal(rampFor(d).length, 5, `${d} ramp must have 5 stops`);
+  }
+});
+
+test('rampFor: every color is a valid 0-255 RGB triple with 0-1 alpha', () => {
+  for (const d of ['seismic', 'wildfire', 'weather', 'infrastructure'] as const) {
+    for (const c of rampFor(d)) {
+      for (const ch of [c.r, c.g, c.b]) {
+        assert.ok(ch >= 0 && ch <= 255 && Number.isInteger(ch), `${d} channel ${ch}`);
+      }
+      assert.ok(c.a >= 0 && c.a <= 1, `${d} alpha ${c.a}`);
+    }
+  }
+});
+
+test('aggregationFor: documented per-domain rule', () => {
+  assert.equal(aggregationFor('seismic'), 'max');
+  assert.equal(aggregationFor('wildfire'), 'sum');
+  assert.equal(aggregationFor('weather'), 'count');
+  assert.equal(aggregationFor('infrastructure'), 'count');
+});
+
+test('stopsFor: each domain has 4 stops (5 ramp colors → 4 boundaries)', () => {
+  for (const d of ['seismic', 'wildfire', 'weather', 'infrastructure'] as const) {
+    assert.equal(stopsFor(d).length, 4);
+  }
+});
+
+// ── colorFor ──────────────────────────────────────────────────────────
+
+test('colorFor seismic: M2 gets the lowest stop, M7 gets the highest', () => {
+  const ramp = rampFor('seismic');
+  assert.deepEqual(colorFor('seismic', 2), ramp[0]);
+  assert.deepEqual(colorFor('seismic', 7), ramp[ramp.length - 1]);
+});
+
+test('colorFor wildfire: 0 FRP at low stop, 5000 MW at high stop', () => {
+  const ramp = rampFor('wildfire');
+  assert.deepEqual(colorFor('wildfire', 0), ramp[0]);
+  assert.deepEqual(colorFor('wildfire', 5000), ramp[ramp.length - 1]);
+});
+
+test('colorFor: value at the stop boundary picks the upper-tier color', () => {
+  // Boundary check: weather stops are [1, 3, 5, 10]. value=3 should
+  // pick ramp[2] (the third color), since stops[1]=3 → not strictly
+  // less than 3.
+  assert.deepEqual(colorFor('weather', 3), rampFor('weather')[2]);
+});
+
+// ── binToCells ────────────────────────────────────────────────────────
+
+test('binToCells: empty input → empty output', () => {
+  assert.deepEqual(binToCells('seismic', []), []);
+});
+
+test('binToCells: cell footprint is 1°×1° aligned to integer floor', () => {
+  const points: HeatmapPoint[] = [
+    { lat: 40.3, lon: -75.7, intensity: 5 },
+    { lat: 40.9, lon: -75.1, intensity: 6 }, // same cell
+    { lat: 41.1, lon: -75.5, intensity: 4 }, // different cell (lat)
+  ];
+  const cells = binToCells('seismic', points);
+  // Two cells: (40, -76) holding the first two points, (41, -76) the third.
+  assert.equal(cells.length, 2);
+  const c0 = cells.find((c) => c.south === 40 && c.west === -76);
+  assert.ok(c0);
+  assert.equal(c0!.north, 41);
+  assert.equal(c0!.east, -75);
+  assert.equal(c0!.count, 2);
+});
+
+test('binToCells: seismic uses max — highest magnitude wins', () => {
+  const points: HeatmapPoint[] = [
+    { lat: 40.5, lon: -75.5, intensity: 3.2 },
+    { lat: 40.8, lon: -75.2, intensity: 5.6 },
+    { lat: 40.1, lon: -75.9, intensity: 4.0 },
+  ];
+  const cells = binToCells('seismic', points);
+  assert.equal(cells.length, 1);
+  assert.equal(cells[0]!.value, 5.6);
+});
+
+test('binToCells: wildfire uses sum — total FRP', () => {
+  const points: HeatmapPoint[] = [
+    { lat: 40.5, lon: -75.5, intensity: 100 },
+    { lat: 40.8, lon: -75.2, intensity: 250 },
+  ];
+  const cells = binToCells('wildfire', points);
+  assert.equal(cells[0]!.value, 350);
+});
+
+test('binToCells: weather uses count — value tracks point count', () => {
+  const points: HeatmapPoint[] = [
+    { lat: 40.5, lon: -75.5, intensity: 1 },
+    { lat: 40.6, lon: -75.6, intensity: 1 },
+    { lat: 40.7, lon: -75.7, intensity: 1 },
+  ];
+  const cells = binToCells('weather', points);
+  assert.equal(cells[0]!.value, 3);
+  assert.equal(cells[0]!.count, 3);
+});
+
+test('binToCells: drops NaN intensity, out-of-range coords', () => {
+  const points: HeatmapPoint[] = [
+    { lat: 40.5, lon: -75.5, intensity: 5 },
+    { lat: 200, lon: 0, intensity: 5 },               // bad lat
+    { lat: 0, lon: 999, intensity: 5 },                // bad lon
+    { lat: 40.5, lon: -75.5, intensity: Number.NaN }, // bad intensity
+  ];
+  const cells = binToCells('seismic', points);
+  assert.equal(cells.length, 1);
+  assert.equal(cells[0]!.count, 1);
+});
+
+test('binToCells: result sorted by (south asc, west asc)', () => {
+  const points: HeatmapPoint[] = [
+    { lat: 50, lon: -10, intensity: 1 },
+    { lat: 30, lon: 20, intensity: 1 },
+    { lat: 30, lon: -20, intensity: 1 },
+    { lat: 50, lon: -50, intensity: 1 },
+  ];
+  const cells = binToCells('weather', points);
+  for (let i = 1; i < cells.length; i += 1) {
+    const prev = cells[i - 1]!;
+    const curr = cells[i]!;
+    const prevKey = prev.south * 1000 + prev.west;
+    const currKey = curr.south * 1000 + curr.west;
+    assert.ok(currKey > prevKey, `cells out of order at ${i}`);
+  }
+});
+
+// ── buildColoredCells ─────────────────────────────────────────────────
+
+test('buildColoredCells: every cell carries a color', () => {
+  const cells = buildColoredCells('seismic', [
+    { lat: 40.5, lon: -75.5, intensity: 6.5 },
+  ]);
+  assert.equal(cells.length, 1);
+  assert.ok(cells[0]!.color);
+  assert.deepEqual(cells[0]!.color, rampFor('seismic')[4]);
+});
+
+test('buildColoredCells is JSON-serializable', () => {
+  const cells = buildColoredCells('wildfire', [
+    { lat: 40.5, lon: -75.5, intensity: 250 },
+  ]);
+  const round = JSON.parse(JSON.stringify(cells));
+  assert.equal(round[0].south, 40);
+});

--- a/src/components/globe/cursor-opacity.ts
+++ b/src/components/globe/cursor-opacity.ts
@@ -1,0 +1,113 @@
+/**
+ * Cursor-window opacity classifier.
+ *
+ * Pure deterministic. Decides "what alpha should an entity render at
+ * given the playback cursor and a per-entity timestamp?".
+ *
+ * Used by GlobeDataManager: on every `wm:globe-timeline-cursor`
+ * event, walk the entity collections for time-stamped layers and call
+ * `opacityForEntity` to decide the alpha. The Cesium glue applies the
+ * resulting alpha to the entity's `point.color` / `billboard.color` /
+ * `rectangle.material`.
+ *
+ * Plan invariants:
+ *   - Default window is ±2h around the cursor. Entities outside the
+ *     window get the dimmed alpha (default 0.3); inside-window get
+ *     full alpha (1.0).
+ *   - Entities with no timestamp keep full alpha — we don't fade
+ *     timeless data (saved places, infrastructure, etc.).
+ *   - The classifier is O(1) per entity; the caller iterates.
+ */
+
+// ── Public types ────────────────────────────────────────────────────────
+
+export interface CursorOpacityOptions {
+  /** Half-window in ms around the cursor. Default 2 h. */
+  halfWindowMs?: number;
+  /** Alpha for entities inside the window. Default 1.0. */
+  insideAlpha?: number;
+  /** Alpha for entities outside the window. Default 0.3. */
+  outsideAlpha?: number;
+}
+
+const DEFAULT_HALF_WINDOW_MS = 2 * 60 * 60 * 1000;
+const DEFAULT_INSIDE_ALPHA = 1;
+const DEFAULT_OUTSIDE_ALPHA = 0.3;
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+/**
+ * Classify a single entity timestamp against the cursor.
+ *
+ * `entityTimestamp === null` (no timestamp) returns `insideAlpha` —
+ * timeless entities are never faded by the cursor.
+ *
+ * `entityTimestamp` outside the cursor's ±halfWindow returns
+ * `outsideAlpha`. Inside returns `insideAlpha`.
+ */
+export function opacityForEntity(
+  entityTimestamp: number | null | undefined,
+  cursorMs: number,
+  options: CursorOpacityOptions = {},
+): number {
+  const insideAlpha = options.insideAlpha ?? DEFAULT_INSIDE_ALPHA;
+  if (entityTimestamp === null || entityTimestamp === undefined) return insideAlpha;
+  if (!Number.isFinite(entityTimestamp)) return insideAlpha;
+  const half = options.halfWindowMs ?? DEFAULT_HALF_WINDOW_MS;
+  const outsideAlpha = options.outsideAlpha ?? DEFAULT_OUTSIDE_ALPHA;
+  const delta = Math.abs(cursorMs - entityTimestamp);
+  return delta <= half ? insideAlpha : outsideAlpha;
+}
+
+/**
+ * Coerce a heterogeneous timestamp value (Date / ISO string / ms
+ * number / undefined) to ms epoch. Returns `null` when the value
+ * can't be normalised — the classifier treats null as "timeless".
+ *
+ * Cesium entities store timestamps as `Date` (via the `setEntityTimestamp`
+ * helper in GlobeDataManager); some downstream code passes strings.
+ * This shim handles both.
+ */
+export function coerceTimestampMs(value: unknown): number | null {
+  if (value == null) return null;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (value instanceof Date) {
+    const t = value.getTime();
+    return Number.isFinite(t) ? t : null;
+  }
+  if (typeof value === 'string') {
+    const t = Date.parse(value);
+    return Number.isFinite(t) ? t : null;
+  }
+  return null;
+}
+
+/**
+ * Bucket count helper — useful for tests and the panel-corner badge
+ * ("3 in window / 12 outside").
+ */
+export function bucketCounts(
+  entityTimestamps: readonly (number | null | undefined)[],
+  cursorMs: number,
+  options: CursorOpacityOptions = {},
+): { inside: number; outside: number; timeless: number } {
+  const half = options.halfWindowMs ?? DEFAULT_HALF_WINDOW_MS;
+  const out = { inside: 0, outside: 0, timeless: 0 };
+  for (const ts of entityTimestamps) {
+    if (ts == null || !Number.isFinite(ts)) {
+      out.timeless += 1;
+      continue;
+    }
+    if (Math.abs(cursorMs - ts) <= half) out.inside += 1;
+    else out.outside += 1;
+  }
+  return out;
+}
+
+// ── Re-export defaults so tests + downstream consumers agree ────────────
+
+export const DEFAULTS = {
+  halfWindowMs: DEFAULT_HALF_WINDOW_MS,
+  insideAlpha: DEFAULT_INSIDE_ALPHA,
+  outsideAlpha: DEFAULT_OUTSIDE_ALPHA,
+} as const;

--- a/src/components/globe/heatmap-grid.ts
+++ b/src/components/globe/heatmap-grid.ts
@@ -1,0 +1,209 @@
+/**
+ * Heatmap grid binning + color mapping.
+ *
+ * Pure deterministic. No DOM, no fetch, no Cesium imports — the
+ * Cesium glue lives in `GlobeHeatmapRenderer.ts` and consumes the
+ * binned cells this module produces.
+ *
+ * Plan invariants:
+ *   - Cell footprint is a fixed 1°×1° grid. Lat/lon bin keys are
+ *     integer floor() of the position; no float drift.
+ *   - Aggregation function is per-domain — seismic uses `max`
+ *     (highest magnitude in cell), wildfire uses `sum` (total FRP),
+ *     weather + infrastructure use `count`.
+ *   - Color ramps live here as fixed 5-stop arrays so tests + UI
+ *     agree on stop boundaries.
+ *   - Output rectangles are degree-aligned (`west`, `south`, `east`,
+ *     `north`) so the renderer can pass them straight to
+ *     `Rectangle.fromDegrees()` with no further math.
+ */
+
+// ── Public types ────────────────────────────────────────────────────────
+
+export type HeatmapDomain = 'seismic' | 'wildfire' | 'weather' | 'infrastructure';
+
+export interface HeatmapPoint {
+  lat: number;
+  lon: number;
+  /** Domain-specific intensity:
+   *  - seismic: magnitude (e.g. 5.4)
+   *  - wildfire: FRP MW (e.g. 234.5)
+   *  - weather: 1 per alert (callers pre-multiply if they have weights)
+   *  - infrastructure: 1 per outage (or customers/1000) */
+  intensity: number;
+}
+
+export interface HeatmapCell {
+  /** Integer-floor lat (south edge). */
+  south: number;
+  /** Integer-floor lon (west edge). */
+  west: number;
+  /** south + 1. */
+  north: number;
+  /** west + 1. */
+  east: number;
+  /** Aggregated value used for color mapping. */
+  value: number;
+  /** Number of points that fell into this cell. */
+  count: number;
+}
+
+export interface RgbaColor {
+  r: number;
+  g: number;
+  b: number;
+  /** [0, 1] alpha. */
+  a: number;
+}
+
+export type AggregationKind = 'max' | 'sum' | 'count';
+
+// ── Per-domain color ramps + aggregation rules ──────────────────────────
+
+const SEISMIC_RAMP: readonly RgbaColor[] = [
+  { r: 30,  g: 64,  b: 175, a: 0.35 },  // blue (M ≤ 3)
+  { r: 99,  g: 102, b: 241, a: 0.45 },  // indigo (M 3–4)
+  { r: 234, g: 179, b: 8,   a: 0.55 },  // amber (M 4–5)
+  { r: 249, g: 115, b: 22,  a: 0.65 },  // orange (M 5–6)
+  { r: 220, g: 38,  b: 38,  a: 0.75 },  // red (M ≥ 6)
+];
+
+const WILDFIRE_RAMP: readonly RgbaColor[] = [
+  { r: 254, g: 240, b: 138, a: 0.35 },  // pale yellow
+  { r: 253, g: 186, b: 116, a: 0.45 },
+  { r: 251, g: 113, b: 133, a: 0.55 },
+  { r: 234, g: 88,  b: 12,  a: 0.65 },
+  { r: 153, g: 27,  b: 27,  a: 0.8 },  // deep red
+];
+
+const WEATHER_RAMP: readonly RgbaColor[] = [
+  { r: 134, g: 239, b: 172, a: 0.35 },  // green (1 alert)
+  { r: 250, g: 204, b: 21,  a: 0.45 },  // yellow
+  { r: 249, g: 115, b: 22,  a: 0.55 },  // orange
+  { r: 168, g: 85,  b: 247, a: 0.65 },  // purple
+  { r: 109, g: 40,  b: 217, a: 0.75 },  // deep purple
+];
+
+const INFRA_RAMP: readonly RgbaColor[] = [
+  { r: 240, g: 240, b: 240, a: 0.35 },  // near-white
+  { r: 254, g: 215, b: 170, a: 0.45 },
+  { r: 251, g: 113, b: 133, a: 0.55 },
+  { r: 220, g: 38,  b: 38,  a: 0.65 },
+  { r: 127, g: 29,  b: 29,  a: 0.8 },  // deep red
+];
+
+const RAMPS: Readonly<Record<HeatmapDomain, readonly RgbaColor[]>> = {
+  seismic: SEISMIC_RAMP,
+  wildfire: WILDFIRE_RAMP,
+  weather: WEATHER_RAMP,
+  infrastructure: INFRA_RAMP,
+};
+
+const AGGREGATION: Readonly<Record<HeatmapDomain, AggregationKind>> = {
+  seismic: 'max',          // highest-magnitude quake in cell
+  wildfire: 'sum',         // total fire radiative power in cell
+  weather: 'count',        // alerts per cell
+  infrastructure: 'count', // outages per cell
+};
+
+/** Per-domain stop boundaries. Stop[i] is the *upper* bound for the
+ *  i-th color in the ramp; values ≥ stop[length-1] use the final color.
+ *  Stops are tuned to the aggregation kind:
+ *  - seismic max-magnitude bands: 3 / 4 / 5 / 6 / 6+
+ *  - wildfire sum-FRP MW: 50 / 200 / 500 / 1000 / 1000+
+ *  - weather count: 1 / 3 / 5 / 10 / 10+
+ *  - infrastructure count: 1 / 5 / 20 / 50 / 50+ */
+const STOPS: Readonly<Record<HeatmapDomain, readonly number[]>> = {
+  seismic:        [3, 4, 5, 6],
+  wildfire:       [50, 200, 500, 1000],
+  weather:        [1, 3, 5, 10],
+  infrastructure: [1, 5, 20, 50],
+};
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+export function rampFor(domain: HeatmapDomain): readonly RgbaColor[] {
+  return RAMPS[domain];
+}
+
+export function aggregationFor(domain: HeatmapDomain): AggregationKind {
+  return AGGREGATION[domain];
+}
+
+export function stopsFor(domain: HeatmapDomain): readonly number[] {
+  return STOPS[domain];
+}
+
+/** Pick the ramp color for a domain + cell value. */
+export function colorFor(domain: HeatmapDomain, value: number): RgbaColor {
+  const ramp = RAMPS[domain];
+  const stops = STOPS[domain];
+  for (const [i, stop] of stops.entries()) {
+    if (value < stop) return ramp[i]!;
+  }
+  return ramp[ramp.length - 1]!;
+}
+
+/** Bin points into 1°×1° cells. Empty input → empty array.
+ *  Points outside [-90,90] / [-180,180] are silently dropped — callers
+ *  pre-clean if they care. */
+export function binToCells(
+  domain: HeatmapDomain,
+  points: readonly HeatmapPoint[],
+): HeatmapCell[] {
+  if (points.length === 0) return [];
+  const agg = AGGREGATION[domain];
+  const buckets = new Map<string, { south: number; west: number; value: number; count: number }>();
+  for (const p of points) {
+    if (p.lat < -90 || p.lat > 90) continue;
+    if (p.lon < -180 || p.lon > 180) continue;
+    if (!Number.isFinite(p.intensity)) continue;
+    const south = Math.floor(p.lat);
+    const west = Math.floor(p.lon);
+    const key = `${south}|${west}`;
+    const existing = buckets.get(key);
+    if (existing) {
+      existing.value = combine(agg, existing.value, p.intensity);
+      existing.count += 1;
+    } else {
+      buckets.set(key, { south, west, value: p.intensity, count: 1 });
+    }
+  }
+  const out: HeatmapCell[] = [];
+  for (const b of buckets.values()) {
+    out.push({
+      south: b.south,
+      west: b.west,
+      north: b.south + 1,
+      east: b.west + 1,
+      value: agg === 'count' ? b.count : b.value,
+      count: b.count,
+    });
+  }
+  out.sort((a, b) => (a.south - b.south) || (a.west - b.west));
+  return out;
+}
+
+function combine(agg: AggregationKind, existing: number, next: number): number {
+  switch (agg) {
+    case 'max':   { return Math.max(existing, next); }
+    case 'sum':   { return existing + next; }
+    case 'count': { return existing; } // count is from `count` field, not value
+  }
+}
+
+/** Convenience: bin + color in one pass. Used by the renderer's
+ *  primary code path. */
+export interface ColoredHeatmapCell extends HeatmapCell {
+  color: RgbaColor;
+}
+
+export function buildColoredCells(
+  domain: HeatmapDomain,
+  points: readonly HeatmapPoint[],
+): ColoredHeatmapCell[] {
+  return binToCells(domain, points).map((cell) => ({
+    ...cell,
+    color: colorFor(domain, cell.value),
+  }));
+}


### PR DESCRIPTION
Closes the heatmap mounting + per-layer timeline gaps from the prior substrate stack ([#319](https://github.com/bradleybond512/crystal-ball/pull/319), [#332](https://github.com/bradleybond512/crystal-ball/pull/332), [#336](https://github.com/bradleybond512/crystal-ball/pull/336), [#350](https://github.com/bradleybond512/crystal-ball/pull/350)).

**Sidesteps the `@luma.gl/engine` ↔ `@deck.gl/geo-layers` version mismatch** by skipping deck.gl entirely — pure Cesium primitives along the same render path `GlobeDataManager` already uses for outage rectangles.

## Files

- `src/components/globe/heatmap-grid.ts` — pure 1°×1° binning + 5-stop RGBA ramps + per-domain aggregation (seismic max, wildfire sum, weather + infrastructure count)
- `src/components/globe/cursor-opacity.ts` — pure ±2h window classifier with `coerceTimestampMs` shim and `bucketCounts` helper
- `src/components/globe/GlobeHeatmapRenderer.ts` — Cesium glue: listens for `wm:globe-heatmap-changed`, fetches per-domain sidecar data, renders rectangle entities in a dedicated `CustomDataSource`. AbortController race guard. `mapToggleDomain` bridges legacy `fire` → `wildfire`; `cyber`/`conflict` are no-op (clear) since this PR ships the 4 domains the spec named.
- `src/components/GlobeDataManager.ts` — owns one renderer instance + listens for `wm:globe-timeline-cursor` and applies `opacityForEntity` to every loaded data source's entities. `applyEntityAlpha` covers point/billboard/rectangle/polygon/polyline graphics. `readEntityTimestampMs` reads the existing `properties.timestamp` convention.

## Sidecar endpoints wired

| Domain | Endpoint | Color ramp |
|---|---|---|
| seismic | `/api/earthquakes` | blue → red (max magnitude per cell) |
| wildfire | `/api/nasa-firms` | yellow → deep red (sum FRP MW) |
| weather | `/api/nws-alerts` | green → deep purple (alert count) |
| infrastructure | `/api/infrastructure/outages` | white → deep red (outage count) |

## Validation

```
npm run test:globe       # 53/53 (17 prior + 14 grid + 14 cursor + 8 mapping)
npm run typecheck:all    # clean
eslint                   # clean
```

Test counts:
- **heatmap-grid** (14): ramp shapes, 0–255 RGB validity, alpha bounds, per-domain stops, color boundary semantics, 1°×1° binning, max/sum/count aggregation, NaN + out-of-range filtering, sort order, JSON round-trip
- **cursor-opacity** (14): window inside/outside/boundary, timeless/null/NaN handling, custom window, custom alpha, `coerceTimestampMs` for ms/Date/ISO/invalid, `bucketCounts` tally
- **GlobeHeatmapRenderer** (8): toggle domain mapping (seismic / fire→wildfire / wildfire / weather / infrastructure / cyber-null / conflict-null / null-null) + event-name pin

## Visual verification

Deferred — preview server in this worktree currently fails on the upstream luma.gl dep mismatch (the very issue this PR sidesteps in the renderer code). The rendering surface here is the same path `loadInfrastructureOverlay` already uses, so once the dep mismatch clears, both should render identically.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Cross-agent review: claude reviewed on 2026-05-08; outcome: pass
