### PR TITLE
feat(export): enhanced multi-section intelligence-brief PDF report

### DIFF
--- a/src/components/IntelligenceBriefingPanel.ts
+++ b/src/components/IntelligenceBriefingPanel.ts
@@ -58,6 +58,7 @@ export class IntelligenceBriefingPanel extends Panel {
   private _collapsedSections = new Set<string>();
   private _loading = false;
   private _error: string | null = null;
+  private _downloading = false;
 
   constructor() {
  super({
@@ -97,6 +98,63 @@ export class IntelligenceBriefingPanel extends Panel {
  this.renderError();
  } finally {
  this._loading = false;
+ }
+  }
+
+  /** Build the enhanced multi-section PDF report and trigger download.
+   *  Falls back to the simple renderer (renderBriefingPdfBlob) when the
+   *  enhanced collector or renderer throws — spec: keep the existing
+   *  simple export as a fallback. */
+  private async handleDownloadReport(): Promise<void> {
+ if (this._downloading) return;
+ this._downloading = true;
+ this.render();
+ try {
+ const blob = await this.buildReportBlob();
+ const filename = await this.buildReportFilename();
+ const url = URL.createObjectURL(blob);
+ const anchor = document.createElement('a');
+ anchor.href = url;
+ anchor.download = filename;
+ document.body.append(anchor);
+ anchor.click();
+ anchor.remove();
+ setTimeout(() => URL.revokeObjectURL(url), 1000);
+ } catch (error) {
+ // The enhanced path already falls back internally; reaching this
+ // catch means even the simple renderer failed. Surface the reason.
+ window.alert(`Report download failed: ${error instanceof Error ? error.message : String(error)}`);
+ } finally {
+ this._downloading = false;
+ this.render();
+ }
+  }
+
+  private async buildReportBlob(): Promise<Blob> {
+ try {
+ const [{ collectEnhancedBriefing }, { renderEnhancedBriefingPdfBlob }] = await Promise.all([
+ import('@/services/export/enhanced-brief-snapshot'),
+ import('@/services/export/enhanced-brief-generator'),
+ ]);
+ const input = await collectEnhancedBriefing();
+ return renderEnhancedBriefingPdfBlob(input);
+ } catch (enhancedError) {
+ // Fallback path — use the simple renderer over the cached briefing.
+ console.warn('[ib-panel] Enhanced report failed, falling back to simple PDF:', enhancedError);
+ const briefing = getCachedBriefing();
+ if (!briefing) throw enhancedError;
+ const { renderBriefingPdfBlob } = await import('@/services/export/brief-pdf');
+ return renderBriefingPdfBlob(briefing);
+ }
+  }
+
+  private async buildReportFilename(): Promise<string> {
+ try {
+ const { enhancedBriefPdfFilename } = await import('@/services/export/enhanced-brief-generator');
+ return enhancedBriefPdfFilename({ dataCurrentAt: Date.now() } as never);
+ } catch {
+ const iso = new Date().toISOString().slice(0, 10);
+ return `crystal-ball-intel-brief-${iso}.pdf`;
  }
   }
 
@@ -234,8 +292,26 @@ export class IntelligenceBriefingPanel extends Panel {
  refreshBtn.addEventListener('click', () => { void this.handleGenerate(); });
  right.append(refreshBtn);
 
+ right.append(this.createDownloadReportButton());
+
  header.append(right);
  return header;
+  }
+
+  /** "Download Report" button \u2014 kicks off the enhanced PDF pipeline.
+   *  Disables itself while a download is in flight so a fast double-click
+   *  doesn't fire two collectors. */
+  private createDownloadReportButton(): HTMLButtonElement {
+ const btn = document.createElement('button');
+ btn.dataset.testid = 'ib-download-report';
+ btn.style.cssText = 'background:rgba(192,132,252,0.1);border:1px solid rgba(192,132,252,0.3);border-radius:4px;padding:0.2rem 0.5rem;font-size:0.68rem;color:#c084fc;cursor:pointer;transition:background 0.15s;';
+ btn.textContent = this._downloading ? '\u2B07\uFE0F Building\u2026' : '\u2B07\uFE0F Download Report';
+ btn.disabled = this._downloading;
+ if (this._downloading) btn.style.opacity = '0.6';
+ btn.addEventListener('mouseenter', () => { if (!this._downloading) btn.style.background = 'rgba(192,132,252,0.2)'; });
+ btn.addEventListener('mouseleave', () => { if (!this._downloading) btn.style.background = 'rgba(192,132,252,0.1)'; });
+ btn.addEventListener('click', () => { void this.handleDownloadReport(); });
+ return btn;
   }
 
   private renderSection(section: BriefingSection): HTMLElement {

--- a/src/services/export/__tests__/enhanced-brief-generator.test.mts
+++ b/src/services/export/__tests__/enhanced-brief-generator.test.mts
@@ -1,0 +1,255 @@
+/**
+ * Pure-renderer tests for src/services/export/enhanced-brief-generator.ts
+ *
+ * The renderer is fully pure (input → jsPDF). Tests fall into four buckets:
+ *   1. Pure derivation helpers (deriveExecutiveSummary, formatTrendArrow,
+ *      topWildfiresByThreat, computeFireThreatScore, formatAuroraLat)
+ *   2. Page contract (cover page count, body page break, footer stamp)
+ *   3. Empty-state contract (every section accepts empty/null and renders
+ *      a placeholder rather than throwing)
+ *   4. Filename / blob output shape
+ *
+ * jsPDF is exercised against its real API (no mock) — these tests catch
+ * the kind of contract drift (renamed methods, signature changes) that
+ * a mocked test would miss.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  computeFireThreatScore,
+  deriveExecutiveSummary,
+  enhancedBriefPdfFilename,
+  formatAuroraLat,
+  formatTrendArrow,
+  renderEnhancedBriefingPdf,
+  renderEnhancedBriefingPdfBlob,
+  topWildfiresByThreat,
+  type EnhancedBriefingInput,
+} from '../enhanced-brief-generator.ts';
+
+/** Decode the PDF's binary output as latin-1 so test assertions can
+ *  match against the literal text in content streams. jsPDF's
+ *  `output('string')` returns null in Node; the arraybuffer path is
+ *  the portable way to inspect what we actually wrote. */
+function pdfText(doc: { output: (kind: 'arraybuffer') => ArrayBuffer }): string {
+  return new TextDecoder('latin1').decode(doc.output('arraybuffer'));
+}
+
+const minimalInput: EnhancedBriefingInput = {
+  threatMatrix: [],
+  activeAlerts: [],
+  spaceWeather: null,
+  topWildfires: [],
+  economicIndicators: [],
+  feedHealth: [],
+  dataCurrentAt: Date.parse('2026-05-08T12:00:00Z'),
+  appVersion: '2.12.2',
+};
+
+// ── deriveExecutiveSummary ───────────────────────────────────────────
+
+test('deriveExecutiveSummary: empty matrix → "no active threats" sentence', () => {
+  const out = deriveExecutiveSummary([]);
+  assert.match(out, /no active threats/i);
+});
+
+test('deriveExecutiveSummary: surfaces critical-severity domains by name', () => {
+  const out = deriveExecutiveSummary([
+    { domain: 'Weather', severity: 'critical', label: '1 active' },
+    { domain: 'Cyber',   severity: 'high',     label: '3 active' },
+  ]);
+  assert.match(out, /1 critical-severity threat/);
+  assert.match(out, /Weather/);
+  assert.match(out, /1 high-severity in Cyber/);
+  assert.match(out, /situational awareness elevated/);
+});
+
+test('deriveExecutiveSummary: low-only matrix → "low-severity activity only"', () => {
+  const out = deriveExecutiveSummary([
+    { domain: 'Maritime', severity: 'low', label: '2 active' },
+  ]);
+  assert.match(out, /low-severity activity only/);
+});
+
+test('deriveExecutiveSummary: lists three+ critical domains with Oxford comma', () => {
+  const out = deriveExecutiveSummary([
+    { domain: 'Weather', severity: 'critical', label: '1' },
+    { domain: 'Cyber',   severity: 'critical', label: '1' },
+    { domain: 'Energy',  severity: 'critical', label: '1' },
+  ]);
+  assert.match(out, /Weather, Cyber, and Energy/);
+});
+
+// ── formatTrendArrow ─────────────────────────────────────────────────
+
+test('formatTrendArrow: null inputs → em dash', () => {
+  assert.equal(formatTrendArrow(null, 100), '—');
+  assert.equal(formatTrendArrow(100, null), '—');
+});
+
+test('formatTrendArrow: positive change → up arrow + percent', () => {
+  const out = formatTrendArrow(110, 100);
+  assert.equal(out, '↑ +10.0%');
+});
+
+test('formatTrendArrow: negative change → down arrow + percent', () => {
+  const out = formatTrendArrow(90, 100);
+  assert.equal(out, '↓ -10.0%');
+});
+
+test('formatTrendArrow: tiny change (<1%) → flat arrow', () => {
+  assert.match(formatTrendArrow(100.5, 100), /^→/);
+});
+
+test('formatTrendArrow: zero baseline edge case', () => {
+  assert.equal(formatTrendArrow(5, 0), '↑');
+  assert.equal(formatTrendArrow(-5, 0), '↓');
+  assert.equal(formatTrendArrow(0, 0), '→');
+});
+
+// ── computeFireThreatScore ────────────────────────────────────────────
+
+test('computeFireThreatScore: 1000ac × 30% contained → 700', () => {
+  assert.equal(computeFireThreatScore(1000, 30), 700);
+});
+
+test('computeFireThreatScore: null acreage → 0', () => {
+  assert.equal(computeFireThreatScore(null, 50), 0);
+  assert.equal(computeFireThreatScore(0, 50), 0);
+});
+
+test('computeFireThreatScore: null containment treated as 0% (worst case)', () => {
+  assert.equal(computeFireThreatScore(500, null), 500);
+});
+
+test('computeFireThreatScore: containment clamped to [0,100]', () => {
+  assert.equal(computeFireThreatScore(1000, 150), 0);     // clamped to 100% → 0 score
+  assert.equal(computeFireThreatScore(1000, -10), 1000);  // clamped to 0% → full score
+});
+
+// ── topWildfiresByThreat ──────────────────────────────────────────────
+
+test('topWildfiresByThreat: returns top 5 sorted desc by score', () => {
+  const fires = Array.from({ length: 8 }, (_, i) => ({
+    name: `F${i}`, state: 'CA', acres: 100 * (i + 1),
+    containmentPct: 0, threatScore: 100 * (i + 1),
+  }));
+  const top = topWildfiresByThreat(fires);
+  assert.equal(top.length, 5);
+  assert.equal(top[0].name, 'F7');     // highest threatScore = 800
+  assert.equal(top[4].name, 'F3');
+});
+
+test('topWildfiresByThreat: respects custom topN', () => {
+  const fires = [
+    { name: 'A', state: null, acres: 100, containmentPct: 0, threatScore: 100 },
+    { name: 'B', state: null, acres: 200, containmentPct: 0, threatScore: 200 },
+  ];
+  assert.equal(topWildfiresByThreat(fires, 1).length, 1);
+});
+
+test('topWildfiresByThreat: empty input returns []', () => {
+  assert.deepEqual(topWildfiresByThreat([]), []);
+});
+
+// ── formatAuroraLat ───────────────────────────────────────────────────
+
+test('formatAuroraLat: null → "Not visible"', () => {
+  assert.match(formatAuroraLat(null), /Not visible/);
+});
+
+test('formatAuroraLat: 65°N → "Visible from 65°N or higher"', () => {
+  assert.equal(formatAuroraLat(65), 'Visible from 65°N or higher');
+});
+
+test('formatAuroraLat: 89+ treated as not visible', () => {
+  assert.match(formatAuroraLat(89), /Not visible/);
+});
+
+// ── renderEnhancedBriefingPdf — page / output contract ───────────────
+
+test('renderEnhancedBriefingPdf: minimal input still produces ≥2 pages (cover + body)', () => {
+  const doc = renderEnhancedBriefingPdf(minimalInput);
+  assert.ok(doc.getNumberOfPages() >= 2, `expected ≥2 pages, got ${doc.getNumberOfPages()}`);
+});
+
+test('renderEnhancedBriefingPdf: all-empty sections render placeholders without throwing', () => {
+  // The point of this test: every section's empty branch must be reachable.
+  const doc = renderEnhancedBriefingPdf(minimalInput);
+  const pdfStr = pdfText(doc);
+  // Empty markers from each section.
+  assert.match(pdfStr, /No active threats in matrix/);
+  assert.match(pdfStr, /No active alerts/);
+  assert.match(pdfStr, /Space-weather data unavailable/);
+  assert.match(pdfStr, /No active wildfire incidents/);
+  assert.match(pdfStr, /Economic stress feed not available/);
+  assert.match(pdfStr, /Feed health snapshot unavailable/);
+});
+
+test('renderEnhancedBriefingPdf: large input adds pages (page break works)', () => {
+  const huge: EnhancedBriefingInput = {
+    ...minimalInput,
+    threatMatrix: Array.from({ length: 30 }, (_, i) => ({
+      domain: `Domain ${i}`, severity: 'high', label: '1 active',
+    })),
+    activeAlerts: Array.from({ length: 25 }, (_, i) => ({
+      source: 'NWS', title: `Long alert title number ${i} that takes up real space`,
+      severity: 'high' as const, location: `Place ${i}, State`,
+    })),
+  };
+  const doc = renderEnhancedBriefingPdf(huge);
+  assert.ok(doc.getNumberOfPages() >= 3, `expected page break, got ${doc.getNumberOfPages()} pages`);
+});
+
+test('renderEnhancedBriefingPdf: cover page includes title + classification + version', () => {
+  const doc = renderEnhancedBriefingPdf(minimalInput, { classification: 'UNCLASSIFIED' });
+  const pdfStr = pdfText(doc);
+  assert.match(pdfStr, /CRYSTAL BALL INTELLIGENCE BRIEF/);
+  assert.match(pdfStr, /UNCLASSIFIED/);
+  assert.match(pdfStr, /Crystal Ball v2\.12\.2/);
+});
+
+test('renderEnhancedBriefingPdf: footer carries data-current-as-of timestamp', () => {
+  const doc = renderEnhancedBriefingPdf(minimalInput);
+  const pdfStr = pdfText(doc);
+  assert.match(pdfStr, /Data current as of 2026-05-08/);
+});
+
+test('renderEnhancedBriefingPdf: caller-supplied executiveSummary wins over derived', () => {
+  const doc = renderEnhancedBriefingPdf({
+    ...minimalInput,
+    executiveSummary: 'A bespoke executive summary the AI brief produced.',
+    threatMatrix: [{ domain: 'Cyber', severity: 'critical', label: '1 active' }],
+  });
+  const pdfStr = pdfText(doc);
+  assert.match(pdfStr, /bespoke executive summary/);
+  // The derived path's "1 critical-severity" would also fire — but only when
+  // executiveSummary is empty. Confirm it didn't fire here.
+  assert.doesNotMatch(pdfStr, /1 critical-severity threat/);
+});
+
+test('renderEnhancedBriefingPdf: feed-health rows render with status indicator', () => {
+  const doc = renderEnhancedBriefingPdf({
+    ...minimalInput,
+    feedHealth: [
+      { feedId: 'nws',  label: 'NWS Weather Alerts', status: 'green', ageSeconds: 30 },
+      { feedId: 'eew',  label: 'USGS EEW',           status: 'red',   ageSeconds: 7200 },
+    ],
+  });
+  const pdfStr = pdfText(doc);
+  assert.match(pdfStr, /NWS Weather Alerts/);
+  assert.match(pdfStr, /USGS EEW/);
+  assert.match(pdfStr, /2h ago/);     // age formatter for 7200s
+});
+
+test('renderEnhancedBriefingPdfBlob: returns a Blob with PDF mime type', () => {
+  const blob = renderEnhancedBriefingPdfBlob(minimalInput);
+  assert.ok(blob instanceof Blob);
+  assert.equal(blob.type, 'application/pdf');
+  assert.ok(blob.size > 0);
+});
+
+test('enhancedBriefPdfFilename: uses ISO date prefix', () => {
+  const fn = enhancedBriefPdfFilename(minimalInput);
+  assert.equal(fn, 'crystal-ball-intel-brief-2026-05-08.pdf');
+});

--- a/src/services/export/__tests__/enhanced-brief-snapshot.test.mts
+++ b/src/services/export/__tests__/enhanced-brief-snapshot.test.mts
@@ -1,0 +1,58 @@
+/**
+ * Pure-helper tests for src/services/export/enhanced-brief-snapshot.ts
+ *
+ * The collector itself is impure (singleton reads + fetch), but the two
+ * exported pure helpers (mapHealthStatusToFeedStatus, topScenarioSeverity)
+ * are the points where the renderer's enum and the upstream enums meet —
+ * exactly where contract drift bites — so they get focused tests.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mapHealthStatusToFeedStatus,
+  topScenarioSeverity,
+} from '../enhanced-brief-mappers.ts';
+
+// ── HealthStatus → FeedStatus ────────────────────────────────────────
+
+test('mapHealthStatusToFeedStatus: healthy → green', () => {
+  assert.equal(mapHealthStatusToFeedStatus('healthy'), 'green');
+});
+
+test('mapHealthStatusToFeedStatus: degraded/stale/unknown → yellow', () => {
+  assert.equal(mapHealthStatusToFeedStatus('degraded'), 'yellow');
+  assert.equal(mapHealthStatusToFeedStatus('stale'),    'yellow');
+  assert.equal(mapHealthStatusToFeedStatus('unknown'),  'yellow');
+});
+
+test('mapHealthStatusToFeedStatus: failing/blind/unsafe → red', () => {
+  assert.equal(mapHealthStatusToFeedStatus('failing'), 'red');
+  assert.equal(mapHealthStatusToFeedStatus('blind'),   'red');
+  // Unsafe is the safety-critical signal — should always surface as red,
+  // never yellow, since the renderer sorts red-first.
+  assert.equal(mapHealthStatusToFeedStatus('unsafe'),  'red');
+});
+
+// ── ScenarioSeverity → ThreatSeverity ────────────────────────────────
+
+test('topScenarioSeverity: catastrophic → critical', () => {
+  assert.equal(topScenarioSeverity('catastrophic'), 'critical');
+});
+
+test('topScenarioSeverity: severe → high', () => {
+  assert.equal(topScenarioSeverity('severe'), 'high');
+});
+
+test('topScenarioSeverity: moderate/minor/positive map cleanly', () => {
+  assert.equal(topScenarioSeverity('moderate'), 'medium');
+  assert.equal(topScenarioSeverity('minor'),    'low');
+  assert.equal(topScenarioSeverity('positive'), 'info');
+});
+
+test('topScenarioSeverity: undefined / unknown → "medium" safe default', () => {
+  // Safer to default an unknown signal to medium than to drop it or
+  // call it "info" — an unmapped severity is more likely a real signal
+  // we haven't categorized than a benign one.
+  assert.equal(topScenarioSeverity(undefined), 'medium');
+  assert.equal(topScenarioSeverity('not-a-real-severity'), 'medium');
+});

--- a/src/services/export/enhanced-brief-generator.ts
+++ b/src/services/export/enhanced-brief-generator.ts
@@ -1,0 +1,673 @@
+/**
+ * Enhanced multi-section intelligence-brief PDF renderer.
+ *
+ * Pure function over a typed `EnhancedBriefingInput`. The companion
+ * snapshot collector (enhanced-brief-snapshot.ts) handles the impure
+ * pull from singletons (situation engine, unified alerts, swpc monitor,
+ * fire intel, etc); this module just renders.
+ *
+ * Sections (in order):
+ *   1. Cover page         — title, classification banner, timestamp
+ *   2. Executive summary  — AI-generated when present, auto-derived from
+ *                            threat-matrix when not
+ *   3. Threat matrix      — colored grid: domain × severity heat map
+ *   4. Active alerts      — bulleted NWS / FEMA / EEW with severity badge
+ *   5. Space weather      — X-ray flux, Kp, aurora lat, active CMEs
+ *   6. Wildfire status    — top 5 fires by threat score (acres × inv. containment)
+ *   7. Economic indicators — VIX, OFR FSI, FRED key series + 30-day trend arrows
+ *   8. Data feed status   — green/yellow/red per feed
+ *   Footer                — version stamp + data-current-as-of timestamp
+ *
+ * Why a separate file from brief-pdf.ts: that one renders the existing
+ * IntelligenceBriefing; this one renders a richer composite snapshot
+ * with sections that aren't part of IntelligenceBriefing's shape.
+ * Spec calls for keeping the simple export as a fallback.
+ */
+
+import { jsPDF } from 'jspdf';
+import type { ThreatSeverity } from '../intelligence-briefing';
+
+// ── Public input types ───────────────────────────────────────────────
+
+export interface ThreatMatrixCell {
+  /** Domain label, e.g. 'Weather', 'Cyber', 'Economic'. */
+  domain: string;
+  severity: ThreatSeverity;
+  /** Short label rendered inside the cell, e.g. '3 active'. */
+  label: string;
+}
+
+export interface AlertEntry {
+  source: string;             // 'NWS' | 'FEMA' | 'EEW' | …
+  title: string;
+  severity: ThreatSeverity;
+  location?: string;
+}
+
+export interface SpaceWeatherSnapshot {
+  /** Free-text class label, e.g. 'M1.2'. Falls back to '—' when empty. */
+  xrayPeakLabel: string;
+  /** Numeric flux for context, W/m². null when unavailable. */
+  xrayPeakFlux: number | null;
+  kp: number | null;
+  /** Lowest geomagnetic latitude °N where aurora is visible overhead.
+   *  90 = invisible. */
+  auroraVisibilityLatN: number | null;
+  /** Count of currently-tracked Earth-directed CMEs. */
+  earthwardCmeCount: number;
+  /** Optional headline list of active CME notes. */
+  cmeNotes?: string[];
+}
+
+export interface WildfireRanked {
+  name: string;
+  state: string | null;
+  acres: number | null;
+  containmentPct: number | null;
+  /** Pre-computed threat score: acres × (1 - containment). */
+  threatScore: number;
+}
+
+export interface EconomicIndicator {
+  id: string;                       // e.g. 'VIXCLS'
+  label: string;
+  /** Latest observation. null when feed degraded or no data. */
+  latestValue: number | null;
+  /** Value 30 days ago (or oldest in window). null when insufficient. */
+  baselineValue: number | null;
+  /** Optional units shown beside the value. */
+  units?: string;
+}
+
+export type FeedStatus = 'green' | 'yellow' | 'red';
+
+export interface FeedHealthRow {
+  feedId: string;
+  label: string;
+  status: FeedStatus;
+  /** Optional age-in-seconds annotation. */
+  ageSeconds?: number;
+}
+
+export interface EnhancedBriefingInput {
+  /** Optional pre-built executive summary (e.g. from AI brief). When
+   *  absent, the renderer derives one from the threat matrix. */
+  executiveSummary?: string;
+  threatMatrix: ThreatMatrixCell[];
+  activeAlerts: AlertEntry[];
+  spaceWeather: SpaceWeatherSnapshot | null;
+  topWildfires: WildfireRanked[];
+  economicIndicators: EconomicIndicator[];
+  feedHealth: FeedHealthRow[];
+  /** Wall-clock data-current-as-of timestamp shown in the footer. */
+  dataCurrentAt: number;
+  /** Crystal Ball app version, shown in the footer. */
+  appVersion: string;
+}
+
+export interface EnhancedBriefOptions {
+  classification?: string;       // default 'UNCLASSIFIED'
+  title?: string;                // default 'CRYSTAL BALL INTELLIGENCE BRIEF'
+}
+
+// ── Constants ────────────────────────────────────────────────────────
+
+const DEFAULT_CLASSIFICATION = 'UNCLASSIFIED';
+const DEFAULT_TITLE = 'CRYSTAL BALL INTELLIGENCE BRIEF';
+
+const PAGE_WIDTH = 612;     // 8.5"
+const PAGE_HEIGHT = 792;    // 11"
+const MARGIN = 54;          // 0.75"
+const CONTENT_WIDTH = PAGE_WIDTH - MARGIN * 2;
+const HEADER_BOTTOM_Y = 80;
+const FOOTER_TOP_Y = PAGE_HEIGHT - 50;
+
+const SEVERITY_RANK: Readonly<Record<ThreatSeverity, number>> = {
+  critical: 4, high: 3, medium: 2, low: 1, info: 0,
+};
+
+const SEVERITY_COLOR: Readonly<Record<ThreatSeverity, [number, number, number]>> = {
+  critical: [194, 0, 0],
+  high:     [217, 86, 0],
+  medium:   [186, 137, 0],
+  low:      [70, 113, 70],
+  info:     [80, 80, 80],
+};
+
+const FEED_STATUS_COLOR: Readonly<Record<FeedStatus, [number, number, number]>> = {
+  green:  [34, 139, 34],
+  yellow: [217, 174, 0],
+  red:    [194, 0, 0],
+};
+
+// ── Public API ────────────────────────────────────────────────────────
+
+export function renderEnhancedBriefingPdf(
+  input: EnhancedBriefingInput,
+  options: EnhancedBriefOptions = {},
+): jsPDF {
+  const doc = new jsPDF({ unit: 'pt', format: 'letter' });
+  const title = options.title ?? DEFAULT_TITLE;
+  const classification = options.classification ?? DEFAULT_CLASSIFICATION;
+
+  drawCoverPage(doc, title, classification, input);
+
+  // Body pages start fresh.
+  doc.addPage();
+  let y = HEADER_BOTTOM_Y + 20;
+  drawHeader(doc, title, input.dataCurrentAt);
+
+  const onPageBreak = () => {
+    drawHeader(doc, title, input.dataCurrentAt);
+    return HEADER_BOTTOM_Y + 20;
+  };
+
+  y = renderExecutiveSummary(doc, input, y, onPageBreak);
+  y = renderThreatMatrix(doc, input.threatMatrix, y, onPageBreak);
+  y = renderActiveAlerts(doc, input.activeAlerts, y, onPageBreak);
+  y = renderSpaceWeather(doc, input.spaceWeather, y, onPageBreak);
+  y = renderWildfires(doc, input.topWildfires, y, onPageBreak);
+  y = renderEconomicIndicators(doc, input.economicIndicators, y, onPageBreak);
+  renderFeedHealth(doc, input.feedHealth, y, onPageBreak);
+
+  // Stamp footer + page numbers across every page.
+  const pageCount = doc.getNumberOfPages();
+  for (let i = 1; i <= pageCount; i += 1) {
+    doc.setPage(i);
+    drawFooter(doc, classification, input, i, pageCount);
+  }
+  return doc;
+}
+
+export function renderEnhancedBriefingPdfBlob(
+  input: EnhancedBriefingInput,
+  options: EnhancedBriefOptions = {},
+): Blob {
+  return renderEnhancedBriefingPdf(input, options).output('blob');
+}
+
+export function enhancedBriefPdfFilename(input: EnhancedBriefingInput): string {
+  const iso = new Date(input.dataCurrentAt).toISOString().slice(0, 10);
+  return `crystal-ball-intel-brief-${iso}.pdf`;
+}
+
+// ── Pure derivation helpers (exported for unit tests) ────────────────
+
+/** When the caller doesn't supply an executive summary, derive a
+ *  3-4-sentence overview from the threat matrix. The summary is purely
+ *  data-driven so it stays accurate even when the AI brief is offline. */
+export function deriveExecutiveSummary(matrix: readonly ThreatMatrixCell[]): string {
+  if (matrix.length === 0) {
+    return 'Crystal Ball detected no active threats across monitored domains. The current operating environment is clear; routine monitoring continues.';
+  }
+  const buckets: Record<ThreatSeverity, ThreatMatrixCell[]> = {
+    critical: [], high: [], medium: [], low: [], info: [],
+  };
+  for (const cell of matrix) buckets[cell.severity].push(cell);
+
+  const parts: string[] = [];
+  if (buckets.critical.length > 0) {
+    parts.push(`${buckets.critical.length} critical-severity threat${buckets.critical.length === 1 ? '' : 's'} active in ${joinDomains(buckets.critical)}`);
+  }
+  if (buckets.high.length > 0) {
+    parts.push(`${buckets.high.length} high-severity in ${joinDomains(buckets.high)}`);
+  }
+  if (buckets.medium.length > 0) {
+    parts.push(`${buckets.medium.length} medium in ${joinDomains(buckets.medium)}`);
+  }
+  if (parts.length === 0) {
+    return `Monitoring ${matrix.length} domain${matrix.length === 1 ? '' : 's'} with low-severity activity only. No elevated threats detected at this time.`;
+  }
+  const lead = parts.join(', ');
+  let tail = 'Routine monitoring posture; review items below for context.';
+  if (buckets.critical.length > 0) {
+    tail = 'Recommend immediate review of critical-severity items below; situational awareness elevated.';
+  } else if (buckets.high.length > 0) {
+    tail = 'Monitoring posture remains elevated; review high-severity items below.';
+  }
+  return `${capitalize(lead)}. ${tail}`;
+}
+
+function joinDomains(cells: readonly ThreatMatrixCell[]): string {
+  const unique = [...new Set(cells.map((c) => c.domain))];
+  if (unique.length <= 2) return unique.join(' and ');
+  return `${unique.slice(0, -1).join(', ')}, and ${unique[unique.length - 1]}`;
+}
+
+function capitalize(s: string): string {
+  if (s.length === 0) return s;
+  const first = s.charAt(0);
+  return first.toUpperCase() + s.slice(1);
+}
+
+/** Format a 30-day trend as an arrow + delta. Pure for tests. */
+export function formatTrendArrow(latest: number | null, baseline: number | null): string {
+  if (latest === null || baseline === null) return '—';
+  if (baseline === 0) {
+    if (latest > 0) return '↑';
+    if (latest < 0) return '↓';
+    return '→';
+  }
+  const pct = ((latest - baseline) / Math.abs(baseline)) * 100;
+  if (Math.abs(pct) < 1) return `→ ${pct.toFixed(1)}%`;
+  if (pct > 0) return `↑ +${pct.toFixed(1)}%`;
+  return `↓ ${pct.toFixed(1)}%`;
+}
+
+/** Sort wildfires by threat score (acres × inverse containment) desc. */
+export function topWildfiresByThreat(
+  fires: readonly WildfireRanked[],
+  topN = 5,
+): WildfireRanked[] {
+  return [...fires].sort((a, b) => b.threatScore - a.threatScore).slice(0, topN);
+}
+
+/** Compute threat score for a single fire. Acres × (1 − containment%/100).
+ *  When containment is null, treat as 0 (worst case for unknowns). */
+export function computeFireThreatScore(acres: number | null, containmentPct: number | null): number {
+  if (acres === null || acres <= 0) return 0;
+  const contained = containmentPct === null ? 0 : Math.max(0, Math.min(100, containmentPct));
+  return acres * (1 - contained / 100);
+}
+
+// ── Cover page ──────────────────────────────────────────────────────
+
+function drawCoverPage(
+  doc: jsPDF,
+  title: string,
+  classification: string,
+  input: EnhancedBriefingInput,
+): void {
+  // Classification banner (top + bottom).
+  doc.setFillColor(20, 20, 20);
+  doc.rect(0, 30, PAGE_WIDTH, 24, 'F');
+  doc.setTextColor(255, 255, 255);
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(11);
+  doc.text(classification, PAGE_WIDTH / 2, 47, { align: 'center' });
+
+  doc.setFillColor(20, 20, 20);
+  doc.rect(0, PAGE_HEIGHT - 54, PAGE_WIDTH, 24, 'F');
+  doc.setTextColor(255, 255, 255);
+  doc.text(classification, PAGE_WIDTH / 2, PAGE_HEIGHT - 38, { align: 'center' });
+
+  // Title — centered, large.
+  doc.setTextColor(20, 20, 20);
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(28);
+  doc.text(title, PAGE_WIDTH / 2, 280, { align: 'center', maxWidth: PAGE_WIDTH - 80 });
+
+  // Subtitle / generated-at.
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(12);
+  doc.setTextColor(80, 80, 80);
+  const ts = new Date(input.dataCurrentAt).toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
+  doc.text(`Data current as of: ${ts}`, PAGE_WIDTH / 2, 320, { align: 'center' });
+  doc.text(`Crystal Ball v${input.appVersion}`, PAGE_WIDTH / 2, 340, { align: 'center' });
+
+  // Quick-glance summary line.
+  const totalCells = input.threatMatrix.length;
+  const criticals = input.threatMatrix.filter((c) => c.severity === 'critical').length;
+  const highs = input.threatMatrix.filter((c) => c.severity === 'high').length;
+  const summary = `${totalCells} domain${totalCells === 1 ? '' : 's'} monitored — ${criticals} critical, ${highs} high`;
+  doc.setFontSize(11);
+  doc.setTextColor(40, 40, 40);
+  doc.text(summary, PAGE_WIDTH / 2, 400, { align: 'center' });
+}
+
+// ── Body sections ────────────────────────────────────────────────────
+
+function renderExecutiveSummary(
+  doc: jsPDF,
+  input: EnhancedBriefingInput,
+  startY: number,
+  onPageBreak: () => number,
+): number {
+  let y = startY;
+  y = drawSectionHeader(doc, 'EXECUTIVE SUMMARY', y);
+  const summary = (input.executiveSummary?.trim().length ?? 0) > 0
+    ? input.executiveSummary!.trim()
+    : deriveExecutiveSummary(input.threatMatrix);
+  return renderWrappedText(doc, summary, y, onPageBreak) + 14;
+}
+
+function renderThreatMatrix(
+  doc: jsPDF,
+  matrix: readonly ThreatMatrixCell[],
+  startY: number,
+  onPageBreak: () => number,
+): number {
+  let y = ensureRoomFor(doc, startY, 80, onPageBreak);
+  y = drawSectionHeader(doc, 'THREAT MATRIX', y);
+  if (matrix.length === 0) {
+    return drawEmptyLine(doc, 'No active threats in matrix.', y) + 14;
+  }
+  // 2-column grid: domain | colored cell with label.
+  const rowHeight = 22;
+  const labelColW = 180;
+  const cellColW = CONTENT_WIDTH - labelColW;
+  const sorted = [...matrix].sort((a, b) => SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity]);
+
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(9);
+  doc.setTextColor(80, 80, 80);
+  doc.text('DOMAIN', MARGIN + 4, y + 14);
+  doc.text('SEVERITY', MARGIN + labelColW + 4, y + 14);
+  y += rowHeight;
+
+  for (const cell of sorted) {
+    y = ensureRoomFor(doc, y, rowHeight, onPageBreak);
+    const [r, g, b] = SEVERITY_COLOR[cell.severity];
+    // Domain cell (white bg, dark text).
+    doc.setDrawColor(220, 220, 220);
+    doc.setLineWidth(0.5);
+    doc.setFillColor(252, 252, 252);
+    doc.rect(MARGIN, y, labelColW, rowHeight, 'FD');
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(10);
+    doc.setTextColor(20, 20, 20);
+    doc.text(cell.domain, MARGIN + 6, y + 14);
+    // Severity heat-cell.
+    doc.setFillColor(r, g, b);
+    doc.rect(MARGIN + labelColW, y, cellColW, rowHeight, 'F');
+    doc.setTextColor(255, 255, 255);
+    doc.setFont('helvetica', 'bold');
+    doc.text(`${cell.severity.toUpperCase()} — ${cell.label}`, MARGIN + labelColW + 6, y + 14);
+    y += rowHeight;
+  }
+  return y + 14;
+}
+
+function renderActiveAlerts(
+  doc: jsPDF,
+  alerts: readonly AlertEntry[],
+  startY: number,
+  onPageBreak: () => number,
+): number {
+  let y = ensureRoomFor(doc, startY, 60, onPageBreak);
+  y = drawSectionHeader(doc, 'ACTIVE ALERTS', y);
+  if (alerts.length === 0) {
+    return drawEmptyLine(doc, 'No active alerts at this time.', y) + 14;
+  }
+  // Sort by severity desc.
+  const sorted = [...alerts].sort((a, b) => SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity]);
+  for (const alert of sorted) {
+    y = ensureRoomFor(doc, y, 24, onPageBreak);
+    const [r, g, b] = SEVERITY_COLOR[alert.severity];
+    // Severity dot.
+    doc.setFillColor(r, g, b);
+    doc.circle(MARGIN + 4, y - 4, 4, 'F');
+    // Body text: source: title (location).
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(10);
+    doc.setTextColor(20, 20, 20);
+    const lead = `[${alert.source}] ${alert.title}`;
+    const locTail = alert.location ? `  —  ${alert.location}` : '';
+    const wrapped = doc.splitTextToSize(lead + locTail, CONTENT_WIDTH - 16) as string[];
+    doc.text(wrapped[0] ?? '', MARGIN + 14, y);
+    y += 14;
+    for (let i = 1; i < wrapped.length; i += 1) {
+      y = ensureRoomFor(doc, y, 12, onPageBreak);
+      doc.setFont('helvetica', 'normal');
+      doc.setFontSize(9);
+      doc.text(wrapped[i] ?? '', MARGIN + 14, y);
+      y += 12;
+    }
+    y += 4;
+  }
+  return y + 8;
+}
+
+function renderSpaceWeather(
+  doc: jsPDF,
+  sw: SpaceWeatherSnapshot | null,
+  startY: number,
+  onPageBreak: () => number,
+): number {
+  let y = ensureRoomFor(doc, startY, 50, onPageBreak);
+  y = drawSectionHeader(doc, 'SPACE WEATHER', y);
+  if (!sw) {
+    return drawEmptyLine(doc, 'Space-weather data unavailable (SWPC not polled).', y) + 14;
+  }
+  const fluxNote = sw.xrayPeakFlux === null ? '' : `  (${sw.xrayPeakFlux.toExponential(2)} W/m²)`;
+  const kpStr = sw.kp === null ? '—' : sw.kp.toFixed(1);
+  const rows: string[] = [
+    `X-ray peak class: ${sw.xrayPeakLabel}${fluxNote}`,
+    `Planetary Kp: ${kpStr}`,
+    `Aurora visibility: ${formatAuroraLat(sw.auroraVisibilityLatN)}`,
+    `Earth-directed CMEs: ${sw.earthwardCmeCount}`,
+  ];
+  for (const row of rows) {
+    y = ensureRoomFor(doc, y, 14, onPageBreak);
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(10);
+    doc.setTextColor(40, 40, 40);
+    doc.text(`• ${row}`, MARGIN, y);
+    y += 14;
+  }
+  if (sw.cmeNotes && sw.cmeNotes.length > 0) {
+    for (const note of sw.cmeNotes.slice(0, 3)) {
+      y = ensureRoomFor(doc, y, 12, onPageBreak);
+      doc.setFont('helvetica', 'italic');
+      doc.setFontSize(9);
+      doc.setTextColor(80, 80, 80);
+      const wrapped = doc.splitTextToSize(`  — ${note}`, CONTENT_WIDTH) as string[];
+      for (const line of wrapped) {
+        y = ensureRoomFor(doc, y, 12, onPageBreak);
+        doc.text(line, MARGIN, y);
+        y += 12;
+      }
+    }
+  }
+  return y + 14;
+}
+
+/** "Aurora visible from 65°N or higher" / "Not visible from typical latitudes" */
+export function formatAuroraLat(latN: number | null): string {
+  if (latN === null || latN >= 89) return 'Not visible from typical latitudes';
+  return `Visible from ${latN.toFixed(0)}°N or higher`;
+}
+
+function renderWildfires(
+  doc: jsPDF,
+  fires: readonly WildfireRanked[],
+  startY: number,
+  onPageBreak: () => number,
+): number {
+  let y = ensureRoomFor(doc, startY, 60, onPageBreak);
+  y = drawSectionHeader(doc, 'WILDFIRE STATUS — TOP 5 BY THREAT SCORE', y);
+  const top = topWildfiresByThreat(fires, 5);
+  if (top.length === 0) {
+    return drawEmptyLine(doc, 'No active wildfire incidents reported.', y) + 14;
+  }
+  for (const fire of top) {
+    y = ensureRoomFor(doc, y, 16, onPageBreak);
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(10);
+    doc.setTextColor(217, 86, 0);
+    const stateSuffix = fire.state ? ` (${fire.state})` : '';
+    doc.text(`• ${fire.name}${stateSuffix}`, MARGIN, y);
+    y += 12;
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(9);
+    doc.setTextColor(60, 60, 60);
+    const acresStr = fire.acres === null ? 'acreage unknown' : `${Math.round(fire.acres).toLocaleString()} acres`;
+    const contStr = fire.containmentPct === null ? 'containment unknown' : `${Math.round(fire.containmentPct)}% contained`;
+    const scoreStr = `threat score ${Math.round(fire.threatScore).toLocaleString()}`;
+    doc.text(`  ${acresStr} • ${contStr} • ${scoreStr}`, MARGIN, y);
+    y += 14;
+  }
+  return y + 8;
+}
+
+function renderEconomicIndicators(
+  doc: jsPDF,
+  indicators: readonly EconomicIndicator[],
+  startY: number,
+  onPageBreak: () => number,
+): number {
+  let y = ensureRoomFor(doc, startY, 60, onPageBreak);
+  y = drawSectionHeader(doc, 'ECONOMIC INDICATORS', y);
+  if (indicators.length === 0) {
+    return drawEmptyLine(doc, 'Economic stress feed not available.', y) + 14;
+  }
+  // Header row. Label / value / trend columns sized for letter width.
+  const labelCol = 220;
+  const valueCol = 100;
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(9);
+  doc.setTextColor(80, 80, 80);
+  doc.text('INDICATOR', MARGIN, y);
+  doc.text('LATEST', MARGIN + labelCol, y);
+  doc.text('30-DAY TREND', MARGIN + labelCol + valueCol, y);
+  y += 6;
+  doc.setDrawColor(200, 200, 200);
+  doc.line(MARGIN, y, MARGIN + CONTENT_WIDTH, y);
+  y += 12;
+
+  for (const ind of indicators) {
+    y = ensureRoomFor(doc, y, 18, onPageBreak);
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(10);
+    doc.setTextColor(20, 20, 20);
+    doc.text(ind.label, MARGIN, y);
+    let valueStr = '—';
+    if (ind.latestValue !== null) {
+      const unitSuffix = ind.units ? ` ${ind.units}` : '';
+      valueStr = `${ind.latestValue.toFixed(2)}${unitSuffix}`;
+    }
+    doc.text(valueStr, MARGIN + labelCol, y);
+    const trend = formatTrendArrow(ind.latestValue, ind.baselineValue);
+    if (trend.startsWith('↑')) doc.setTextColor(194, 0, 0);
+    else if (trend.startsWith('↓')) doc.setTextColor(34, 139, 34);
+    else doc.setTextColor(80, 80, 80);
+    doc.text(trend, MARGIN + labelCol + valueCol, y);
+    y += 16;
+  }
+  return y + 8;
+}
+
+function renderFeedHealth(
+  doc: jsPDF,
+  rows: readonly FeedHealthRow[],
+  startY: number,
+  onPageBreak: () => number,
+): number {
+  let y = ensureRoomFor(doc, startY, 50, onPageBreak);
+  y = drawSectionHeader(doc, 'DATA FEED STATUS', y);
+  if (rows.length === 0) {
+    return drawEmptyLine(doc, 'Feed health snapshot unavailable.', y) + 14;
+  }
+  const statusOrder: FeedStatus[] = ['red', 'yellow', 'green'];
+  const sorted = [...rows].sort((a, b) => statusOrder.indexOf(a.status) - statusOrder.indexOf(b.status));
+  for (const row of sorted) {
+    y = ensureRoomFor(doc, y, 14, onPageBreak);
+    const [r, g, b] = FEED_STATUS_COLOR[row.status];
+    doc.setFillColor(r, g, b);
+    doc.circle(MARGIN + 4, y - 4, 3.5, 'F');
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(10);
+    doc.setTextColor(20, 20, 20);
+    const ageStr = typeof row.ageSeconds === 'number'
+      ? `  (last update ${formatAge(row.ageSeconds)})` : '';
+    doc.text(`${row.label}${ageStr}`, MARGIN + 14, y);
+    y += 14;
+  }
+  return y;
+}
+
+function formatAge(ageSeconds: number): string {
+  if (ageSeconds < 60) return `${Math.round(ageSeconds)}s ago`;
+  if (ageSeconds < 3600) return `${Math.round(ageSeconds / 60)}m ago`;
+  if (ageSeconds < 86_400) return `${Math.round(ageSeconds / 3600)}h ago`;
+  return `${Math.round(ageSeconds / 86_400)}d ago`;
+}
+
+// ── Layout primitives ────────────────────────────────────────────────
+
+function drawHeader(doc: jsPDF, title: string, dataCurrentAt: number): void {
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(11);
+  doc.setTextColor(40, 40, 40);
+  const ts = new Date(dataCurrentAt).toISOString().replace('T', ' ').slice(0, 16) + ' UTC';
+  doc.text(`${title}  —  ${ts}`, MARGIN, MARGIN + 12);
+  doc.setDrawColor(160, 160, 160);
+  doc.setLineWidth(0.5);
+  doc.line(MARGIN, HEADER_BOTTOM_Y, PAGE_WIDTH - MARGIN, HEADER_BOTTOM_Y);
+}
+
+function drawFooter(
+  doc: jsPDF,
+  classification: string,
+  input: EnhancedBriefingInput,
+  page: number,
+  total: number,
+): void {
+  doc.setDrawColor(160, 160, 160);
+  doc.setLineWidth(0.5);
+  doc.line(MARGIN, FOOTER_TOP_Y, PAGE_WIDTH - MARGIN, FOOTER_TOP_Y);
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(8);
+  doc.setTextColor(80, 80, 80);
+  doc.text(`Classification: ${classification}`, MARGIN, FOOTER_TOP_Y + 14);
+  doc.setFont('helvetica', 'normal');
+  const ts = new Date(input.dataCurrentAt).toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
+  doc.text(
+    `Generated by Crystal Ball v${input.appVersion}  |  Data current as of ${ts}`,
+    PAGE_WIDTH / 2, FOOTER_TOP_Y + 28, { align: 'center' },
+  );
+  doc.text(`Page ${page} of ${total}`, PAGE_WIDTH - MARGIN, FOOTER_TOP_Y + 14, { align: 'right' });
+}
+
+function drawSectionHeader(doc: jsPDF, label: string, startY: number): number {
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(13);
+  doc.setTextColor(20, 20, 20);
+  doc.text(label, MARGIN, startY);
+  doc.setDrawColor(20, 20, 20);
+  doc.setLineWidth(1.5);
+  doc.line(MARGIN, startY + 4, MARGIN + 80, startY + 4);
+  return startY + 22;
+}
+
+function drawEmptyLine(doc: jsPDF, message: string, startY: number): number {
+  doc.setFont('helvetica', 'italic');
+  doc.setFontSize(10);
+  doc.setTextColor(120, 120, 120);
+  doc.text(message, MARGIN, startY);
+  return startY + 14;
+}
+
+function renderWrappedText(
+  doc: jsPDF,
+  text: string,
+  startY: number,
+  onPageBreak: () => number,
+  x: number = MARGIN,
+  width: number = CONTENT_WIDTH,
+): number {
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(10);
+  doc.setTextColor(40, 40, 40);
+  const wrapped = doc.splitTextToSize(text, width) as string[];
+  let y = startY;
+  for (const line of wrapped) {
+    y = ensureRoomFor(doc, y, 13, onPageBreak);
+    doc.text(line, x, y);
+    y += 13;
+  }
+  return y;
+}
+
+function ensureRoomFor(
+  doc: jsPDF,
+  y: number,
+  needed: number,
+  onPageBreak: () => number,
+): number {
+  if (y + needed >= FOOTER_TOP_Y - 10) {
+    doc.addPage();
+    return onPageBreak();
+  }
+  return y;
+}

--- a/src/services/export/enhanced-brief-mappers.ts
+++ b/src/services/export/enhanced-brief-mappers.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure mapping helpers for the enhanced-brief snapshot collector.
+ *
+ * Extracted from enhanced-brief-snapshot.ts so they can be unit-tested
+ * without importing the snapshot module's full dependency tree (which
+ * pulls in Vite-specific `?worker` query imports through the situation
+ * engine and alert store).
+ */
+
+import type { ThreatSeverity } from '../intelligence-briefing';
+import type { HealthStatus } from '../diagnostics/system-health-types';
+import type { FeedStatus } from './enhanced-brief-generator';
+
+/** Map FeatureHealthRegistry status → traffic-light feed status.
+ *
+ *  Why three buckets instead of seven:
+ *    - 'healthy' is unambiguous → green
+ *    - 'degraded' / 'stale' / 'unknown' all mean "working with caveats"
+ *      that the user should know about but doesn't need to act on → yellow
+ *    - 'failing' / 'blind' / 'unsafe' all mean a feed needs attention → red
+ *      ('unsafe' must always be red since the renderer sorts red-first)
+ */
+export function mapHealthStatusToFeedStatus(s: HealthStatus): FeedStatus {
+  switch (s) {
+    case 'healthy': { return 'green';
+    }
+    case 'degraded':
+    case 'stale':
+    case 'unknown': { return 'yellow';
+    }
+    case 'failing':
+    case 'blind':
+    case 'unsafe': { return 'red';
+    }
+    default: { return 'yellow';
+    }
+  }
+}
+
+/** Map situation-engine ScenarioSeverity (catastrophic / severe /
+ *  moderate / minor / positive) → renderer's ThreatSeverity (critical /
+ *  high / medium / low / info).
+ *
+ *  Default for unknown / undefined is 'medium' rather than 'info' or
+ *  'low' — an unmapped severity is more likely a real signal we
+ *  haven't categorized than a benign one. */
+export function topScenarioSeverity(scenarioSev: string | undefined): ThreatSeverity {
+  switch (scenarioSev) {
+    case 'catastrophic': { return 'critical';
+    }
+    case 'severe': {       return 'high';
+    }
+    case 'moderate': {     return 'medium';
+    }
+    case 'minor': {        return 'low';
+    }
+    case 'positive': {     return 'info';
+    }
+    default: {             return 'medium';
+    }
+  }
+}

--- a/src/services/export/enhanced-brief-snapshot.ts
+++ b/src/services/export/enhanced-brief-snapshot.ts
@@ -1,0 +1,276 @@
+/**
+ * Enhanced-brief snapshot collector — bridges live singletons into the
+ * pure renderer's input shape (EnhancedBriefingInput).
+ *
+ * This is the impure half of the enhanced-brief stack. It pulls from
+ * the unified-alert store, the situation engine, the SWPC space-weather
+ * monitor, the fire-intel service, and the feature-health registry.
+ *
+ * Per-section try/catches: a failure in one collector (e.g. economic
+ * stress when /api/economic/stress isn't yet polled) degrades only that
+ * section, not the whole report. Renderer accepts null/empty inputs and
+ * shows "Data unavailable" placeholders.
+ *
+ * The collector is intentionally light on transformation logic — most
+ * derivation (executive-summary fallback, threat-score sort, trend
+ * arrows) lives in enhanced-brief-generator.ts where it's pure-testable.
+ */
+
+import { unifiedAlertStore } from '../unified-alerts';
+import type { UnifiedAlert } from '../unified-alerts';
+import { situationEngine } from '../situation-engine';
+import { getCachedBriefing } from '../intelligence-briefing';
+import { getFeatureHealthRegistry } from '../diagnostics/diagnostics-state';
+import type { ThreatSeverity } from '../intelligence-briefing';
+import { getApiBaseUrl } from '../runtime';
+import {
+  type AlertEntry,
+  type EconomicIndicator,
+  type EnhancedBriefingInput,
+  type FeedHealthRow,
+  type SpaceWeatherSnapshot,
+  type ThreatMatrixCell,
+  type WildfireRanked,
+  computeFireThreatScore,
+} from './enhanced-brief-generator';
+import { mapHealthStatusToFeedStatus, topScenarioSeverity } from './enhanced-brief-mappers';
+
+
+// ── Public API ───────────────────────────────────────────────────────
+
+export interface CollectOptions {
+  /** Optional override for the app version stamped in the footer. */
+  appVersion?: string;
+  /** Optional injection of `now` for deterministic tests. */
+  now?: () => number;
+  /** Optional override for the API base — tests inject ''/mock; the
+   *  default reads from runtime.ts. */
+  apiBaseUrl?: string;
+}
+
+export async function collectEnhancedBriefing(
+  options: CollectOptions = {},
+): Promise<EnhancedBriefingInput> {
+  const now = options.now ?? Date.now;
+  const appVersion = options.appVersion ?? readAppVersion();
+  const apiBase = options.apiBaseUrl ?? getApiBaseUrl();
+
+  // All collectors are independently try/catch'd — never let one section
+  // sink the whole snapshot.
+  const [executiveSummary, threatMatrix, activeAlerts, spaceWeather, topWildfires, economicIndicators, feedHealth] =
+    await Promise.all([
+      Promise.resolve().then(() => collectExecutiveSummary()),
+      Promise.resolve().then(() => collectThreatMatrix()),
+      Promise.resolve().then(() => collectActiveAlerts()),
+      collectSpaceWeather(apiBase),
+      Promise.resolve().then(() => collectTopWildfires()),
+      collectEconomicIndicators(apiBase),
+      Promise.resolve().then(() => collectFeedHealth()),
+    ]);
+
+  return {
+    executiveSummary, threatMatrix, activeAlerts, spaceWeather,
+    topWildfires, economicIndicators, feedHealth,
+    dataCurrentAt: now(), appVersion,
+  };
+}
+
+// ── Per-section collectors ───────────────────────────────────────────
+
+function collectExecutiveSummary(): string | undefined {
+  // Reuse the AI brief's executive-summary section when available so the
+  // PDF doesn't paraphrase what the briefing panel already shows.
+  try {
+    const briefing = getCachedBriefing();
+    if (!briefing) return undefined;
+    const exec = briefing.sections.find((s) => s.type === 'executive-summary');
+    const trimmed = exec?.content?.trim();
+    return trimmed && trimmed.length > 0 ? trimmed : undefined;
+  } catch { return undefined; }
+}
+
+/** Build a domain × severity matrix from active situations.
+ *  Per-domain we pick the worst-severity active situation. */
+export function collectThreatMatrix(): ThreatMatrixCell[] {
+  try {
+    const sits = situationEngine.getSituations()
+      .filter((s) => s.phase === 'active' || s.phase === 'developing');
+    if (sits.length === 0) return [];
+    // Group by domain, pick worst severity.
+    const byDomain = new Map<string, { worstScore: number; severity: ThreatSeverity; count: number }>();
+    for (const sit of sits) {
+      const sev = topScenarioSeverity(sit.scenarios?.[0]?.severity as string | undefined);
+      const score = severityScore(sev);
+      const existing = byDomain.get(sit.domain);
+      if (!existing || score > existing.worstScore) {
+        byDomain.set(sit.domain, { worstScore: score, severity: sev, count: (existing?.count ?? 0) + 1 });
+      } else {
+        existing.count += 1;
+      }
+    }
+    return [...byDomain.entries()].map(([domain, info]) => ({
+      domain: prettyDomain(domain),
+      severity: info.severity,
+      label: `${info.count} active`,
+    }));
+  } catch { return []; }
+}
+
+// (topScenarioSeverity is re-exported from enhanced-brief-mappers above.)
+
+const SEVERITY_SCORES: Record<ThreatSeverity, number> = {
+  critical: 4, high: 3, medium: 2, low: 1, info: 0,
+};
+function severityScore(sev: ThreatSeverity): number { return SEVERITY_SCORES[sev]; }
+
+function prettyDomain(domain: string): string {
+  return domain.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Map UnifiedAlert → AlertEntry; cap at 25 critical/high alerts. */
+export function collectActiveAlerts(): AlertEntry[] {
+  try {
+    const alerts: UnifiedAlert[] = unifiedAlertStore.getAll();
+    const now = Date.now();
+    const filtered = alerts
+      .filter((a) => !a.acknowledged && (a.snoozedUntil ?? 0) <= now)
+      .filter((a) => a.severity === 'critical' || a.severity === 'high');
+    return filtered.slice(0, 25).map((a) => ({
+      source: a.source.toUpperCase(),
+      title: a.title,
+      severity: alertSeverityToThreatSeverity(a.severity),
+      location: a.location?.label,
+    }));
+  } catch { return []; }
+}
+
+function alertSeverityToThreatSeverity(s: UnifiedAlert['severity']): ThreatSeverity {
+  switch (s) {
+    case 'critical': { return 'critical';
+    }
+    case 'high': {     return 'high';
+    }
+    case 'medium': {   return 'medium';
+    }
+    case 'low': {      return 'low';
+    }
+    default: {         return 'info';
+    }
+  }
+}
+
+async function collectSpaceWeather(apiBaseUrl: string): Promise<SpaceWeatherSnapshot | null> {
+  try {
+    const r = await fetch(`${apiBaseUrl}/api/spaceweather/status`, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!r.ok) return null;
+    const payload = (await r.json()) as Partial<{
+      xrayPeakLabel: string; xrayPeakFlux: number;
+      kp: number; auroraVisibilityLatN: number;
+      earthwardCmes: { note?: string }[];
+    }>;
+    return {
+      xrayPeakLabel: payload.xrayPeakLabel ?? '—',
+      xrayPeakFlux: typeof payload.xrayPeakFlux === 'number' ? payload.xrayPeakFlux : null,
+      kp: typeof payload.kp === 'number' ? payload.kp : null,
+      auroraVisibilityLatN: typeof payload.auroraVisibilityLatN === 'number' ? payload.auroraVisibilityLatN : null,
+      earthwardCmeCount: Array.isArray(payload.earthwardCmes) ? payload.earthwardCmes.length : 0,
+      cmeNotes: Array.isArray(payload.earthwardCmes)
+        ? payload.earthwardCmes.map((c) => c?.note).filter((n): n is string => typeof n === 'string')
+        : undefined,
+    };
+  } catch { return null; }
+}
+
+/** Map RankedThreat → WildfireRanked via the renderer's pure scorer.
+ *  The collector only reaches into the inciweb-shaped IncidentReport
+ *  (acresBurned, percentContained); the renderer applies the
+ *  acres × (1 − containment) scoring uniformly. */
+export function collectTopWildfires(): WildfireRanked[] {
+  try {
+    interface InciLike {
+      name: string; state: string;
+      acresBurned: number | null; percentContained: number | null;
+    }
+    interface RankedLike { incident: InciLike; threatScore: number }
+    const fireServiceModule = getFireServiceState();
+    if (!fireServiceModule) return [];
+    const rankedRaw = fireServiceModule as RankedLike[];
+    return rankedRaw.map((r) => ({
+      name: r.incident.name,
+      state: r.incident.state || null,
+      acres: r.incident.acresBurned,
+      containmentPct: r.incident.percentContained,
+      threatScore: r.threatScore || computeFireThreatScore(r.incident.acresBurned, r.incident.percentContained),
+    }));
+  } catch { return []; }
+}
+
+/** Read the current ranked-threats snapshot if the fire-intel service
+ *  has cached one; otherwise return null. The snapshot is populated by
+ *  the panel/data-loader; the collector never triggers a fetch. */
+function getFireServiceState(): unknown {
+  try {
+    interface MaybeWithFireSnap { __fireIntelSnapshot?: { rankedThreats?: unknown[] } }
+    const w = (globalThis as unknown as MaybeWithFireSnap);
+    return Array.isArray(w.__fireIntelSnapshot?.rankedThreats) ? w.__fireIntelSnapshot!.rankedThreats : null;
+  } catch { return null; }
+}
+
+async function collectEconomicIndicators(apiBaseUrl: string): Promise<EconomicIndicator[]> {
+  try {
+    const r = await fetch(`${apiBaseUrl}/api/economic/stress`, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!r.ok) return [];
+    interface StressPayload {
+      indicators?: {
+        id: string; label: string;
+        latest?: { value?: number } | null;
+        history?: { date?: string; value?: number }[];
+        degraded?: boolean;
+      }[];
+    }
+    const payload = (await r.json()) as StressPayload;
+    if (!Array.isArray(payload.indicators)) return [];
+    return payload.indicators
+      .filter((ind) => !ind.degraded)
+      .map((ind) => {
+        const history = Array.isArray(ind.history) ? ind.history : [];
+        const latest = typeof ind.latest?.value === 'number' ? ind.latest.value : null;
+        // Baseline = oldest in window (which the route promises is ~30 days back).
+        const baseline = history.length > 0 && typeof history[0]?.value === 'number'
+          ? history[0].value : null;
+        return { id: ind.id, label: ind.label, latestValue: latest, baselineValue: baseline };
+      });
+  } catch { return []; }
+}
+
+// (mapHealthStatusToFeedStatus is re-exported from enhanced-brief-mappers above.)
+
+export function collectFeedHealth(now: number = Date.now()): FeedHealthRow[] {
+  try {
+    const registry = getFeatureHealthRegistry();
+    const rows = registry.all();
+    return rows.map((r) => ({
+      feedId: r.featureId,
+      label: r.label,
+      status: mapHealthStatusToFeedStatus(r.status),
+      ageSeconds: r.lastSuccessAt ? Math.max(0, Math.round((now - r.lastSuccessAt) / 1000)) : undefined,
+    }));
+  } catch { return []; }
+}
+
+function readAppVersion(): string {
+  // Vite injects __APP_VERSION__ at build time; falls back to a generic
+  // marker in dev/test where the constant isn't defined.
+  try {
+    const v = (globalThis as unknown as { __APP_VERSION__?: string }).__APP_VERSION__;
+    return typeof v === 'string' && v.length > 0 ? v : 'dev';
+  } catch { return 'dev'; }
+}
+
+export {mapHealthStatusToFeedStatus, topScenarioSeverity} from './enhanced-brief-mappers';


### PR DESCRIPTION
## What
Replaces the basic text-only PDF export with a structured 8-section intelligence report. The existing \`renderBriefingPdf\` stays as the spec-required fallback when the enhanced pipeline throws.

## Sections
1. **Cover page** — title + UNCLASSIFIED banner (top + bottom) + version + data-current-as-of timestamp + quick-glance counts
2. **Executive summary** — uses the AI brief's exec section when cached; auto-derives a 3-sentence overview from the threat matrix when the AI brief is unavailable
3. **Threat matrix** — colored grid table (domain × severity), heat-mapped with the same severity palette the panel uses
4. **Active alerts** — bulleted, severity-sorted, with location annotation
5. **Space weather** — X-ray peak class + flux, planetary Kp, aurora visibility latitude, Earth-directed CME count + notes
6. **Wildfire status** — top 5 fires by threat score (acres × inverse containment)
7. **Economic indicators** — VIX, OFR FSI, FRED key series with red/green 30-day trend arrows
8. **Data feed status** — green/yellow/red traffic-light per feed, sorted red-first

Footer on every page: "Generated by Crystal Ball v2.12.x | Data current as of …" + classification stamp + page-N-of-M.

## Architecture
- \`enhanced-brief-generator.ts\` — pure renderer (input → jsPDF), 100% testable with deterministic fixtures. Inline pure derivation helpers (\`deriveExecutiveSummary\`, \`formatTrendArrow\`, \`computeFireThreatScore\`, \`topWildfiresByThreat\`, \`formatAuroraLat\`) exposed for unit tests.
- \`enhanced-brief-snapshot.ts\` — impure collector pulling from \`unifiedAlertStore\`, \`situationEngine\`, SWPC monitor, fire-intel service, and the feature-health registry. Per-section try/catch so one broken source doesn't sink the whole report.
- \`enhanced-brief-mappers.ts\` — pure mapping helpers (\`HealthStatus\` → \`FeedStatus\`, \`ScenarioSeverity\` → \`ThreatSeverity\`) extracted to a dependency-free file so unit tests don't drag in the snapshot's Vite-tainted import tree.
- \`IntelligenceBriefingPanel\` — adds **Download Report** button next to Refresh; falls back to the simple renderer if the enhanced pipeline throws (per spec).

## Verification
- \`tsx --test src/services/export/__tests__/enhanced-brief-generator.test.mts src/services/export/__tests__/enhanced-brief-snapshot.test.mts\` → **35/35 pass**
- \`npm run typecheck:all\` → clean
- ESLint clean (lint-staged ran pre-commit)

## Test coverage (35 tests, well over the spec's ≥12)
**Pure derivation (19):** executive-summary derivation across 4 scenarios, trend arrow across 5 input shapes (null, +, -, tiny, zero baseline), fire threat scoring across 4 edge cases (null acreage, null containment, clamped to 0/100), wildfire top-N sort, aurora latitude formatting.

**Renderer output contract (10):** ≥2 page minimum, empty-state placeholders for every section, page-break adds pages, cover page includes title + classification + version, footer carries data-current-as-of, caller-supplied executiveSummary wins over derived, feed-health rows render with status indicator + age, blob is application/pdf, filename uses ISO date prefix.

**Enum mapping (6):** HealthStatus→FeedStatus across all 7 statuses (incl. unsafe→red invariant); ScenarioSeverity→ThreatSeverity across all 5 levels + safe-default for unknown.

## Notable implementation note
PDF text content is inspected via \`TextDecoder('latin1')\` over jsPDF's arraybuffer output — \`output('string')\` returns null in Node, so the binary path is the portable way to assert what text was actually written into content streams. A helper \`pdfText()\` in the test file encapsulates this.