### PR TITLE
feat(sanctions): OFAC SDN parser, cache, panel + AIS cross-reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "test:playback": "tsx --test src/services/playback/__tests__/timeline-cursor.test.mts",
     "test:globe": "tsx --test src/services/globe/__tests__/heatmap-layers.test.mts",
     "test:adsb": "tsx --test src/services/adsb/__tests__/adsb-aggregate.test.mts",
+    "test:sanctions": "tsx --test src/services/sanctions/__tests__/ofac.test.mts",
     "test:synthesis": "tsx --test src/services/synthesis/__tests__/signal-watch.test.mts",
     "test:bio": "tsx --test src/services/biosurveillance/__tests__/cdc-ari.test.mts",
     "test:macro": "tsx --test src/services/economic/__tests__/macro-stress.test.mts src/services/cyber/__tests__/ransomware-mentions.test.mts",

--- a/src-tauri/sidecar/__tests__/ofac-cache.test.mjs
+++ b/src-tauri/sidecar/__tests__/ofac-cache.test.mjs
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseSdnXml, normalizeVesselName, normalizeImo } from '../ofac-cache.mjs';
+
+const FIXTURE = `<?xml version="1.0"?>
+<sdnList xmlns="http://tempuri.org/sdnList.xsd">
+  <sdnEntry>
+    <uid>2001</uid>
+    <lastName>STAR PROVIDER</lastName>
+    <sdnType>Vessel</sdnType>
+    <programList><program>IRAN</program></programList>
+    <vesselInfo>
+      <callSign>9HA4321</callSign>
+      <vesselFlag>Iran</vesselFlag>
+    </vesselInfo>
+    <idList>
+      <id><uid>22</uid><idType>IMO Number</idType><idNumber>9123456</idNumber></id>
+    </idList>
+  </sdnEntry>
+</sdnList>`;
+
+test('sidecar parser produces same vessel shape as renderer parser', () => {
+  const out = parseSdnXml(FIXTURE);
+  assert.equal(out.length, 1);
+  const v = out[0];
+  assert.equal(v.uid, '2001');
+  assert.equal(v.type, 'vessel');
+  assert.equal(v.name, 'STAR PROVIDER');
+  assert.equal(v.vessel.callSign, '9HA4321');
+  assert.equal(v.vessel.vesselFlag, 'Iran');
+  assert.equal(v.vessel.imo, '9123456');
+  assert.deepEqual(v.programs, ['iran']);
+});
+
+test('sidecar normalizers behave identically to renderer-side', () => {
+  assert.equal(normalizeVesselName('M/V Star-Provider!!'), 'star provider');
+  assert.equal(normalizeImo('IMO 9123456'), '9123456');
+  assert.equal(normalizeImo('99123456'), '9123456');
+});

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { OfacCache } from './ofac-cache.mjs';
 import http, { createServer } from 'node:http';
 import { timingSafeEqual } from 'node:crypto';
 import https from 'node:https';
@@ -4374,13 +4375,72 @@ async function dispatch(requestUrl, req, routes, context) {
       Number(requestUrl.searchParams.get('maxAgeMs') || (15 * 60_000))));
     const rows = [...aisState.vessels.values()];
     const vessels = filterVesselsInRiskZonesSidecar(rows, { maxAgeMs });
+    // Cross-reference each vessel against the OFAC SDN cache. Match
+    // is opportunistic — if the cache hasn't loaded yet we just
+    // return the vessels unflagged rather than blocking on a fresh
+    // 28MB download mid-request.
+    let sanctionedCount = 0;
+    if (ofacCache.indexes) {
+      for (const v of vessels) {
+        const m = ofacCache.matchVessel({ name: v.name, imo: v.imo ?? null, callSign: v.callSign ?? null });
+        if (m.matched) {
+          v.sanctioned = true;
+          v.sanctionedReason = m.reason;
+          v.sanctionedBadge = m.badge;
+          sanctionedCount++;
+        }
+      }
+    } else {
+      // Kick off a background refresh so the next call can flag.
+      ofacCache.ensureLoaded().catch(() => {});
+    }
     const summary = summarizeVesselsSidecar(vessels);
     return json({
       vessels,
       summary,
+      sanctionedCount,
       asOf: new Date().toISOString(),
       sampleSize: rows.length,
     });
+  }
+
+  // ── OFAC SDN: search ─────────────────────────────────────────────────────
+  // GET /api/sanctions/search?q=...&type=vessel|aircraft|individual|entity&limit=50
+  if (requestUrl.pathname === '/api/sanctions/search') {
+    const q = requestUrl.searchParams.get('q') ?? '';
+    const type = requestUrl.searchParams.get('type');
+    const limit = Number.parseInt(requestUrl.searchParams.get('limit') ?? '50', 10);
+    if (!q.trim()) return json({ hits: [], meta: ofacCache.getCacheMeta() });
+    try {
+      await ofacCache.ensureLoaded();
+      const hits = ofacCache.searchSanctions(q, {
+        type: type && ['individual','vessel','aircraft','entity','unknown'].includes(type) ? type : undefined,
+        limit: Number.isFinite(limit) ? limit : 50,
+      });
+      return json({ hits, meta: ofacCache.getCacheMeta() });
+    } catch (error) {
+      return json({ hits: [], error: `sanctions-search error: ${error.message ?? error}` }, 502);
+    }
+  }
+
+  // ── OFAC SDN: all sanctioned vessels (for AIS cross-reference) ──────────
+  if (requestUrl.pathname === '/api/sanctions/vessels') {
+    try {
+      await ofacCache.ensureLoaded();
+      return json({ vessels: ofacCache.getSanctionedVessels(), meta: ofacCache.getCacheMeta() });
+    } catch (error) {
+      return json({ vessels: [], error: `sanctions-vessels error: ${error.message ?? error}` }, 502);
+    }
+  }
+
+  // ── OFAC SDN: all sanctioned aircraft ────────────────────────────────────
+  if (requestUrl.pathname === '/api/sanctions/aircraft') {
+    try {
+      await ofacCache.ensureLoaded();
+      return json({ aircraft: ofacCache.getSanctionedAircraft(), meta: ofacCache.getCacheMeta() });
+    } catch (error) {
+      return json({ aircraft: [], error: `sanctions-aircraft error: ${error.message ?? error}` }, 502);
+    }
   }
 
   // ── ThreatFox IOC feed ───────────────────────────────────────────────────
@@ -10835,6 +10895,7 @@ export async function createLocalApiServer(options = {}) {
   const context = resolveConfig(options);
   loadVerboseState(context.dataDir);
   const routes = await buildRouteTable(context.apiDir);
+  const ofacCache = new OfacCache({ dataDir: context.dataDir });
 
   const server = createServer(async (req, res) => {
  const requestUrl = new URL(req.url || '/', `http://127.0.0.1:${context.port}`);

--- a/src-tauri/sidecar/ofac-cache.mjs
+++ b/src-tauri/sidecar/ofac-cache.mjs
@@ -1,0 +1,399 @@
+/**
+ * OFAC SDN cache for the Node.js sidecar.
+ *
+ * - Reads the parsed cache from `${dataDir}/data/ofac-cache.json` on
+ *   first call.
+ * - Refreshes from https://www.treasury.gov/ofac/downloads/sdn.xml when
+ *   the cache is missing or older than 7 days.
+ * - Parses the XML in-process (no DOM dependency, just a tag-extraction
+ *   walk that mirrors the renderer-side TS in src/services/sanctions/
+ *   ofac-parser.ts — kept lean here so the sidecar boot doesn't have to
+ *   pull in the renderer toolchain).
+ * - Exposes:
+ *     getCacheMeta()
+ *     getAllEntries()
+ *     getSanctionedVessels()
+ *     getSanctionedAircraft()
+ *     searchSanctions(query, opts?)
+ *     matchVessel({ name, imo, callSign })
+ */
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const SDN_XML_URL = 'https://www.treasury.gov/ofac/downloads/sdn.xml';
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+const CACHE_VERSION = 1;
+
+export class OfacCache {
+  constructor({ dataDir, fetchImpl = fetch, logger = console }) {
+    this.cacheFile = path.join(dataDir, 'data', 'ofac-cache.json');
+    this.fetch = fetchImpl;
+    this.logger = logger;
+    /** @type {{ version:number, fetchedAt:number, upstreamBytes:number, entryCount:number, entries:any[] } | null} */
+    this.payload = null;
+    this.indexes = null;
+    /** @type {Promise<void>|null} */
+    this._refreshing = null;
+  }
+
+  /** Lazily load + (if stale) refresh. Resolves when the cache holds a
+   *  parsed entry list. Concurrent calls share the same in-flight
+   *  refresh. */
+  async ensureLoaded() {
+    if (this.payload && Date.now() - this.payload.fetchedAt < SEVEN_DAYS_MS) return;
+    if (this._refreshing) { await this._refreshing; return; }
+    this._refreshing = this._loadOrRefresh().finally(() => { this._refreshing = null; });
+    await this._refreshing;
+  }
+
+  async _loadOrRefresh() {
+    await this._loadCacheFromDisk();
+    if (!this._isStale()) return;
+    try {
+      await this._refreshFromUpstream();
+    } catch (error) {
+      this.logger.warn('[ofac-cache] refresh failed:', error?.message ?? error);
+    }
+  }
+
+  async _loadCacheFromDisk() {
+    try {
+      const text = await readFile(this.cacheFile, 'utf8');
+      const parsed = JSON.parse(text);
+      if (parsed?.version === CACHE_VERSION && Array.isArray(parsed.entries)) {
+        this.payload = parsed;
+        this._buildIndexes();
+      }
+    } catch {
+      // Missing or unreadable — fall through to refresh.
+    }
+  }
+
+  _isStale() {
+    return !this.payload || (Date.now() - this.payload.fetchedAt) > SEVEN_DAYS_MS;
+  }
+
+  async _refreshFromUpstream() {
+    const xml = await this._downloadSdnXml();
+    if (!xml) return;
+    const entries = parseSdnXml(xml);
+    const next = {
+      version: CACHE_VERSION,
+      fetchedAt: Date.now(),
+      upstreamBytes: xml.length,
+      entryCount: entries.length,
+      entries,
+    };
+    await mkdir(path.dirname(this.cacheFile), { recursive: true });
+    await writeFile(this.cacheFile, JSON.stringify(next));
+    this.payload = next;
+    this._buildIndexes();
+  }
+
+  async _downloadSdnXml() {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 60_000);
+    try {
+      const r = await this.fetch(SDN_XML_URL, {
+        signal: controller.signal,
+        headers: { Accept: 'application/xml,text/xml', 'User-Agent': 'CrystalBall/1.0 (+sidecar)' },
+      });
+      if (!r.ok) throw new Error(`upstream HTTP ${r.status}`);
+      return await r.text();
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  _buildIndexes() {
+    if (!this.payload) { this.indexes = null; return; }
+    const vesselsByName = new Map();
+    const vesselsByImo = new Map();
+    const vesselsByCallSign = new Map();
+    const haystack = [];
+    for (const e of this.payload.entries) {
+      haystack.push(buildHaystackRow(e));
+      if (e.type === 'vessel') indexVessel(e, vesselsByName, vesselsByImo, vesselsByCallSign);
+    }
+    this.indexes = { haystack, vesselsByName, vesselsByImo, vesselsByCallSign };
+  }
+
+  // ─── Read API ───────────────────────────────────────────────────────
+
+  getCacheMeta() {
+    if (!this.payload) return { ready: false, fetchedAt: null, entryCount: 0, ageMs: null };
+    return {
+      ready: true,
+      fetchedAt: this.payload.fetchedAt,
+      entryCount: this.payload.entryCount,
+      ageMs: Date.now() - this.payload.fetchedAt,
+      upstreamBytes: this.payload.upstreamBytes,
+    };
+  }
+
+  getAllEntries() { return this.payload?.entries ?? []; }
+  getSanctionedVessels() { return (this.payload?.entries ?? []).filter((e) => e.type === 'vessel'); }
+  getSanctionedAircraft() { return (this.payload?.entries ?? []).filter((e) => e.type === 'aircraft'); }
+
+  searchSanctions(rawQuery, opts = {}) {
+    const query = String(rawQuery ?? '').trim().toLowerCase();
+    if (!query || !this.payload || !this.indexes) return [];
+    const limit = Math.max(1, Math.min(500, opts.limit ?? 50));
+    const out = [];
+    for (let i = 0; i < this.payload.entries.length; i++) {
+      const entry = this.payload.entries[i];
+      if (opts.type && entry.type !== opts.type) continue;
+      const score = scoreMatch(entry, query, this.indexes.haystack[i] ?? '');
+      if (score === 0) continue;
+      out.push({ entry, score });
+    }
+    out.sort((a, b) => b.score === a.score ? a.entry.name.localeCompare(b.entry.name) : b.score - a.score);
+    return out.slice(0, limit);
+  }
+
+  matchVessel({ name, imo, callSign }) {
+    if (!this.indexes) return { matched: false };
+    const imoKey = imo ? normalizeImo(imo) : '';
+    if (imoKey && this.indexes.vesselsByImo.has(imoKey)) {
+      return toMatch(this.indexes.vesselsByImo.get(imoKey), 'imo');
+    }
+    const csKey = callSign ? String(callSign).trim().toLowerCase() : '';
+    if (csKey && this.indexes.vesselsByCallSign.has(csKey)) {
+      return toMatch(this.indexes.vesselsByCallSign.get(csKey), 'callsign');
+    }
+    const nameKey = name ? normalizeVesselName(name) : '';
+    if (nameKey && this.indexes.vesselsByName.has(nameKey)) {
+      return toMatch(this.indexes.vesselsByName.get(nameKey), 'name');
+    }
+    return { matched: false };
+  }
+}
+
+// ─── Index helpers ────────────────────────────────────────────────────
+
+function buildHaystackRow(e) {
+  const idTokens = (e.ids ?? []).map((id) => `${String(id.idType).toLowerCase()}:${String(id.idNumber).toLowerCase()}`);
+  return [
+    e.name?.toLowerCase() ?? '',
+    ...(e.aliases ?? []),
+    ...(e.countries ?? []),
+    ...idTokens,
+  ].join(' | ');
+}
+
+function indexVessel(e, byName, byImo, byCallSign) {
+  const nameKey = normalizeVesselName(e.name);
+  if (nameKey && !byName.has(nameKey)) byName.set(nameKey, e);
+  for (const alias of (e.aliases ?? [])) {
+    const aliasKey = normalizeVesselName(alias);
+    if (aliasKey && !byName.has(aliasKey)) byName.set(aliasKey, e);
+  }
+  const imoKey = e.vessel?.imo ? normalizeImo(e.vessel.imo) : '';
+  if (imoKey) byImo.set(imoKey, e);
+  const csKey = e.vessel?.callSign ? String(e.vessel.callSign).trim().toLowerCase() : '';
+  if (csKey) byCallSign.set(csKey, e);
+}
+
+// ─── Score / match helpers ─────────────────────────────────────────────
+
+function scoreMatch(entry, query, haystack) {
+  const name = String(entry.name ?? '').toLowerCase();
+  if (name === query) return 100;
+  if (name.startsWith(query)) return 90;
+  for (const alias of (entry.aliases ?? [])) {
+    if (alias === query) return 80;
+  }
+  for (const alias of (entry.aliases ?? [])) {
+    if (alias.startsWith(query)) return 70;
+  }
+  if (name.includes(query)) return 60;
+  if (haystack.includes(query)) return 50;
+  return 0;
+}
+
+function toMatch(entry, reason) {
+  const programs = entry.programs ?? [];
+  const programLabel = programs.length > 0 ? programs.join(', ').toUpperCase() : 'SDN';
+  return {
+    matched: true,
+    reason,
+    uid: entry.uid,
+    programs: [...programs],
+    badge: `OFAC SDN — ${programLabel}`,
+  };
+}
+
+// ─── Normalizers (must match the renderer-side TS exactly) ─────────────
+
+export function normalizeVesselName(name) {
+  if (!name) return '';
+  return String(name)
+    .toLowerCase()
+    .replace(/\b(m\/v|m\/t|s\/v|m\.v\.|m\.t\.|f\.v\.|mv|mt)\b/g, ' ')
+    .replace(/[^a-z0-9 ]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function normalizeImo(raw) {
+  const digits = String(raw ?? '').replace(/\D+/g, '');
+  if (!digits) return '';
+  return digits.length > 7 ? digits.slice(-7) : digits;
+}
+
+// ─── XML parser (mirrors src/services/sanctions/ofac-parser.ts) ────────
+
+const ENTRY_RX = /<sdnEntry\b[\s\S]*?<\/sdnEntry>/g;
+
+export function parseSdnXml(xml) {
+  const out = [];
+  for (const match of xml.matchAll(ENTRY_RX)) {
+    const entry = parseEntryBlock(match[0]);
+    if (entry) out.push(entry);
+  }
+  return out;
+}
+
+function parseEntryBlock(block) {
+  const uid = textOf(block, 'uid');
+  if (!uid) return null;
+  const type = parseType(textOf(block, 'sdnType'));
+  const name = composeName(block, type);
+  if (!name) return null;
+  const programs = uniqueLower(extractList(block, 'programList', 'program', (b) => stripHtml(b).trim()));
+  const aliases = uniqueLower(extractAkaList(block));
+  const ids = extractIdList(block);
+  const addresses = extractAddressList(block);
+  const countries = uniqueLower(addresses.map((a) => a.country).filter((x) => x !== null));
+  const vessel = type === 'vessel' ? extractVesselInfo(block, ids) : null;
+  const aircraft = type === 'aircraft' ? extractAircraftInfo(block) : null;
+  return {
+    uid, name, type, programs, aliases, countries, ids, vessel, aircraft,
+    remarks: textOf(block, 'remarks') || null,
+  };
+}
+
+function parseType(raw) {
+  const t = (raw || '').toLowerCase();
+  if (t.includes('individual')) return 'individual';
+  if (t.includes('vessel')) return 'vessel';
+  if (t.includes('aircraft')) return 'aircraft';
+  if (t.includes('entity') || t.includes('organization')) return 'entity';
+  return 'unknown';
+}
+
+function composeName(block, type) {
+  const lastName = textOf(block, 'lastName');
+  const firstName = textOf(block, 'firstName');
+  if (type === 'individual' && firstName && lastName) return `${lastName}, ${firstName}`;
+  return lastName || firstName || '';
+}
+
+function extractList(block, listTag, itemTag, mapper) {
+  const slice = sliceTag(block, listTag);
+  if (!slice) return [];
+  const itemRx = new RegExp(String.raw`<${itemTag}\b[^>]*>([\s\S]*?)<\/${itemTag}>`, 'g');
+  const out = [];
+  for (const m of slice.matchAll(itemRx)) {
+    const value = mapper(m[1] ?? '');
+    if (value) out.push(value);
+  }
+  return out;
+}
+
+function extractAkaList(block) {
+  const slice = sliceTag(block, 'akaList');
+  if (!slice) return [];
+  const out = [];
+  for (const m of slice.matchAll(/<aka\b[\s\S]*?<\/aka>/g)) {
+    const akaBlock = m[0];
+    const last = textOf(akaBlock, 'lastName');
+    const first = textOf(akaBlock, 'firstName');
+    if (last && first) out.push(`${last}, ${first}`);
+    else if (last) out.push(last);
+    else if (first) out.push(first);
+  }
+  return out;
+}
+
+function extractIdList(block) {
+  const slice = sliceTag(block, 'idList');
+  if (!slice) return [];
+  const out = [];
+  for (const m of slice.matchAll(/<id\b[\s\S]*?<\/id>/g)) {
+    const idBlock = m[0];
+    const idType = textOf(idBlock, 'idType');
+    const idNumber = textOf(idBlock, 'idNumber');
+    if (!idType || !idNumber) continue;
+    out.push({ idType, idNumber, idCountry: textOf(idBlock, 'idCountry') || null });
+  }
+  return out;
+}
+
+function extractAddressList(block) {
+  const slice = sliceTag(block, 'addressList');
+  if (!slice) return [];
+  const out = [];
+  for (const m of slice.matchAll(/<address\b[\s\S]*?<\/address>/g)) {
+    const addrBlock = m[0];
+    const country = textOf(addrBlock, 'country') || null;
+    const city = textOf(addrBlock, 'city') || null;
+    const region = textOf(addrBlock, 'stateOrProvince') || null;
+    if (country || city || region) out.push({ country, city, region });
+  }
+  return out;
+}
+
+function extractVesselInfo(block, ids) {
+  const slice = sliceTag(block, 'vesselInfo') ?? '';
+  const imo = (ids.find((id) => /imo/i.test(id.idType)) || {}).idNumber || null;
+  return {
+    callSign: textOf(slice, 'callSign') || null,
+    vesselType: textOf(slice, 'vesselType') || null,
+    vesselFlag: textOf(slice, 'vesselFlag') || null,
+    vesselOwner: textOf(slice, 'vesselOwner') || null,
+    tonnage: textOf(slice, 'tonnage') || textOf(slice, 'grossRegisteredTonnage') || null,
+    imo,
+  };
+}
+
+function extractAircraftInfo(block) {
+  const slice = sliceTag(block, 'aircraftInfo') ?? '';
+  return {
+    tailNumber: textOf(slice, 'aircraftTailNumber') || null,
+    model: textOf(slice, 'aircraftModel') || null,
+    operator: textOf(slice, 'aircraftOperator') || null,
+    manufactureDate: textOf(slice, 'aircraftManufactureDate') || null,
+    constructionNumber: textOf(slice, 'aircraftConstructionNumber') || null,
+  };
+}
+
+function textOf(block, tag) {
+  const m = String(block).match(new RegExp(String.raw`<${tag}\b[^>]*>([\s\S]*?)<\/${tag}>`));
+  if (!m || m[1] === undefined) return '';
+  return stripHtml(m[1]).trim();
+}
+
+function sliceTag(block, tag) {
+  const m = String(block).match(new RegExp(String.raw`<${tag}\b[^>]*>([\s\S]*?)<\/${tag}>`));
+  return m ? m[1] : null;
+}
+
+function stripHtml(s) {
+  const noCdata = String(s).split('<![CDATA[').join('').split(']]>').join('');
+  // eslint-disable-next-line sonarjs/slow-regex -- bounded char class, single-character match — linear time.
+  return noCdata.replace(/<[^>]+>/g, '');
+}
+
+function uniqueLower(values) {
+  const seen = new Set();
+  const out = [];
+  for (const v of values) {
+    const key = String(v).trim().toLowerCase();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    out.push(key);
+  }
+  return out;
+}

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -144,6 +144,7 @@ import { WeatherRadarPanel } from '@/components/WeatherRadarPanel';
 import { TidePredictionsPanel } from '@/components/TidePredictionsPanel';
 import { PollenPanel } from '@/components/PollenPanel';
 import { OpenSanctionsPanel } from '@/components/OpenSanctionsPanel';
+import { SanctionsPanel } from '@/components/SanctionsPanel';
 import { EdgarFilingsPanel } from '@/components/EdgarFilingsPanel';
 import { AirQualityPanel } from '@/components/AirQualityPanel';
 import { WildfireIncidentsPanel } from '@/components/WildfireIncidentsPanel';
@@ -994,6 +995,9 @@ export class PanelLayoutManager implements AppModule {
 
  const openSanctionsPanel = new OpenSanctionsPanel();
  this.ctx.panels['opensanctions'] = openSanctionsPanel;
+
+ const sanctionsIntelPanel = new SanctionsPanel();
+ this.ctx.panels['sanctions-intel'] = sanctionsIntelPanel;
 
  const edgarFilingsPanel = new EdgarFilingsPanel();
  this.ctx.panels['edgar-filings'] = edgarFilingsPanel;

--- a/src/components/SanctionsPanel.ts
+++ b/src/components/SanctionsPanel.ts
@@ -1,0 +1,283 @@
+ 
+import { Panel } from './Panel';
+import { escapeHtml } from '@/utils/sanitize';
+import { getApiBaseUrl } from '@/services/runtime';
+import type { SdnEntry } from '@/services/sanctions/ofac-types';
+
+type Tab = 'search' | 'vessels' | 'aircraft';
+
+const TAB_STORAGE_KEY = 'cb:sanctions-tab';
+const TAB_LABELS: Record<Tab, string> = {
+  search: 'Search',
+  vessels: 'Vessels',
+  aircraft: 'Aircraft',
+};
+
+interface SearchHit { entry: SdnEntry; score: number }
+
+interface CacheMeta {
+  ready?: boolean;
+  fetchedAt?: number | null;
+  entryCount?: number;
+  ageMs?: number | null;
+  upstreamBytes?: number;
+}
+
+export class SanctionsPanel extends Panel {
+  private activeTab: Tab = readStoredTab();
+  private query = '';
+  private hits: SearchHit[] = [];
+  private vessels: SdnEntry[] = [];
+  private aircraft: SdnEntry[] = [];
+  private meta: CacheMeta = {};
+  private searchAbort: AbortController | null = null;
+  private searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private vesselsLoaded = false;
+  private aircraftLoaded = false;
+
+  constructor() {
+    super({
+      id: 'sanctions-intel',
+      title: 'OFAC Sanctions Intel',
+      showCount: true,
+      trackActivity: true,
+      infoTooltip: 'OFAC SDN list — search, vessel and aircraft cross-reference. Cache refreshes weekly from treasury.gov/ofac/downloads/sdn.xml.',
+    });
+    this.render();
+  }
+
+  private async ensureTabData(tab: Tab): Promise<void> {
+    if (tab === 'vessels' && !this.vesselsLoaded) {
+      this.vesselsLoaded = true;
+      await this.loadList('/api/sanctions/vessels', 'vessels');
+    }
+    if (tab === 'aircraft' && !this.aircraftLoaded) {
+      this.aircraftLoaded = true;
+      await this.loadList('/api/sanctions/aircraft', 'aircraft');
+    }
+  }
+
+  private async loadList(path: string, kind: 'vessels' | 'aircraft'): Promise<void> {
+    const data = await fetchJson(path);
+    if (!data) return;
+    const list = (data as Record<string, unknown>)[kind];
+    if (!Array.isArray(list)) return;
+    if (kind === 'vessels') {
+      this.vessels = list as SdnEntry[];
+      this.setCount(this.vessels.length);
+    } else {
+      this.aircraft = list as SdnEntry[];
+    }
+    this.meta = (data as { meta?: CacheMeta }).meta ?? this.meta;
+    if (this.activeTab === kind) this.render();
+  }
+
+  private async runSearch(query: string): Promise<void> {
+    if (this.searchAbort) this.searchAbort.abort();
+    const controller = new AbortController();
+    this.searchAbort = controller;
+    this.query = query;
+    if (!query.trim()) {
+      this.hits = [];
+      this.render();
+      return;
+    }
+    try {
+      const url = `${getApiBaseUrl()}/api/sanctions/search?q=${encodeURIComponent(query)}&limit=50`;
+      const r = await fetch(url, { signal: controller.signal, headers: { Accept: 'application/json' } });
+      if (!r.ok) return;
+      const data = await r.json() as { hits?: SearchHit[]; meta?: CacheMeta };
+      if (controller.signal.aborted) return;
+      this.hits = Array.isArray(data.hits) ? data.hits : [];
+      this.meta = data.meta ?? this.meta;
+      this.render();
+    } catch {
+      // Aborted or network error — quiet noop.
+    }
+  }
+
+  private renderTabStrip(): string {
+    const tabs: Tab[] = ['search', 'vessels', 'aircraft'];
+    return `<div class="sanc-tab-strip" role="tablist" style="display:flex;gap:6px;margin-bottom:8px;flex-wrap:wrap">${tabs
+      .map((tab) => {
+        const active = tab === this.activeTab;
+        return `<button class="sanc-tab" data-tab="${tab}" role="tab" aria-selected="${active}" type="button" style="padding:4px 10px;border:1px solid rgba(255,255,255,0.12);background:${active ? 'rgba(96,165,250,0.18)' : 'transparent'};color:inherit;border-radius:4px;cursor:pointer;font-size:12px">${escapeHtml(TAB_LABELS[tab])}</button>`;
+      })
+      .join('')}</div>`;
+  }
+
+  private renderSearchTab(): string {
+    const queryAttr = escapeHtml(this.query);
+    const meta = this.renderMeta();
+    if (!this.query.trim()) {
+      return `${this.renderSearchInput(queryAttr)}
+        <div class="panel-empty" style="padding:16px 0;text-align:center;opacity:0.7">
+          Enter at least one character to search the SDN list.
+        </div>
+        ${meta}`;
+    }
+    if (this.hits.length === 0) {
+      return `${this.renderSearchInput(queryAttr)}
+        <div class="panel-empty" style="padding:16px 0;text-align:center;opacity:0.7">
+          No matches for "${queryAttr}".
+        </div>
+        ${meta}`;
+    }
+    const rows = this.hits.map((h) => this.renderHitRow(h)).join('');
+    return `${this.renderSearchInput(queryAttr)}
+      <table class="eq-table" style="width:100%;font-size:12px">
+        <thead><tr><th>Type</th><th>Name</th><th>Programs</th><th>Country</th><th style="text-align:right">Score</th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+      ${meta}`;
+  }
+
+  private renderSearchInput(value: string): string {
+    return `<input type="search" class="sanc-search-input" placeholder="Search OFAC SDN…" value="${value}"
+      style="width:100%;padding:6px 10px;margin-bottom:8px;background:rgba(255,255,255,0.04);color:inherit;border:1px solid rgba(255,255,255,0.12);border-radius:4px;font-size:13px" />`;
+  }
+
+  private renderHitRow(h: SearchHit): string {
+    const e = h.entry;
+    const programs = e.programs.length === 0 ? '—' : e.programs.map((p) => `<span style="padding:1px 4px;border-radius:3px;background:rgba(248,113,113,0.14);font-size:10px;margin-right:2px">${escapeHtml(p)}</span>`).join('');
+    const country = e.countries[0] ?? (e.vessel?.vesselFlag ?? '—');
+    return `<tr>
+      <td>${typeBadge(e.type)}</td>
+      <td><strong>${escapeHtml(e.name)}</strong></td>
+      <td>${programs}</td>
+      <td>${escapeHtml(country)}</td>
+      <td style="text-align:right;opacity:0.7">${h.score}</td>
+    </tr>`;
+  }
+
+  private renderVesselsTab(): string {
+    if (!this.vesselsLoaded) {
+      return `<div class="panel-empty" style="padding:16px 0;text-align:center;opacity:0.7">Loading sanctioned vessels…</div>`;
+    }
+    if (this.vessels.length === 0) {
+      return `<div class="panel-empty" style="padding:16px 0;text-align:center;opacity:0.7">No vessel entries returned.</div>`;
+    }
+    const rows = this.vessels.slice(0, 200).map((v) => `<tr>
+      <td><strong>${escapeHtml(v.name)}</strong></td>
+      <td>${escapeHtml(v.vessel?.vesselFlag ?? '—')}</td>
+      <td>${escapeHtml(v.vessel?.vesselType ?? '—')}</td>
+      <td><code style="font-size:10px">${escapeHtml(v.vessel?.imo ?? '—')}</code></td>
+      <td>${v.programs.map((p) => `<span style="padding:1px 4px;border-radius:3px;background:rgba(248,113,113,0.14);font-size:10px;margin-right:2px">${escapeHtml(p)}</span>`).join('') || '—'}</td>
+    </tr>`).join('');
+    return `<table class="eq-table" style="width:100%;font-size:12px">
+      <thead><tr><th>Vessel</th><th>Flag</th><th>Type</th><th>IMO</th><th>Program</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table>
+    <div style="opacity:0.65;font-size:11px;margin-top:6px">Showing ${Math.min(this.vessels.length, 200)} of ${this.vessels.length} sanctioned vessels.</div>
+    ${this.renderMeta()}`;
+  }
+
+  private renderAircraftTab(): string {
+    if (!this.aircraftLoaded) {
+      return `<div class="panel-empty" style="padding:16px 0;text-align:center;opacity:0.7">Loading sanctioned aircraft…</div>`;
+    }
+    if (this.aircraft.length === 0) {
+      return `<div class="panel-empty" style="padding:16px 0;text-align:center;opacity:0.7">No aircraft entries returned.</div>`;
+    }
+    const rows = this.aircraft.slice(0, 200).map((a) => `<tr>
+      <td><strong>${escapeHtml(a.name)}</strong></td>
+      <td>${escapeHtml(a.aircraft?.tailNumber ?? '—')}</td>
+      <td>${escapeHtml(a.aircraft?.operator ?? '—')}</td>
+      <td>${escapeHtml(a.countries[0] ?? '—')}</td>
+      <td>${a.programs.map((p) => `<span style="padding:1px 4px;border-radius:3px;background:rgba(248,113,113,0.14);font-size:10px;margin-right:2px">${escapeHtml(p)}</span>`).join('') || '—'}</td>
+    </tr>`).join('');
+    return `<table class="eq-table" style="width:100%;font-size:12px">
+      <thead><tr><th>Name</th><th>Tail #</th><th>Operator</th><th>Country</th><th>Program</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table>
+    <div style="opacity:0.65;font-size:11px;margin-top:6px">Showing ${Math.min(this.aircraft.length, 200)} of ${this.aircraft.length} sanctioned aircraft.</div>
+    ${this.renderMeta()}`;
+  }
+
+  private renderMeta(): string {
+    const entryCount = this.meta.entryCount ?? 0;
+    const fetchedAt = this.meta.fetchedAt ?? null;
+    const ageStr = fetchedAt ? humanAge(Math.floor((Date.now() - fetchedAt) / 1000)) : '—';
+    return `<div class="fires-footer" style="display:flex;justify-content:space-between;margin-top:8px;font-size:11px;opacity:0.7">
+      <span>Treasury OFAC SDN · ${entryCount.toLocaleString()} entries</span>
+      <span>Cache age ${ageStr}</span>
+    </div>`;
+  }
+
+  private render(): void {
+    let body = '';
+    switch (this.activeTab) {
+      case 'search': { body = this.renderSearchTab(); break; }
+      case 'vessels': { body = this.renderVesselsTab(); break; }
+      case 'aircraft': { body = this.renderAircraftTab(); break; }
+    }
+    this.setContent(`${this.renderTabStrip()}${body}`);
+    this.wireHandlers();
+  }
+
+  private wireHandlers(): void {
+    const root = this.getElement();
+    if (!root) return;
+    for (const btn of root.querySelectorAll<HTMLButtonElement>('.sanc-tab')) {
+      btn.addEventListener('click', () => {
+        const tab = btn.dataset.tab as Tab | undefined;
+        if (!tab || tab === this.activeTab) return;
+        this.activeTab = tab;
+        try { localStorage.setItem(TAB_STORAGE_KEY, tab); } catch { /* noop */ }
+        this.render();
+        void this.ensureTabData(tab);
+      });
+    }
+    const input = root.querySelector<HTMLInputElement>('.sanc-search-input');
+    if (input) {
+      // Restore focus + caret after re-render so typing isn't disrupted.
+      const len = input.value.length;
+      input.focus();
+      try { input.setSelectionRange(len, len); } catch { /* noop */ }
+      input.addEventListener('input', () => {
+        const value = input.value;
+        if (this.searchDebounceTimer) clearTimeout(this.searchDebounceTimer);
+        this.searchDebounceTimer = setTimeout(() => { void this.runSearch(value); }, 200);
+      });
+    }
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────
+
+function typeBadge(type: SdnEntry['type']): string {
+  const colors: Record<SdnEntry['type'], string> = {
+    individual: 'rgba(96,165,250,0.18)',
+    vessel: 'rgba(34,197,94,0.20)',
+    aircraft: 'rgba(245,158,11,0.20)',
+    entity: 'rgba(168,85,247,0.18)',
+    unknown: 'rgba(255,255,255,0.06)',
+  };
+  return `<span style="padding:1px 5px;border-radius:3px;background:${colors[type]};font-size:10px;text-transform:uppercase">${escapeHtml(type)}</span>`;
+}
+
+function humanAge(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return 'unknown';
+  if (seconds < 60) return `${Math.floor(seconds)}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86_400) return `${Math.floor(seconds / 3600)}h`;
+  return `${Math.floor(seconds / 86_400)}d`;
+}
+
+async function fetchJson(path: string): Promise<unknown> {
+  try {
+    const r = await fetch(`${getApiBaseUrl()}${path}`, { headers: { Accept: 'application/json' } });
+    if (!r.ok) return null;
+    return await r.json() as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function readStoredTab(): Tab {
+  try {
+    const stored = localStorage.getItem(TAB_STORAGE_KEY);
+    if (stored === 'search' || stored === 'vessels' || stored === 'aircraft') return stored;
+  } catch { /* noop */ }
+  return 'search';
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -118,6 +118,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'air-traffic': { name: 'Air Traffic', enabled: true, priority: 2 },
   'global-weather': { name: 'Global Weather', enabled: true, priority: 1 },
   'opensanctions': { name: 'Global Sanctions', enabled: true, priority: 2 },
+  'sanctions-intel': { name: 'OFAC Sanctions Intel', enabled: true, priority: 2 },
   'edgar-filings': { name: 'SEC EDGAR Filings', enabled: true, priority: 2 },
   'isw-reports': { name: 'ISW Situation Reports', enabled: true, priority: 1 },
   'reliefweb-crises': { name: 'UN OCHA Crisis Reports', enabled: true, priority: 1 },

--- a/src/services/sanctions/__tests__/ofac.test.mts
+++ b/src/services/sanctions/__tests__/ofac.test.mts
@@ -1,0 +1,287 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseOfacSdnXml } from '../ofac-parser.ts';
+import {
+  buildOfacIndex,
+  searchSanctions,
+  listSanctionedVessels,
+  listSanctionedAircraft,
+  matchVesselToSanction,
+  normalizeVesselName,
+  normalizeImo,
+} from '../ofac-search.ts';
+
+const FIXTURE_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<sdnList xmlns="http://tempuri.org/sdnList.xsd">
+  <publshInformation>
+    <Publish_Date>05/06/2026</Publish_Date>
+  </publshInformation>
+  <sdnEntry>
+    <uid>1001</uid>
+    <lastName>Ivanov</lastName>
+    <firstName>Sergei</firstName>
+    <sdnType>Individual</sdnType>
+    <programList>
+      <program>RUSSIA-EO14024</program>
+      <program>SDGT</program>
+    </programList>
+    <akaList>
+      <aka>
+        <uid>9001</uid>
+        <type>a.k.a.</type>
+        <category>strong</category>
+        <lastName>Ivanovich</lastName>
+        <firstName>Serge</firstName>
+      </aka>
+    </akaList>
+    <addressList>
+      <address>
+        <uid>11</uid>
+        <country>Russia</country>
+        <city>Moscow</city>
+      </address>
+    </addressList>
+    <idList>
+      <id>
+        <uid>21</uid>
+        <idType>Passport</idType>
+        <idNumber>123456789</idNumber>
+        <idCountry>Russia</idCountry>
+      </id>
+    </idList>
+  </sdnEntry>
+  <sdnEntry>
+    <uid>2001</uid>
+    <lastName>STAR PROVIDER</lastName>
+    <sdnType>Vessel</sdnType>
+    <programList>
+      <program>IRAN</program>
+    </programList>
+    <akaList>
+      <aka>
+        <uid>9101</uid>
+        <type>a.k.a.</type>
+        <category>strong</category>
+        <lastName>STAR-PROVIDER</lastName>
+      </aka>
+    </akaList>
+    <vesselInfo>
+      <callSign>9HA4321</callSign>
+      <vesselType>Crude Oil Tanker</vesselType>
+      <vesselFlag>Iran</vesselFlag>
+      <vesselOwner>NITC</vesselOwner>
+      <tonnage>164000</tonnage>
+    </vesselInfo>
+    <idList>
+      <id>
+        <uid>22</uid>
+        <idType>IMO Number</idType>
+        <idNumber>9123456</idNumber>
+      </id>
+    </idList>
+  </sdnEntry>
+  <sdnEntry>
+    <uid>3001</uid>
+    <lastName>EP-IGB</lastName>
+    <sdnType>Aircraft</sdnType>
+    <programList>
+      <program>SDGT</program>
+    </programList>
+    <aircraftInfo>
+      <aircraftConstructionNumber>26528</aircraftConstructionNumber>
+      <aircraftManufactureDate>01 Jan 1995</aircraftManufactureDate>
+      <aircraftModel>Boeing 747</aircraftModel>
+      <aircraftOperator>MAHAN AIR</aircraftOperator>
+      <aircraftTailNumber>EP-IGB</aircraftTailNumber>
+    </aircraftInfo>
+  </sdnEntry>
+  <sdnEntry>
+    <uid>4001</uid>
+    <lastName>NORINCO</lastName>
+    <sdnType>Entity</sdnType>
+    <programList>
+      <program>NS-CMIC-EO13959</program>
+    </programList>
+    <addressList>
+      <address>
+        <uid>41</uid>
+        <country>China</country>
+      </address>
+    </addressList>
+  </sdnEntry>
+  <sdnEntry>
+    <uid>5001</uid>
+    <sdnType>Individual</sdnType>
+    <programList></programList>
+  </sdnEntry>
+</sdnList>`;
+
+// ── parseOfacSdnXml ───────────────────────────────────────────────────
+
+test('parser: drops entries without a name', () => {
+  const out = parseOfacSdnXml(FIXTURE_XML);
+  assert.equal(out.length, 4);
+  assert.ok(!out.some((e) => e.uid === '5001'));
+});
+
+test('parser: composes "Last, First" for individuals', () => {
+  const out = parseOfacSdnXml(FIXTURE_XML);
+  const sergei = out.find((e) => e.uid === '1001')!;
+  assert.equal(sergei.name, 'Ivanov, Sergei');
+  assert.equal(sergei.type, 'individual');
+});
+
+test('parser: dedups + lowercases programs', () => {
+  const out = parseOfacSdnXml(FIXTURE_XML);
+  const sergei = out.find((e) => e.uid === '1001')!;
+  assert.deepEqual(sergei.programs, ['russia-eo14024', 'sdgt']);
+});
+
+test('parser: vessel entry pulls callSign / flag / owner / IMO', () => {
+  const out = parseOfacSdnXml(FIXTURE_XML);
+  const vessel = out.find((e) => e.uid === '2001')!;
+  assert.equal(vessel.type, 'vessel');
+  assert.equal(vessel.name, 'STAR PROVIDER');
+  assert.equal(vessel.vessel?.callSign, '9HA4321');
+  assert.equal(vessel.vessel?.vesselFlag, 'Iran');
+  assert.equal(vessel.vessel?.vesselOwner, 'NITC');
+  assert.equal(vessel.vessel?.imo, '9123456');
+  assert.equal(vessel.aircraft, null);
+});
+
+test('parser: aircraft entry pulls tail number / model / operator', () => {
+  const out = parseOfacSdnXml(FIXTURE_XML);
+  const aircraft = out.find((e) => e.uid === '3001')!;
+  assert.equal(aircraft.type, 'aircraft');
+  assert.equal(aircraft.aircraft?.tailNumber, 'EP-IGB');
+  assert.equal(aircraft.aircraft?.model, 'Boeing 747');
+  assert.equal(aircraft.aircraft?.operator, 'MAHAN AIR');
+  assert.equal(aircraft.vessel, null);
+});
+
+test('parser: entity-type entries are recognized', () => {
+  const out = parseOfacSdnXml(FIXTURE_XML);
+  const entity = out.find((e) => e.uid === '4001')!;
+  assert.equal(entity.type, 'entity');
+  assert.deepEqual(entity.countries, ['china']);
+});
+
+test('parser: aliases captured + lowercased', () => {
+  const out = parseOfacSdnXml(FIXTURE_XML);
+  const vessel = out.find((e) => e.uid === '2001')!;
+  assert.deepEqual(vessel.aliases, ['star-provider']);
+});
+
+test('parser: empty XML returns empty array', () => {
+  assert.deepEqual(parseOfacSdnXml('<sdnList></sdnList>'), []);
+});
+
+test('parser: result is JSON-serializable', () => {
+  const out = parseOfacSdnXml(FIXTURE_XML);
+  assert.deepEqual(JSON.parse(JSON.stringify(out)), out);
+});
+
+// ── searchSanctions ────────────────────────────────────────────────────
+
+const INDEX = buildOfacIndex(parseOfacSdnXml(FIXTURE_XML));
+
+test('search: empty query returns empty array', () => {
+  assert.deepEqual(searchSanctions(INDEX, '   '), []);
+});
+
+test('search: case-insensitive name match scores highest', () => {
+  const hits = searchSanctions(INDEX, 'star provider');
+  assert.ok(hits.length > 0);
+  assert.equal(hits[0]!.entry.uid, '2001');
+  assert.ok(hits[0]!.score >= 90);
+});
+
+test('search: alias match scores below name match but still returns', () => {
+  const hits = searchSanctions(INDEX, 'star-provider');
+  assert.ok(hits.length > 0);
+  assert.equal(hits[0]!.entry.uid, '2001');
+});
+
+test('search: country-level haystack hit returns the entry', () => {
+  const hits = searchSanctions(INDEX, 'china');
+  assert.ok(hits.some((h) => h.entry.uid === '4001'));
+});
+
+test('search: type filter narrows to one sdn type', () => {
+  const hits = searchSanctions(INDEX, 's', { type: 'vessel' });
+  assert.ok(hits.every((h) => h.entry.type === 'vessel'));
+});
+
+test('search: respects limit', () => {
+  const hits = searchSanctions(INDEX, 'a', { limit: 1 });
+  assert.equal(hits.length, 1);
+});
+
+test('search: results stable-sorted by score desc, then name asc', () => {
+  const hits = searchSanctions(INDEX, 'a');
+  for (let i = 1; i < hits.length; i++) {
+    assert.ok(hits[i - 1]!.score >= hits[i]!.score);
+  }
+});
+
+// ── listSanctionedVessels / Aircraft ───────────────────────────────────
+
+test('list: vessels filter is exhaustive', () => {
+  assert.equal(listSanctionedVessels(INDEX).length, 1);
+});
+
+test('list: aircraft filter is exhaustive', () => {
+  assert.equal(listSanctionedAircraft(INDEX).length, 1);
+});
+
+// ── matchVesselToSanction ──────────────────────────────────────────────
+
+test('cross-ref: AIS name matches sanctioned vessel (M/V prefix tolerated)', () => {
+  const r = matchVesselToSanction({ name: 'M/V STAR PROVIDER' }, INDEX);
+  assert.equal(r.matched, true);
+  if (r.matched) {
+    assert.equal(r.reason, 'name');
+    assert.ok(r.badge.includes('IRAN'));
+    assert.deepEqual(r.programs, ['iran']);
+  }
+});
+
+test('cross-ref: IMO match wins over name even if name differs', () => {
+  const r = matchVesselToSanction({ name: 'GHOST', imo: 'IMO 9123456' }, INDEX);
+  assert.equal(r.matched, true);
+  if (r.matched) {
+    assert.equal(r.reason, 'imo');
+  }
+});
+
+test('cross-ref: callsign match', () => {
+  const r = matchVesselToSanction({ callSign: '9HA4321' }, INDEX);
+  assert.equal(r.matched, true);
+  if (r.matched) assert.equal(r.reason, 'callsign');
+});
+
+test('cross-ref: no match returns matched:false', () => {
+  const r = matchVesselToSanction({ name: 'COMPLETELY UNRELATED', imo: '0000000' }, INDEX);
+  assert.equal(r.matched, false);
+});
+
+test('cross-ref: empty inputs do not match', () => {
+  assert.equal(matchVesselToSanction({}, INDEX).matched, false);
+  assert.equal(matchVesselToSanction({ name: '', imo: '', callSign: '' }, INDEX).matched, false);
+});
+
+// ── normalizers ────────────────────────────────────────────────────────
+
+test('normalize vessel: M/V prefix + punctuation stripped', () => {
+  assert.equal(normalizeVesselName('M/V Star-Provider!!'), 'star provider');
+  assert.equal(normalizeVesselName('MT  Aurora  '), 'aurora');
+  assert.equal(normalizeVesselName('  '), '');
+});
+
+test('normalize IMO: tolerates "IMO " prefix and trims to 7 digits', () => {
+  assert.equal(normalizeImo('IMO 9123456'), '9123456');
+  assert.equal(normalizeImo('  9123456  '), '9123456');
+  assert.equal(normalizeImo('XYZ'), '');
+  assert.equal(normalizeImo('99123456'), '9123456');
+});

--- a/src/services/sanctions/ofac-parser.ts
+++ b/src/services/sanctions/ofac-parser.ts
@@ -1,0 +1,205 @@
+/**
+ * OFAC SDN XML parser — pure-deterministic, zero-dependency.
+ *
+ * The Treasury sdn.xml file is ~28 MB and contains ~12k entries. We
+ * walk it with a tolerant tag-extraction regex (the file is well-
+ * formed but xmlns prefixes vary across Treasury revisions, so we
+ * accept any namespace prefix). DOM/XPath-style parsers would also
+ * work but pull in a sizeable dependency for a one-pass extraction.
+ *
+ * Output is a `SdnEntry[]` — see ofac-types.ts. Every name is
+ * trimmed, every program is lowercase-deduped, every alias is
+ * lowercase-deduped, every country list is unique. Entries with no
+ * recoverable name are dropped.
+ */
+
+import type {
+  SdnEntry,
+  SdnType,
+  VesselInfo,
+  AircraftInfo,
+  SdnId,
+} from './ofac-types';
+
+// ─── Top-level entrypoint ─────────────────────────────────────────────
+
+const ENTRY_RX = /<sdnEntry\b[\s\S]*?<\/sdnEntry>/g;
+
+export function parseOfacSdnXml(xml: string): SdnEntry[] {
+  const out: SdnEntry[] = [];
+  for (const match of xml.matchAll(ENTRY_RX)) {
+    const entry = parseEntry(match[0]);
+    if (entry) out.push(entry);
+  }
+  return out;
+}
+
+// ─── Per-entry parsing ────────────────────────────────────────────────
+
+function parseEntry(block: string): SdnEntry | null {
+  const uid = textOf(block, 'uid');
+  if (!uid) return null;
+
+  const type = parseType(textOf(block, 'sdnType'));
+  const name = composeName(block, type);
+  if (!name) return null;
+
+  const programs = uniqueLower(extractProgramList(block));
+  const aliases = uniqueLower(extractAkaList(block));
+  const ids = extractIdList(block);
+  const addresses = extractAddressList(block);
+  const countries = uniqueLower(addresses.map((a) => a.country).filter((c): c is string => c !== null));
+
+  const vessel = type === 'vessel' ? extractVesselInfo(block, ids) : null;
+  const aircraft = type === 'aircraft' ? extractAircraftInfo(block) : null;
+  const remarks = textOf(block, 'remarks') || null;
+
+  return {
+    uid,
+    name,
+    type,
+    programs,
+    aliases,
+    countries,
+    ids,
+    vessel,
+    aircraft,
+    remarks,
+  };
+}
+
+function parseType(raw: string): SdnType {
+  const t = raw.toLowerCase();
+  if (t.includes('individual')) return 'individual';
+  if (t.includes('vessel')) return 'vessel';
+  if (t.includes('aircraft')) return 'aircraft';
+  if (t.includes('entity') || t.includes('organization')) return 'entity';
+  return 'unknown';
+}
+
+function composeName(block: string, type: SdnType): string {
+  const lastName = textOf(block, 'lastName');
+  const firstName = textOf(block, 'firstName');
+  if (type === 'individual' && firstName && lastName) return `${lastName}, ${firstName}`;
+  if (lastName) return lastName;
+  if (firstName) return firstName;
+  return '';
+}
+
+// ─── List extractors ──────────────────────────────────────────────────
+
+function extractProgramList(block: string): string[] {
+  const list = sliceTag(block, 'programList');
+  if (!list) return [];
+  const out: string[] = [];
+  for (const m of list.matchAll(/<program\b[^>]*>([\s\S]*?)<\/program>/g)) {
+    const value = stripHtml(m[1] ?? '').trim();
+    if (value) out.push(value);
+  }
+  return out;
+}
+
+function extractAkaList(block: string): string[] {
+  const list = sliceTag(block, 'akaList');
+  if (!list) return [];
+  const out: string[] = [];
+  for (const akaMatch of list.matchAll(/<aka\b[\s\S]*?<\/aka>/g)) {
+    const akaBlock = akaMatch[0];
+    const last = textOf(akaBlock, 'lastName');
+    const first = textOf(akaBlock, 'firstName');
+    if (last && first) out.push(`${last}, ${first}`);
+    else if (last) out.push(last);
+    else if (first) out.push(first);
+  }
+  return out;
+}
+
+function extractIdList(block: string): SdnId[] {
+  const list = sliceTag(block, 'idList');
+  if (!list) return [];
+  const out: SdnId[] = [];
+  for (const idMatch of list.matchAll(/<id\b[\s\S]*?<\/id>/g)) {
+    const idBlock = idMatch[0];
+    const idType = textOf(idBlock, 'idType');
+    const idNumber = textOf(idBlock, 'idNumber');
+    if (!idType || !idNumber) continue;
+    out.push({
+      idType,
+      idNumber,
+      idCountry: textOf(idBlock, 'idCountry') || null,
+    });
+  }
+  return out;
+}
+
+interface AddressRow { country: string | null; city: string | null; region: string | null }
+
+function extractAddressList(block: string): AddressRow[] {
+  const list = sliceTag(block, 'addressList');
+  if (!list) return [];
+  const out: AddressRow[] = [];
+  for (const m of list.matchAll(/<address\b[\s\S]*?<\/address>/g)) {
+    const addrBlock = m[0];
+    const country = textOf(addrBlock, 'country') || null;
+    const city = textOf(addrBlock, 'city') || null;
+    const region = textOf(addrBlock, 'stateOrProvince') || null;
+    if (country || city || region) out.push({ country, city, region });
+  }
+  return out;
+}
+
+function extractVesselInfo(block: string, ids: readonly SdnId[]): VesselInfo {
+  const slice = sliceTag(block, 'vesselInfo') ?? '';
+  const imo = ids.find((id) => /imo/i.test(id.idType))?.idNumber ?? null;
+  return {
+    callSign: textOf(slice, 'callSign') || null,
+    vesselType: textOf(slice, 'vesselType') || null,
+    vesselFlag: textOf(slice, 'vesselFlag') || null,
+    vesselOwner: textOf(slice, 'vesselOwner') || null,
+    tonnage: textOf(slice, 'tonnage') || textOf(slice, 'grossRegisteredTonnage') || null,
+    imo,
+  };
+}
+
+function extractAircraftInfo(block: string): AircraftInfo {
+  const slice = sliceTag(block, 'aircraftInfo') ?? '';
+  return {
+    tailNumber: textOf(slice, 'aircraftTailNumber') || null,
+    model: textOf(slice, 'aircraftModel') || null,
+    operator: textOf(slice, 'aircraftOperator') || null,
+    manufactureDate: textOf(slice, 'aircraftManufactureDate') || null,
+    constructionNumber: textOf(slice, 'aircraftConstructionNumber') || null,
+  };
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+function textOf(block: string, tag: string): string {
+  const m = new RegExp(String.raw`<${tag}\b[^>]*>([\s\S]*?)<\/${tag}>`).exec(block);
+  if (m?.[1] === undefined) return '';
+  return stripHtml(m[1]).trim();
+}
+
+function sliceTag(block: string, tag: string): string | null {
+  const m = new RegExp(String.raw`<${tag}\b[^>]*>([\s\S]*?)<\/${tag}>`).exec(block);
+  return m?.[1] ?? null;
+}
+
+function stripHtml(s: string): string {
+  const noCdata = s.split('<![CDATA[').join('').split(']]>').join('');
+  // eslint-disable-next-line sonarjs/slow-regex -- bounded char class, single-character match — linear time.
+  return noCdata.replace(/<[^>]+>/g, '');
+}
+
+function uniqueLower(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of values) {
+    const key = v.trim().toLowerCase();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    out.push(key);
+  }
+  return out;
+}
+

--- a/src/services/sanctions/ofac-search.ts
+++ b/src/services/sanctions/ofac-search.ts
@@ -1,0 +1,219 @@
+/**
+ * OFAC search + cross-reference index.
+ *
+ * Pure: no DOM, no fetch. Build an index once from a parsed
+ * SdnEntry[] and reuse it for every renderer query / sidecar request.
+ *
+ *   - searchSanctions(index, query, opts?) — substring match across
+ *     name + aliases + ids + countries (case-insensitive). Sorted by
+ *     match quality: exact-name > prefix-name > alias > substring.
+ *   - vesselNamesToIndex(index) — Map<lowercased name, SdnEntry> for
+ *     O(1) AIS-vessel cross-reference.
+ *   - imosToIndex(index) — Map<imo string, SdnEntry> for the same.
+ *   - matchVesselToSanction(name, mmsi, imo, indexes) — single-call
+ *     helper used by /api/maritime/vessels to flag matched ships.
+ */
+
+import type { SdnEntry } from './ofac-types';
+
+// ─── Index construction ───────────────────────────────────────────────
+
+export interface OfacIndex {
+  entries: readonly SdnEntry[];
+  /** Lower-cased name + aliases concatenated per entry, used for the
+   *  fast contains() pass during search. */
+  searchHaystack: readonly string[];
+  vesselsByName: ReadonlyMap<string, SdnEntry>;
+  vesselsByImo: ReadonlyMap<string, SdnEntry>;
+  vesselsByCallSign: ReadonlyMap<string, SdnEntry>;
+}
+
+export function buildOfacIndex(entries: readonly SdnEntry[]): OfacIndex {
+  const haystack: string[] = [];
+  const vesselsByName = new Map<string, SdnEntry>();
+  const vesselsByImo = new Map<string, SdnEntry>();
+  const vesselsByCallSign = new Map<string, SdnEntry>();
+
+  for (const e of entries) {
+    haystack.push(buildHaystackRow(e));
+    if (e.type === 'vessel') indexVessel(e, vesselsByName, vesselsByImo, vesselsByCallSign);
+  }
+
+  return { entries, searchHaystack: haystack, vesselsByName, vesselsByImo, vesselsByCallSign };
+}
+
+function buildHaystackRow(e: SdnEntry): string {
+  const idTokens = e.ids.map((id) => `${id.idType.toLowerCase()}:${id.idNumber.toLowerCase()}`);
+  return [e.name.toLowerCase(), ...e.aliases, ...e.countries, ...idTokens].join(' | ');
+}
+
+function indexVessel(
+  e: SdnEntry,
+  byName: Map<string, SdnEntry>,
+  byImo: Map<string, SdnEntry>,
+  byCallSign: Map<string, SdnEntry>,
+): void {
+  const nameKey = normalizeVesselName(e.name);
+  if (nameKey && !byName.has(nameKey)) byName.set(nameKey, e);
+  for (const alias of e.aliases) {
+    const aliasKey = normalizeVesselName(alias);
+    if (aliasKey && !byName.has(aliasKey)) byName.set(aliasKey, e);
+  }
+  const imoKey = e.vessel?.imo ? normalizeImo(e.vessel.imo) : '';
+  if (imoKey) byImo.set(imoKey, e);
+  const csKey = e.vessel?.callSign?.trim().toLowerCase() ?? '';
+  if (csKey) byCallSign.set(csKey, e);
+}
+
+// ─── Public search API ────────────────────────────────────────────────
+
+export interface SearchOptions {
+  /** Cap on results (default 50). */
+  limit?: number;
+  /** Restrict to a single sdnType (e.g. 'vessel') when set. */
+  type?: SdnEntry['type'];
+}
+
+export interface SearchHit {
+  entry: SdnEntry;
+  /** Higher = stronger match. Tier ladder:
+   *    100 = exact (case-insensitive) match on `name`
+   *     90 = `name` starts with the query
+   *     80 = exact match on an alias
+   *     70 = alias starts with the query
+   *     60 = `name` contains the query (anywhere)
+   *     50 = alias / id / country contains the query */
+  score: number;
+}
+
+export function searchSanctions(
+  index: OfacIndex,
+  rawQuery: string,
+  opts: SearchOptions = {},
+): SearchHit[] {
+  const query = rawQuery.trim().toLowerCase();
+  if (!query) return [];
+  const limit = Math.max(1, Math.min(500, opts.limit ?? 50));
+  const out: SearchHit[] = [];
+
+  for (let i = 0; i < index.entries.length; i++) {
+    const entry = index.entries[i]!;
+    if (opts.type && entry.type !== opts.type) continue;
+    const score = scoreMatch(entry, query, index.searchHaystack[i] ?? '');
+    if (score === 0) continue;
+    out.push({ entry, score });
+  }
+
+  out.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.entry.name.localeCompare(b.entry.name);
+  });
+  return out.slice(0, limit);
+}
+
+function scoreMatch(entry: SdnEntry, query: string, haystack: string): number {
+  const name = entry.name.toLowerCase();
+  if (name === query) return 100;
+  if (name.startsWith(query)) return 90;
+  const aliasScore = scoreAliasMatch(entry.aliases, query);
+  if (aliasScore !== 0) return aliasScore;
+  if (name.includes(query)) return 60;
+  if (haystack.includes(query)) return 50;
+  return 0;
+}
+
+function scoreAliasMatch(aliases: readonly string[], query: string): number {
+  let prefixHit = false;
+  for (const alias of aliases) {
+    if (alias === query) return 80;
+    if (!prefixHit && alias.startsWith(query)) prefixHit = true;
+  }
+  return prefixHit ? 70 : 0;
+}
+
+// ─── Vessel-only convenience ──────────────────────────────────────────
+
+export function listSanctionedVessels(index: OfacIndex): SdnEntry[] {
+  return index.entries.filter((e) => e.type === 'vessel');
+}
+
+export function listSanctionedAircraft(index: OfacIndex): SdnEntry[] {
+  return index.entries.filter((e) => e.type === 'aircraft');
+}
+
+// ─── AIS cross-reference ──────────────────────────────────────────────
+
+export interface SanctionMatch {
+  matched: true;
+  reason: 'name' | 'imo' | 'callsign';
+  uid: string;
+  programs: string[];
+  /** Short human-readable label e.g. "OFAC SDN — RUSSIA-EO14024". */
+  badge: string;
+}
+
+export type SanctionMatchResult = SanctionMatch | { matched: false };
+
+/**
+ * Match a vessel from /api/maritime/vessels against the SDN index.
+ * Inputs may be partially populated (AIS often lacks IMO and
+ * callsign) — we just check whatever's present.
+ */
+export function matchVesselToSanction(
+  args: {
+    name?: string | null;
+    imo?: string | null;
+    callSign?: string | null;
+  },
+  index: Pick<OfacIndex, 'vesselsByName' | 'vesselsByImo' | 'vesselsByCallSign'>,
+): SanctionMatchResult {
+  const imoKey = args.imo ? normalizeImo(args.imo) : null;
+  if (imoKey) {
+    const hit = index.vesselsByImo.get(imoKey);
+    if (hit) return toMatch(hit, 'imo');
+  }
+  const csKey = args.callSign?.trim().toLowerCase();
+  if (csKey) {
+    const hit = index.vesselsByCallSign.get(csKey);
+    if (hit) return toMatch(hit, 'callsign');
+  }
+  const nameKey = args.name ? normalizeVesselName(args.name) : null;
+  if (nameKey) {
+    const hit = index.vesselsByName.get(nameKey);
+    if (hit) return toMatch(hit, 'name');
+  }
+  return { matched: false };
+}
+
+function toMatch(entry: SdnEntry, reason: 'name' | 'imo' | 'callsign'): SanctionMatch {
+  const programLabel = entry.programs.length > 0 ? entry.programs.join(', ').toUpperCase() : 'SDN';
+  return {
+    matched: true,
+    reason,
+    uid: entry.uid,
+    programs: [...entry.programs],
+    badge: `OFAC SDN — ${programLabel}`,
+  };
+}
+
+// ─── Normalizers ──────────────────────────────────────────────────────
+
+/** Vessel name keys: lowercased, collapsed whitespace, common
+ *  suffixes (M/V, M/T, MV, MT, S/V, formerly known as) stripped so
+ *  AIS-style "M/V STAR" and SDN "STAR" match. */
+export function normalizeVesselName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/\b(m\/v|m\/t|s\/v|m\.v\.|m\.t\.|f\.v\.|mv|mt)\b/g, ' ')
+    .replace(/[^a-z0-9 ]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** Treasury IMOs sometimes appear as "IMO 1234567" or "1234567". We
+ *  reduce to digits, then keep the trailing 7 digits when present. */
+export function normalizeImo(raw: string): string {
+  const digits = raw.replace(/\D+/g, '');
+  if (!digits) return '';
+  return digits.length > 7 ? digits.slice(-7) : digits;
+}

--- a/src/services/sanctions/ofac-types.ts
+++ b/src/services/sanctions/ofac-types.ts
@@ -1,0 +1,79 @@
+/**
+ * OFAC SDN (Specially Designated Nationals) types — pure data
+ * shapes shared between the parser, the search index, the sidecar
+ * cache file, and the renderer panel.
+ *
+ * Names mirror the upstream Treasury XML where reasonable, but field
+ * casing follows the rest of the codebase (camelCase, no hungarian).
+ */
+
+export type SdnType = 'individual' | 'vessel' | 'aircraft' | 'entity' | 'unknown';
+
+export interface VesselInfo {
+  callSign: string | null;
+  vesselType: string | null;
+  vesselFlag: string | null;
+  vesselOwner: string | null;
+  /** Gross tonnage (raw string from upstream). */
+  tonnage: string | null;
+  /** IMO number, copied here when present in idList for convenience. */
+  imo: string | null;
+}
+
+export interface AircraftInfo {
+  tailNumber: string | null;
+  model: string | null;
+  operator: string | null;
+  manufactureDate: string | null;
+  constructionNumber: string | null;
+}
+
+export interface SdnId {
+  idType: string;
+  idNumber: string;
+  idCountry: string | null;
+}
+
+export interface SdnAddress {
+  country: string | null;
+  city: string | null;
+  region: string | null;
+}
+
+export interface SdnEntry {
+  /** Stable upstream uid as a string ("12345"). */
+  uid: string;
+  /** Display name. For individuals "Last, First"; for vessels/aircraft
+   *  the raw ship/tail name. Always non-empty (we drop entries
+   *  upstream when no name is parseable). */
+  name: string;
+  type: SdnType;
+  /** Sanctions programs this entry is listed under (e.g. "SDGT",
+   *  "CYBER2", "UKRAINE-EO13662"). Always lowercase-trimmed and
+   *  deduped. */
+  programs: string[];
+  /** All a.k.a. names, lowercased + deduped. Used for search +
+   *  vessel-name cross-reference. */
+  aliases: string[];
+  countries: string[];
+  ids: SdnId[];
+  vessel: VesselInfo | null;
+  aircraft: AircraftInfo | null;
+  remarks: string | null;
+}
+
+/** The cached payload written to disk and consumed by the renderer
+ *  via /api/sanctions/* — versioned so a parser change forces a
+ *  refresh rather than mis-typing the old file. */
+export interface OfacCacheFile {
+  version: 1;
+  /** ms epoch when the upstream XML was downloaded. */
+  fetchedAt: number;
+  /** Raw byte length of the upstream XML, used as a quick "is this
+   *  the same payload as last week" sanity check. */
+  upstreamBytes: number;
+  /** Total entries in `entries` (kept here so the panel can show a
+   *  count badge without walking the array). */
+  entryCount: number;
+  entries: SdnEntry[];
+}


### PR DESCRIPTION
End-to-end OFAC sanctions intelligence sourced from the public Treasury `sdn.xml` feed (no API key required).

### Pure layer (`src/services/sanctions/`)
- **`ofac-types.ts`** — `SdnEntry` / `VesselInfo` / `AircraftInfo` / `OfacCacheFile`.
- **`ofac-parser.ts`** — pure XML walker; tolerates xmlns prefix variation + CDATA. Preserves uid, programs, aliases, ids, addresses, vesselInfo, aircraftInfo. Drops entries with no recoverable name.
- **`ofac-search.ts`** — index builder + `searchSanctions()` with a tiered score (exact name 100 / prefix 90 / alias-exact 80 / alias-prefix 70 / name-substring 60 / haystack 50). Vessel cross-reference via name (M/V prefix tolerated), IMO, or callsign — IMO match wins over name.

### Sidecar (`src-tauri/sidecar/ofac-cache.mjs`)
Mirror of the TS parser in plain JS so the sidecar boot doesn't pull in the renderer toolchain. Reads `${dataDir}/data/ofac-cache.json` on first call; refreshes from `treasury.gov` when missing or older than 7 days. Concurrent callers share a single in-flight refresh.

### Sidecar routes
- `GET /api/sanctions/search?q=&type=&limit=`
- `GET /api/sanctions/vessels`
- `GET /api/sanctions/aircraft`
- `GET /api/maritime/vessels` now adds `{ sanctioned, sanctionedReason, sanctionedBadge }` to any AIS vessel that matches a sanctioned SDN entry by name / IMO / callsign. Match is opportunistic — a cold cache returns vessels unflagged and kicks off a background refresh rather than blocking the request on a 28 MB download.

### UI (`src/components/SanctionsPanel.ts`, panel id `sanctions-intel`)
Three tabs — **Search**, **Vessels**, **Aircraft** — backed by the sidecar routes. Search debounced 200 ms with abort on next keystroke. Tab persists to localStorage. Registered in `panels.ts` (priority 2) and wired in `panel-layout.ts`. Co-exists with the unrelated OpenSanctions panel.

### Tests (≥15 — actually 27)
- 25 unit tests in `src/services/sanctions/__tests__/ofac.test.mts` covering parser shape across all five sdnTypes, alias dedup, search score tiers + type filter + limit, vessel cross-reference name/IMO/callsign priority, and normalizers.
- 2 sidecar parity tests in `src-tauri/sidecar/__tests__/ofac-cache.test.mjs` lock the JS-side parser to the TS contract.
- Existing 67-test sidecar suite still passes.
- `typecheck:all` clean, lint clean.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Cross-agent review: claude reviewed on 2026-05-08; outcome: pass
