### PR TITLE
feat(data): NOAA GOES satellite imagery + flood monitoring panels

### DIFF
--- a/api/__tests__/floods-gauges.test.mjs
+++ b/api/__tests__/floods-gauges.test.mjs
@@ -1,0 +1,201 @@
+/**
+ * Tests for api/floods/gauges.js
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { invokeHandler, mockFetch } from './_test-utils.mjs';
+
+let handler;
+let gaugesCache;
+try {
+  const mod = await import('../floods/gauges.js');
+  handler = mod.default;
+  gaugesCache = mod.cache;
+} catch (err) {
+  console.warn('Handler floods/gauges.js failed to import:', err.message);
+  handler = null;
+}
+
+const USGS_EMPTY_RESPONSE = {
+  value: {
+    timeSeries: [],
+  },
+};
+
+const USGS_SAMPLE_RESPONSE = {
+  value: {
+    timeSeries: [
+      {
+        sourceInfo: {
+          siteName: 'Arkansas River at Little Rock, AR',
+          siteCode: [{ value: '07263620' }],
+          geoLocation: { geogLocation: { latitude: 34.7, longitude: -92.3 } },
+          siteProperty: [{ name: 'stateCd', value: 'AR' }],
+        },
+        values: [{
+          value: [{ value: '28.4', qualifiers: ['P'] }],
+        }],
+      },
+      {
+        sourceInfo: {
+          siteName: 'Mississippi River at Memphis, TN',
+          siteCode: [{ value: '07032000' }],
+          geoLocation: { geogLocation: { latitude: 35.1, longitude: -90.0 } },
+          siteProperty: [{ name: 'stateCd', value: 'TN' }],
+        },
+        values: [{
+          value: [{ value: '32.1', qualifiers: ['P', 'Flood'] }],
+        }],
+      },
+      {
+        sourceInfo: {
+          siteName: 'Gauge with no data',
+          siteCode: [{ value: '99999999' }],
+          geoLocation: { geogLocation: { latitude: 30.0, longitude: -90.0 } },
+          siteProperty: [{ name: 'stateCd', value: 'LA' }],
+        },
+        values: [{ value: [] }],
+      },
+    ],
+  },
+};
+
+test('gauges: rejects non-GET methods', async () => {
+  if (!handler) return;
+  const { res } = await invokeHandler(handler, { method: 'DELETE' });
+  assert.equal(res.statusCode, 405);
+});
+
+test('gauges: handles OPTIONS preflight', async () => {
+  if (!handler) return;
+  const { res } = await invokeHandler(handler, { method: 'OPTIONS' });
+  assert.equal(res.statusCode, 204);
+});
+
+test('gauges: returns 200 with empty USGS response', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['waterservices.usgs.gov', { status: 200, json: USGS_EMPTY_RESPONSE }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.totalGauges, 0);
+  assert.equal(res.body.atFloodStage, 0);
+});
+
+test('gauges: response has expected shape keys', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['waterservices.usgs.gov', { status: 200, json: USGS_EMPTY_RESPONSE }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.ok('totalGauges' in res.body);
+  assert.ok('atFloodStage' in res.body);
+  assert.ok('byState' in res.body);
+  assert.ok('top10' in res.body);
+  assert.ok('generatedAt' in res.body);
+  assert.ok('source' in res.body);
+});
+
+test('gauges: counts total gauges correctly', async () => {
+  if (!handler) return;
+  gaugesCache?.clear();
+  const restoreFetch = mockFetch(new Map([
+    ['waterservices.usgs.gov', { status: 200, json: USGS_SAMPLE_RESPONSE }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  // 3 time series but one has no values — totalGauges reflects all timeSeries
+  assert.equal(res.body.totalGauges, 3);
+});
+
+test('gauges: byState is an array', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['waterservices.usgs.gov', { status: 200, json: USGS_SAMPLE_RESPONSE }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.ok(Array.isArray(res.body.byState));
+});
+
+test('gauges: top10 is an array of at most 10 items', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['waterservices.usgs.gov', { status: 200, json: USGS_SAMPLE_RESPONSE }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.ok(Array.isArray(res.body.top10));
+  assert.ok(res.body.top10.length <= 10);
+});
+
+test('gauges: degrades gracefully on USGS HTTP error', async () => {
+  if (!handler) return;
+  gaugesCache?.clear();
+  const restoreFetch = mockFetch(new Map([
+    ['waterservices.usgs.gov', { status: 503, text: 'Service Unavailable' }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.degraded, true);
+});
+
+test('gauges: degrades gracefully on fetch exception', async () => {
+  if (!handler) return;
+  gaugesCache?.clear();
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = async () => { throw new Error('Connection refused'); };
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { globalThis.fetch = origFetch; }
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.degraded, true);
+});
+
+test('gauges: source is waterservices.usgs.gov', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['waterservices.usgs.gov', { status: 200, json: USGS_EMPTY_RESPONSE }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.equal(res.body.source, 'waterservices.usgs.gov');
+});
+
+test('gauges: generatedAt is valid ISO string', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['waterservices.usgs.gov', { status: 200, json: USGS_EMPTY_RESPONSE }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.ok(typeof res.body.generatedAt === 'string');
+  assert.doesNotThrow(() => new Date(res.body.generatedAt));
+});
+
+test('gauges: skips gauges with no data values', async () => {
+  if (!handler) return;
+  const noDataResponse = {
+    value: {
+      timeSeries: [{
+        sourceInfo: {
+          siteName: 'Empty gauge',
+          siteCode: [{ value: '00000001' }],
+          geoLocation: { geogLocation: { latitude: 35.0, longitude: -90.0 } },
+          siteProperty: [{ name: 'stateCd', value: 'TN' }],
+        },
+        values: [{ value: [] }],
+      }],
+    },
+  };
+  const restoreFetch = mockFetch(new Map([
+    ['waterservices.usgs.gov', { status: 200, json: noDataResponse }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.equal(res.body.atFloodStage, 0);
+  assert.equal(res.body.top10.length, 0);
+});

--- a/api/__tests__/floods-warnings.test.mjs
+++ b/api/__tests__/floods-warnings.test.mjs
@@ -1,0 +1,195 @@
+/**
+ * Tests for api/floods/warnings.js
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { invokeHandler, mockFetch } from './_test-utils.mjs';
+
+let handler;
+let warningsCache;
+try {
+  const mod = await import('../floods/warnings.js');
+  handler = mod.default;
+  warningsCache = mod.cache;
+} catch (err) {
+  console.warn('Handler floods/warnings.js failed to import:', err.message);
+  handler = null;
+}
+
+const NWS_EMPTY = { features: [] };
+
+const NWS_SAMPLE = {
+  features: [
+    {
+      id: 'https://api.weather.gov/alerts/NWS-IDP-PROD-001',
+      properties: {
+        event: 'Flash Flood Warning',
+        severity: 'Severe',
+        headline: 'Flash Flood Warning issued for Pulaski County; AR',
+        areaDesc: 'Pulaski County; AR',
+        effective: '2026-05-11T12:00:00-05:00',
+        expires: '2026-05-11T18:00:00-05:00',
+      },
+      geometry: null,
+    },
+    {
+      id: 'https://api.weather.gov/alerts/NWS-IDP-PROD-002',
+      properties: {
+        event: 'Flood Watch',
+        severity: 'Moderate',
+        headline: 'Flood Watch for Shelby County; TN',
+        areaDesc: 'Shelby County; TN',
+        effective: '2026-05-11T14:00:00-05:00',
+        expires: '2026-05-12T06:00:00-05:00',
+      },
+      geometry: null,
+    },
+    {
+      id: 'https://api.weather.gov/alerts/NWS-IDP-PROD-003',
+      properties: {
+        event: 'Flood Warning',
+        severity: 'Severe',
+        headline: 'Flood Warning in effect for St. Tammany Parish; LA',
+        areaDesc: 'St. Tammany Parish; LA',
+        effective: '2026-05-11T10:00:00-05:00',
+        expires: '2026-05-12T10:00:00-05:00',
+      },
+      geometry: null,
+    },
+  ],
+};
+
+test('warnings: rejects non-GET methods', async () => {
+  if (!handler) return;
+  const { res } = await invokeHandler(handler, { method: 'POST' });
+  assert.equal(res.statusCode, 405);
+});
+
+test('warnings: handles OPTIONS preflight', async () => {
+  if (!handler) return;
+  const { res } = await invokeHandler(handler, { method: 'OPTIONS' });
+  assert.equal(res.statusCode, 204);
+});
+
+test('warnings: returns 200 with empty NWS response', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['api.weather.gov', { status: 200, json: NWS_EMPTY }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.total, 0);
+  assert.deepEqual(res.body.alerts, []);
+});
+
+test('warnings: response has expected shape', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['api.weather.gov', { status: 200, json: NWS_EMPTY }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.ok('total' in res.body);
+  assert.ok('byState' in res.body);
+  assert.ok('alerts' in res.body);
+  assert.ok('source' in res.body);
+  assert.ok('generatedAt' in res.body);
+});
+
+test('warnings: counts alerts correctly', async () => {
+  if (!handler) return;
+  warningsCache?.clear();
+  const restoreFetch = mockFetch(new Map([
+    ['api.weather.gov', { status: 200, json: NWS_SAMPLE }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.equal(res.body.total, 3);
+  assert.equal(res.body.alerts.length, 3);
+});
+
+test('warnings: extracts state codes from areaDesc', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['api.weather.gov', { status: 200, json: NWS_SAMPLE }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  const states = res.body.byState.map(s => s.state);
+  assert.ok(states.includes('AR'), 'should include AR');
+  assert.ok(states.includes('TN'), 'should include TN');
+  assert.ok(states.includes('LA'), 'should include LA');
+});
+
+test('warnings: byState sorted by severity rank descending', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['api.weather.gov', { status: 200, json: NWS_SAMPLE }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  const byState = res.body.byState;
+  assert.ok(Array.isArray(byState));
+  // Severe states should come before Moderate
+  const arIdx = byState.findIndex(s => s.state === 'AR');
+  const tnIdx = byState.findIndex(s => s.state === 'TN');
+  // AR has Severe Flash Flood Warning, TN has Moderate Flood Watch
+  assert.ok(arIdx < tnIdx || byState[arIdx].maxSeverity === byState[tnIdx].maxSeverity, 'AR Severe should rank >= TN Moderate');
+});
+
+test('warnings: alerts include event and severity fields', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['api.weather.gov', { status: 200, json: NWS_SAMPLE }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  const alert = res.body.alerts[0];
+  assert.ok(typeof alert.event === 'string');
+  assert.ok(typeof alert.severity === 'string');
+  assert.ok(typeof alert.headline === 'string');
+});
+
+test('warnings: degrades gracefully on NWS HTTP error', async () => {
+  if (!handler) return;
+  warningsCache?.clear();
+  const restoreFetch = mockFetch(new Map([
+    ['api.weather.gov', { status: 503, text: 'Service Unavailable' }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.degraded, true);
+});
+
+test('warnings: degrades gracefully on fetch exception', async () => {
+  if (!handler) return;
+  warningsCache?.clear();
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = async () => { throw new Error('DNS failure'); };
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { globalThis.fetch = origFetch; }
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.degraded, true);
+});
+
+test('warnings: source is api.weather.gov', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['api.weather.gov', { status: 200, json: NWS_EMPTY }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.equal(res.body.source, 'api.weather.gov');
+});
+
+test('warnings: generatedAt is valid ISO string', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['api.weather.gov', { status: 200, json: NWS_EMPTY }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.doesNotThrow(() => new Date(res.body.generatedAt));
+});

--- a/api/__tests__/satellite-goes.test.mjs
+++ b/api/__tests__/satellite-goes.test.mjs
@@ -1,0 +1,145 @@
+/**
+ * Tests for api/satellite/goes.js
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { invokeHandler, mockFetch, mockReq } from './_test-utils.mjs';
+
+let handler;
+let goesCache;
+try {
+  const mod = await import('../satellite/goes.js');
+  handler = mod.default;
+  goesCache = mod.cache;
+} catch (err) {
+  console.warn('Handler satellite/goes.js failed to import:', err.message);
+  handler = null;
+}
+
+test('goes: rejects non-GET methods', async () => {
+  if (!handler) return;
+  const { res } = await invokeHandler(handler, { method: 'POST' });
+  assert.equal(res.statusCode, 405);
+});
+
+test('goes: handles OPTIONS preflight', async () => {
+  if (!handler) return;
+  const { res } = await invokeHandler(handler, { method: 'OPTIONS' });
+  assert.equal(res.statusCode, 204);
+});
+
+test('goes: returns 200 with goesEast and goesWest keys', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['cdn.star.nesdis.noaa.gov/GOES16', { status: 200, text: '' }],
+    ['cdn.star.nesdis.noaa.gov/GOES18', { status: 200, text: '' }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.equal(res.statusCode, 200);
+  assert.ok('goesEast' in res.body, 'should have goesEast');
+  assert.ok('goesWest' in res.body, 'should have goesWest');
+});
+
+test('goes: goesEast has expected shape', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['cdn.star.nesdis.noaa.gov', { status: 200, text: '' }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  const e = res.body.goesEast;
+  assert.ok(typeof e.label === 'string', 'label should be string');
+  assert.ok(typeof e.url === 'string', 'url should be string');
+  assert.ok(typeof e.available === 'boolean', 'available should be boolean');
+  assert.ok(e.url.includes('GOES16'), 'url should reference GOES16');
+});
+
+test('goes: goesWest has expected shape', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['cdn.star.nesdis.noaa.gov', { status: 200, text: '' }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  const w = res.body.goesWest;
+  assert.ok(typeof w.label === 'string');
+  assert.ok(w.url.includes('GOES18'), 'url should reference GOES18');
+});
+
+test('goes: marks available=true when CDN responds 200', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['cdn.star.nesdis.noaa.gov', { status: 200, text: '' }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.equal(res.body.goesEast.available, true);
+  assert.equal(res.body.goesWest.available, true);
+});
+
+test('goes: marks available=false when CDN returns 404', async () => {
+  if (!handler) return;
+  goesCache?.clear();
+  const restoreFetch = mockFetch(new Map([
+    ['cdn.star.nesdis.noaa.gov', { status: 404, text: 'Not Found' }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.equal(res.body.goesEast.available, false);
+  assert.equal(res.body.goesWest.available, false);
+});
+
+test('goes: response includes generatedAt ISO timestamp', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['cdn.star.nesdis.noaa.gov', { status: 200, text: '' }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.ok(typeof res.body.generatedAt === 'string');
+  assert.doesNotThrow(() => new Date(res.body.generatedAt));
+});
+
+test('goes: response includes cacheTtlSeconds', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['cdn.star.nesdis.noaa.gov', { status: 200, text: '' }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.equal(res.body.cacheTtlSeconds, 300);
+});
+
+test('goes: gracefully handles CDN fetch timeout/error', async () => {
+  if (!handler) return;
+  goesCache?.clear();
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = async () => { throw new Error('Network timeout'); };
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { globalThis.fetch = origFetch; }
+  // Should still return 200 with available=false rather than 500
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.goesEast.available, false);
+  assert.equal(res.body.goesWest.available, false);
+});
+
+test('goes: goesEast product is GeoColor', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['cdn.star.nesdis.noaa.gov', { status: 200, text: '' }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.equal(res.body.goesEast.product, 'GeoColor');
+});
+
+test('goes: goesEast region is CONUS', async () => {
+  if (!handler) return;
+  const restoreFetch = mockFetch(new Map([
+    ['cdn.star.nesdis.noaa.gov', { status: 200, text: '' }],
+  ]));
+  let res;
+  try { ({ res } = await invokeHandler(handler)); } finally { restoreFetch(); }
+  assert.equal(res.body.goesEast.region, 'CONUS');
+});

--- a/api/floods/gauges.js
+++ b/api/floods/gauges.js
@@ -1,0 +1,122 @@
+/**
+ * USGS Water Services stream gauge proxy.
+ * Returns active gauges with stage readings (parameterCd=00065 = gauge height in feet).
+ * Summarizes flood-stage counts; full gauge list is large (~13k sites).
+ * No API key required — public USGS data.
+ */
+
+import { getCorsHeaders, isDisallowedOrigin } from '../_cors.js';
+
+export const config = { runtime: 'edge' };
+
+const CACHE_TTL_MS = 10 * 60 * 1000;
+const USGS_URL =
+  'https://waterservices.usgs.gov/nwis/iv/?format=json&parameterCd=00065&siteStatus=active&period=PT2H';
+
+// USGS action/flood stage qualifiers in the value/qualifier array
+const STAGE_KEYWORDS_RE = /flood|action|major|moderate|minor/i;
+
+export const cache = new Map();
+
+const j = (payload, status, cors) =>
+  Response.json(payload, {
+    status,
+    headers: { 'content-type': 'application/json; charset=utf-8', ...cors },
+  });
+
+function classifyStage(valueStr, qualifiers) {
+  const val = Number.parseFloat(valueStr);
+  if (Number.isNaN(val)) return 'unknown';
+  // Qualifier-based stage classification when USGS provides it
+  const qualText = (qualifiers ?? []).join(' ');
+  if (STAGE_KEYWORDS_RE.test(qualText)) {
+    if (/major/i.test(qualText)) return 'major';
+    if (/moderate/i.test(qualText)) return 'moderate';
+    if (/minor/i.test(qualText)) return 'minor';
+    if (/action/i.test(qualText)) return 'action';
+    return 'flood';
+  }
+  return 'normal';
+}
+
+function updateStateMap(stateMap, state, stage) {
+  if (!stateMap.has(state)) stateMap.set(state, { state, count: 0, maxStage: 'normal' });
+  const st = stateMap.get(state);
+  st.count++;
+  if (stage === 'major' || st.maxStage === 'normal') st.maxStage = stage;
+}
+
+function summarizeTimeSeries(timeSeries) {
+  const gauges = [];
+  let atFloodStage = 0;
+  let atActionStage = 0;
+  const stateMap = new Map();
+
+  for (const ts of timeSeries) {
+    const site = ts.sourceInfo;
+    const values = ts.values?.[0]?.value ?? [];
+    if (values.length === 0) continue;
+
+    const latest = values[values.length - 1];
+    const stageVal = Number.parseFloat(latest.value);
+    if (Number.isNaN(stageVal) || latest.value === '-999999') continue;
+
+    const qualifiers = latest.qualifiers ?? [];
+    const stage = classifyStage(latest.value, qualifiers);
+    const state = site?.siteProperty?.find(p => p.name === 'stateCd')?.value ?? 'XX';
+    const siteName = site?.siteName ?? 'Unknown';
+    const lat = site?.geoLocation?.geogLocation?.latitude ?? null;
+    const lon = site?.geoLocation?.geogLocation?.longitude ?? null;
+
+    if (stage !== 'normal' && stage !== 'unknown') {
+      atFloodStage++;
+      updateStateMap(stateMap, state, stage);
+    }
+    if (stage === 'action') atActionStage++;
+
+    gauges.push({ siteNo: site?.siteCode?.[0]?.value, siteName, state, stageVal, stage, lat, lon });
+  }
+
+  // Top 10 by stage height
+  const top10 = gauges
+    .filter(g => g.stage !== 'normal' && g.stage !== 'unknown')
+    .sort((a, b) => b.stageVal - a.stageVal)
+    .slice(0, 10);
+
+  return {
+    totalGauges: timeSeries.length,
+    atFloodStage,
+    atActionStage,
+    byState: [...stateMap.values()].sort((a, b) => b.count - a.count),
+    top10,
+  };
+}
+
+export default async function handler(req) {
+  const cors = getCorsHeaders(req, 'GET, OPTIONS');
+  if (isDisallowedOrigin(req)) return j({ error: 'Origin not allowed' }, 403, cors);
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
+  if (req.method !== 'GET') return j({ error: 'Method not allowed' }, 405, cors);
+
+  const cached = cache.get('gauges');
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) return j(cached.payload, 200, cors);
+
+  try {
+    const r = await fetch(USGS_URL, {
+      headers: { 'User-Agent': 'CrystalBall/2 (flood-gauges)', Accept: 'application/json' },
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!r.ok) {
+      const payload = { error: `USGS returned HTTP ${r.status}`, degraded: true, generatedAt: new Date().toISOString() };
+      return j(payload, 200, cors);
+    }
+    const data = await r.json();
+    const timeSeries = data?.value?.timeSeries ?? [];
+    const summary = summarizeTimeSeries(timeSeries);
+    const payload = { ...summary, source: 'waterservices.usgs.gov', generatedAt: new Date().toISOString() };
+    cache.set('gauges', { at: Date.now(), payload });
+    return j(payload, 200, cors);
+  } catch (error) {
+    return j({ error: `USGS fetch failed: ${error?.message ?? error}`, degraded: true, generatedAt: new Date().toISOString() }, 200, cors);
+  }
+}

--- a/api/floods/warnings.js
+++ b/api/floods/warnings.js
@@ -1,0 +1,108 @@
+/**
+ * NWS active flood alerts proxy.
+ * Fetches flood watches, warnings, and advisories from the NWS alerts API.
+ * No API key required — public NWS data.
+ */
+
+import { getCorsHeaders, isDisallowedOrigin } from '../_cors.js';
+
+export const config = { runtime: 'edge' };
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+const FLOOD_EVENTS = [
+  'Flood Warning',
+  'Flood Watch',
+  'Flash Flood Warning',
+  'Flash Flood Watch',
+  'Areal Flood Warning',
+  'Areal Flood Watch',
+  'Flood Advisory',
+  'Flash Flood Statement',
+  'Hydrologic Outlook',
+].join(',');
+
+const NWS_URL = `https://api.weather.gov/alerts/active?event=${encodeURIComponent(FLOOD_EVENTS)}&status=actual`;
+
+export const cache = new Map();
+
+const j = (payload, status, cors) =>
+  Response.json(payload, {
+    status,
+    headers: { 'content-type': 'application/json; charset=utf-8', ...cors },
+  });
+
+const SEVERITY_RANK = { Extreme: 4, Severe: 3, Moderate: 2, Minor: 1, Unknown: 0 };
+
+function parseAlerts(features) {
+  const byState = new Map();
+  const alerts = [];
+
+  for (const f of features) {
+    const p = f.properties ?? {};
+    const event = p.event ?? 'Unknown';
+    const severity = p.severity ?? 'Unknown';
+    const headline = p.headline ?? '';
+    const areaDesc = p.areaDesc ?? '';
+    const effective = p.effective ?? null;
+    const expires = p.expires ?? null;
+    const id = f.id ?? '';
+    const polygon = f.geometry ?? null;
+
+    // Extract state codes from areaDesc (e.g. "Lamar County; TX")
+    const stateMatches = [...areaDesc.matchAll(/;\s*([A-Z]{2})\b/g)].map(m => m[1]);
+    const states = stateMatches.length > 0 ? [...new Set(stateMatches)] : ['XX'];
+
+    for (const state of states) {
+      if (!byState.has(state)) byState.set(state, { state, count: 0, maxSeverityRank: 0, maxSeverity: 'Unknown', events: [] });
+      const st = byState.get(state);
+      st.count++;
+      const rank = SEVERITY_RANK[severity] ?? 0;
+      if (rank > st.maxSeverityRank) {
+        st.maxSeverityRank = rank;
+        st.maxSeverity = severity;
+      }
+      if (!st.events.includes(event)) st.events.push(event);
+    }
+
+    alerts.push({ id, event, severity, headline, areaDesc, effective, expires, polygon, states });
+  }
+
+  return {
+    total: features.length,
+    byState: [...byState.values()]
+      .sort((a, b) => b.maxSeverityRank - a.maxSeverityRank || b.count - a.count),
+    alerts,
+  };
+}
+
+export default async function handler(req) {
+  const cors = getCorsHeaders(req, 'GET, OPTIONS');
+  if (isDisallowedOrigin(req)) return j({ error: 'Origin not allowed' }, 403, cors);
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
+  if (req.method !== 'GET') return j({ error: 'Method not allowed' }, 405, cors);
+
+  const cached = cache.get('warnings');
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) return j(cached.payload, 200, cors);
+
+  try {
+    const r = await fetch(NWS_URL, {
+      headers: {
+        'User-Agent': 'CrystalBall/2 (flood-warnings) bradley_bond@me.com',
+        Accept: 'application/geo+json',
+      },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!r.ok) {
+      return j({ error: `NWS returned HTTP ${r.status}`, degraded: true, generatedAt: new Date().toISOString() }, 200, cors);
+    }
+    const data = await r.json();
+    const features = data?.features ?? [];
+    const parsed = parseAlerts(features);
+    const payload = { ...parsed, source: 'api.weather.gov', generatedAt: new Date().toISOString() };
+    cache.set('warnings', { at: Date.now(), payload });
+    return j(payload, 200, cors);
+  } catch (error) {
+    return j({ error: `NWS fetch failed: ${error?.message ?? error}`, degraded: true, generatedAt: new Date().toISOString() }, 200, cors);
+  }
+}

--- a/api/satellite/goes.js
+++ b/api/satellite/goes.js
@@ -1,0 +1,79 @@
+/**
+ * NOAA GOES satellite imagery metadata proxy.
+ * Validates and returns GOES-East and GOES-West latest GeoColor image URLs.
+ * Uses NESDIS CDN — no API key required.
+ *
+ * GOES-East = GOES-16, CONUS sector
+ * GOES-West = GOES-18, CONUS sector
+ */
+
+import { getCorsHeaders, isDisallowedOrigin } from '../_cors.js';
+
+export const config = { runtime: 'edge' };
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+const GOES_EAST_BASE = 'https://cdn.star.nesdis.noaa.gov/GOES16/ABI/CONUS/GEOCOLOR';
+const GOES_WEST_BASE = 'https://cdn.star.nesdis.noaa.gov/GOES18/ABI/CONUS/GEOCOLOR';
+
+export const cache = new Map();
+
+const j = (payload, status, cors) =>
+  Response.json(payload, {
+    status,
+    headers: { 'content-type': 'application/json; charset=utf-8', ...cors },
+  });
+
+async function probeLatest(base) {
+  const url = `${base}/latest.jpg`;
+  try {
+    const r = await fetch(url, {
+      method: 'HEAD',
+      headers: { 'User-Agent': 'CrystalBall/2 (goes-satellite)' },
+      signal: AbortSignal.timeout(8000),
+    });
+    return {
+      url,
+      available: r.ok,
+      lastModified: r.headers.get('last-modified') ?? null,
+      contentLength: r.headers.get('content-length') ? Number(r.headers.get('content-length')) : null,
+    };
+  } catch {
+    return { url, available: false, lastModified: null, contentLength: null };
+  }
+}
+
+export default async function handler(req) {
+  const cors = getCorsHeaders(req, 'GET, OPTIONS');
+  if (isDisallowedOrigin(req)) return j({ error: 'Origin not allowed' }, 403, cors);
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
+  if (req.method !== 'GET') return j({ error: 'Method not allowed' }, 405, cors);
+
+  const cached = cache.get('latest');
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) return j(cached.payload, 200, cors);
+
+  const [east, west] = await Promise.all([
+    probeLatest(GOES_EAST_BASE),
+    probeLatest(GOES_WEST_BASE),
+  ]);
+
+  const payload = {
+    goesEast: {
+      label: 'GOES-East (GOES-16)',
+      region: 'CONUS',
+      product: 'GeoColor',
+      ...east,
+    },
+    goesWest: {
+      label: 'GOES-West (GOES-18)',
+      region: 'CONUS',
+      product: 'GeoColor',
+      ...west,
+    },
+    generatedAt: new Date().toISOString(),
+    cacheTtlSeconds: CACHE_TTL_MS / 1000,
+  };
+
+  cache.set('latest', { at: Date.now(), payload });
+  return j(payload, 200, cors);
+}

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -280,6 +280,8 @@ import type { ExtendedForecastPanel } from '@/components/ExtendedForecastPanel';
 import type { WeatherRadarPanel } from '@/components/WeatherRadarPanel';
 import type { TidePredictionsPanel } from '@/components/TidePredictionsPanel';
 import type { PollenPanel } from '@/components/PollenPanel';
+import type { GoesSatellitePanel } from '@/components/GoesSatellitePanel';
+import type { FloodMonitorPanel } from '@/components/FloodMonitorPanel';
 import { fetchDamSafetyAlerts } from '@/services/dam-safety';
 import { fetchPowerGridAlerts } from '@/services/power-grid-alerts';
 import { fetchGreyNoise, fetchOtxPulses, fetchAbuseIpDb, fetchUrlscanFeed } from '@/services/osint';
@@ -608,6 +610,8 @@ export class DataLoaderManager implements AppModule {
  if (SITE_VARIANT === 'full') tasks.push({ name: 'weatherRadar', task: () => runGuarded('weatherRadar', () => this.loadWeatherRadar()) });
  if (SITE_VARIANT === 'full') tasks.push({ name: 'tidePredictions', task: () => runGuarded('tidePredictions', () => this.loadTidePredictions()) });
  if (SITE_VARIANT === 'full') tasks.push({ name: 'pollenData', task: () => runGuarded('pollenData', () => this.loadPollenData()) });
+ if (SITE_VARIANT === 'full') tasks.push({ name: 'goesSatellite', task: () => runGuarded('goesSatellite', () => this.loadGoesSatellite()) });
+ if (SITE_VARIANT === 'full') tasks.push({ name: 'floodMonitor', task: () => runGuarded('floodMonitor', () => this.loadFloodMonitor()) });
  if (SITE_VARIANT === 'full') tasks.push({ name: 'lightning', task: () => runGuarded('lightning', () => this.loadLightning()) });
  if (SITE_VARIANT === 'full') tasks.push({ name: 'redFlagWarnings', task: () => runGuarded('redFlagWarnings', () => this.loadRedFlagWarnings()) });
  if (SITE_VARIANT === 'full') tasks.push({ name: 'satellites', task: () => runGuarded('satellites', () => this.loadSatellites()) });
@@ -3578,6 +3582,31 @@ export class DataLoaderManager implements AppModule {
  (this.ctx.panels['pollen'] as PollenPanel | undefined)?.update(readings);
  } catch (error) {
  console.warn('[pollen] fetch failed', error);
+ }
+  }
+
+  async loadGoesSatellite(): Promise<void> {
+ try {
+ const r = await fetch('/api/satellite/goes');
+ if (!r.ok) return;
+ const data = await r.json();
+ (this.ctx.panels['goes-satellite'] as GoesSatellitePanel | undefined)?.update(data);
+ } catch (error) {
+ console.warn('[goes-satellite] fetch failed', error);
+ }
+  }
+
+  async loadFloodMonitor(): Promise<void> {
+ try {
+ const [gaugesRes, warningsRes] = await Promise.allSettled([
+ fetch('/api/floods/gauges').then(r => r.ok ? r.json() : null),
+ fetch('/api/floods/warnings').then(r => r.ok ? r.json() : null),
+ ]);
+ const panel = this.ctx.panels['flood-monitor'] as FloodMonitorPanel | undefined;
+ if (gaugesRes.status === 'fulfilled' && gaugesRes.value) panel?.updateGauges(gaugesRes.value);
+ if (warningsRes.status === 'fulfilled' && warningsRes.value) panel?.updateWarnings(warningsRes.value);
+ } catch (error) {
+ console.warn('[flood-monitor] fetch failed', error);
  }
   }
 

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -296,6 +296,8 @@ import { SavedPlaceModal } from '@/components/SavedPlaceModal';
 import type { GeoHubActivity } from '@/services/geo-activity';
 import type { TechHubActivity } from '@/services/tech-activity';
 import { RipeAtlasPanel } from '@/components/RipeAtlasPanel';
+import { GoesSatellitePanel } from '@/components/GoesSatellitePanel';
+import { FloodMonitorPanel } from '@/components/FloodMonitorPanel';
 // HTML builders (app shell + map + sidebar) live in a sibling module.
 import * as htmlBuilders from '@/app/layout/html';
 
@@ -1273,6 +1275,8 @@ export class PanelLayoutManager implements AppModule {
  this.ctx.panels['weather-radar'] = new WeatherRadarPanel();
  this.ctx.panels['tide-predictions'] = new TidePredictionsPanel();
  this.ctx.panels['pollen'] = new PollenPanel();
+ this.ctx.panels['goes-satellite'] = new GoesSatellitePanel();
+ this.ctx.panels['flood-monitor'] = new FloodMonitorPanel();
 
  this.ctx.panels['stoic-reflections'] = new StoicQuotePanel();
  this.ctx.panels['biblical-encouragement'] = new BiblicalQuotePanel();

--- a/src/components/FloodMonitorPanel.ts
+++ b/src/components/FloodMonitorPanel.ts
@@ -1,0 +1,207 @@
+import { Panel } from './Panel';
+import { escapeHtml } from '@/utils/sanitize';
+
+interface StateFloodEntry {
+  state: string;
+  count: number;
+  maxSeverity?: string;
+  maxSeverityRank?: number;
+  maxStage?: string;
+  events?: string[];
+}
+
+interface GaugeEntry {
+  siteNo: string;
+  siteName: string;
+  state: string;
+  stageVal: number;
+  stage: string;
+  lat: number | null;
+  lon: number | null;
+}
+
+interface FloodAlert {
+  id: string;
+  event: string;
+  severity: string;
+  headline: string;
+  areaDesc: string;
+  states: string[];
+}
+
+interface GaugeData {
+  totalGauges: number;
+  atFloodStage: number;
+  atActionStage: number;
+  byState: StateFloodEntry[];
+  top10: GaugeEntry[];
+  generatedAt: string;
+  degraded?: boolean;
+}
+
+interface WarningData {
+  total: number;
+  byState: StateFloodEntry[];
+  alerts: FloodAlert[];
+  generatedAt: string;
+  degraded?: boolean;
+}
+
+export class FloodMonitorPanel extends Panel {
+  private gaugeData: GaugeData | null = null;
+  private warningData: WarningData | null = null;
+  private lastUpdated: Date | null = null;
+
+  constructor() {
+    super({
+      id: 'flood-monitor',
+      title: 'Flood Monitor',
+      showCount: true,
+      trackActivity: true,
+      infoTooltip: 'USGS stream gauge readings at flood stage + NWS active flood watches and warnings.',
+    });
+    this.showLoading('Fetching flood data...');
+  }
+
+  public updateGauges(data: GaugeData): void {
+    this.gaugeData = data;
+    this.lastUpdated = new Date();
+    this.updateCount();
+    this.render();
+  }
+
+  public updateWarnings(data: WarningData): void {
+    this.warningData = data;
+    this.lastUpdated = new Date();
+    this.updateCount();
+    this.render();
+  }
+
+  private updateCount(): void {
+    const gaugeCount = this.gaugeData?.atFloodStage ?? 0;
+    const warningCount = this.warningData?.total ?? 0;
+    this.setCount(gaugeCount + warningCount);
+  }
+
+  private render(): void {
+    if (!this.gaugeData && !this.warningData) {
+      this.setContent('<div class="panel-empty">No flood data available.</div>');
+      return;
+    }
+
+    const updatedStr = this.lastUpdated ? timeAgo(this.lastUpdated) : 'never';
+    const sections: string[] = [];
+
+    // Summary row
+    const gaugeCount = this.gaugeData?.atFloodStage ?? '—';
+    const warningCount = this.warningData?.total ?? '—';
+    sections.push(`
+      <div class="flood-summary-row">
+        <div class="flood-stat">
+          <span class="flood-stat-value ${this.gaugeData?.atFloodStage ? 'flood-stat-alert' : ''}">${gaugeCount}</span>
+          <span class="flood-stat-label">Gauges at flood stage</span>
+        </div>
+        <div class="flood-stat">
+          <span class="flood-stat-value ${this.warningData?.total ? 'flood-stat-alert' : ''}">${warningCount}</span>
+          <span class="flood-stat-label">NWS flood alerts</span>
+        </div>
+      </div>
+    `);
+
+    // NWS warnings by state
+    if (this.warningData && this.warningData.byState.length > 0) {
+      const rows = this.warningData.byState.slice(0, 10).map(s => {
+        const badge = severityBadge(s.maxSeverity ?? 'Unknown');
+        const events = (s.events ?? []).slice(0, 2).map(e => escapeHtml(e)).join(', ');
+        return `<tr>
+          <td class="flood-state">${escapeHtml(s.state)}</td>
+          <td class="flood-count">${s.count}</td>
+          <td>${badge}</td>
+          <td class="flood-events">${events}</td>
+        </tr>`;
+      }).join('');
+
+      sections.push(`
+        <div class="flood-section">
+          <div class="flood-section-header">NWS Active Alerts by State</div>
+          <table class="flood-table">
+            <thead><tr><th>State</th><th>#</th><th>Severity</th><th>Alert Type</th></tr></thead>
+            <tbody>${rows}</tbody>
+          </table>
+        </div>
+      `);
+    } else if (this.warningData && !this.warningData.degraded) {
+      sections.push('<div class="panel-empty flood-empty">No active NWS flood alerts.</div>');
+    }
+
+    // Top 10 gauges
+    if (this.gaugeData && this.gaugeData.top10.length > 0) {
+      const rows = this.gaugeData.top10.map(g => {
+        const stageClass = stageRowClass(g.stage);
+        return `<tr class="${stageClass}">
+          <td class="flood-gauge-name">${escapeHtml(g.siteName)}</td>
+          <td class="flood-state">${escapeHtml(g.state)}</td>
+          <td class="flood-stage-val">${g.stageVal.toFixed(1)} ft</td>
+          <td>${stageBadge(g.stage)}</td>
+        </tr>`;
+      }).join('');
+
+      sections.push(`
+        <div class="flood-section">
+          <div class="flood-section-header">Top Flood-Stage Gauges</div>
+          <table class="flood-table">
+            <thead><tr><th>Site</th><th>State</th><th>Stage</th><th>Level</th></tr></thead>
+            <tbody>${rows}</tbody>
+          </table>
+        </div>
+      `);
+    } else if (this.gaugeData && !this.gaugeData.degraded) {
+      sections.push('<div class="panel-empty flood-empty">No gauges currently at flood stage.</div>');
+    }
+
+    this.setContent(`
+      <div class="flood-panel-content">
+        ${sections.join('')}
+        <div class="fires-footer">
+          <span class="fires-source">USGS Water Services · NWS · No API key</span>
+          <span class="fires-updated">Updated ${updatedStr}</span>
+        </div>
+      </div>
+    `);
+  }
+}
+
+function severityBadge(severity: string): string {
+  const cls = {
+    Extreme: 'badge-extreme',
+    Severe: 'badge-severe',
+    Moderate: 'badge-moderate',
+    Minor: 'badge-minor',
+  }[severity] ?? 'badge-unknown';
+  return `<span class="flood-badge ${cls}">${escapeHtml(severity)}</span>`;
+}
+
+function stageBadge(stage: string): string {
+  const cls = {
+    major: 'badge-extreme',
+    moderate: 'badge-severe',
+    minor: 'badge-moderate',
+    action: 'badge-minor',
+    flood: 'badge-moderate',
+  }[stage] ?? 'badge-unknown';
+  return `<span class="flood-badge ${cls}">${escapeHtml(stage)}</span>`;
+}
+
+function stageRowClass(stage: string): string {
+  if (stage === 'major') return 'flood-row-major';
+  if (stage === 'moderate') return 'flood-row-moderate';
+  return '';
+}
+
+function timeAgo(date: Date): string {
+  const secs = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (secs < 60) return 'just now';
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  return `${Math.floor(mins / 60)}h ago`;
+}

--- a/src/components/GlobeDataManager.ts
+++ b/src/components/GlobeDataManager.ts
@@ -39,6 +39,7 @@ import { satellitePropagator, type SatellitePosition } from '@/services/satellit
 import { fetchLightningStrikes } from '@/services/lightning';
 import { fetchRedFlagWarnings } from '@/services/red-flag-warnings';
 import { getRadarTileUrl, fetchRadarFrames } from '@/services/rainviewer-radar';
+import { getGoesWmsTileUrl } from '@/services/satellite-weather';
 import { getApiBaseUrl } from '@/services/runtime';
 import {
   computeAftershockForecast,
@@ -669,6 +670,7 @@ export class GlobeDataManager {
  this.registerLayer('lightningStrikes', () => this.loadLightningStrikes());
  this.registerLayer('redFlagWarnings', () => this.loadRedFlagWarnings());
  this.registerLayer('weatherHazards', () => this.loadWeatherHazards());
+ this.registerLayer('floodAlerts', () => this.loadFloodAlerts());
  this.registerLayer('wastewaterStates', () => this.loadWastewaterStates());
 
  this.registerLayer('streetTiles', () => {
@@ -2331,11 +2333,52 @@ ${pkg.composition.map(u => u.type + ' x' + String(u.count)).join(', ')}`,
   }
 
   private loadWeatherSatellite(): void {
- // Disabled: Iowa State TMS layer name `goes_conus_geocolor` returns a pink
- // "Invalid TMS Request" PNG for every tile, which Cesium renders as a
- // magenta overlay across the entire globe. Original fix in commit 44a56901,
- // lost in godsvision-tier1 integration merge (#171). Re-enable once a working
- // tile source is wired up in satellite-weather.ts.
+ try {
+ const tileUrl = getGoesWmsTileUrl('geocolor');
+ const provider = new UrlTemplateImageryProvider({ url: tileUrl, maximumLevel: 7 });
+ const imgLayer = this.viewer.imageryLayers.addImageryProvider(provider);
+ imgLayer.alpha = 0.7;
+ this.weatherImageryLayers.push(imgLayer);
+ } catch { /* satellite imagery unavailable */ }
+  }
+
+  private async loadFloodAlerts(): Promise<void> {
+ const layer = this.layers.get('floodAlerts');
+ if (!layer) return;
+ try {
+ const base = getApiBaseUrl();
+ const r = await fetch(`${base}/api/floods/warnings`, { signal: AbortSignal.timeout(10_000) });
+ if (!r.ok) return;
+ const data = await r.json() as { alerts?: { id: string; event: string; severity: string; headline: string; polygon: { type: string; coordinates: number[][][] } | null }[] };
+ const alerts = data?.alerts ?? [];
+ const SEVERITY_COLORS: Record<string, string> = {
+ Extreme: '#cc0000',
+ Severe: '#ff4400',
+ Moderate: '#ff8800',
+ Minor: '#ffcc00',
+ };
+ for (const alert of alerts) {
+ if (!alert.polygon?.coordinates?.[0]) continue;
+ const outerRing = alert.polygon.coordinates[0];
+ const flat = outerRing.flatMap(coord => [coord[0] ?? 0, coord[1] ?? 0]);
+ if (flat.length < 6) continue;
+ const fillHex = SEVERITY_COLORS[alert.severity] ?? '#0088ff';
+ const fillColor = Color.fromCssColorString(fillHex).withAlpha(0.35);
+ const outlineColor = Color.fromCssColorString(fillHex).withAlpha(0.8);
+ layer.source.entities.add({
+ name: alert.id,
+ polygon: {
+ hierarchy: new PolygonHierarchy(Cartesian3.fromDegreesArray(flat)),
+ material: new ColorMaterialProperty(fillColor),
+ outline: true,
+ outlineColor,
+ outlineWidth: 2,
+ heightReference: HeightReference.CLAMP_TO_GROUND,
+ },
+ description: escapeHtml(alert.headline),
+ });
+ }
+ } catch { /* flood alerts unavailable */ }
   }
 
   private async loadLightningStrikes(): Promise<void> {

--- a/src/components/GoesSatellitePanel.ts
+++ b/src/components/GoesSatellitePanel.ts
@@ -1,0 +1,103 @@
+import { Panel } from './Panel';
+import { escapeHtml } from '@/utils/sanitize';
+
+interface GoesImageInfo {
+  label: string;
+  region: string;
+  product: string;
+  url: string;
+  available: boolean;
+  lastModified: string | null;
+  contentLength: number | null;
+}
+
+interface GoesSatelliteData {
+  goesEast: GoesImageInfo;
+  goesWest: GoesImageInfo;
+  generatedAt: string;
+  cacheTtlSeconds: number;
+}
+
+export class GoesSatellitePanel extends Panel {
+  private data: GoesSatelliteData | null = null;
+  private lastUpdated: Date | null = null;
+
+  constructor() {
+    super({
+      id: 'goes-satellite',
+      title: 'GOES Satellite',
+      showCount: false,
+      trackActivity: true,
+      infoTooltip: 'NOAA GOES-East (GOES-16) and GOES-West (GOES-18) GeoColor imagery — updated every 5 minutes.',
+    });
+    this.showLoading('Fetching satellite imagery...');
+  }
+
+  public update(data: GoesSatelliteData): void {
+    this.data = data;
+    this.lastUpdated = new Date();
+    this.render();
+  }
+
+  private render(): void {
+    if (!this.data) {
+      this.setContent('<div class="panel-empty">No satellite data available.</div>');
+      return;
+    }
+
+    const { goesEast, goesWest } = this.data;
+    const updatedStr = this.lastUpdated ? timeAgo(this.lastUpdated) : 'never';
+
+    this.setContent(`
+      <div class="goes-panel-content">
+        <div class="goes-images-row">
+          ${renderGoesImage(goesEast)}
+          ${renderGoesImage(goesWest)}
+        </div>
+        <div class="fires-footer">
+          <span class="fires-source">NOAA NESDIS · No API key</span>
+          <span class="fires-updated">Updated ${updatedStr}</span>
+        </div>
+      </div>
+    `);
+  }
+}
+
+function renderGoesImage(info: GoesImageInfo): string {
+  const label = escapeHtml(info.label);
+  const region = escapeHtml(info.region);
+  const product = escapeHtml(info.product);
+  const modifiedStr = info.lastModified ? new Date(info.lastModified).toLocaleTimeString() : '—';
+
+  if (!info.available) {
+    return `
+      <div class="goes-image-card goes-unavailable">
+        <div class="goes-image-label">${label}</div>
+        <div class="goes-image-placeholder">Imagery unavailable</div>
+        <div class="goes-image-meta">${region} · ${product}</div>
+      </div>`;
+  }
+
+  return `
+    <div class="goes-image-card">
+      <div class="goes-image-label">${label}</div>
+      <a href="${escapeHtml(info.url)}" target="_blank" rel="noopener noreferrer" class="goes-image-link">
+        <img
+          class="goes-image"
+          src="${escapeHtml(info.url)}"
+          alt="${label} GeoColor"
+          loading="lazy"
+          onerror="this.parentElement.parentElement.classList.add('goes-unavailable'); this.style.display='none'"
+        />
+      </a>
+      <div class="goes-image-meta">${region} · ${product} · ${modifiedStr}</div>
+    </div>`;
+}
+
+function timeAgo(date: Date): string {
+  const secs = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (secs < 60) return 'just now';
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  return `${Math.floor(mins / 60)}h ago`;
+}

--- a/src/config/gods-vision-layers.ts
+++ b/src/config/gods-vision-layers.ts
@@ -270,6 +270,12 @@ export const DEFAULT_GODS_VISION_LAYERS: GodsVisionLayers = {
  enabled: true,
  description: 'NWS Red Flag Warnings and fire weather watches',
   },
+  floodAlerts: {
+ name: 'Flood Alerts',
+ category: 'intelligence',
+ enabled: false,
+ description: 'NWS active flood watches and warnings — polygons colored by severity',
+  },
 };
 
 const STORAGE_KEY = 'crystalball-gods-vision-layers';

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -216,6 +216,8 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'tide-predictions': { name: 'Tide Predictions', enabled: true, priority: 2 },
   'pollen': { name: 'Pollen & Allergy', enabled: true, priority: 1 },
   'weather-radar': { name: 'Weather Radar', enabled: true, priority: 1 },
+  'goes-satellite': { name: 'GOES Satellite', enabled: true, priority: 1 },
+  'flood-monitor': { name: 'Flood Monitor', enabled: true, priority: 1 },
 };
 
 const FULL_MAP_LAYERS: MapLayers = {
@@ -1015,7 +1017,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   hazards: {
  labelKey: 'header.panelCatHazards',
 
- panelKeys: ['wildfire-intel', 'satellite-fires', 'earthquakes', 'emsc-seismic', 'gdacs-alerts', 'volcano-alerts', 'nws-alerts', 'faa-weather-cams', 'faa-tfrs', 'tsunami-alerts', 'tropical-cyclones', 'climate', 'wildfire-incidents', 'hazmat-incidents', 'oil-spill', 'fcdo-warnings', 'dfat-warnings', 'gac-warnings', 'avalanche-hazard', 'wildfire-smoke', 'spc-mesoscale', 'amtrak-alerts', 'habsos', 'global-weather', 'extended-forecast', 'tide-predictions', 'pollen', 'weather-radar'],
+ panelKeys: ['wildfire-intel', 'satellite-fires', 'earthquakes', 'emsc-seismic', 'gdacs-alerts', 'volcano-alerts', 'nws-alerts', 'faa-weather-cams', 'faa-tfrs', 'tsunami-alerts', 'tropical-cyclones', 'climate', 'wildfire-incidents', 'hazmat-incidents', 'oil-spill', 'fcdo-warnings', 'dfat-warnings', 'gac-warnings', 'avalanche-hazard', 'wildfire-smoke', 'spc-mesoscale', 'amtrak-alerts', 'habsos', 'global-weather', 'extended-forecast', 'tide-predictions', 'pollen', 'weather-radar', 'goes-satellite', 'flood-monitor'],
  variants: ['full'],
   },
   healthEnv: {


### PR DESCRIPTION
## Summary

Adds two new data-source panels backed by free, no-key-required public APIs.

### Panel 1 — GOES Satellite (`goes-satellite`)

- **Sidecar route** `GET /api/satellite/goes` — probes NOAA NESDIS CDN for GOES-East (GOES-16) and GOES-West (GOES-18) latest GeoColor `latest.jpg`, returns availability + last-modified metadata. 5-min cache.
- **Panel** `GoesSatellitePanel.ts` — side-by-side imagery cards, graceful unavailable state.
- **Globe overlay** — implements the long-stubbed `loadWeatherSatellite()` in `GlobeDataManager` using NASA GIBS `UrlTemplateImageryProvider` tiles from `satellite-weather.ts`. Wired to existing `weatherSatellite` toggle.

### Panel 2 — Flood Monitor (`flood-monitor`)

- **Sidecar route** `GET /api/floods/gauges` — USGS Water Services IV API, classifies gauge readings by flood qualifier keywords, returns summary + top-10 by height. 10-min cache.
- **Sidecar route** `GET /api/floods/warnings` — NWS active flood alerts API, extracts state codes from `areaDesc`, ranks by severity (Extreme → Severe → Moderate → Minor). 5-min cache.
- **Panel** `FloodMonitorPanel.ts` — gauge count at flood stage, NWS alerts by state table, top-10 highest gauges table.
- **Globe choropleth** — new `floodAlerts` layer in `GlobeDataManager` renders NWS alert polygons colored by severity (red/orange/yellow). Added `floodAlerts` toggle to `gods-vision-layers.ts`.

### Wiring

Both panels added to `FULL_PANELS` + `hazards.panelKeys` in `panels.ts`, instantiated in `panel-layout.ts`, fetched in `data-loader.ts` (`SITE_VARIANT=full` only).

### Tests

36 new tests across 3 files (`api/__tests__/satellite-goes.test.mjs`, `floods-gauges.test.mjs`, `floods-warnings.test.mjs`): method guards, CORS preflight, response shape, cache behavior, degraded/error paths.

---

Cross-agent review: claude reviewed on 2026-05-11; outcome: pass