### PR TITLE
feat(aviation): live commercial/cargo/GA flights with emergency squawk + TFR/SIGMET cross-ref

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -9940,6 +9940,162 @@ async function dispatch(requestUrl, req, routes, context) {
  }
   }
 
+  // ── Live flights — all categories (commercial, cargo, military, GA, helo) ─
+  // Wraps OpenSky `states/all`, classifies by callsign + hex range, and returns
+  // a category breakdown plus the full classified list. 10-min cache because
+  // OpenSky's anonymous tier is rate-limited to ~100 req/day.
+  if (requestUrl.pathname === '/api/aviation/flights') {
+ const CACHE_TTL = 10 * 60 * 1000;
+ const cached = getCached('aviation-flights', CACHE_TTL);
+ if (cached) return json(cached);
+
+ const clientId = process.env.OPENSKY_CLIENT_ID?.trim() || '';
+ const clientSecret = process.env.OPENSKY_CLIENT_SECRET?.trim() || '';
+ const headers = { 'User-Agent': CHROME_UA };
+ if (clientId && clientSecret) {
+ const creds = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+ headers['Authorization'] = `Basic ${creds}`;
+ }
+
+ const PASSENGER_AIRLINES = new Set([
+ 'AAL','DAL','UAL','SWA','JBU','ASA','SKW','RPA','ENY','ACA','WJA','BAW','VIR',
+ 'AFR','DLH','KLM','IBE','AZA','AUA','SWR','SAS','FIN','THY','UAE','ETD','QTR',
+ 'SVA','ELY','JAL','ANA','KAL','AAR','CES','CSN','CCA','SIA','CPA','QFA','ANZ',
+ 'AMX','LAN','TAM','AVA','RYR','EZY','WZZ','TRA','THA','MAS','AIC','IGO','EIN','AEE',
+ ]);
+ const CARGO_AIRLINES = new Set([
+ 'FDX','UPS','ABX','CKS','GTI','CLX','ABW','EVA','CAL','CKK','GEC','POT','SOO',
+ 'ICE','CTM','ABD','DHX','BCS','GLO',
+ ]);
+ const MILITARY_PREFIXES = new Set([
+ 'RCH','REACH','CNV','PAT','GOLD','SHELL','TEAL','HOMER','MAGIC','SENTRY','RIVET',
+ 'PYTHON','RAGE','VIPER','EAGLE','RAIDER','DOOM','BISON','ARMY','PEDRO','DUSTOFF',
+ 'NATO','RRR','ASCOT','RAFAIR','AUSY','CFC','CANFORCE','MIL','NAVY','AF',
+ ]);
+ const HELO_HINTS = ['HEMS','LIFEFLIGHT','AIRMED','MERCY','MEDFLIGHT','CARESTAR','CHP','COASTGUARD','USCG','RESCUE'];
+ const EMERGENCY_SQUAWKS = new Set(['7500', '7600', '7700']);
+ const MILITARY_HEX_RANGES = [
+ ['ADF7C7','ADF7CF'], ['AE0000','AFFFFF'], ['A00000','A3FFFF'], ['43C000','43CFFF'],
+ ['3A0000','3AFFFF'], ['3B0000','3BFFFF'], ['3F0000','3FFFFF'], ['738000','73FFFF'],
+ ['4D0000','4D03FF'], ['300000','33FFFF'], ['340000','37FFFF'], ['480000','480FFF'],
+ ['4BA000','4BCFFF'], ['710000','717FFF'], ['896000','896FFF'], ['06A000','06AFFF'],
+ ['706000','706FFF'], ['840000','87FFFF'], ['718000','71FFFF'], ['7CF800','7CFFFF'],
+ ['C00000','C0FFFF'], ['800000','83FFFF'], ['760000','767FFF'], ['500000','5003FF'],
+ ['488000','48FFFF'], ['468000','46FFFF'], ['4A8000','4AFFFF'], ['478000','47FFFF'],
+ ['768000','76FFFF'],
+ ];
+ const isMilitaryHex = (hex) => {
+ if (!hex) return false;
+ const upper = hex.toUpperCase();
+ if (!/^[0-9A-F]{6}$/.test(upper)) return false;
+ for (const [s, e] of MILITARY_HEX_RANGES) {
+ if (upper >= s && upper <= e) return true;
+ }
+ return false;
+ };
+ const operatorPrefix = (callsign) => {
+ if (!callsign) return null;
+ const upper = callsign.trim().toUpperCase();
+ if (upper.length < 3) return null;
+ const prefix = upper.slice(0, 3);
+ return /^[A-Z]{3}$/.test(prefix) ? prefix : null;
+ };
+ const classify = (state) => {
+ const icao24 = (state[0] ?? '').toString().toLowerCase().trim();
+ const callsignRaw = (state[1] ?? '').toString().trim();
+ const callsign = callsignRaw.length > 0 ? callsignRaw : null;
+ const lat = state[6];
+ const lon = state[5];
+ if (!icao24 || lat == null || lon == null) return null;
+ const squawk = state[14] ?? null;
+ const emergency = EMERGENCY_SQUAWKS.has(squawk);
+ const upperCallsign = callsign ? callsign.toUpperCase() : '';
+ const prefix = operatorPrefix(callsign);
+ let category;
+ let operatorIcao = prefix;
+ if (
+ isMilitaryHex(icao24) ||
+ (prefix && MILITARY_PREFIXES.has(prefix)) ||
+ (upperCallsign && [...MILITARY_PREFIXES].some((m) => upperCallsign.startsWith(m)))
+ ) {
+ category = 'military';
+ } else if (prefix && CARGO_AIRLINES.has(prefix)) {
+ category = 'cargo';
+ } else if (prefix && PASSENGER_AIRLINES.has(prefix)) {
+ category = 'commercial';
+ } else if (HELO_HINTS.some((h) => upperCallsign.startsWith(h))) {
+ category = 'helicopter';
+ } else {
+ category = 'general_aviation';
+ operatorIcao = prefix; // may still be a 3-letter prefix we don't know
+ }
+ return {
+ icao24,
+ callsign,
+ originCountry: (state[2] ?? '').toString().trim() || null,
+ category,
+ operatorIcao,
+ operatorName: null, // operator-name lookup happens renderer-side
+ lat,
+ lon,
+ altitudeFt: state[7] == null ? null : Math.round(state[7] * 3.28084),
+ velocityKts: state[9] == null ? null : Math.round(state[9] * 1.94384),
+ headingDeg: state[10] == null ? null : state[10],
+ squawk,
+ emergency,
+ emergencySquawk: emergency ? squawk : null,
+ onGround: state[8] === true,
+ lastSeen: typeof state[4] === 'number' ? state[4] * 1000 : Date.now(),
+ };
+ };
+ try {
+ const r = await fetchWithTimeout('https://opensky-network.org/api/states/all', { headers }, 12000);
+ if (r.status === 429) {
+ const env = {
+ flights: [], counts: { military: 0, commercial: 0, cargo: 0, helicopter: 0, general_aviation: 0, total: 0, emergency: 0, squawk7500: 0, squawk7600: 0, squawk7700: 0 },
+ fetchedAt: Date.now(), degraded: true, reason: 'rate limited', source: 'opensky-network.org',
+ };
+ return json(env, 429);
+ }
+ if (!r.ok) throw new Error(`OpenSky HTTP ${r.status}`);
+ const data = await r.json();
+ const flights = [];
+ const counts = { military: 0, commercial: 0, cargo: 0, helicopter: 0, general_aviation: 0, total: 0, emergency: 0, squawk7500: 0, squawk7600: 0, squawk7700: 0 };
+ for (const state of (data.states ?? [])) {
+ if (!Array.isArray(state) || state.length < 15) continue;
+ const flight = classify(state);
+ if (!flight) continue;
+ flights.push(flight);
+ counts[flight.category] += 1;
+ counts.total += 1;
+ if (flight.emergency) {
+ counts.emergency += 1;
+ if (flight.emergencySquawk === '7500') counts.squawk7500 += 1;
+ else if (flight.emergencySquawk === '7600') counts.squawk7600 += 1;
+ else if (flight.emergencySquawk === '7700') counts.squawk7700 += 1;
+ }
+ }
+ const envelope = {
+ flights,
+ counts,
+ fetchedAt: Date.now(),
+ degraded: false,
+ source: 'opensky-network.org',
+ };
+ setCached('aviation-flights', envelope);
+ return json(envelope);
+ } catch (error) {
+ return json({
+ flights: [],
+ counts: { military: 0, commercial: 0, cargo: 0, helicopter: 0, general_aviation: 0, total: 0, emergency: 0, squawk7500: 0, squawk7600: 0, squawk7700: 0 },
+ fetchedAt: Date.now(),
+ degraded: true,
+ reason: error?.message ?? String(error),
+ source: 'opensky-network.org',
+ }, 502);
+ }
+  }
+
   // ── Tor relay metrics ────────────────────────────────────────────────────
   if (requestUrl.pathname === '/api/tor-metrics') {
  const cached = getCached('tor-metrics', 60 * 60 * 1000);

--- a/src/components/AviationIntelPanel.ts
+++ b/src/components/AviationIntelPanel.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sonarjs/no-nested-template-literals */
 /**
  * Aviation Intelligence Panel — PR 2 of the aviation stack.
  *

--- a/src/components/AviationIntelPanel.ts
+++ b/src/components/AviationIntelPanel.ts
@@ -28,11 +28,37 @@ import {
   type AviationSigmet,
   type MilitaryAircraft,
 } from '@/services/aviation/aviation-intel-service';
+import {
+  fetchLiveFlights,
+  type LiveFlightsEnvelope,
+} from '@/services/aviation/commercial-flights-service';
+import {
+  emergencyLabel,
+  flightsInsideHazardZones,
+  type FlightCategory,
+  type LiveFlight,
+} from '@/services/aviation/commercial-flights-classify';
 import { escapeHtml } from '@/utils/sanitize';
 
 const REFRESH_MS = 5 * 60 * 1000;
 
-type Tab = 'notams' | 'sigmets' | 'pireps' | 'military' | 'delays';
+type Tab = 'notams' | 'sigmets' | 'pireps' | 'military' | 'delays' | 'flights';
+
+const FLIGHT_CATEGORY_LABEL: Record<FlightCategory, string> = {
+  military: 'Military',
+  commercial: 'Commercial',
+  cargo: 'Cargo',
+  helicopter: 'Helicopter',
+  general_aviation: 'General Aviation',
+};
+
+const FLIGHT_CATEGORY_HEX: Record<FlightCategory, string> = {
+  military: '#ffeb3b',
+  commercial: '#4a9eff',
+  cargo: '#9c27b0',
+  helicopter: '#8bc34a',
+  general_aviation: '#9e9e9e',
+};
 
 const HAZARD_COLOR: Record<AviationSigmet['hazard'], string> = {
   volcanic_ash: '#ff9800',
@@ -67,6 +93,7 @@ interface TabState {
   pireps: AviationFetchEnvelope<AviationPirep> | null;
   military: AviationFetchEnvelope<MilitaryAircraft> | null;
   delays: AviationFetchEnvelope<AirportGroundDelay> | null;
+  flights: LiveFlightsEnvelope | null;
 }
 
 export class AviationIntelPanel extends Panel {
@@ -78,6 +105,7 @@ export class AviationIntelPanel extends Panel {
     pireps: null,
     military: null,
     delays: null,
+    flights: null,
   };
   private loading = false;
 
@@ -88,7 +116,7 @@ export class AviationIntelPanel extends Panel {
       showCount: true,
       trackActivity: true,
       infoTooltip:
-        'TFRs, SIGMETs, PIREPs, military aircraft, airport delays. Refreshes every 5 min.',
+        'TFRs, SIGMETs, PIREPs, military aircraft, airport delays, and live commercial/cargo/GA flights with emergency squawk and TFR/SIGMET cross-reference. Refreshes every 5 min (live flights every 10 min — OpenSky rate limit).',
     });
     this.start();
   }
@@ -110,14 +138,15 @@ export class AviationIntelPanel extends Panel {
     if (this.loading) return;
     this.loading = true;
     try {
-      const [notams, sigmets, pireps, military, delays] = await Promise.all([
+      const [notams, sigmets, pireps, military, delays, flights] = await Promise.all([
         fetchNotams(),
         fetchSigmets(),
         fetchPireps(),
         fetchMilitaryAircraft(),
         fetchAirportDelays(),
+        fetchLiveFlights(),
       ]);
-      this.state = { notams, sigmets, pireps, military, delays };
+      this.state = { notams, sigmets, pireps, military, delays, flights };
     } catch {
       // Errors are surfaced as `degraded: true` in the envelopes — nothing
       // to do here beyond letting the previous snapshot stay visible.
@@ -128,12 +157,13 @@ export class AviationIntelPanel extends Panel {
   }
 
   private render(): void {
-    const counts = {
+    const counts: Record<Tab, number> = {
       notams: selectTfrs(this.state.notams?.data ?? []).length,
       sigmets: this.state.sigmets?.data.length ?? 0,
       pireps: this.state.pireps?.data.length ?? 0,
       military: this.state.military?.data.length ?? 0,
       delays: this.state.delays?.data.length ?? 0,
+      flights: this.state.flights?.counts.total ?? 0,
     };
     const totalCount = Object.values(counts).reduce((a, b) => a + b, 0);
     this.setCount(totalCount);
@@ -157,6 +187,7 @@ export class AviationIntelPanel extends Panel {
       { id: 'pireps', label: 'PIREPs' },
       { id: 'military', label: 'Military' },
       { id: 'delays', label: 'Delays' },
+      { id: 'flights', label: 'Live Flights' },
     ];
     return `
       <div style="display:flex;gap:4px;border-bottom:1px solid rgba(255,255,255,0.1);margin-bottom:6px;">
@@ -210,10 +241,14 @@ export class AviationIntelPanel extends Panel {
       case 'delays': {
         return banner + this.renderDelays(envelope as AviationFetchEnvelope<AirportGroundDelay>);
       }
+      case 'flights': {
+        return banner + this.renderFlights(envelope as LiveFlightsEnvelope);
+      }
     }
   }
 
-  private envelopeFor(tab: Tab): AviationFetchEnvelope<unknown> | null {
+  private envelopeFor(tab: Tab): { degraded: boolean; reason?: string; source: string } | null {
+    if (tab === 'flights') return this.state.flights;
     return this.state[tab];
   }
 
@@ -382,6 +417,101 @@ export class AviationIntelPanel extends Panel {
         `;
       })
       .join('');
+  }
+
+  private renderFlights(env: LiveFlightsEnvelope): string {
+    const c = env.counts;
+    if (env.flights.length === 0) {
+      return `<div style="opacity:0.6;">No flights tracked. ${escapeHtml(env.reason ?? '')}</div>`;
+    }
+    const categoryRow = (Object.keys(FLIGHT_CATEGORY_LABEL) as FlightCategory[])
+      .filter((cat) => c[cat] > 0)
+      .map((cat) => {
+        const hex = FLIGHT_CATEGORY_HEX[cat];
+        return `<span style="display:inline-block;padding:2px 8px;border:1px solid ${hex};border-radius:8px;font-size:11px;color:${hex};margin:0 4px 4px 0;">${escapeHtml(
+          FLIGHT_CATEGORY_LABEL[cat],
+        )} <strong>${c[cat]}</strong></span>`;
+      })
+      .join('');
+
+    const emergencyBlock = c.emergency > 0
+      ? this.renderEmergencyBlock(env.flights)
+      : '';
+
+    const tfrs = (this.state.notams?.data ?? []).filter(
+      (n) => (n.classification === 'TFR' || /TFR/i.test(n.text)) && n.center !== undefined,
+    );
+    const sigmets = this.state.sigmets?.data ?? [];
+    const inHazard = flightsInsideHazardZones(env.flights, tfrs, sigmets);
+    const hazardBlock = inHazard.length > 0
+      ? this.renderHazardBlock(inHazard)
+      : '';
+
+    const summaryLine = `<div style="font-size:11px;opacity:0.8;margin-bottom:6px;">
+        Total: <strong>${c.total}</strong> · Emergency: <strong style="color:${
+      c.emergency > 0 ? '#d50000' : 'inherit'
+    };">${c.emergency}</strong> · In TFR/SIGMET: <strong style="color:${
+      inHazard.length > 0 ? '#ff9800' : 'inherit'
+    };">${inHazard.length}</strong>
+      </div>`;
+
+    return `
+      ${summaryLine}
+      <div style="margin-bottom:6px;">${categoryRow}</div>
+      ${emergencyBlock}
+      ${hazardBlock}
+    `;
+  }
+
+  private renderEmergencyBlock(flights: readonly LiveFlight[]): string {
+    const emergencies = flights.filter((f) => f.emergency);
+    if (emergencies.length === 0) return '';
+    const rows = emergencies
+      .slice(0, 20)
+      .map((f) => {
+        const labelText = f.emergencySquawk ? emergencyLabel(f.emergencySquawk) : 'Emergency';
+        const where = `${f.lat.toFixed(2)}°, ${f.lon.toFixed(2)}°`;
+        const callsign = f.callsign ?? `ICAO ${f.icao24}`;
+        return `<div style="margin:4px 0;padding:6px;border-left:3px solid #d50000;background:rgba(213,0,0,0.10);">
+          <div style="display:flex;justify-content:space-between;font-weight:700;color:#d50000;">
+            <span>${escapeHtml(callsign)} • SQ ${escapeHtml(f.squawk ?? '')} • ${escapeHtml(labelText)}</span>
+            <span style="font-size:11px;">${escapeHtml(where)}</span>
+          </div>
+          <div style="font-size:11px;opacity:0.85;">
+            ${escapeHtml(FLIGHT_CATEGORY_LABEL[f.category])}${f.operatorName ? ` · ${escapeHtml(f.operatorName)}` : ''}${
+              f.altitudeFt === null ? '' : ` · ${f.altitudeFt} ft`
+            }${f.velocityKts === null ? '' : ` · ${f.velocityKts} kt`}
+          </div>
+        </div>`;
+      })
+      .join('');
+    return `<h4 style="margin:8px 0 4px 0;color:#d50000;">⚠ Unusual squawks (${emergencies.length})</h4>${rows}`;
+  }
+
+  private renderHazardBlock(
+    flights: readonly (LiveFlight & { hazards: { tfrIds: string[]; sigmetIds: string[] } })[],
+  ): string {
+    const rows = flights
+      .slice(0, 20)
+      .map((f) => {
+        const callsign = f.callsign ?? `ICAO ${f.icao24}`;
+        const tfrTag = f.hazards.tfrIds.length > 0
+          ? `<span style="color:#f44336;">TFR ${escapeHtml(f.hazards.tfrIds.join(', '))}</span>`
+          : '';
+        const sigmetTag = f.hazards.sigmetIds.length > 0
+          ? `<span style="color:#ffeb3b;">${escapeHtml(f.hazards.sigmetIds.join(', '))}</span>`
+          : '';
+        const sep = tfrTag && sigmetTag ? ' · ' : '';
+        return `<div style="margin:4px 0;padding:6px;border-left:3px solid #ff9800;background:rgba(255,152,0,0.08);">
+          <div style="display:flex;justify-content:space-between;font-weight:600;">
+            <span>${escapeHtml(callsign)} • ${escapeHtml(FLIGHT_CATEGORY_LABEL[f.category])}</span>
+            <span style="font-size:11px;opacity:0.8;">${f.lat.toFixed(2)}°, ${f.lon.toFixed(2)}°</span>
+          </div>
+          <div style="font-size:11px;">${tfrTag}${sep}${sigmetTag}</div>
+        </div>`;
+      })
+      .join('');
+    return `<h4 style="margin:8px 0 4px 0;color:#ff9800;">In TFR / SIGMET zones (${flights.length})</h4>${rows}`;
   }
 
   private wireHandlers(): void {

--- a/src/components/GlobeDataManager.ts
+++ b/src/components/GlobeDataManager.ts
@@ -74,6 +74,8 @@ import {
   ICON_BASE,
   ICON_BASE_NAVAL,
   ICON_BASE_AIR,
+  ICON_TRANSPORT,
+  ICON_HELICOPTER,
   ICON_AIRSTRIKE,
   ICON_DARK_VESSEL,
   ICON_GPS_JAM,
@@ -420,6 +422,45 @@ function diseaseScale(casesPerM: number): number {
 
 const LABEL_OFFSET = new Cartesian3(0, -20, 0) as unknown as import('cesium').Cartesian2;
 const LABEL_OFFSET_SM = new Cartesian3(0, -18, 0) as unknown as import('cesium').Cartesian2;
+
+const COMMERCIAL_FLIGHT_HEX: Record<
+  import('@/services/aviation/commercial-flights-classify').FlightCategory,
+  string
+> = {
+  military: '#ffeb3b',
+  commercial: '#4a9eff',
+  cargo: '#9c27b0',
+  helicopter: '#8bc34a',
+  general_aviation: '#9e9e9e',
+};
+
+function categoryRank(
+  category: import('@/services/aviation/commercial-flights-classify').FlightCategory,
+): number {
+  if (category === 'commercial') return 0;
+  if (category === 'cargo') return 1;
+  if (category === 'helicopter') return 2;
+  if (category === 'general_aviation') return 3;
+  return 4;
+}
+
+function commercialFlightDescriptionHtml(
+  flight: import('@/services/aviation/commercial-flights-classify').LiveFlight,
+): string {
+  const lines: string[] = [
+    `<h3>${escapeHtml(flight.callsign ?? flight.icao24)}</h3>`,
+    `<div>Category: ${escapeHtml(flight.category.replace(/_/g, ' '))}</div>`,
+    flight.operatorName ? `<div>Operator: ${escapeHtml(flight.operatorName)}</div>` : '',
+    flight.originCountry ? `<div>Origin: ${escapeHtml(flight.originCountry)}</div>` : '',
+    flight.altitudeFt === null ? '' : `<div>Altitude: ${flight.altitudeFt} ft</div>`,
+    flight.velocityKts === null ? '' : `<div>Speed: ${flight.velocityKts} kt</div>`,
+    flight.headingDeg === null ? '' : `<div>Heading: ${Math.round(flight.headingDeg)}°</div>`,
+    flight.emergency
+      ? `<strong style="color:#d50000;">EMERGENCY squawk ${escapeHtml(flight.squawk ?? '')}</strong>`
+      : '',
+  ];
+  return lines.filter(Boolean).join('\n');
+}
 
 function setEntityTimestamp(entity: import('cesium').Entity, when: Date): void {
   entity.properties ??= new PropertyBag();
@@ -1561,11 +1602,15 @@ ${pkg.composition.map(u => u.type + ' x' + String(u.count)).join(', ')}`,
  const layer = this.layers.get('aviationIntel');
  if (!layer) return;
 
- const [{ fetchAviationIntelSnapshot }, helpers] = await Promise.all([
+ const [{ fetchAviationIntelSnapshot }, helpers, { fetchLiveFlights }] = await Promise.all([
  import('@/services/aviation/aviation-intel-service'),
  import('@/services/aviation/aviation-globe-helpers'),
+ import('@/services/aviation/commercial-flights-service'),
  ]);
- const snapshot = await fetchAviationIntelSnapshot();
+ const [snapshot, liveFlights] = await Promise.all([
+ fetchAviationIntelSnapshot(),
+ fetchLiveFlights(),
+ ]);
 
  layer.source.entities.removeAll();
 
@@ -1581,6 +1626,112 @@ ${pkg.composition.map(u => u.type + ' x' + String(u.count)).join(', ')}`,
  for (const ac of helpers.aircraftWithPosition(snapshot.military.data)) {
  this.addAviationAircraftEntity(layer, ac, helpers);
  }
+ // Commercial / cargo / GA flights — emergencies always render with a red
+ // pulse; non-emergency flights are capped to keep the globe usable.
+ for (const flight of this.selectFlightsForGlobe(liveFlights.flights)) {
+ this.addCommercialFlightEntity(layer, flight);
+ }
+  }
+
+  private selectFlightsForGlobe(
+ flights: readonly import('@/services/aviation/commercial-flights-classify').LiveFlight[],
+  ): import('@/services/aviation/commercial-flights-classify').LiveFlight[] {
+ const NON_EMERGENCY_CAP = 1500;
+ const out: import('@/services/aviation/commercial-flights-classify').LiveFlight[] = [];
+ const nonEmergency: import('@/services/aviation/commercial-flights-classify').LiveFlight[] = [];
+ for (const f of flights) {
+ if (f.onGround) continue;
+ if (f.emergency) {
+ out.push(f);
+ } else if (f.category !== 'military') {
+ // Military aircraft are already rendered via the existing
+ // aircraftWithPosition pass — skip to avoid duplicates.
+ nonEmergency.push(f);
+ }
+ }
+ // Sort cargo + commercial first so the cap doesn't drop the most
+ // recognisable category.
+ nonEmergency.sort((a, b) => categoryRank(a.category) - categoryRank(b.category));
+ for (const f of nonEmergency.slice(0, NON_EMERGENCY_CAP)) out.push(f);
+ return out;
+  }
+
+  private addCommercialFlightEntity(
+ layer: GlobeLayer,
+ flight: import('@/services/aviation/commercial-flights-classify').LiveFlight,
+  ): void {
+ const altMeters = flight.altitudeFt === null ? 0 : flight.altitudeFt * 0.3048;
+ const heading = flight.headingDeg ?? 0;
+ const colorHex = COMMERCIAL_FLIGHT_HEX[flight.category] ?? '#9e9e9e';
+ const color = Color.fromCssColorString(colorHex);
+ if (flight.emergency) {
+ // Red pulsing dot — pulsing achieved via a CallbackProperty on alpha.
+ const startMs = Date.now();
+ const pulse = new CallbackProperty(() => {
+ const t = ((Date.now() - startMs) % 1200) / 1200;
+ const alpha = 0.4 + 0.6 * Math.abs(Math.sin(t * Math.PI));
+ return Color.RED.withAlpha(alpha);
+ }, false);
+ layer.source.entities.add(new Entity({
+ id: `aviation-flight-${flight.icao24}`,
+ position: Cartesian3.fromDegrees(flight.lon, flight.lat, altMeters),
+ point: {
+ pixelSize: 14,
+ color: pulse,
+ outlineColor: Color.WHITE,
+ outlineWidth: 2,
+ heightReference: HeightReference.NONE,
+ },
+ label: flight.callsign ? {
+ text: `${flight.callsign}  SQ ${flight.squawk ?? ''}`,
+ font: '11px monospace',
+ fillColor: Color.RED,
+ outlineColor: Color.BLACK,
+ outlineWidth: 2,
+ style: 2,
+ pixelOffset: LABEL_OFFSET_SM,
+ horizontalOrigin: HorizontalOrigin.CENTER,
+ verticalOrigin: VerticalOrigin.BOTTOM,
+ scaleByDistance: new NearFarScalar(1e5, 1, 1.5e7, 0.4),
+ distanceDisplayCondition: new DistanceDisplayCondition(0, 1.5e7),
+ } : undefined,
+ description: commercialFlightDescriptionHtml(flight),
+ name: flight.callsign ?? flight.icao24,
+ }));
+ return;
+ }
+ const icon = flight.category === 'helicopter' ? ICON_HELICOPTER : ICON_TRANSPORT;
+ layer.source.entities.add(new Entity({
+ id: `aviation-flight-${flight.icao24}`,
+ position: Cartesian3.fromDegrees(flight.lon, flight.lat, altMeters),
+ billboard: {
+ image: icon,
+ color,
+ scale: 0.22,
+ rotation: CesiumMath.toRadians(-heading),
+ alignedAxis: Cartesian3.UNIT_Z,
+ heightReference: HeightReference.NONE,
+ horizontalOrigin: HorizontalOrigin.CENTER,
+ verticalOrigin: VerticalOrigin.CENTER,
+ scaleByDistance: new NearFarScalar(1e5, 0.9, 1.5e7, 0.25),
+ distanceDisplayCondition: new DistanceDisplayCondition(0, 8e6),
+ },
+ label: flight.callsign ? {
+ text: flight.callsign,
+ font: '9px monospace',
+ fillColor: color,
+ outlineColor: Color.BLACK,
+ outlineWidth: 2,
+ style: 2,
+ pixelOffset: LABEL_OFFSET_SM,
+ horizontalOrigin: HorizontalOrigin.CENTER,
+ verticalOrigin: VerticalOrigin.BOTTOM,
+ scaleByDistance: new NearFarScalar(1e5, 1, 1.5e7, 0.4),
+ distanceDisplayCondition: new DistanceDisplayCondition(0, 3e6),
+ } : undefined,
+ description: commercialFlightDescriptionHtml(flight),
+ name: flight.callsign ?? flight.icao24,
+ }));
   }
 
   private addAviationTfrEntity(

--- a/src/services/aviation/__tests__/commercial-flights-classify.test.mts
+++ b/src/services/aviation/__tests__/commercial-flights-classify.test.mts
@@ -1,0 +1,412 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  classifyFlight,
+  classifyFlights,
+  crossReferenceHazards,
+  emergencyLabel,
+  filterByAnyPlace,
+  filterByBoundingBox,
+  filterByRadius,
+  flightsInsideHazardZones,
+  flightStyle,
+  flightCategoryColor,
+  haversineKm,
+  isEmergencySquawk,
+  isFlightInSigmet,
+  isFlightInTfr,
+  isMilitaryHex,
+  operatorIcaoFromCallsign,
+  summariseFlights,
+  type LiveFlight,
+  type OpenSkyStateTuple,
+} from '../commercial-flights-classify';
+import type { AviationNotam, AviationSigmet } from '../aviation-intel-types';
+
+function makeState(overrides: Partial<{
+  icao24: string;
+  callsign: string | null;
+  country: string;
+  lon: number;
+  lat: number;
+  altMeters: number | null;
+  onGround: boolean;
+  velocityMps: number | null;
+  trackDeg: number | null;
+  squawk: string | null;
+}> = {}): OpenSkyStateTuple {
+  const v = {
+    // Default to a civilian-allocated US hex (A40000–ADF7C6) — A1B2C3 etc. fall
+    // inside the USAF military range A00000–A3FFFF and would be misclassified.
+    icao24: 'a4dead',
+    callsign: 'AAL123  ',
+    country: 'United States',
+    lon: -97.5,
+    lat: 35.0,
+    altMeters: 10_000,
+    onGround: false,
+    velocityMps: 230,
+    trackDeg: 90,
+    squawk: '1234',
+    ...overrides,
+  };
+  return [
+    v.icao24,
+    v.callsign,
+    v.country,
+    Math.floor(Date.now() / 1000),
+    Math.floor(Date.now() / 1000),
+    v.lon,
+    v.lat,
+    v.altMeters,
+    v.onGround,
+    v.velocityMps,
+    v.trackDeg,
+    null,
+    null,
+    null,
+    v.squawk,
+    null,
+    0,
+  ] as unknown as OpenSkyStateTuple;
+}
+
+describe('isEmergencySquawk', () => {
+  it('detects 7500 (hijack)', () => {
+    assert.equal(isEmergencySquawk('7500'), true);
+  });
+  it('detects 7600 (comms failure)', () => {
+    assert.equal(isEmergencySquawk('7600'), true);
+  });
+  it('detects 7700 (general emergency)', () => {
+    assert.equal(isEmergencySquawk('7700'), true);
+  });
+  it('rejects normal squawks', () => {
+    assert.equal(isEmergencySquawk('1200'), false);
+    assert.equal(isEmergencySquawk('7000'), false);
+    assert.equal(isEmergencySquawk(null), false);
+    assert.equal(isEmergencySquawk(undefined), false);
+    assert.equal(isEmergencySquawk(''), false);
+  });
+  it('emergencyLabel produces human-readable strings', () => {
+    assert.equal(emergencyLabel('7500'), 'Hijack');
+    assert.equal(emergencyLabel('7600'), 'Comms failure');
+    assert.equal(emergencyLabel('7700'), 'General emergency');
+  });
+});
+
+describe('isMilitaryHex', () => {
+  it('matches USA range', () => {
+    assert.equal(isMilitaryHex('AE0001'), true);
+    assert.equal(isMilitaryHex('AFFFFE'), true);
+  });
+  it('matches lower-case hex', () => {
+    assert.equal(isMilitaryHex('ae0001'), true);
+  });
+  it('rejects non-military hex', () => {
+    // A45678 is in the civilian US allocation (above A3FFFF, below ADF7C7).
+    assert.equal(isMilitaryHex('A45678'), false);
+    assert.equal(isMilitaryHex('1234'), false);
+    assert.equal(isMilitaryHex(''), false);
+    assert.equal(isMilitaryHex('not-hex'), false);
+  });
+});
+
+describe('operatorIcaoFromCallsign', () => {
+  it('extracts the leading 3-letter prefix', () => {
+    assert.equal(operatorIcaoFromCallsign('UAL3456'), 'UAL');
+    assert.equal(operatorIcaoFromCallsign('aal12  '), 'AAL');
+  });
+  it('returns null for tail numbers and short callsigns', () => {
+    assert.equal(operatorIcaoFromCallsign('N12345'), null);
+    assert.equal(operatorIcaoFromCallsign('AB'), null);
+    assert.equal(operatorIcaoFromCallsign(null), null);
+    assert.equal(operatorIcaoFromCallsign(''), null);
+  });
+});
+
+describe('classifyFlight', () => {
+  it('classifies American Airlines as commercial with operator name', () => {
+    const f = classifyFlight(makeState({ callsign: 'AAL123', icao24: 'abcdef' }));
+    assert.ok(f);
+    assert.equal(f.category, 'commercial');
+    assert.equal(f.operatorIcao, 'AAL');
+    assert.equal(f.operatorName, 'American Airlines');
+    assert.equal(f.emergency, false);
+  });
+
+  it('classifies FedEx as cargo', () => {
+    const f = classifyFlight(makeState({ callsign: 'FDX1' }));
+    assert.ok(f);
+    assert.equal(f.category, 'cargo');
+    assert.equal(f.operatorName, 'FedEx Express');
+  });
+
+  it('classifies USAF C-17 (REACH callsign + military hex) as military', () => {
+    const f = classifyFlight(makeState({ callsign: 'RCH473', icao24: 'AE1234' }));
+    assert.ok(f);
+    assert.equal(f.category, 'military');
+  });
+
+  it('classifies medical helo (LIFEFLIGHT prefix) as helicopter', () => {
+    const f = classifyFlight(makeState({ callsign: 'LIFEFLIGHT2', icao24: 'a40001' }));
+    assert.ok(f);
+    assert.equal(f.category, 'helicopter');
+  });
+
+  it('classifies unknown N-tail as general_aviation', () => {
+    const f = classifyFlight(makeState({ callsign: 'N12345', icao24: 'a40002' }));
+    assert.ok(f);
+    assert.equal(f.category, 'general_aviation');
+    assert.equal(f.operatorIcao, null);
+  });
+
+  it('flags emergency=true with emergencySquawk for squawk 7700', () => {
+    const f = classifyFlight(makeState({ callsign: 'DAL999', squawk: '7700' }));
+    assert.ok(f);
+    assert.equal(f.emergency, true);
+    assert.equal(f.emergencySquawk, '7700');
+    // category is still commercial — emergency is orthogonal
+    assert.equal(f.category, 'commercial');
+  });
+
+  it('converts altitude meters → feet (nearest int)', () => {
+    const f = classifyFlight(makeState({ altMeters: 10_000 }));
+    assert.ok(f);
+    assert.equal(f.altitudeFt, 32_808);
+  });
+
+  it('converts velocity m/s → knots', () => {
+    const f = classifyFlight(makeState({ velocityMps: 230 }));
+    assert.ok(f);
+    assert.equal(f.velocityKts, 447);
+  });
+
+  it('returns null for missing position', () => {
+    const f = classifyFlight(
+      makeState({ lat: null as unknown as number, lon: null as unknown as number }),
+    );
+    assert.equal(f, null);
+  });
+
+  it('returns null for empty icao24', () => {
+    const f = classifyFlight(makeState({ icao24: '' }));
+    assert.equal(f, null);
+  });
+});
+
+describe('classifyFlights (full payload)', () => {
+  it('skips invalid rows and classifies valid ones', () => {
+    const payload = {
+      states: [
+        ['abcdef', 'UAL55  ', 'United States', 0, 0, -97, 35, 9000, false, 200, 270, null, null, null, '1200', null, 0],
+        ['AE9999', 'RCH123 ', 'United States', 0, 0, -100, 40, 11_000, false, 250, 90, null, null, null, '7700', null, 0],
+        // Invalid row
+        ['short'],
+      ],
+    };
+    const flights = classifyFlights(payload);
+    assert.equal(flights.length, 2);
+    assert.equal(flights[0]!.category, 'commercial');
+    assert.equal(flights[1]!.category, 'military');
+    assert.equal(flights[1]!.emergency, true);
+  });
+  it('returns [] for malformed payload', () => {
+    assert.deepEqual(classifyFlights(null), []);
+    assert.deepEqual(classifyFlights({ wrong: 'shape' }), []);
+    assert.deepEqual(classifyFlights({ states: 'not-an-array' }), []);
+  });
+});
+
+describe('summariseFlights', () => {
+  it('counts each category and emergency squawks', () => {
+    const flights: LiveFlight[] = [
+      { ...makeFlight('commercial'), emergency: false, emergencySquawk: null },
+      { ...makeFlight('cargo'), emergency: false, emergencySquawk: null },
+      { ...makeFlight('military'), emergency: true, emergencySquawk: '7700' },
+      { ...makeFlight('general_aviation'), emergency: true, emergencySquawk: '7500' },
+      { ...makeFlight('helicopter'), emergency: true, emergencySquawk: '7600' },
+    ];
+    const counts = summariseFlights(flights);
+    assert.equal(counts.total, 5);
+    assert.equal(counts.commercial, 1);
+    assert.equal(counts.cargo, 1);
+    assert.equal(counts.military, 1);
+    assert.equal(counts.helicopter, 1);
+    assert.equal(counts.general_aviation, 1);
+    assert.equal(counts.emergency, 3);
+    assert.equal(counts.squawk7500, 1);
+    assert.equal(counts.squawk7600, 1);
+    assert.equal(counts.squawk7700, 1);
+  });
+});
+
+describe('haversineKm', () => {
+  it('returns ~111 km for 1 degree of latitude', () => {
+    const d = haversineKm({ lat: 0, lon: 0 }, { lat: 1, lon: 0 });
+    assert.ok(Math.abs(d - 111) < 1, `expected ~111km, got ${d}`);
+  });
+  it('returns 0 for identical points', () => {
+    assert.equal(haversineKm({ lat: 35, lon: -97 }, { lat: 35, lon: -97 }), 0);
+  });
+});
+
+describe('filterByBoundingBox', () => {
+  const flights = [
+    { lat: 35, lon: -97 },
+    { lat: 35, lon: -130 },
+    { lat: -10, lon: 50 },
+  ];
+  it('filters to inside-the-box flights', () => {
+    const out = filterByBoundingBox(flights, { west: -110, south: 30, east: -90, north: 40 });
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.lon, -97);
+  });
+  it('handles antimeridian-crossing boxes (west > east)', () => {
+    // Flights at lon 170, -170 should both be inside a box that wraps the dateline.
+    const wrap = filterByBoundingBox(
+      [{ lat: 0, lon: 170 }, { lat: 0, lon: -170 }, { lat: 0, lon: 0 }],
+      { west: 160, south: -10, east: -160, north: 10 },
+    );
+    assert.equal(wrap.length, 2);
+  });
+});
+
+describe('filterByRadius / filterByAnyPlace', () => {
+  const place = { id: 'home', name: 'La Porte IN', lat: 41.6, lon: -86.7, radiusKm: 100 };
+  const flights = [
+    { lat: 41.7, lon: -86.6 }, // ~12 km away
+    { lat: 35.0, lon: -97.0 }, // ~1100 km away
+  ];
+  it('keeps flights inside radius', () => {
+    const out = filterByRadius(flights, place);
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.lon, -86.6);
+  });
+  it('returns input unchanged when no places given', () => {
+    const out = filterByAnyPlace(flights, []);
+    assert.equal(out.length, 2);
+  });
+  it('union across multiple places', () => {
+    const place2 = { id: 'okc', name: 'OKC', lat: 35.5, lon: -97.5, radiusKm: 100 };
+    const out = filterByAnyPlace(flights, [place, place2]);
+    assert.equal(out.length, 2);
+  });
+});
+
+describe('TFR / SIGMET cross-reference', () => {
+  const tfr: AviationNotam = {
+    id: 'tfr-1',
+    notamNumber: '1/1234',
+    classification: 'TFR',
+    affectedFir: null,
+    featureName: null,
+    icaoId: null,
+    text: 'TFR',
+    effectiveStart: 0,
+    effectiveEnd: 0,
+    center: { lat: 41.6, lon: -86.7, radiusNm: 30 },
+    presidential: false,
+  };
+  const sigmet: AviationSigmet = {
+    id: 'sig-1',
+    hazard: 'turbulence',
+    severity: 'moderate',
+    polygon: [
+      { lat: 40, lon: -90 },
+      { lat: 45, lon: -90 },
+      { lat: 45, lon: -85 },
+      { lat: 40, lon: -85 },
+    ],
+    text: 'TURB',
+    validFrom: 0,
+    validTo: 0,
+    isAirmet: false,
+  };
+
+  it('flags a flight inside the TFR circle', () => {
+    assert.equal(isFlightInTfr({ lat: 41.6, lon: -86.7 }, tfr), true);
+  });
+  it('does NOT flag a flight far outside the TFR', () => {
+    assert.equal(isFlightInTfr({ lat: 35, lon: -97 }, tfr), false);
+  });
+  it('TFR with no center returns false', () => {
+    const noCenter: AviationNotam = { ...tfr, center: undefined };
+    assert.equal(isFlightInTfr({ lat: 41.6, lon: -86.7 }, noCenter), false);
+  });
+
+  it('flags a flight inside a SIGMET polygon', () => {
+    assert.equal(isFlightInSigmet({ lat: 42, lon: -87 }, sigmet), true);
+  });
+  it('does NOT flag a flight outside the SIGMET polygon', () => {
+    assert.equal(isFlightInSigmet({ lat: 35, lon: -97 }, sigmet), false);
+  });
+  it('SIGMET with <3 points returns false', () => {
+    const small: AviationSigmet = {
+      ...sigmet,
+      polygon: [{ lat: 40, lon: -90 }, { lat: 45, lon: -90 }],
+    };
+    assert.equal(isFlightInSigmet({ lat: 42, lon: -87 }, small), false);
+  });
+
+  it('crossReferenceHazards collects TFR + SIGMET ids', () => {
+    const r = crossReferenceHazards({ lat: 41.6, lon: -86.7 }, [tfr], [sigmet]);
+    assert.deepEqual(r.tfrIds, ['tfr-1']);
+    assert.deepEqual(r.sigmetIds, ['sig-1']);
+  });
+
+  it('flightsInsideHazardZones returns only intersecting flights', () => {
+    const flights: LiveFlight[] = [
+      { ...makeFlight('commercial'), lat: 41.6, lon: -86.7 }, // in TFR + SIGMET
+      { ...makeFlight('cargo'), lat: 35, lon: -97 },           // in neither
+    ];
+    const inside = flightsInsideHazardZones(flights, [tfr], [sigmet]);
+    assert.equal(inside.length, 1);
+    assert.deepEqual(inside[0]!.hazards.tfrIds, ['tfr-1']);
+  });
+});
+
+describe('flightStyle / flightCategoryColor', () => {
+  it('emergency flights render red regardless of category', () => {
+    const f: LiveFlight = { ...makeFlight('commercial'), emergency: true, emergencySquawk: '7500' };
+    const style = flightStyle(f);
+    assert.equal(style.hex, '#d50000');
+    assert.equal(style.emergency, true);
+    assert.ok(style.pixelSize >= 10);
+  });
+  it('non-emergency flights use category color', () => {
+    const f = { ...makeFlight('cargo'), emergency: false, emergencySquawk: null };
+    const style = flightStyle(f);
+    assert.equal(style.hex, flightCategoryColor('cargo'));
+    assert.equal(style.emergency, false);
+  });
+  it('every category has a stable color', () => {
+    for (const cat of ['military', 'commercial', 'cargo', 'helicopter', 'general_aviation'] as const) {
+      assert.ok(flightCategoryColor(cat).startsWith('#'));
+    }
+  });
+});
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function makeFlight(category: LiveFlight['category']): LiveFlight {
+  return {
+    icao24: 'abcdef',
+    callsign: 'TEST123',
+    originCountry: 'United States',
+    category,
+    operatorIcao: 'AAL',
+    operatorName: 'American Airlines',
+    lat: 35,
+    lon: -97,
+    altitudeFt: 30_000,
+    velocityKts: 450,
+    headingDeg: 90,
+    squawk: '1200',
+    emergency: false,
+    emergencySquawk: null,
+    onGround: false,
+    lastSeen: Date.now(),
+  };
+}

--- a/src/services/aviation/__tests__/commercial-flights-service.test.mts
+++ b/src/services/aviation/__tests__/commercial-flights-service.test.mts
@@ -1,0 +1,136 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  __TEST_HOOKS__,
+  clearLiveFlightsCache,
+  fetchLiveFlights,
+} from '../commercial-flights-service';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function mockFetch(handler: (url: string) => Response | Promise<Response>): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).fetch = (input: unknown): Promise<Response> => {
+    const url = typeof input === 'string' ? input : (input as { url: string }).url;
+    return Promise.resolve(handler(url));
+  };
+}
+
+function restoreFetch(): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).fetch = ORIGINAL_FETCH;
+}
+
+beforeEach(() => clearLiveFlightsCache());
+afterEach(() => restoreFetch());
+
+describe('fetchLiveFlights', () => {
+  it('returns the envelope from a successful sidecar response', async () => {
+    mockFetch(() =>
+      new Response(
+        JSON.stringify({
+          flights: [],
+          counts: {
+            military: 0, commercial: 0, cargo: 0, helicopter: 0, general_aviation: 0,
+            total: 0, emergency: 0, squawk7500: 0, squawk7600: 0, squawk7700: 0,
+          },
+          fetchedAt: 1_700_000_000_000,
+          degraded: false,
+          source: 'opensky-network.org',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    const env = await fetchLiveFlights();
+    assert.equal(env.degraded, false);
+    assert.equal(env.flights.length, 0);
+    assert.equal(env.source, 'opensky-network.org');
+  });
+
+  it('marks envelope degraded on non-2xx HTTP', async () => {
+    mockFetch(() => new Response('boom', { status: 500 }));
+    const env = await fetchLiveFlights();
+    assert.equal(env.degraded, true);
+    assert.match(env.reason ?? '', /HTTP 500/);
+    assert.equal(env.flights.length, 0);
+  });
+
+  it('classifies a raw OpenSky payload (fallback shape)', async () => {
+    mockFetch(() =>
+      new Response(
+        JSON.stringify({
+          states: [
+            ['abcdef', 'AAL55  ', 'United States', 0, 0, -97, 35, 9000, false, 200, 270, null, null, null, '1200', null, 0],
+            ['AE1111', 'RCH99  ', 'United States', 0, 0, -100, 40, 11_000, false, 250, 90, null, null, null, '7700', null, 0],
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    const env = await fetchLiveFlights();
+    assert.equal(env.flights.length, 2);
+    assert.equal(env.counts.commercial, 1);
+    assert.equal(env.counts.military, 1);
+    assert.equal(env.counts.emergency, 1);
+  });
+
+  it('serves the in-memory cache within the poll interval', async () => {
+    let calls = 0;
+    mockFetch(() => {
+      calls += 1;
+      return new Response(
+        JSON.stringify({
+          flights: [],
+          counts: {
+            military: 0, commercial: 0, cargo: 0, helicopter: 0, general_aviation: 0,
+            total: 0, emergency: 0, squawk7500: 0, squawk7600: 0, squawk7700: 0,
+          },
+          fetchedAt: Date.now(),
+          degraded: false,
+          source: 'opensky-network.org',
+        }),
+        { status: 200 },
+      );
+    });
+    await fetchLiveFlights();
+    await fetchLiveFlights();
+    await fetchLiveFlights();
+    assert.equal(calls, 1, 'second + third call should hit the cache');
+  });
+
+  it('handles the rate-limited response shape', async () => {
+    mockFetch(() =>
+      new Response(JSON.stringify({ rateLimited: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const env = await fetchLiveFlights();
+    assert.equal(env.degraded, true);
+    assert.match(env.reason ?? '', /rate limited/i);
+  });
+
+  it('clearLiveFlightsCache forces a refetch', async () => {
+    let calls = 0;
+    mockFetch(() => {
+      calls += 1;
+      return new Response(
+        JSON.stringify({ flights: [], counts: {
+          military: 0, commercial: 0, cargo: 0, helicopter: 0, general_aviation: 0,
+          total: 0, emergency: 0, squawk7500: 0, squawk7600: 0, squawk7700: 0,
+        }, fetchedAt: Date.now(), degraded: false, source: 'opensky-network.org' }),
+        { status: 200 },
+      );
+    });
+    await fetchLiveFlights();
+    clearLiveFlightsCache();
+    await fetchLiveFlights();
+    assert.equal(calls, 2);
+  });
+
+  it('exposes POLL_INTERVAL_MS for inspection', () => {
+    assert.equal(typeof __TEST_HOOKS__.POLL_INTERVAL_MS, 'number');
+    assert.ok(__TEST_HOOKS__.POLL_INTERVAL_MS >= 60_000);
+  });
+});

--- a/src/services/aviation/__tests__/commercial-flights-service.test.mts
+++ b/src/services/aviation/__tests__/commercial-flights-service.test.mts
@@ -10,16 +10,14 @@ import {
 const ORIGINAL_FETCH = globalThis.fetch;
 
 function mockFetch(handler: (url: string) => Response | Promise<Response>): void {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (globalThis as any).fetch = (input: unknown): Promise<Response> => {
+  Reflect.set(globalThis, 'fetch', (input: unknown): Promise<Response> => {
     const url = typeof input === 'string' ? input : (input as { url: string }).url;
     return Promise.resolve(handler(url));
-  };
+  });
 }
 
 function restoreFetch(): void {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (globalThis as any).fetch = ORIGINAL_FETCH;
+  Reflect.set(globalThis, 'fetch', ORIGINAL_FETCH);
 }
 
 beforeEach(() => clearLiveFlightsCache());

--- a/src/services/aviation/commercial-flights-classify.ts
+++ b/src/services/aviation/commercial-flights-classify.ts
@@ -1,0 +1,562 @@
+/**
+ * Commercial flight classification — pure-deterministic core.
+ *
+ * Takes a parsed OpenSky `states/all` record (or generic flight tuple) and
+ * returns a typed `LiveFlight` with category + emergency-squawk flag. No
+ * I/O, no globals, no fetch — everything is unit-testable with static
+ * fixtures.
+ *
+ * Categories:
+ *   - military          : known military hex range OR military callsign prefix
+ *   - commercial        : known passenger airline ICAO callsign prefix
+ *   - cargo             : known cargo airline ICAO callsign prefix
+ *   - helicopter        : medical/HEMS/utility helo callsign hints
+ *   - general_aviation  : everything else with a position
+ *
+ * Emergency squawks (7500 hijack, 7600 comms failure, 7700 general) are a
+ * separate flag — a commercial 737 with squawk 7700 is still `commercial`,
+ * but `emergency` is true and the panel/globe surface it as a red pulse.
+ */
+
+import type { AviationNotam, AviationSigmet } from './aviation-intel-types';
+
+export type FlightCategory =
+  | 'military'
+  | 'commercial'
+  | 'cargo'
+  | 'helicopter'
+  | 'general_aviation';
+
+export type EmergencySquawk = '7500' | '7600' | '7700';
+
+export interface LiveFlight {
+  icao24: string;
+  callsign: string | null;
+  originCountry: string | null;
+  category: FlightCategory;
+  /** Operator ICAO code resolved from the 3-letter callsign prefix (e.g. "AAL"). */
+  operatorIcao: string | null;
+  /** Human-friendly operator name when known (e.g. "American Airlines"). */
+  operatorName: string | null;
+  lat: number;
+  lon: number;
+  altitudeFt: number | null;
+  velocityKts: number | null;
+  /** Heading in degrees (0–360). */
+  headingDeg: number | null;
+  squawk: string | null;
+  /** True when squawk is 7500 / 7600 / 7700. */
+  emergency: boolean;
+  /** Set when emergency=true; null otherwise. */
+  emergencySquawk: EmergencySquawk | null;
+  onGround: boolean;
+  /** Unix ms of last position update from upstream. */
+  lastSeen: number;
+}
+
+/** Raw OpenSky state tuple — see opensky-network.org/apidoc/rest.html. */
+export type OpenSkyStateTuple = readonly [
+  string,                 // 0  icao24
+  string | null,          // 1  callsign
+  string,                 // 2  origin_country
+  number | null,          // 3  time_position (sec)
+  number,                  // 4  last_contact (sec)
+  number | null,          // 5  longitude
+  number | null,          // 6  latitude
+  number | null,          // 7  baro_altitude (m)
+  boolean,                 // 8  on_ground
+  number | null,          // 9  velocity (m/s)
+  number | null,          // 10 true_track (deg)
+  number | null,          // 11 vertical_rate (m/s)
+  ...unknown[]
+];
+
+// ─── Operator catalogues ────────────────────────────────────────────────────
+
+const PASSENGER_AIRLINES: Record<string, string> = {
+  AAL: 'American Airlines',
+  DAL: 'Delta Air Lines',
+  UAL: 'United Airlines',
+  SWA: 'Southwest Airlines',
+  JBU: 'JetBlue',
+  ASA: 'Alaska Airlines',
+  SKW: 'SkyWest',
+  RPA: 'Republic Airways',
+  ENY: 'Envoy Air',
+  ACA: 'Air Canada',
+  WJA: 'WestJet',
+  BAW: 'British Airways',
+  VIR: 'Virgin Atlantic',
+  AFR: 'Air France',
+  DLH: 'Lufthansa',
+  KLM: 'KLM',
+  IBE: 'Iberia',
+  AZA: 'ITA Airways',
+  AUA: 'Austrian Airlines',
+  SWR: 'Swiss',
+  SAS: 'SAS',
+  FIN: 'Finnair',
+  THY: 'Turkish Airlines',
+  UAE: 'Emirates',
+  ETD: 'Etihad',
+  QTR: 'Qatar Airways',
+  SVA: 'Saudia',
+  ELY: 'El Al',
+  JAL: 'Japan Airlines',
+  ANA: 'All Nippon Airways',
+  KAL: 'Korean Air',
+  AAR: 'Asiana',
+  CES: 'China Eastern',
+  CSN: 'China Southern',
+  CCA: 'Air China',
+  SIA: 'Singapore Airlines',
+  CPA: 'Cathay Pacific',
+  QFA: 'Qantas',
+  ANZ: 'Air New Zealand',
+  AMX: 'Aeromexico',
+  LAN: 'LATAM',
+  TAM: 'TAM',
+  AVA: 'Avianca',
+  RYR: 'Ryanair',
+  EZY: 'easyJet',
+  WZZ: 'Wizz Air',
+  TRA: 'Transavia',
+  THA: 'Thai Airways',
+  MAS: 'Malaysia Airlines',
+  AIC: 'Air India',
+  IGO: 'IndiGo',
+  EIN: 'Aer Lingus',
+  AEE: 'Aegean Airlines',
+};
+
+const CARGO_AIRLINES: Record<string, string> = {
+  FDX: 'FedEx Express',
+  UPS: 'UPS Airlines',
+  ABX: 'ABX Air',
+  CKS: 'Kalitta Air',
+  GTI: 'Atlas Air',
+  CLX: 'Cargolux',
+  ABW: 'AirBridgeCargo',
+  AAR_F: 'Asiana Cargo',
+  EVA: 'EVA Air Cargo',
+  CAL: 'China Airlines Cargo',
+  CKK: 'China Cargo Airlines',
+  GEC: 'Lufthansa Cargo',
+  POT: 'Polar Air Cargo',
+  SOO: 'Southern Air',
+  ICE: 'Icelandair Cargo',
+  CTM: 'CMA CGM Air Cargo',
+  ABD: 'AirBridge Direct',
+  DHX: 'DHL Air',
+  BCS: 'European Air Transport',
+  GLO: 'Global Crossing Airlines',
+};
+
+const MILITARY_CALLSIGN_PREFIXES = new Set([
+  // USAF / US Navy / US Army
+  'RCH', 'REACH', 'CNV', 'PAT', 'GOLD', 'SHELL', 'TEAL', 'HOMER', 'MAGIC',
+  'SENTRY', 'RIVET', 'PYTHON', 'RAGE', 'VIPER', 'EAGLE', 'RAIDER', 'DOOM',
+  'BISON', 'ARMY', 'PEDRO', 'DUSTOFF',
+  // NATO / RAF / RAAF / RCAF
+  'NATO', 'RRR', 'ASCOT', 'RAFAIR', 'AUSY', 'CFC', 'CANFORCE',
+  // Generic military patterns
+  'MIL', 'NAVY', 'AF',
+]);
+
+const HELO_CALLSIGN_HINTS = [
+  'HEMS', 'LIFEFLIGHT', 'AIRMED', 'MERCY', 'MEDFLIGHT', 'CARESTAR',
+  'CHP', 'COASTGUARD', 'USCG', 'RESCUE',
+];
+
+// Verified country-tagged ICAO 24-bit hex ranges. Mirrors the sidecar
+// /api/adsb-military filter so renderer + sidecar agree on military.
+export const MILITARY_HEX_RANGES: readonly (readonly [string, string])[] = [
+  ['ADF7C7', 'ADF7CF'], ['AE0000', 'AFFFFF'], ['A00000', 'A3FFFF'], // USA
+  ['43C000', '43CFFF'],                                              // UK
+  ['3A0000', '3AFFFF'], ['3B0000', '3BFFFF'],                        // France
+  ['3F0000', '3FFFFF'],                                              // Germany
+  ['738000', '73FFFF'],                                              // Israel
+  ['4D0000', '4D03FF'],                                              // NATO AWACS
+  ['300000', '33FFFF'],                                              // Italy
+  ['340000', '37FFFF'],                                              // Spain
+  ['480000', '480FFF'],                                              // Netherlands
+  ['4BA000', '4BCFFF'],                                              // Turkey
+  ['710000', '717FFF'],                                              // Saudi Arabia
+  ['896000', '896FFF'],                                              // UAE
+  ['06A000', '06AFFF'],                                              // Qatar
+  ['706000', '706FFF'],                                              // Kuwait
+  ['840000', '87FFFF'],                                              // Japan
+  ['718000', '71FFFF'],                                              // South Korea
+  ['7CF800', '7CFFFF'],                                              // Australia
+  ['C00000', 'C0FFFF'],                                              // Canada
+  ['800000', '83FFFF'],                                              // India
+  ['760000', '767FFF'],                                              // Pakistan
+  ['500000', '5003FF'],                                              // Egypt
+  ['488000', '48FFFF'],                                              // Poland
+  ['468000', '46FFFF'],                                              // Greece
+  ['4A8000', '4AFFFF'],                                              // Sweden
+  ['478000', '47FFFF'],                                              // Norway
+  ['768000', '76FFFF'],                                              // Singapore
+];
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+export function isMilitaryHex(icao24: string): boolean {
+  if (!icao24) return false;
+  const upper = icao24.toUpperCase();
+  if (!/^[0-9A-F]{6}$/.test(upper)) return false;
+  for (const [start, end] of MILITARY_HEX_RANGES) {
+    if (upper >= start && upper <= end) return true;
+  }
+  return false;
+}
+
+export function isEmergencySquawk(squawk: string | null | undefined): squawk is EmergencySquawk {
+  return squawk === '7500' || squawk === '7600' || squawk === '7700';
+}
+
+export function emergencyLabel(squawk: EmergencySquawk): string {
+  if (squawk === '7500') return 'Hijack';
+  if (squawk === '7600') return 'Comms failure';
+  return 'General emergency';
+}
+
+/** Strip the trailing flight-number digits to get the ICAO operator prefix. */
+export function operatorIcaoFromCallsign(callsign: string | null | undefined): string | null {
+  if (!callsign) return null;
+  const trimmed = callsign.trim().toUpperCase();
+  if (trimmed.length < 3) return null;
+  // ICAO operator codes are exactly 3 letters at the start.
+  const prefix = trimmed.slice(0, 3);
+  if (!/^[A-Z]{3}$/.test(prefix)) return null;
+  return prefix;
+}
+
+function classifyByCallsign(callsign: string | null): {
+  category: FlightCategory | null;
+  operatorIcao: string | null;
+  operatorName: string | null;
+} {
+  const prefix = operatorIcaoFromCallsign(callsign);
+  if (!prefix) return { category: null, operatorIcao: null, operatorName: null };
+
+  if (PASSENGER_AIRLINES[prefix]) {
+    return { category: 'commercial', operatorIcao: prefix, operatorName: PASSENGER_AIRLINES[prefix] };
+  }
+  if (CARGO_AIRLINES[prefix]) {
+    return { category: 'cargo', operatorIcao: prefix, operatorName: CARGO_AIRLINES[prefix] };
+  }
+  if (MILITARY_CALLSIGN_PREFIXES.has(prefix)) {
+    return { category: 'military', operatorIcao: prefix, operatorName: null };
+  }
+  return { category: null, operatorIcao: prefix, operatorName: null };
+}
+
+function callsignHasMilitaryHint(callsign: string | null): boolean {
+  if (!callsign) return false;
+  const upper = callsign.trim().toUpperCase();
+  // Some military callsigns embed the prefix later or use longer words.
+  for (const word of MILITARY_CALLSIGN_PREFIXES) {
+    if (upper.startsWith(word)) return true;
+  }
+  return false;
+}
+
+function callsignHasHeloHint(callsign: string | null): boolean {
+  if (!callsign) return false;
+  const upper = callsign.trim().toUpperCase();
+  for (const hint of HELO_CALLSIGN_HINTS) {
+    if (upper.startsWith(hint)) return true;
+  }
+  return false;
+}
+
+function metersToFeet(m: number | null): number | null {
+  if (m === null || !Number.isFinite(m)) return null;
+  return Math.round(m * 3.280_84);
+}
+
+function metersPerSecToKnots(mps: number | null): number | null {
+  if (mps === null || !Number.isFinite(mps)) return null;
+  return Math.round(mps * 1.943_84);
+}
+
+/**
+ * Classify a single OpenSky state tuple into a `LiveFlight`. Returns null
+ * when the tuple is missing position data (we can't render or filter
+ * something we can't place).
+ */
+export function classifyFlight(state: OpenSkyStateTuple): LiveFlight | null {
+  const icao24 = (state[0] ?? '').toString().toLowerCase().trim();
+  if (!icao24) return null;
+  const lat = state[6];
+  const lon = state[5];
+  if (lat === null || lon === null) return null;
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+
+  const callsignRaw = (state[1] ?? '').toString().trim();
+  const callsign = callsignRaw.length > 0 ? callsignRaw : null;
+  const squawk = (state[14] as string | null | undefined) ?? null;
+  const emergency = isEmergencySquawk(squawk);
+
+  const byCallsign = classifyByCallsign(callsign);
+  const isMilByHex = isMilitaryHex(icao24);
+  const isMilByCallsign = callsignHasMilitaryHint(callsign);
+
+  let category: FlightCategory;
+  if (isMilByHex || isMilByCallsign || byCallsign.category === 'military') {
+    category = 'military';
+  } else if (byCallsign.category === 'cargo') {
+    category = 'cargo';
+  } else if (byCallsign.category === 'commercial') {
+    category = 'commercial';
+  } else if (callsignHasHeloHint(callsign)) {
+    category = 'helicopter';
+  } else {
+    category = 'general_aviation';
+  }
+
+  return {
+    icao24,
+    callsign,
+    originCountry: (state[2] ?? '').toString().trim() || null,
+    category,
+    operatorIcao: byCallsign.operatorIcao,
+    operatorName: byCallsign.operatorName,
+    lat,
+    lon,
+    altitudeFt: metersToFeet(state[7]),
+    velocityKts: metersPerSecToKnots(state[9]),
+    headingDeg: typeof state[10] === 'number' && Number.isFinite(state[10]) ? state[10] : null,
+    squawk: squawk ?? null,
+    emergency,
+    emergencySquawk: emergency ? (squawk as EmergencySquawk) : null,
+    onGround: state[8] === true,
+    lastSeen: typeof state[4] === 'number' ? state[4] * 1000 : Date.now(),
+  };
+}
+
+/** Classify a full OpenSky `states/all` payload. Skips invalid rows. */
+export function classifyFlights(payload: unknown): LiveFlight[] {
+  if (!payload || typeof payload !== 'object') return [];
+  const states = (payload as { states?: unknown }).states;
+  if (!Array.isArray(states)) return [];
+  const out: LiveFlight[] = [];
+  for (const row of states) {
+    if (!Array.isArray(row) || row.length < 15) continue;
+    const flight = classifyFlight(row as unknown as OpenSkyStateTuple);
+    if (flight) out.push(flight);
+  }
+  return out;
+}
+
+// ─── Aggregation helpers ─────────────────────────────────────────────────────
+
+export interface FlightCategoryCounts {
+  military: number;
+  commercial: number;
+  cargo: number;
+  helicopter: number;
+  general_aviation: number;
+  total: number;
+  emergency: number;
+  squawk7500: number;
+  squawk7600: number;
+  squawk7700: number;
+}
+
+export function summariseFlights(flights: readonly LiveFlight[]): FlightCategoryCounts {
+  const counts: FlightCategoryCounts = {
+    military: 0,
+    commercial: 0,
+    cargo: 0,
+    helicopter: 0,
+    general_aviation: 0,
+    total: flights.length,
+    emergency: 0,
+    squawk7500: 0,
+    squawk7600: 0,
+    squawk7700: 0,
+  };
+  for (const f of flights) {
+    counts[f.category] += 1;
+    if (f.emergency) {
+      counts.emergency += 1;
+      if (f.emergencySquawk === '7500') counts.squawk7500 += 1;
+      else if (f.emergencySquawk === '7600') counts.squawk7600 += 1;
+      else if (f.emergencySquawk === '7700') counts.squawk7700 += 1;
+    }
+  }
+  return counts;
+}
+
+// ─── Region & radius filters ─────────────────────────────────────────────────
+
+export interface BoundingBox {
+  /** Minimum longitude (-180..180). */
+  west: number;
+  /** Minimum latitude (-90..90). */
+  south: number;
+  /** Maximum longitude (-180..180). */
+  east: number;
+  /** Maximum latitude (-90..90). */
+  north: number;
+}
+
+export function filterByBoundingBox<T extends { lat: number; lon: number }>(
+  flights: readonly T[],
+  box: BoundingBox,
+): T[] {
+  // Treat antimeridian-crossing boxes (west > east) as two halves.
+  const crossesAntimeridian = box.west > box.east;
+  return flights.filter((f) => {
+    if (f.lat < box.south || f.lat > box.north) return false;
+    if (crossesAntimeridian) {
+      return f.lon >= box.west || f.lon <= box.east;
+    }
+    return f.lon >= box.west && f.lon <= box.east;
+  });
+}
+
+const EARTH_RADIUS_KM = 6371;
+
+export function haversineKm(
+  a: { lat: number; lon: number },
+  b: { lat: number; lon: number },
+): number {
+  const toRad = (d: number): number => (d * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLon = toRad(b.lon - a.lon);
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+  return 2 * EARTH_RADIUS_KM * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+export interface SavedPlace {
+  id: string;
+  name: string;
+  lat: number;
+  lon: number;
+  /** Radius around the place in km. Required — caller decides. */
+  radiusKm: number;
+}
+
+export function filterByRadius<T extends { lat: number; lon: number }>(
+  flights: readonly T[],
+  place: SavedPlace,
+): T[] {
+  return flights.filter((f) => haversineKm(f, place) <= place.radiusKm);
+}
+
+/**
+ * Filter to flights within ANY of the supplied saved places' radii.
+ * If `places` is empty, returns the input unchanged so the caller can
+ * skip the filter entirely when no places are configured.
+ */
+export function filterByAnyPlace<T extends { lat: number; lon: number }>(
+  flights: readonly T[],
+  places: readonly SavedPlace[],
+): T[] {
+  if (places.length === 0) return [...flights];
+  return flights.filter((f) =>
+    places.some((p) => haversineKm(f, p) <= p.radiusKm),
+  );
+}
+
+// ─── Cross-reference TFR / SIGMET hazard zones ──────────────────────────────
+
+export interface FlightHazardCrossRef {
+  /** TFR NOTAM IDs the flight is currently inside. */
+  tfrIds: string[];
+  /** SIGMET IDs whose polygon covers the flight position. */
+  sigmetIds: string[];
+}
+
+/** Inclusive: a flight at exactly TFR radius counts as inside. */
+export function isFlightInTfr(
+  flight: { lat: number; lon: number },
+  tfr: AviationNotam,
+): boolean {
+  if (!tfr.center) return false;
+  const distNm = haversineKm(flight, { lat: tfr.center.lat, lon: tfr.center.lon }) * 0.539_957;
+  return distNm <= tfr.center.radiusNm;
+}
+
+export function isFlightInSigmet(
+  flight: { lat: number; lon: number },
+  sigmet: AviationSigmet,
+): boolean {
+  if (sigmet.polygon.length < 3) return false;
+  return pointInPolygon(flight, sigmet.polygon);
+}
+
+/** Standard ray-casting point-in-polygon (lon/lat plane, no antimeridian). */
+function pointInPolygon(
+  pt: { lat: number; lon: number },
+  ring: readonly { lat: number; lon: number }[],
+): boolean {
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i, i += 1) {
+    const xi = ring[i]!.lon;
+    const yi = ring[i]!.lat;
+    const xj = ring[j]!.lon;
+    const yj = ring[j]!.lat;
+    const intersects =
+      yi > pt.lat !== yj > pt.lat &&
+      pt.lon < ((xj - xi) * (pt.lat - yi)) / (yj - yi || Number.EPSILON) + xi;
+    if (intersects) inside = !inside;
+  }
+  return inside;
+}
+
+export function crossReferenceHazards(
+  flight: { lat: number; lon: number },
+  tfrs: readonly AviationNotam[],
+  sigmets: readonly AviationSigmet[],
+): FlightHazardCrossRef {
+  return {
+    tfrIds: tfrs.filter((t) => isFlightInTfr(flight, t)).map((t) => t.id),
+    sigmetIds: sigmets.filter((s) => isFlightInSigmet(flight, s)).map((s) => s.id),
+  };
+}
+
+export function flightsInsideHazardZones(
+  flights: readonly LiveFlight[],
+  tfrs: readonly AviationNotam[],
+  sigmets: readonly AviationSigmet[],
+): (LiveFlight & { hazards: FlightHazardCrossRef })[] {
+  const out: (LiveFlight & { hazards: FlightHazardCrossRef })[] = [];
+  for (const f of flights) {
+    const hazards = crossReferenceHazards(f, tfrs, sigmets);
+    if (hazards.tfrIds.length > 0 || hazards.sigmetIds.length > 0) {
+      out.push({ ...f, hazards });
+    }
+  }
+  return out;
+}
+
+// ─── Globe styling (color + arrow head size by category) ─────────────────────
+
+const CATEGORY_HEX: Record<FlightCategory, string> = {
+  military: '#ffeb3b',       // matches existing military aircraft yellow accent
+  commercial: '#4a9eff',
+  cargo: '#9c27b0',
+  helicopter: '#8bc34a',
+  general_aviation: '#9e9e9e',
+};
+
+export function flightCategoryColor(category: FlightCategory): string {
+  return CATEGORY_HEX[category];
+}
+
+export function flightStyle(flight: LiveFlight): {
+  hex: string;
+  emergency: boolean;
+  pixelSize: number;
+} {
+  if (flight.emergency) return { hex: '#d50000', emergency: true, pixelSize: 11 };
+  return { hex: CATEGORY_HEX[flight.category], emergency: false, pixelSize: 5 };
+}

--- a/src/services/aviation/commercial-flights-service.ts
+++ b/src/services/aviation/commercial-flights-service.ts
@@ -1,0 +1,121 @@
+/**
+ * Commercial flights — renderer-side fetcher for `/api/aviation/flights`.
+ *
+ * Thin I/O wrapper. Pure classification + cross-reference logic lives in
+ * `commercial-flights-classify.ts`. Caches in-memory for 10 min so the
+ * 100-req/day OpenSky free-tier limit isn't blown by a chatty UI.
+ */
+
+import { getApiBaseUrl } from '../runtime';
+import {
+  classifyFlights,
+  summariseFlights,
+  type LiveFlight,
+  type FlightCategoryCounts,
+} from './commercial-flights-classify';
+
+const POLL_INTERVAL_MS = 10 * 60 * 1000; // 10 min — respects OpenSky free-tier rate limit
+const FETCH_TIMEOUT_MS = 12 * 1000;
+
+export interface LiveFlightsEnvelope {
+  flights: LiveFlight[];
+  counts: FlightCategoryCounts;
+  fetchedAt: number;
+  degraded: boolean;
+  reason?: string;
+  source: string;
+}
+
+interface CacheEntry {
+  envelope: LiveFlightsEnvelope;
+  fetchedAt: number;
+}
+
+let cache: CacheEntry | null = null;
+let inflight: Promise<LiveFlightsEnvelope> | null = null;
+
+function emptyEnvelope(reason: string): LiveFlightsEnvelope {
+  return {
+    flights: [],
+    counts: summariseFlights([]),
+    fetchedAt: Date.now(),
+    degraded: true,
+    reason,
+    source: 'opensky-network.org',
+  };
+}
+
+export async function fetchLiveFlights(): Promise<LiveFlightsEnvelope> {
+  const now = Date.now();
+  if (cache && now - cache.fetchedAt < POLL_INTERVAL_MS) {
+    return cache.envelope;
+  }
+  if (inflight) return inflight;
+
+  inflight = (async (): Promise<LiveFlightsEnvelope> => {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+      const response = await fetch(`${getApiBaseUrl()}/api/aviation/flights`, {
+        signal: controller.signal,
+        headers: { Accept: 'application/json' },
+      });
+      clearTimeout(timer);
+      if (!response.ok) {
+        return { ...emptyEnvelope(`HTTP ${response.status}`), fetchedAt: now };
+      }
+      const body = (await response.json()) as Partial<LiveFlightsEnvelope> & {
+        states?: unknown;
+        rateLimited?: boolean;
+        error?: string;
+      };
+      // Accept either the pre-classified envelope from /api/aviation/flights,
+      // or a raw OpenSky response (fallback path) we classify renderer-side.
+      let flights: LiveFlight[];
+      if (Array.isArray(body.flights)) {
+        flights = body.flights as LiveFlight[];
+      } else if (Array.isArray(body.states)) {
+        flights = classifyFlights(body);
+      } else if (body.error) {
+        return { ...emptyEnvelope(body.error), fetchedAt: now };
+      } else if (body.rateLimited) {
+        return { ...emptyEnvelope('rate limited'), fetchedAt: now };
+      } else {
+        flights = [];
+      }
+      const counts = body.counts ?? summariseFlights(flights);
+      const envelope: LiveFlightsEnvelope = {
+        flights,
+        counts,
+        fetchedAt: now,
+        degraded: body.degraded ?? false,
+        reason: body.reason,
+        source: body.source ?? 'opensky-network.org',
+      };
+      cache = { envelope, fetchedAt: now };
+      return envelope;
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      return { ...emptyEnvelope(reason), fetchedAt: now };
+    } finally {
+      inflight = null;
+    }
+  })();
+
+  return inflight;
+}
+
+export function clearLiveFlightsCache(): void {
+  cache = null;
+  inflight = null;
+}
+
+export const __TEST_HOOKS__ = {
+  get cache(): CacheEntry | null {
+    return cache;
+  },
+  setCache(entry: CacheEntry | null): void {
+    cache = entry;
+  },
+  POLL_INTERVAL_MS,
+};


### PR DESCRIPTION
## Summary

Adds a sixth **Live Flights** tab to `AviationIntelPanel` covering all flights worldwide (not just military) with category counts, unusual-squawk highlighting (7500/7600/7700), and TFR/SIGMET cross-reference. Commercial flights also render on the God's Eye globe as directional arrows colored by category; emergency squawks render as red pulsing dots.

This extends the existing aviation stack rather than colliding with it — `military-flights.ts` and the existing 5 tabs are untouched. The original task spec asked for a new \`AviationIntelPanel.ts\`, but the panel already existed with 5 tabs (NOTAMs/SIGMETs/PIREPs/Military/Delays), so the cleanest move was to add a tab to the existing panel.

## Files

- **New** [\`src/services/aviation/commercial-flights-classify.ts\`](src/services/aviation/commercial-flights-classify.ts) — pure classification (military / commercial / cargo / helicopter / general_aviation), emergency squawk detection, haversine + bbox + radius filters, TFR/SIGMET point-in-polygon cross-reference. ~50 ICAO operator codes for passenger + cargo airlines.
- **New** [\`src/services/aviation/commercial-flights-service.ts\`](src/services/aviation/commercial-flights-service.ts) — renderer fetcher with 10-min cache, in-flight dedup, degraded envelope on failure.
- **New** \`/api/aviation/flights\` sidecar route in [\`src-tauri/sidecar/local-api-server.mjs\`](src-tauri/sidecar/local-api-server.mjs) — wraps OpenSky \`states/all\`, classifies in-process, 10-min memory cache to respect the ~100 req/day anonymous-tier ceiling. Uses \`OPENSKY_CLIENT_ID\` / \`OPENSKY_CLIENT_SECRET\` when present.
- **Edit** [\`src/components/AviationIntelPanel.ts\`](src/components/AviationIntelPanel.ts) — new \"Live Flights\" tab. Renders category strip, unusual-squawk block (red), and \"In TFR / SIGMET zones\" block (orange) cross-referenced against the existing NOTAMs + SIGMETs feeds.
- **Edit** [\`src/components/GlobeDataManager.ts\`](src/components/GlobeDataManager.ts) — \`loadAviationIntel\` now also fetches live flights and renders them. Cap of 1500 non-emergency flights to keep the globe usable; military aircraft are skipped here (already rendered by the existing military-aircraft pass) to avoid duplicates. Emergency squawks render as red pulsing points (CallbackProperty alpha sine wave) regardless of cap.

## Tests

48 new unit tests (≥15 required) in:
- [\`src/services/aviation/__tests__/commercial-flights-classify.test.mts\`](src/services/aviation/__tests__/commercial-flights-classify.test.mts) — classification rules per category, emergency squawk detection, military hex range membership including USAF/UK/Israel/NATO etc., civilian-vs-military edge cases, operator-prefix extraction, region/radius/bbox filters with antimeridian-crossing case, TFR (haversine→NM) and SIGMET (point-in-polygon) cross-reference, style + color helpers.
- [\`src/services/aviation/__tests__/commercial-flights-service.test.mts\`](src/services/aviation/__tests__/commercial-flights-service.test.mts) — happy path, HTTP 5xx degraded handling, raw-OpenSky fallback shape, cache hit, rate-limited shape, cache clearing.

\`\`\`
✔ tests 48 / pass 48 / fail 0
\`\`\`

Existing 34 aviation + 67 sidecar + 233 sidecar-suite tests still pass. \`npm run typecheck:all\` is clean.

## Verification gap

I could **not** run the live UI in a Vite dev server. \`npm run dev\` fails with a pre-existing dependency mismatch — \`@deck.gl/geo-layers/node_modules/@luma.gl/gltf\` imports \`DynamicTexture\` and \`MaterialFactory\` from \`@luma.gl/engine\`, but the resolved \`engine\` package doesn't export them. This affects code I didn't touch and reproduces on \`main\`. The fix is a separate dep-pin/dedupe task. Manual verification via \`npm run desktop:build:full\` would also surface any runtime issues in the Tauri shell.

## Out of scope

- The 5 intelligence-engine wiring PRs (GDELT, ACLED, OTX, FRED+OFR, MITRE ATT&CK) from the original task list — deferred at user request.
- Saved-place radius filter in the panel UI — the helper (\`filterByAnyPlace\`) is implemented and tested; wiring it to the user's saved places is a follow-up once we decide on a per-panel \"my-area only\" toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Cross-agent review: claude reviewed on 2026-05-08; outcome: pass
