### PR TITLE
feat(spaceweather): live solar imagery tab (SDO + LASCO)

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "test:geopolitics": "tsx --test src/services/geopolitics/__tests__/grayzone-classifier.test.mts",
     "test:finance": "tsx --test src/services/finance/__tests__/stress-monitor.test.mts",
     "test:climate": "tsx --test src/services/climate/__tests__/enso-monitor.test.mts",
-    "test:spaceweather": "tsx --test src/services/spaceweather/__tests__/swpc-monitor.test.mts src/services/spaceweather/__tests__/globe-overlay.test.mts && node --test src-tauri/sidecar/__tests__/spaceweather-parity.test.mjs",
+    "test:spaceweather": "tsx --test src/services/spaceweather/__tests__/swpc-monitor.test.mts src/services/spaceweather/__tests__/globe-overlay.test.mts src/services/spaceweather/__tests__/solar-imagery.test.mts && node --test src-tauri/sidecar/__tests__/spaceweather-parity.test.mjs && node --import tsx --test src-tauri/sidecar/__tests__/spaceweather-imagery-parity.test.mjs",
     "test:panels:smoke": "node tests/panels/run-harness.mjs",
     "test:components": "tsx --test src/components/__tests__/disease-outbreak-tabs.test.mts src/components/__tests__/space-weather-panel.test.mts",
     "test:alerts": "tsx --test src/services/alerts/__tests__/ipaws-monitor.test.mts",

--- a/src-tauri/sidecar/__tests__/spaceweather-imagery-parity.test.mjs
+++ b/src-tauri/sidecar/__tests__/spaceweather-imagery-parity.test.mjs
@@ -1,0 +1,49 @@
+/**
+ * Parity test: the renderer-side solar imagery catalog
+ * (`src/services/spaceweather/solar-imagery.ts`) and the sidecar
+ * catalog must agree on slugs, labels, descriptions, and upstream
+ * URLs. Drift between the two surfaces would mean the panel ships an
+ * <img src> the proxy refuses, or vice versa — silent breakage.
+ */
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+process.env.LOCAL_API_TOKEN ??= 'test-token-imagery-parity';
+
+import { SOLAR_IMAGERY_CATALOG as SIDECAR_CATALOG } from '../local-api-server.mjs';
+import { SOLAR_IMAGERY_CATALOG as RENDERER_CATALOG } from '../../../src/services/spaceweather/solar-imagery.ts';
+
+test('catalog parity: identical entry count', () => {
+  assert.equal(SIDECAR_CATALOG.length, RENDERER_CATALOG.length);
+});
+
+test('catalog parity: same slug ordering', () => {
+  const sidecar = SIDECAR_CATALOG.map((e) => e.slug);
+  const renderer = RENDERER_CATALOG.map((e) => e.slug);
+  assert.deepEqual(sidecar, renderer);
+});
+
+test('catalog parity: every entry matches on every field', () => {
+  for (const [i, sideEntry] of SIDECAR_CATALOG.entries()) {
+    const rendEntry = RENDERER_CATALOG[i];
+    assert.equal(sideEntry.slug, rendEntry.slug, `slug at index ${i}`);
+    assert.equal(sideEntry.label, rendEntry.label, `${sideEntry.slug} label`);
+    assert.equal(sideEntry.description, rendEntry.description, `${sideEntry.slug} description`);
+    assert.equal(sideEntry.upstreamUrl, rendEntry.upstreamUrl, `${sideEntry.slug} upstreamUrl`);
+  }
+});
+
+test('catalog parity: sidecar entries are frozen (no accidental mutation)', () => {
+  for (const entry of SIDECAR_CATALOG) {
+    assert.ok(Object.isFrozen(entry), `${entry.slug} should be frozen`);
+  }
+  assert.ok(Object.isFrozen(SIDECAR_CATALOG), 'top-level catalog frozen');
+});
+
+test('catalog parity: every upstream URL is on the NASA host allowlist', () => {
+  const allowed = new Set(['sdo.gsfc.nasa.gov', 'soho.nascom.nasa.gov']);
+  for (const entry of SIDECAR_CATALOG) {
+    const host = new URL(entry.upstreamUrl).hostname;
+    assert.ok(allowed.has(host), `${entry.slug} upstream host ${host}`);
+  }
+});

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -1846,6 +1846,67 @@ const SPACEWX_ALERTS_WINDOW_MS = 24 * SPACEWX_HOUR_MS;
 const SPACEWX_EARTHWARD_LON_DEG = 30;
 const SPACEWX_CACHE_TTL_MS = 5 * 60 * 1000;
 
+// Solar imagery catalog — kept in sync with
+// src/services/spaceweather/solar-imagery.ts (the renderer-side source
+// of truth). The slug allowlist is the SSRF guard for the byte proxy.
+const SOLAR_IMAGERY_TTL_MS = 15 * 60 * 1000;
+const SOLAR_IMAGERY_BYTES_TTL_MS = 15 * 60 * 1000;
+export const SOLAR_IMAGERY_CATALOG = Object.freeze([
+  Object.freeze({
+    slug: 'sdo-aia-171',
+    label: 'SDO AIA 171Å',
+    description: 'Quiet corona — coronal loops at ~600 000 K. Bright active regions and coronal holes.',
+    upstreamUrl: 'https://sdo.gsfc.nasa.gov/assets/img/latest/latest_1024_0171.jpg',
+  }),
+  Object.freeze({
+    slug: 'sdo-aia-304',
+    label: 'SDO AIA 304Å',
+    description: 'Chromosphere / transition region at ~50 000 K. Filaments, prominences, and erupting plasma.',
+    upstreamUrl: 'https://sdo.gsfc.nasa.gov/assets/img/latest/latest_1024_0304.jpg',
+  }),
+  Object.freeze({
+    slug: 'sdo-hmi-magnetogram',
+    label: 'SDO HMI Magnetogram',
+    description: 'Photospheric line-of-sight magnetic field. Sunspots and active-region polarity.',
+    upstreamUrl: 'https://sdo.gsfc.nasa.gov/assets/img/latest/latest_1024_HMIBC.jpg',
+  }),
+  Object.freeze({
+    slug: 'lasco-c2',
+    label: 'LASCO C2',
+    description: 'Coronagraph 2–6 R☉. Earliest visibility for halo CMEs after eruption.',
+    upstreamUrl: 'https://soho.nascom.nasa.gov/data/realtime/c2/1024/latest.jpg',
+  }),
+  Object.freeze({
+    slug: 'lasco-c3',
+    label: 'LASCO C3',
+    description: 'Wider coronagraph 3.5–32 R☉. Tracks CMEs once they leave C2 field.',
+    upstreamUrl: 'https://soho.nascom.nasa.gov/data/realtime/c3/1024/latest.jpg',
+  }),
+]);
+
+/** HEAD probe for an upstream solar imagery URL. Returns the
+ *  Last-Modified header (ISO-normalised when possible) and a short
+ *  upstream status string for diagnostics. Never throws — failures
+ *  surface as `{ lastModified: null, upstreamStatus: 'timeout' | ... }`. */
+async function probeUpstreamLastModified(upstreamUrl) {
+  try {
+    const resp = await fetchWithTimeout(
+      upstreamUrl,
+      { method: 'HEAD', headers: { 'User-Agent': CHROME_UA } },
+      8_000,
+    );
+    if (!resp.ok) return { lastModified: null, upstreamStatus: `http_${resp.status}` };
+    const raw = resp.headers.get('last-modified');
+    if (!raw) return { lastModified: null, upstreamStatus: 'ok' };
+    const ms = Date.parse(raw);
+    if (!Number.isFinite(ms)) return { lastModified: raw, upstreamStatus: 'ok' };
+    return { lastModified: new Date(ms).toISOString(), upstreamStatus: 'ok' };
+  } catch (error) {
+    const reason = error?.name === 'AbortError' ? 'timeout' : 'error';
+    return { lastModified: null, upstreamStatus: reason };
+  }
+}
+
 let spacewxStatusCache = null;
 let spacewxStatusCachedAt = 0;
 let spacewxAlertsCache = null;
@@ -5866,6 +5927,76 @@ async function dispatch(requestUrl, req, routes, context) {
   if (requestUrl.pathname === '/api/spaceweather/alerts') {
     const alerts = await fetchSpaceweatherAlertsSidecar();
     return json({ alerts, asOf: new Date().toISOString() });
+  }
+
+  // ── Solar imagery catalog (metadata) — mirrors
+  //    src/services/spaceweather/solar-imagery.ts ────────────────────────
+  if (requestUrl.pathname === '/api/spaceweather/imagery') {
+    const cached = getCached('spaceweather-imagery', SOLAR_IMAGERY_TTL_MS);
+    if (cached) return json(cached);
+    const images = await Promise.all(
+      SOLAR_IMAGERY_CATALOG.map(async (entry) => {
+        const probe = await probeUpstreamLastModified(entry.upstreamUrl);
+        return {
+          slug: entry.slug,
+          label: entry.label,
+          description: entry.description,
+          proxyUrl: `/api/spaceweather/imagery/${entry.slug}.jpg`,
+          lastModified: probe.lastModified,
+          upstreamStatus: probe.upstreamStatus,
+        };
+      }),
+    );
+    const response = { asOf: new Date().toISOString(), images };
+    setCached('spaceweather-imagery', response, SOLAR_IMAGERY_TTL_MS);
+    return json(response);
+  }
+
+  // ── Solar imagery proxy (bytes) ────────────────────────────────────────
+  // Streams a NASA JPEG through the sidecar so the renderer never hits
+  // NASA directly (consistent caching, CORS-safe). Slug is matched against
+  // a static allowlist; any other path falls through to 404.
+  if (requestUrl.pathname.startsWith('/api/spaceweather/imagery/')) {
+    const tail = requestUrl.pathname.slice('/api/spaceweather/imagery/'.length);
+    const slug = tail.endsWith('.jpg') ? tail.slice(0, -'.jpg'.length) : null;
+    const entry = slug ? SOLAR_IMAGERY_CATALOG.find((e) => e.slug === slug) : null;
+    if (!entry) return json({ error: 'unknown solar imagery slug' }, 404);
+    const cacheKey = `spaceweather-imagery-bytes:${entry.slug}`;
+    const cachedBytes = getCached(cacheKey, SOLAR_IMAGERY_BYTES_TTL_MS);
+    if (cachedBytes) {
+      return new Response(cachedBytes.body, {
+        status: 200,
+        headers: {
+          'content-type': 'image/jpeg',
+          'cache-control': `public, max-age=${Math.floor(SOLAR_IMAGERY_BYTES_TTL_MS / 1000)}`,
+          ...(cachedBytes.lastModified && { 'last-modified': cachedBytes.lastModified }),
+        },
+      });
+    }
+    try {
+      const upstream = await fetchWithTimeout(
+        entry.upstreamUrl,
+        { headers: { Accept: 'image/jpeg, image/*', 'User-Agent': CHROME_UA } },
+        20_000,
+      );
+      if (!upstream.ok) {
+        return json({ error: `upstream ${upstream.status} for ${entry.slug}` }, 502);
+      }
+      const buffer = await upstream.arrayBuffer();
+      const lastModified = upstream.headers.get('last-modified') ?? null;
+      const body = new Uint8Array(buffer);
+      setCached(cacheKey, { body, lastModified }, SOLAR_IMAGERY_BYTES_TTL_MS);
+      return new Response(body, {
+        status: 200,
+        headers: {
+          'content-type': 'image/jpeg',
+          'cache-control': `public, max-age=${Math.floor(SOLAR_IMAGERY_BYTES_TTL_MS / 1000)}`,
+          ...(lastModified && { 'last-modified': lastModified }),
+        },
+      });
+    } catch (error) {
+      return json({ error: `imagery proxy fetch error: ${error.message ?? error}` }, 502);
+    }
   }
 
   // ── Air Quality proxy (Open-Meteo, no API key, forwards lat/lon) ──────────

--- a/src/components/SpaceWeatherPanel.ts
+++ b/src/components/SpaceWeatherPanel.ts
@@ -6,6 +6,13 @@ import type {
   SpaceWxAlert,
   EarthwardCme,
 } from '@/services/spaceweather/swpc-monitor';
+import {
+  buildDefaultImageryResponse,
+  formatLastUpdated,
+  isSolarImageryResponse,
+  type SolarImageryResponse,
+  type SolarImageryStatus,
+} from '@/services/spaceweather/solar-imagery';
 import { escapeHtml } from '@/utils/sanitize';
 import { t } from '@/services/i18n';
 import { getApiBaseUrl } from '@/services/runtime';
@@ -22,6 +29,9 @@ import {
 } from './space-weather-helpers';
 
 const STATUS_REFRESH_MS = 5 * 60 * 1000;
+const IMAGERY_REFRESH_MS = 15 * 60 * 1000;
+
+type Tab = 'status' | 'imagery';
 
 interface AlertsResponse {
   alerts?: SpaceWxAlert[];
@@ -34,6 +44,12 @@ export class SpaceWeatherPanel extends Panel {
   private statusFetchedAt: number | null = null;
   private statusFetchError: string | null = null;
   private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  private activeTab: Tab = 'status';
+  private imagery: SolarImageryResponse = buildDefaultImageryResponse(new Date(0).toISOString());
+  private imageryFetchedAt: number | null = null;
+  private imageryFetchError: string | null = null;
+  private imageryTimer: ReturnType<typeof setInterval> | null = null;
+  private modalEl: HTMLDivElement | null = null;
 
   constructor() {
     super({
@@ -42,11 +58,42 @@ export class SpaceWeatherPanel extends Panel {
       showCount: true,
       trackActivity: true,
       infoTooltip:
-        'NOAA SWPC: X-ray flare class, geomagnetic Kp + G0–G5 storm level, aurora visibility, GPS / HF disruption risk, earthward CMEs.',
+        'NOAA SWPC: X-ray flare class, geomagnetic Kp + G0–G5 storm level, aurora visibility, GPS / HF disruption risk, earthward CMEs. Solar Imagery tab: live SDO + LASCO from NASA.',
     });
     this.showLoading('Fetching NOAA space weather...');
     queueMicrotask(() => { void this.refreshStatus(); });
     this.refreshTimer = setInterval(() => void this.refreshStatus(), STATUS_REFRESH_MS);
+    // Single delegated click handler so we don't fight the setContent
+    // debounce when wiring tab / imagery buttons.
+    this.getContentElement().addEventListener('click', (event) => this.onContentClick(event));
+  }
+
+  private onContentClick(event: MouseEvent): void {
+    const target = event.target as Element | null;
+    if (!target) return;
+    const tabBtn = target.closest<HTMLElement>('.sw-tab[data-sw-tab]');
+    if (tabBtn) {
+      const next = tabBtn.dataset.swTab as Tab | undefined;
+      if (!next || next === this.activeTab) return;
+      this.activeTab = next;
+      this.render();
+      if (next === 'imagery') {
+        void this.refreshImagery();
+        this.imageryTimer ??= setInterval(() => void this.refreshImagery(), IMAGERY_REFRESH_MS);
+      }
+      return;
+    }
+    const refreshBtn = target.closest<HTMLElement>('[data-sw-imagery-refresh]');
+    if (refreshBtn) {
+      void this.refreshImagery();
+      return;
+    }
+    const openBtn = target.closest<HTMLElement>('[data-sw-imagery-open]');
+    if (openBtn) {
+      const slug = openBtn.dataset.swImageryOpen;
+      const img = slug ? this.imagery.images.find((i) => i.slug === slug) : null;
+      if (img) this.openModal(img);
+    }
   }
 
   public update(data: SpaceWeatherData): void {
@@ -59,6 +106,11 @@ export class SpaceWeatherPanel extends Panel {
       clearInterval(this.refreshTimer);
       this.refreshTimer = null;
     }
+    if (this.imageryTimer) {
+      clearInterval(this.imageryTimer);
+      this.imageryTimer = null;
+    }
+    this.closeModal();
     super.destroy();
   }
 
@@ -99,18 +151,28 @@ export class SpaceWeatherPanel extends Panel {
 
   private render(): void {
     this.setCount(this.computeBadgeCount());
-    if (!this.data && !this.status) {
+    if (!this.data && !this.status && this.activeTab === 'status') {
       this.setContent('<div class="panel-empty">Space weather data unavailable.</div>');
       return;
     }
-    const sections = [
+    const tabBar = `<div class="sw-tabs" role="tablist">
+      <button class="sw-tab${this.activeTab === 'status' ? ' sw-tab--active' : ''}"
+        role="tab" data-sw-tab="status" type="button">Status</button>
+      <button class="sw-tab${this.activeTab === 'imagery' ? ' sw-tab--active' : ''}"
+        role="tab" data-sw-tab="imagery" type="button">Solar Imagery</button>
+    </div>`;
+    const body = this.activeTab === 'imagery' ? this.renderImagery() : this.renderStatus();
+    this.setContent(`<div class="sw-panel-content">${tabBar}${body}</div>`);
+  }
+
+  private renderStatus(): string {
+    return [
       this.renderHeadlineGrid(),
       this.renderAuroraStrip(),
       this.renderEarthwardCmes(),
       this.renderAlerts(),
       this.renderFooter(),
     ].filter((s) => s.length > 0).join('');
-    this.setContent(`<div class="sw-panel-content">${sections}</div>`);
   }
 
   // ── Headline metrics ──────────────────────────────────────────────────
@@ -252,5 +314,126 @@ export class SpaceWeatherPanel extends Panel {
       <span class="fires-updated">Updated ${escapeHtml(ageStr)}${errBadge}</span>
     </div>`;
   }
+
+  // ── Solar Imagery tab ──────────────────────────────────────────────────
+
+  private renderImagery(): string {
+    const now = Date.now();
+    const cards = this.imagery.images.map((img) => this.renderImageryCard(img, now)).join('');
+    const sourceFooter = this.imageryFetchError
+      ? `<span style="color:#ff9800;">⚠ ${escapeHtml(this.imageryFetchError)}</span>`
+      : `<span class="fires-source">NASA SDO · SOHO/LASCO</span>`;
+    const fetchedLabel = this.imageryFetchedAt
+      ? timeAgo(new Date(this.imageryFetchedAt))
+      : 'never';
+    return `<div class="sw-imagery">
+      <div class="sw-imagery-toolbar">
+        <button type="button" class="sw-imagery-refresh" data-sw-imagery-refresh>
+          ↻ Refresh imagery
+        </button>
+        <span class="sw-imagery-meta">Catalog fetched ${escapeHtml(fetchedLabel)}</span>
+      </div>
+      <div class="sw-imagery-grid">${cards}</div>
+      <div class="fires-footer">
+        ${sourceFooter}
+        <span class="fires-updated">Auto-refresh every 15 min</span>
+      </div>
+    </div>`;
+  }
+
+  private renderImageryCard(image: SolarImageryStatus, nowMs: number): string {
+    const lastModMs = image.lastModified ? Date.parse(image.lastModified) : null;
+    const ageLabel = formatLastUpdated(
+      lastModMs !== null && Number.isFinite(lastModMs) ? lastModMs : null,
+      nowMs,
+    );
+    const upstreamWarn = image.upstreamStatus !== 'ok' && image.upstreamStatus !== 'unknown'
+      ? `<span class="sw-imagery-warn" title="upstream ${escapeHtml(image.upstreamStatus)}">⚠</span>`
+      : '';
+    const base = getApiBaseUrl();
+    const src = `${base}${image.proxyUrl}`;
+    return `<figure class="sw-imagery-card" data-sw-imagery-slug="${escapeHtml(image.slug)}">
+      <button type="button" class="sw-imagery-img-btn"
+        data-sw-imagery-open="${escapeHtml(image.slug)}"
+        aria-label="Open ${escapeHtml(image.label)} full size">
+        <img class="sw-imagery-img" src="${escapeHtml(src)}"
+          alt="${escapeHtml(image.label)} — ${escapeHtml(image.description)}"
+          loading="lazy" />
+      </button>
+      <figcaption class="sw-imagery-cap">
+        <div class="sw-imagery-label">${escapeHtml(image.label)} ${upstreamWarn}</div>
+        <div class="sw-imagery-desc">${escapeHtml(image.description)}</div>
+        <div class="sw-imagery-time">${escapeHtml(ageLabel)}</div>
+      </figcaption>
+    </figure>`;
+  }
+
+  private async refreshImagery(): Promise<void> {
+    try {
+      const base = getApiBaseUrl();
+      const resp = await fetch(`${base}/api/spaceweather/imagery`, {
+        headers: { Accept: 'application/json' },
+      });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const body: unknown = await resp.json();
+      if (!isSolarImageryResponse(body)) throw new Error('malformed imagery payload');
+      this.imagery = body;
+      this.imageryFetchedAt = Date.now();
+      this.imageryFetchError = null;
+    } catch (error) {
+      this.imageryFetchError = error instanceof Error ? error.message : String(error);
+    }
+    if (this.activeTab === 'imagery') this.render();
+  }
+
+  private openModal(image: SolarImageryStatus): void {
+    this.closeModal();
+    const modal = document.createElement('div');
+    modal.className = 'sw-imagery-modal';
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-label', `${image.label} full size`);
+
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'sw-imagery-modal-close';
+    closeBtn.setAttribute('aria-label', 'Close');
+    closeBtn.textContent = '×';
+
+    const figure = document.createElement('figure');
+    figure.className = 'sw-imagery-modal-figure';
+
+    const img = document.createElement('img');
+    img.src = `${getApiBaseUrl()}${image.proxyUrl}`;
+    img.alt = image.label;
+
+    const caption = document.createElement('figcaption');
+    caption.textContent = `${image.label} — ${image.description}`;
+
+    figure.append(img, caption);
+    modal.append(closeBtn, figure);
+
+    modal.addEventListener('click', (event) => {
+      if (event.target === modal || event.target === closeBtn) this.closeModal();
+    });
+
+    document.body.append(modal);
+    this.modalEl = modal;
+
+    const onEsc = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        this.closeModal();
+        document.removeEventListener('keydown', onEsc);
+      }
+    };
+    document.addEventListener('keydown', onEsc);
+  }
+
+  private closeModal(): void {
+    if (this.modalEl) {
+      this.modalEl.remove();
+      this.modalEl = null;
+    }
+  }
+
 }
 

--- a/src/services/spaceweather/__tests__/solar-imagery.test.mts
+++ b/src/services/spaceweather/__tests__/solar-imagery.test.mts
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  SOLAR_IMAGERY_CATALOG,
+  buildDefaultImageryResponse,
+  findSolarImageryEntry,
+  formatLastUpdated,
+  isSolarImagerySlug,
+  isSolarImageryResponse,
+  proxyPathForSlug,
+  type SolarImageryStatus,
+} from '../solar-imagery.ts';
+
+// ── Catalog shape ─────────────────────────────────────────────────────
+
+test('catalog: has the five required wavelengths/instruments', () => {
+  const slugs = SOLAR_IMAGERY_CATALOG.map((e) => e.slug).sort();
+  assert.deepEqual(slugs, [
+    'lasco-c2',
+    'lasco-c3',
+    'sdo-aia-171',
+    'sdo-aia-304',
+    'sdo-hmi-magnetogram',
+  ]);
+});
+
+test('catalog: every entry has a non-empty label, description, and https upstream URL', () => {
+  for (const entry of SOLAR_IMAGERY_CATALOG) {
+    assert.ok(entry.label.length > 0, `${entry.slug} label`);
+    assert.ok(entry.description.length > 0, `${entry.slug} description`);
+    assert.ok(/^https:\/\//.test(entry.upstreamUrl), `${entry.slug} upstream is https`);
+  }
+});
+
+test('catalog: upstream URLs only point at NASA hosts (SSRF guard)', () => {
+  const allowed = new Set(['sdo.gsfc.nasa.gov', 'soho.nascom.nasa.gov']);
+  for (const entry of SOLAR_IMAGERY_CATALOG) {
+    const host = new URL(entry.upstreamUrl).hostname;
+    assert.ok(allowed.has(host), `${entry.slug} host ${host} not in allowlist`);
+  }
+});
+
+// ── Slug validation ───────────────────────────────────────────────────
+
+test('isSolarImagerySlug: accepts every catalog slug', () => {
+  for (const e of SOLAR_IMAGERY_CATALOG) assert.equal(isSolarImagerySlug(e.slug), true);
+});
+
+test('isSolarImagerySlug: rejects unknown / non-string input', () => {
+  assert.equal(isSolarImagerySlug('not-a-slug'), false);
+  assert.equal(isSolarImagerySlug(''), false);
+  assert.equal(isSolarImagerySlug(null), false);
+  assert.equal(isSolarImagerySlug(undefined), false);
+  assert.equal(isSolarImagerySlug(42), false);
+  // Path-traversal probe — must be rejected by the validator before
+  // it is ever concatenated into a sidecar fetch URL.
+  assert.equal(isSolarImagerySlug('../etc/passwd'), false);
+});
+
+test('findSolarImageryEntry: returns the entry by slug, null when missing', () => {
+  assert.equal(findSolarImageryEntry('sdo-aia-171')?.label, 'SDO AIA 171Å');
+  assert.equal(findSolarImageryEntry('does-not-exist'), null);
+});
+
+// ── Proxy path ────────────────────────────────────────────────────────
+
+test('proxyPathForSlug: returns a sidecar-relative path for every slug', () => {
+  for (const e of SOLAR_IMAGERY_CATALOG) {
+    const path = proxyPathForSlug(e.slug);
+    assert.ok(path.startsWith('/api/spaceweather/imagery/'));
+    assert.ok(path.endsWith('.jpg'));
+    assert.ok(path.includes(e.slug));
+  }
+});
+
+// ── formatLastUpdated ─────────────────────────────────────────────────
+
+test('formatLastUpdated: null timestamp falls back to "unknown"', () => {
+  assert.equal(formatLastUpdated(null, 1_745_000_000_000), 'updated time unknown');
+});
+
+test('formatLastUpdated: <30 s reads as "just now"', () => {
+  const now = 1_745_000_000_000;
+  assert.equal(formatLastUpdated(now - 5_000, now), 'updated just now');
+  assert.equal(formatLastUpdated(now - 29_000, now), 'updated just now');
+});
+
+test('formatLastUpdated: minutes and hours bucket correctly', () => {
+  const now = 1_745_000_000_000;
+  assert.equal(formatLastUpdated(now - 60_000, now), 'updated 1 min ago');
+  assert.equal(formatLastUpdated(now - 14 * 60_000, now), 'updated 14 min ago');
+  assert.equal(formatLastUpdated(now - 60 * 60_000, now), 'updated 1 hr ago');
+  assert.equal(formatLastUpdated(now - 5 * 60 * 60_000, now), 'updated 5 hr ago');
+});
+
+test('formatLastUpdated: clock skew (negative delta) reads as "just now"', () => {
+  const now = 1_745_000_000_000;
+  assert.equal(formatLastUpdated(now + 60_000, now), 'updated just now');
+});
+
+test('formatLastUpdated: days threshold', () => {
+  const now = 1_745_000_000_000;
+  assert.equal(formatLastUpdated(now - 24 * 60 * 60_000, now), 'updated 1 day ago');
+  assert.equal(formatLastUpdated(now - 3 * 24 * 60 * 60_000, now), 'updated 3 days ago');
+});
+
+// ── Response shape validator ──────────────────────────────────────────
+
+test('isSolarImageryResponse: accepts a well-formed response', () => {
+  const response = buildDefaultImageryResponse(new Date(1_745_000_000_000).toISOString());
+  assert.equal(isSolarImageryResponse(response), true);
+});
+
+test('isSolarImageryResponse: rejects malformed payloads', () => {
+  assert.equal(isSolarImageryResponse(null), false);
+  assert.equal(isSolarImageryResponse({}), false);
+  assert.equal(isSolarImageryResponse({ asOf: '2026-05-08', images: 'not-array' }), false);
+  // bad slug inside an entry
+  const bad = buildDefaultImageryResponse('2026-05-08T00:00:00Z');
+  (bad.images[0] as unknown as { slug: string }).slug = 'invented';
+  assert.equal(isSolarImageryResponse(bad), false);
+});
+
+test('buildDefaultImageryResponse: every image starts with null lastModified + unknown status', () => {
+  const r = buildDefaultImageryResponse('2026-05-08T00:00:00Z');
+  assert.equal(r.images.length, SOLAR_IMAGERY_CATALOG.length);
+  for (const img of r.images) {
+    assert.equal(img.lastModified, null);
+    assert.equal(img.upstreamStatus, 'unknown');
+    assert.ok(img.proxyUrl.startsWith('/api/spaceweather/imagery/'));
+  }
+});
+
+test('buildDefaultImageryResponse: round-trips through JSON', () => {
+  const r = buildDefaultImageryResponse('2026-05-08T00:00:00Z');
+  const round = JSON.parse(JSON.stringify(r)) as unknown;
+  assert.equal(isSolarImageryResponse(round), true);
+});
+
+// ── Status type smoke (catches accidental drift) ──────────────────────
+
+test('SolarImageryStatus: width matches the catalog (no extra/missing fields)', () => {
+  const r = buildDefaultImageryResponse('2026-05-08T00:00:00Z');
+  const sample: SolarImageryStatus = r.images[0]!;
+  const keys = Object.keys(sample).sort();
+  assert.deepEqual(keys, [
+    'description',
+    'label',
+    'lastModified',
+    'proxyUrl',
+    'slug',
+    'upstreamStatus',
+  ]);
+});

--- a/src/services/spaceweather/solar-imagery.ts
+++ b/src/services/spaceweather/solar-imagery.ts
@@ -1,0 +1,174 @@
+/**
+ * Solar imagery catalog — pure helper module shared by the renderer
+ * (SpaceWeatherPanel) and the sidecar (`/api/spaceweather/imagery`).
+ *
+ * NASA serves these JPEGs publicly without an API key. Both the
+ * upstream URLs and the sidecar proxy paths live here so the two
+ * surfaces cannot disagree on the allowlist, and a refactor to the
+ * catalog lands in one place.
+ *
+ * Pure deterministic. No DOM, no fetch, no globals at import time.
+ */
+
+export type SolarImagerySlug =
+  | 'sdo-aia-171'
+  | 'sdo-aia-304'
+  | 'sdo-hmi-magnetogram'
+  | 'lasco-c2'
+  | 'lasco-c3';
+
+export interface SolarImageryEntry {
+  /** URL-safe identifier used in sidecar paths and DOM ids. */
+  slug: SolarImagerySlug;
+  /** Short label for the UI (instrument + wavelength). */
+  label: string;
+  /** One-line description of what the image shows. */
+  description: string;
+  /** Upstream NASA URL. The sidecar proxy fetches this. */
+  upstreamUrl: string;
+}
+
+export interface SolarImageryStatus {
+  slug: SolarImagerySlug;
+  label: string;
+  description: string;
+  /** Sidecar-relative proxy URL (`/api/spaceweather/imagery/{slug}.jpg`).
+   *  The renderer renders <img src> from this so the browser never
+   *  hits NASA directly — caching is consistent and CORS is bypassed. */
+  proxyUrl: string;
+  /** ISO timestamp of the upstream Last-Modified header, or null when
+   *  the sidecar HEAD probe failed / upstream is silent. */
+  lastModified: string | null;
+  /** Free-form upstream status note for diagnostics ('ok', '404',
+   *  'timeout', ...). Surfaced in the panel only when not-ok. */
+  upstreamStatus: string;
+}
+
+export interface SolarImageryResponse {
+  /** ISO timestamp the response was assembled. */
+  asOf: string;
+  images: SolarImageryStatus[];
+}
+
+/** The full image catalog. Order is the rendering order in the panel. */
+export const SOLAR_IMAGERY_CATALOG: readonly SolarImageryEntry[] = [
+  {
+    slug: 'sdo-aia-171',
+    label: 'SDO AIA 171Å',
+    description: 'Quiet corona — coronal loops at ~600 000 K. Bright active regions and coronal holes.',
+    upstreamUrl: 'https://sdo.gsfc.nasa.gov/assets/img/latest/latest_1024_0171.jpg',
+  },
+  {
+    slug: 'sdo-aia-304',
+    label: 'SDO AIA 304Å',
+    description: 'Chromosphere / transition region at ~50 000 K. Filaments, prominences, and erupting plasma.',
+    upstreamUrl: 'https://sdo.gsfc.nasa.gov/assets/img/latest/latest_1024_0304.jpg',
+  },
+  {
+    slug: 'sdo-hmi-magnetogram',
+    label: 'SDO HMI Magnetogram',
+    description: 'Photospheric line-of-sight magnetic field. Sunspots and active-region polarity.',
+    upstreamUrl: 'https://sdo.gsfc.nasa.gov/assets/img/latest/latest_1024_HMIBC.jpg',
+  },
+  {
+    slug: 'lasco-c2',
+    label: 'LASCO C2',
+    description: 'Coronagraph 2–6 R☉. Earliest visibility for halo CMEs after eruption.',
+    upstreamUrl: 'https://soho.nascom.nasa.gov/data/realtime/c2/1024/latest.jpg',
+  },
+  {
+    slug: 'lasco-c3',
+    label: 'LASCO C3',
+    description: 'Wider coronagraph 3.5–32 R☉. Tracks CMEs once they leave C2 field.',
+    upstreamUrl: 'https://soho.nascom.nasa.gov/data/realtime/c3/1024/latest.jpg',
+  },
+];
+
+const VALID_SLUGS = new Set<string>(SOLAR_IMAGERY_CATALOG.map((e) => e.slug));
+
+/** True when `s` is a known catalog slug. Use this for sidecar input
+ *  validation so the proxy can never be coerced into fetching an
+ *  arbitrary URL (SSRF defense). */
+export function isSolarImagerySlug(s: unknown): s is SolarImagerySlug {
+  return typeof s === 'string' && VALID_SLUGS.has(s);
+}
+
+/** Look up a catalog entry by slug, or null when unknown. */
+export function findSolarImageryEntry(slug: string): SolarImageryEntry | null {
+  return SOLAR_IMAGERY_CATALOG.find((e) => e.slug === slug) ?? null;
+}
+
+/** Sidecar proxy path for `slug`. The route is bytes-stable across
+ *  reloads — workbox / SW caching can use it as a stable key. */
+export function proxyPathForSlug(slug: SolarImagerySlug): string {
+  return `/api/spaceweather/imagery/${slug}.jpg`;
+}
+
+/**
+ * Format "Last updated X ago" for the panel. Returns 'just now' when
+ * `nowMs - lastModifiedMs < 30 s`, then minutes / hours / days. Pure
+ * function — caller supplies `now` for deterministic tests.
+ */
+export function formatLastUpdated(
+  lastModifiedMs: number | null,
+  nowMs: number,
+): string {
+  if (lastModifiedMs === null || !Number.isFinite(lastModifiedMs)) {
+    return 'updated time unknown';
+  }
+  const deltaMs = nowMs - lastModifiedMs;
+  if (deltaMs < 0) return 'updated just now';
+  if (deltaMs < 30_000) return 'updated just now';
+  const minutes = Math.floor(deltaMs / 60_000);
+  if (minutes < 1) return 'updated <1 min ago';
+  if (minutes === 1) return 'updated 1 min ago';
+  if (minutes < 60) return `updated ${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours === 1) return 'updated 1 hr ago';
+  if (hours < 24) return `updated ${hours} hr ago`;
+  const days = Math.floor(hours / 24);
+  return days === 1 ? 'updated 1 day ago' : `updated ${days} days ago`;
+}
+
+/**
+ * Validate a SolarImageryResponse shape (used by both the panel and
+ * sidecar parity tests to make sure the wire format does not drift).
+ */
+export function isSolarImageryResponse(x: unknown): x is SolarImageryResponse {
+  if (!x || typeof x !== 'object') return false;
+  const obj = x as Record<string, unknown>;
+  if (typeof obj.asOf !== 'string') return false;
+  const images = obj.images;
+  if (!Array.isArray(images)) return false;
+  return images.every((img) => isSolarImageryStatus(img));
+}
+
+function isSolarImageryStatus(x: unknown): x is SolarImageryStatus {
+  if (!x || typeof x !== 'object') return false;
+  const obj = x as Record<string, unknown>;
+  return (
+    isSolarImagerySlug(obj.slug)
+    && typeof obj.label === 'string'
+    && typeof obj.description === 'string'
+    && typeof obj.proxyUrl === 'string'
+    && (obj.lastModified === null || typeof obj.lastModified === 'string')
+    && typeof obj.upstreamStatus === 'string'
+  );
+}
+
+/** Build a default-status response (used when the renderer can't
+ *  reach the sidecar — every image still renders, just without a
+ *  fresh-time stamp). */
+export function buildDefaultImageryResponse(nowIso: string): SolarImageryResponse {
+  return {
+    asOf: nowIso,
+    images: SOLAR_IMAGERY_CATALOG.map((e) => ({
+      slug: e.slug,
+      label: e.label,
+      description: e.description,
+      proxyUrl: proxyPathForSlug(e.slug),
+      lastModified: null,
+      upstreamStatus: 'unknown',
+    })),
+  };
+}

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -317,6 +317,30 @@
 .sw-alert-msg { flex: 1; font-size: 10px; color: var(--text-secondary); line-height: 1.35; }
 .sw-alert-age { font-size: 9px; color: var(--text-muted); white-space: nowrap; padding-top: 1px; }
 .sw-footer { display: flex; justify-content: space-between; padding: 8px 0 0; color: var(--text-faint); font-size: 10px; }
+.sw-tabs { display: flex; gap: 4px; border-bottom: 1px solid var(--border); margin-bottom: 8px; }
+.sw-tab { background: transparent; border: 0; color: var(--text-muted); padding: 6px 10px; font-size: 11px; cursor: pointer; border-bottom: 2px solid transparent; }
+.sw-tab:hover { color: var(--text-secondary); }
+.sw-tab--active { color: var(--text-primary); border-bottom-color: var(--accent); }
+.sw-imagery { display: flex; flex-direction: column; gap: 8px; }
+.sw-imagery-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.sw-imagery-refresh { background: var(--overlay-subtle); border: 1px solid var(--border); color: var(--text-secondary); padding: 4px 8px; border-radius: 4px; font-size: 11px; cursor: pointer; }
+.sw-imagery-refresh:hover { background: var(--overlay-strong); }
+.sw-imagery-meta { font-size: 10px; color: var(--text-muted); }
+.sw-imagery-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; }
+.sw-imagery-card { margin: 0; background: var(--overlay-subtle); border: 1px solid var(--border); border-radius: 4px; overflow: hidden; }
+.sw-imagery-img-btn { display: block; width: 100%; padding: 0; border: 0; background: #000; cursor: zoom-in; }
+.sw-imagery-img { width: 100%; height: auto; display: block; aspect-ratio: 1 / 1; object-fit: cover; }
+.sw-imagery-cap { padding: 6px 8px; }
+.sw-imagery-label { font-size: 11px; font-weight: 600; color: var(--text-primary); display: flex; align-items: center; gap: 4px; }
+.sw-imagery-warn { color: var(--semantic-warning, #ff9f0a); font-size: 10px; }
+.sw-imagery-desc { font-size: 10px; color: var(--text-muted); margin-top: 2px; line-height: 1.3; }
+.sw-imagery-time { font-size: 9px; color: var(--text-faint); margin-top: 4px; font-variant-numeric: tabular-nums; }
+.sw-imagery-modal { position: fixed; inset: 0; background: rgba(0, 0, 0, 0.85); z-index: 9999; display: flex; align-items: center; justify-content: center; padding: 24px; cursor: zoom-out; }
+.sw-imagery-modal-figure { margin: 0; max-width: 100%; max-height: 100%; display: flex; flex-direction: column; align-items: center; gap: 8px; cursor: default; }
+.sw-imagery-modal-figure img { max-width: 100%; max-height: calc(100vh - 120px); object-fit: contain; box-shadow: 0 4px 32px rgba(0, 0, 0, 0.6); }
+.sw-imagery-modal-figure figcaption { color: var(--text-primary); font-size: 12px; text-align: center; }
+.sw-imagery-modal-close { position: absolute; top: 12px; right: 16px; background: transparent; border: 0; color: #fff; font-size: 32px; cursor: pointer; line-height: 1; }
+.sw-imagery-modal-close:hover { color: var(--accent); }
 .sw-footer a { color: var(--accent); text-decoration: none; }
 .sw-footer a:hover { text-decoration: underline; }
 .sw-aurora-strip { margin: 8px 0; padding: 8px 10px; background: var(--overlay-subtle); border: 1px solid var(--border); border-radius: 4px; }


### PR DESCRIPTION
## Summary
Adds a **Solar Imagery** tab to the existing SpaceWeatherPanel that shows five live NASA images and refreshes them every 15 minutes:

- **SDO AIA 171Å** — quiet corona, coronal loops at ~600 000 K
- **SDO AIA 304Å** — chromosphere, filaments and erupting plasma
- **SDO HMI Magnetogram** — photospheric magnetic field, sunspots
- **SOHO/LASCO C2** — coronagraph 2–6 R☉, earliest CME visibility
- **SOHO/LASCO C3** — wider coronagraph 3.5–32 R☉, tracks CMEs as they leave C2

Each card carries a per-image `updated X min ago` timestamp populated from the upstream `Last-Modified` header. Clicking opens the image full-size in a modal (Esc / click-outside / × all close).

## Architecture

- `src/services/spaceweather/solar-imagery.ts` — pure helper module (catalog + slug validator + age formatter + response shape validator). Renderer-side source of truth.
- `/api/spaceweather/imagery` — sidecar metadata route. HEAD-probes every upstream URL and returns the proxy URL + `lastModified` for each image. 15 min cache.
- `/api/spaceweather/imagery/{slug}.jpg` — sidecar byte proxy. **SSRF guard**: the slug must match the static catalog allowlist; bogus slugs and path-traversal probes (`../etc/passwd`) return 404 cleanly.
- Sidecar parity test (`spaceweather-imagery-parity.test.mjs`) freezes both catalogs and asserts they cannot drift on slugs, labels, descriptions, or upstream URLs.

## UX details

- The imagery refresh timer only starts once the user opens the tab — no background bandwidth on the Status tab.
- Tab + button clicks routed through a single delegated listener on the panel root, so `setContent`'s 150 ms debounce can't strand the new buttons.
- Modal built with `document.createElement` — never `innerHTML` on image-supplied fields.
- Manual refresh button on the toolbar.

## Tests

- **17** unit tests for the helper module (catalog shape, NASA-host allowlist, slug validation incl. path-traversal probe, time formatter buckets, response-shape validator).
- **5** sidecar parity tests (entry count, slug ordering, per-field equality, frozen entries, host allowlist).
- `test:spaceweather` wired up.

## Verification

- `npm run typecheck:all` → clean.
- `npm run test:spaceweather` → all green.
- Sidecar smoke-tested live against real NASA: HEAD probes returned `upstreamStatus: ok` with valid `Last-Modified` headers; `/api/spaceweather/imagery/not-a-real-slug.jpg` and `/api/spaceweather/imagery/..%2Fetc%2Fpasswd.jpg` both returned **404**.
- ⚠ The Vite dev server in this worktree is currently broken by a pre-existing `@deck.gl/geo-layers` → `@luma.gl/gltf` version mismatch (missing `DynamicTexture` / `MaterialFactory` exports). This blocks visual preview but is unrelated to this change. CSS + DOM construction follows the existing tabbed-panel pattern (DiseaseIntelPanel) exactly, so the live render should be straightforward — happy to add a screenshot in a follow-up once the dep issue is fixed.

## Out of scope

- Full image archives / time-lapse playback (NASA's Helioviewer is the right tool for that).
- Embedding LASCO running-difference movies (the `*latest.jpg` endpoints are static frames).
- Service-worker caching of the proxy bytes — current cache is in-memory only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Cross-agent review: claude reviewed on 2026-05-08; outcome: pass
