### PR TITLE
feat(panels): Bitcoin Abuse + Reddit OSINT panels

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,8 @@
     "test:panels:smoke": "node tests/panels/run-harness.mjs",
     "test:components": "tsx --test src/components/__tests__/disease-outbreak-tabs.test.mts src/components/__tests__/space-weather-panel.test.mts",
     "test:alerts": "tsx --test src/services/alerts/__tests__/ipaws-monitor.test.mts",
+    "test:crypto": "tsx --test src/services/crypto/__tests__/bitcoin-abuse-service.test.mts",
+    "test:osint": "tsx --test src/services/osint/__tests__/reddit-service.test.mts",
     "test:notifications": "tsx --test src/services/notifications/__tests__/eew-tiers.test.mts src/services/notifications/__tests__/notification-ledger.test.mts src/services/notifications/__tests__/push-notifier.test.mts src/services/notifications/__tests__/imessage-bridge-extended.test.mts src/services/notifications/__tests__/voice-alerter.test.mts src/services/notifications/__tests__/event-bridge.test.mts",
     "test:panels:fixtures": "tsx --import ./tests/panels/register-hook.mjs --test tests/panels/panel-fixtures.test.mts",
     "test:strategic-self-improvement": "tsx --test src/services/diagnostics/__tests__/failure-prediction.test.mts src/services/governance/__tests__/policy-engine.test.mts src/services/governance/__tests__/model-governance.test.mts src/services/experiments/__tests__/experiment-manager.test.mts src/services/ops/__tests__/causal-attribution.test.mts src/services/ops/__tests__/trust-budget.test.mts src/services/ops/__tests__/playbook-engine.test.mts src/services/scenarios/__tests__/scenario-library.test.mts src/services/personal/__tests__/resilience-model.test.mts src/services/quality/__tests__/quality-debt.test.mts src/services/quality/__tests__/self-improvement-scheduler.test.mts",

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -7583,6 +7583,225 @@ async function dispatch(requestUrl, req, routes, context) {
  }
   }
 
+  // ── Reddit OSINT multi-subreddit feed ────────────────────────────────────
+  // Reads up to ~6 threat-relevant subreddits in parallel, no OAuth.
+  // 15-min cache per (subreddit, limit) tuple so a tab switch or another
+  // process probing the route doesn't burn Reddit's ratelimit.
+  if (requestUrl.pathname === '/api/osint/reddit') {
+    const REDDIT_OSINT_TTL_MS = 15 * 60 * 1000;
+    const REDDIT_DEFAULT_SUBS = ['netsec', 'cybersecurity', 'worldnews', 'geopolitics', 'RBI', 'EmergencyManagement'];
+    const subsParam = requestUrl.searchParams.get('subreddits') ?? '';
+    const VALID_SUB = /^[a-z0-9][a-z0-9_]{1,20}$/i;
+    const parsed = subsParam
+      .split(',')
+      .map(s => s.trim().replace(/^r\//i, ''))
+      .filter(s => VALID_SUB.test(s));
+    const subs = parsed.length > 0 ? Array.from(new Set(parsed)) : REDDIT_DEFAULT_SUBS;
+    const limitRaw = Number.parseInt(requestUrl.searchParams.get('limit') ?? '', 10);
+    const limit = Number.isFinite(limitRaw) && limitRaw > 0 ? Math.min(100, limitRaw) : 25;
+
+    const fetchSub = async (sub) => {
+      const cacheKey = `reddit-osint-${sub.toLowerCase()}-${limit}`;
+      const cached = getCached(cacheKey, REDDIT_OSINT_TTL_MS);
+      if (cached) return { sub, posts: cached, ok: true };
+      try {
+        const resp = await fetchWithTimeout(
+          `https://www.reddit.com/r/${encodeURIComponent(sub)}/new.json?limit=${limit}&raw_json=1`,
+          { headers: { 'User-Agent': 'CrystalBall/2.13 (threat intelligence aggregator)' } },
+          10_000,
+        );
+        if (!resp.ok) return { sub, posts: [], ok: false, reason: `HTTP ${resp.status}` };
+        const data = await resp.json();
+        const children = data?.data?.children ?? [];
+        const posts = [];
+        for (const child of children) {
+          if (child?.kind !== 't3') continue;
+          const p = child.data ?? {};
+          if (p.stickied === true) continue;
+          if (!p.id || !p.title) continue;
+          const permalinkPath = typeof p.permalink === 'string' ? p.permalink : `/r/${p.subreddit ?? sub}/comments/${p.id}`;
+          posts.push({
+            id: p.id,
+            subreddit: p.subreddit ?? sub,
+            title: p.title,
+            url: typeof p.url === 'string' ? p.url : `https://www.reddit.com${permalinkPath}`,
+            permalink: `https://www.reddit.com${permalinkPath}`,
+            score: typeof p.score === 'number' ? p.score : 0,
+            numComments: typeof p.num_comments === 'number' ? p.num_comments : 0,
+            createdUtc: typeof p.created_utc === 'number' ? p.created_utc : 0,
+            flair: typeof p.link_flair_text === 'string' && p.link_flair_text.length > 0 ? p.link_flair_text : null,
+            author: typeof p.author === 'string' && p.author.length > 0 ? p.author : '[deleted]',
+            domain: typeof p.domain === 'string' && p.domain.length > 0 ? p.domain : null,
+            over18: p.over_18 === true,
+          });
+        }
+        setCached(cacheKey, posts, REDDIT_OSINT_TTL_MS);
+        return { sub, posts, ok: true };
+      } catch (error) {
+        return { sub, posts: [], ok: false, reason: error?.message ?? String(error) };
+      }
+    };
+
+    const results = await Promise.all(subs.map(fetchSub));
+    const successfulSubs = [];
+    const reasons = [];
+    const merged = [];
+    for (const r of results) {
+      if (r.ok) {
+        successfulSubs.push(r.sub);
+        for (const post of r.posts) merged.push(post);
+      } else if (r.reason) {
+        reasons.push(`${r.sub}: ${r.reason}`);
+      }
+    }
+    merged.sort((a, b) => b.createdUtc - a.createdUtc);
+    return json({
+      posts: merged,
+      subreddits: successfulSubs,
+      degraded: reasons.length > 0,
+      generatedAt: new Date().toISOString(),
+      reason: reasons.length > 0 ? reasons.join('; ') : null,
+    });
+  }
+
+  // ── CryptoScamDB + Bitcoin Abuse aggregator ──────────────────────────────
+  // No-key default: pulls scam addresses + domains from CryptoScamDB
+  // (public). When BITCOINABUSE_API_KEY is present we'd ALSO union in
+  // Bitcoin Abuse reports — left out of this PR per spec (key-gated).
+  // 6h cache because CryptoScamDB updates slowly.
+  if (requestUrl.pathname === '/api/crypto/bitcoin-abuse') {
+    const CRYPTO_SCAM_TTL_MS = 6 * 60 * 60 * 1000;
+    const cached = getCached('crypto-bitcoin-abuse', CRYPTO_SCAM_TTL_MS);
+    if (cached) return json(cached);
+
+    const normaliseCategory = (raw) => {
+      if (typeof raw !== 'string') return 'other';
+      const lower = raw.toLowerCase();
+      if (lower.includes('ransom')) return 'ransomware';
+      if (lower.includes('phish')) return 'phishing';
+      if (lower.includes('mixer') || lower.includes('tumbler')) return 'mixer';
+      if (lower.includes('darknet') || lower.includes('darkmarket')) return 'darknet';
+      if (lower.includes('mining') || lower.includes('miner')) return 'mining';
+      if (lower.includes('scam') || lower.includes('fraud') || lower.includes('fake')) return 'scam';
+      return 'other';
+    };
+    const stripProtocol = (v) => String(v).replace(/^https?:\/\//i, '').replace(/\/$/, '');
+
+    const recordsFromResult = (raw) => {
+      if (!raw || typeof raw !== 'object') return [];
+      const result = raw.result;
+      if (Array.isArray(result)) return result.filter(r => r && typeof r === 'object').map(r => ({ key: null, rec: r }));
+      if (result && typeof result === 'object') {
+        return Object.entries(result).filter(([_, v]) => v && typeof v === 'object').map(([k, v]) => ({ key: k, rec: v }));
+      }
+      return [];
+    };
+
+    let addresses = [];
+    let domains = [];
+    let degraded = false;
+    let provenance = 'CryptoScamDB';
+
+    try {
+      const [addrResp, domResp] = await Promise.allSettled([
+        fetchWithTimeout('https://api.cryptoscamdb.org/v1/addresses', { headers: { 'User-Agent': 'CrystalBall/2.13' } }, 15_000),
+        fetchWithTimeout('https://api.cryptoscamdb.org/v1/domains', { headers: { 'User-Agent': 'CrystalBall/2.13' } }, 15_000),
+      ]);
+      if (addrResp.status === 'fulfilled' && addrResp.value.ok) {
+        const json = await addrResp.value.json();
+        for (const { key, rec } of recordsFromResult(json)) {
+          const coin = typeof rec.coin === 'string' ? rec.coin.toUpperCase() : '';
+          if (coin && coin !== 'BTC') continue;
+          const address = (typeof rec.address === 'string' && rec.address) || key;
+          if (!address) continue;
+          addresses.push({
+            address,
+            category: normaliseCategory(rec.subcategory ?? rec.category),
+            reportCount: typeof rec.reports === 'number' ? rec.reports : (typeof rec.reportedaddresses === 'number' ? rec.reportedaddresses : 1),
+            name: typeof rec.name === 'string' ? rec.name : undefined,
+          });
+        }
+      } else {
+        degraded = true;
+      }
+      if (domResp.status === 'fulfilled' && domResp.value.ok) {
+        const json = await domResp.value.json();
+        for (const { key, rec } of recordsFromResult(json)) {
+          const domain = (typeof rec.domain === 'string' && rec.domain) || (typeof rec.url === 'string' && rec.url) || key;
+          if (!domain) continue;
+          const statusRaw = typeof rec.status === 'string' ? rec.status.toLowerCase() : '';
+          const status = statusRaw.includes('offline') || statusRaw.includes('inactive') || statusRaw === 'dead' ? 'inactive'
+            : statusRaw.includes('active') || statusRaw === 'online' ? 'active'
+            : 'unknown';
+          domains.push({
+            domain: stripProtocol(domain),
+            category: normaliseCategory(rec.subcategory ?? rec.category),
+            status,
+            name: typeof rec.name === 'string' ? rec.name : undefined,
+            reportedAt: typeof rec.reported === 'string' ? rec.reported : undefined,
+          });
+        }
+      } else {
+        degraded = true;
+      }
+    } catch (error) {
+      degraded = true;
+      provenance = `CryptoScamDB error: ${error?.message ?? error}`;
+    }
+
+    const payload = {
+      addresses,
+      domains,
+      degraded,
+      source: provenance,
+      generatedAt: new Date().toISOString(),
+    };
+    setCached('crypto-bitcoin-abuse', payload, CRYPTO_SCAM_TTL_MS);
+    return json(payload);
+  }
+
+  // ── Per-address check: scam DB lookup + blockchain.info chain stats ──────
+  if (requestUrl.pathname === '/api/crypto/bitcoin-abuse/check') {
+    const address = (requestUrl.searchParams.get('address') ?? '').trim();
+    const isBtc = /^bc1[ac-hj-np-z02-9]+$/i.test(address) || /^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$/.test(address);
+    if (!isBtc) {
+      return json({ address, scamMatch: null, balanceSat: null, txCount: null, source: 'invalid-address-format', fetchedAt: new Date().toISOString() }, 400);
+    }
+    // Snapshot of the scam feed for cheap address membership check.
+    const feed = getCached('crypto-bitcoin-abuse', 6 * 60 * 60 * 1000);
+    let scamMatch = null;
+    if (feed && Array.isArray(feed.addresses)) {
+      scamMatch = feed.addresses.find(e => typeof e?.address === 'string' && e.address === address) ?? null;
+    }
+    let balanceSat = null;
+    let txCount = null;
+    let provenance = 'blockchain.info';
+    try {
+      const resp = await fetchWithTimeout(
+        `https://blockchain.info/rawaddr/${encodeURIComponent(address)}?limit=0`,
+        { headers: { 'User-Agent': 'CrystalBall/2.13' } },
+        15_000,
+      );
+      if (resp.ok) {
+        const data = await resp.json();
+        if (typeof data.final_balance === 'number') balanceSat = data.final_balance;
+        if (typeof data.n_tx === 'number') txCount = data.n_tx;
+      } else {
+        provenance = `blockchain.info HTTP ${resp.status}`;
+      }
+    } catch (error) {
+      provenance = `blockchain.info error: ${error?.message ?? error}`;
+    }
+    return json({
+      address,
+      scamMatch,
+      balanceSat,
+      txCount,
+      source: provenance,
+      fetchedAt: new Date().toISOString(),
+    });
+  }
+
   // ── OpenAQ real-time air quality readings ────────────────────────────────
   if (requestUrl.pathname === '/api/openaq-readings') {
  const cached = getCached('openaq-readings');

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -148,6 +148,8 @@ import { OpenSanctionsPanel } from '@/components/OpenSanctionsPanel';
 import { SanctionsPanel } from '@/components/SanctionsPanel';
 import { HibpBreachesPanel } from '@/components/HibpBreachesPanel';
 import { IpInfoPanel } from '@/components/IpInfoPanel';
+import { BitcoinAbusePanel } from '@/components/BitcoinAbusePanel';
+import { RedditOsintPanel } from '@/components/RedditOsintPanel';
 import { EdgarFilingsPanel } from '@/components/EdgarFilingsPanel';
 import { AirQualityPanel } from '@/components/AirQualityPanel';
 import { WildfireIncidentsPanel } from '@/components/WildfireIncidentsPanel';
@@ -1020,6 +1022,12 @@ export class PanelLayoutManager implements AppModule {
 
  this.ctx.panels['hibp-breaches'] = new HibpBreachesPanel();
  this.ctx.panels['ipinfo-lookup'] = new IpInfoPanel();
+
+ const bitcoinAbusePanel = new BitcoinAbusePanel();
+ this.ctx.panels['bitcoin-abuse'] = bitcoinAbusePanel;
+
+ const redditOsintPanel = new RedditOsintPanel();
+ this.ctx.panels['reddit-osint'] = redditOsintPanel;
 
  const edgarFilingsPanel = new EdgarFilingsPanel();
  this.ctx.panels['edgar-filings'] = edgarFilingsPanel;

--- a/src/components/BitcoinAbusePanel.ts
+++ b/src/components/BitcoinAbusePanel.ts
@@ -1,0 +1,285 @@
+import { Panel } from './Panel';
+import { escapeHtml } from '@/utils/sanitize';
+import {
+  fetchBitcoinAbuseFeed,
+  fetchBitcoinAddressCheck,
+  formatSatoshisAsBtc,
+  isPlausibleBtcAddress,
+  truncateAddress,
+  type AddressCheckResult,
+  type BitcoinAbuseFeed,
+  type ScamAddressCategory,
+  type ScamAddressEntry,
+  type ScamDomainEntry,
+} from '@/services/crypto/bitcoin-abuse-service';
+
+type Tab = 'addresses' | 'domains' | 'lookup';
+
+const TAB_STORAGE_KEY = 'cb:bitcoin-abuse-tab';
+const TAB_LABELS: Record<Tab, string> = {
+  addresses: 'Scam Addresses',
+  domains: 'Scam Domains',
+  lookup: 'Address Lookup',
+};
+
+const CATEGORY_COLOR: Record<ScamAddressCategory, string> = {
+  scam: 'rgba(248,113,113,0.18)',
+  ransomware: 'rgba(220,38,38,0.28)',
+  darknet: 'rgba(124,58,237,0.20)',
+  phishing: 'rgba(245,158,11,0.20)',
+  mixer: 'rgba(34,197,94,0.18)',
+  mining: 'rgba(96,165,250,0.16)',
+  other: 'rgba(255,255,255,0.08)',
+};
+
+export class BitcoinAbusePanel extends Panel {
+  private activeTab: Tab = readStoredTab();
+  private feed: BitcoinAbuseFeed | null = null;
+  private feedLoading = false;
+  private lookupAddress = '';
+  private lookupResult: AddressCheckResult | null = null;
+  private lookupLoading = false;
+  private lookupError: string | null = null;
+
+  constructor() {
+    super({
+      id: 'bitcoin-abuse',
+      title: 'Bitcoin Abuse',
+      showCount: true,
+      trackActivity: true,
+      infoTooltip: 'CryptoScamDB scam-address feed + blockchain.info chain lookup. Refresh ≈ every 6h.',
+    });
+    this.render();
+    queueMicrotask(() => { void this.loadFeed(); });
+  }
+
+  private async loadFeed(): Promise<void> {
+    if (this.feedLoading) return;
+    this.feedLoading = true;
+    try {
+      this.feed = await fetchBitcoinAbuseFeed();
+      this.setCount(this.feed.addresses.length);
+    } finally {
+      this.feedLoading = false;
+      this.render();
+    }
+  }
+
+  private async runLookup(): Promise<void> {
+    const trimmed = this.lookupAddress.trim();
+    if (!trimmed) {
+      this.lookupError = 'Enter a BTC address to check.';
+      this.render();
+      return;
+    }
+    if (!isPlausibleBtcAddress(trimmed)) {
+      this.lookupError = 'Doesn’t look like a valid BTC address (P2PKH / P2SH / bech32).';
+      this.lookupResult = null;
+      this.render();
+      return;
+    }
+    this.lookupError = null;
+    this.lookupLoading = true;
+    this.render();
+    try {
+      this.lookupResult = await fetchBitcoinAddressCheck(trimmed);
+    } finally {
+      this.lookupLoading = false;
+      this.render();
+    }
+  }
+
+  private renderTabStrip(): string {
+    const tabs: Tab[] = ['addresses', 'domains', 'lookup'];
+    return `<div class="bta-tab-strip" role="tablist" style="display:flex;gap:6px;margin-bottom:8px;flex-wrap:wrap">${tabs.map((tab) => {
+      const active = tab === this.activeTab;
+      return `<button class="bta-tab" data-tab="${tab}" role="tab" aria-selected="${active}" type="button" style="padding:4px 10px;border:1px solid rgba(255,255,255,0.12);background:${active ? 'rgba(96,165,250,0.18)' : 'transparent'};color:inherit;border-radius:4px;cursor:pointer;font-size:12px">${escapeHtml(TAB_LABELS[tab])}</button>`;
+    }).join('')}</div>`;
+  }
+
+  private renderAddresses(): string {
+    if (!this.feed && this.feedLoading) {
+      return `<div class="panel-empty" style="padding:16px 0;text-align:center;opacity:0.7">Loading scam-address feed…</div>`;
+    }
+    const addresses = this.feed?.addresses ?? [];
+    if (addresses.length === 0) {
+      return `<div class="panel-empty" style="padding:16px 0;text-align:center;opacity:0.7">No scam addresses returned. ${this.feed?.degraded ? 'Upstream degraded — try again later.' : ''}</div>${this.renderFooter()}`;
+    }
+    const rows = addresses.slice(0, 200).map((entry) => this.renderAddressRow(entry)).join('');
+    return `<table class="eq-table" style="width:100%;font-size:12px">
+      <thead><tr><th>Address</th><th>Category</th><th style="text-align:right">Reports</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table>
+    <div style="opacity:0.65;font-size:11px;margin-top:6px">Showing ${Math.min(addresses.length, 200)} of ${addresses.length} addresses.</div>
+    ${this.renderFooter()}`;
+  }
+
+  private renderAddressRow(entry: ScamAddressEntry): string {
+    const display = escapeHtml(truncateAddress(entry.address));
+    const fullTitle = escapeHtml(entry.address);
+    const name = entry.name ? `<div style="opacity:0.7;font-size:10px">${escapeHtml(entry.name)}</div>` : '';
+    return `<tr>
+      <td><code title="${fullTitle}" style="font-size:11px">${display}</code>${name}</td>
+      <td>${categoryBadge(entry.category)}</td>
+      <td style="text-align:right">${entry.reportCount.toLocaleString()}</td>
+    </tr>`;
+  }
+
+  private renderDomains(): string {
+    if (!this.feed && this.feedLoading) {
+      return `<div class="panel-empty" style="padding:16px 0;text-align:center;opacity:0.7">Loading scam-domain feed…</div>`;
+    }
+    const domains = this.feed?.domains ?? [];
+    if (domains.length === 0) {
+      return `<div class="panel-empty" style="padding:16px 0;text-align:center;opacity:0.7">No scam domains returned.</div>${this.renderFooter()}`;
+    }
+    const rows = domains.slice(0, 200).map((entry) => this.renderDomainRow(entry)).join('');
+    return `<table class="eq-table" style="width:100%;font-size:12px">
+      <thead><tr><th>Domain</th><th>Category</th><th>Status</th></tr></thead>
+      <tbody>${rows}</tbody>
+    </table>
+    <div style="opacity:0.65;font-size:11px;margin-top:6px">Showing ${Math.min(domains.length, 200)} of ${domains.length} domains.</div>
+    ${this.renderFooter()}`;
+  }
+
+  private renderDomainRow(entry: ScamDomainEntry): string {
+    return `<tr>
+      <td>${escapeHtml(entry.domain)}</td>
+      <td>${categoryBadge(entry.category)}</td>
+      <td>${statusBadge(entry.status)}</td>
+    </tr>`;
+  }
+
+  private renderLookup(): string {
+    const valueAttr = escapeHtml(this.lookupAddress);
+    const errorBlock = this.lookupError ? `<div style="color:#fca5a5;font-size:11px;margin-top:6px">${escapeHtml(this.lookupError)}</div>` : '';
+    let result = '';
+    if (this.lookupLoading) {
+      result = `<div style="padding:12px 0;opacity:0.7">Checking…</div>`;
+    } else if (this.lookupResult) {
+      result = this.renderLookupResult(this.lookupResult);
+    }
+    return `<form class="bta-lookup-form" style="display:flex;gap:6px">
+      <input type="text" class="bta-lookup-input" placeholder="BTC address (1…, 3…, bc1…)" value="${valueAttr}"
+        autocomplete="off" spellcheck="false"
+        style="flex:1;padding:6px 10px;background:rgba(255,255,255,0.04);color:inherit;border:1px solid rgba(255,255,255,0.12);border-radius:4px;font-size:13px;font-family:monospace" />
+      <button class="bta-lookup-btn" type="submit"
+        style="padding:6px 12px;border:1px solid rgba(96,165,250,0.4);background:rgba(96,165,250,0.18);color:inherit;border-radius:4px;cursor:pointer;font-size:12px">Check</button>
+    </form>
+    ${errorBlock}
+    ${result}
+    ${this.renderFooter()}`;
+  }
+
+  private renderLookupResult(result: AddressCheckResult): string {
+    const scam = this.renderScamBlock(result);
+    const chain = this.renderChainBlock(result);
+    return `<div style="margin-top:8px"><code style="font-size:11px;opacity:0.8">${escapeHtml(result.address)}</code>${scam}${chain}</div>`;
+  }
+
+  private renderScamBlock(result: AddressCheckResult): string {
+    if (!result.scamMatch) {
+      return `<div style="margin-top:6px;padding:6px 8px;background:rgba(34,197,94,0.14);border-left:3px solid #22c55e;border-radius:3px;color:#bbf7d0;font-size:12px">No scam-DB match.</div>`;
+    }
+    const match = result.scamMatch;
+    const nameBlock = match.name
+      ? `<div style="font-size:11px;opacity:0.85">${escapeHtml(match.name)}</div>`
+      : '';
+    return `<div style="margin-top:6px;padding:6px 8px;background:rgba(220,38,38,0.18);border-left:3px solid #dc2626;border-radius:3px">
+      <strong style="color:#fca5a5">SCAM DB MATCH</strong> ${categoryBadge(match.category)}
+      ${nameBlock}
+      <div style="font-size:11px;opacity:0.7">${match.reportCount.toLocaleString()} reports</div>
+    </div>`;
+  }
+
+  private renderChainBlock(result: AddressCheckResult): string {
+    if (result.balanceSat === null && result.txCount === null) {
+      return `<div style="opacity:0.7;font-size:11px;margin-top:4px">Chain lookup failed (${escapeHtml(result.source)}).</div>`;
+    }
+    const txCellText = result.txCount === null ? '—' : result.txCount.toLocaleString();
+    return `<table class="eq-table" style="width:100%;font-size:12px;margin-top:6px">
+      <tbody>
+        <tr><td style="opacity:0.7">Balance</td><td><code>${escapeHtml(formatSatoshisAsBtc(result.balanceSat))}</code></td></tr>
+        <tr><td style="opacity:0.7">Transactions</td><td>${txCellText}</td></tr>
+      </tbody>
+    </table>`;
+  }
+
+  private renderFooter(): string {
+    if (!this.feed || this.feed.generatedAt.startsWith('1970')) {
+      const placeholder = this.feed?.degraded
+        ? `Degraded: ${escapeHtml(this.feed.source)}`
+        : 'Awaiting first refresh';
+      return `<div style="margin-top:8px;font-size:11px;opacity:0.6">${placeholder}</div>`;
+    }
+    const degradedSuffix = this.feed.degraded ? ' (degraded)' : '';
+    return `<div style="margin-top:8px;font-size:11px;opacity:0.6;display:flex;justify-content:space-between">
+      <span>${escapeHtml(this.feed.source)}${degradedSuffix}</span>
+      <span>Generated ${escapeHtml(this.feed.generatedAt)}</span>
+    </div>`;
+  }
+
+  private render(): void {
+    let body = '';
+    switch (this.activeTab) {
+      case 'addresses': { body = this.renderAddresses(); break; }
+      case 'domains': { body = this.renderDomains(); break; }
+      case 'lookup': { body = this.renderLookup(); break; }
+    }
+    this.setContent(`${this.renderTabStrip()}${body}`);
+    this.wireHandlers();
+  }
+
+  private wireHandlers(): void {
+    const root = this.getElement();
+    if (!root) return;
+    for (const btn of root.querySelectorAll<HTMLButtonElement>('.bta-tab')) {
+      btn.addEventListener('click', () => {
+        const tab = btn.dataset.tab as Tab | undefined;
+        if (!tab || tab === this.activeTab) return;
+        this.activeTab = tab;
+        try { localStorage.setItem(TAB_STORAGE_KEY, tab); } catch { /* noop */ }
+        this.render();
+      });
+    }
+    const form = root.querySelector<HTMLFormElement>('.bta-lookup-form');
+    const input = root.querySelector<HTMLInputElement>('.bta-lookup-input');
+    if (form && input) {
+      form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        this.lookupAddress = input.value;
+        void this.runLookup();
+      });
+      input.addEventListener('input', () => { this.lookupAddress = input.value; });
+      // Preserve focus + caret across re-render on the lookup tab.
+      if (this.activeTab === 'lookup') {
+        const len = input.value.length;
+        input.focus();
+        try { input.setSelectionRange(len, len); } catch { /* noop */ }
+      }
+    }
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────
+
+function categoryBadge(category: ScamAddressCategory): string {
+  return `<span style="padding:1px 6px;border-radius:3px;background:${CATEGORY_COLOR[category]};font-size:10px;text-transform:uppercase;letter-spacing:0.04em">${escapeHtml(category)}</span>`;
+}
+
+function statusBadge(status: 'active' | 'inactive' | 'unknown'): string {
+  const colors: Record<typeof status, string> = {
+    active: 'rgba(248,113,113,0.22)',
+    inactive: 'rgba(120,120,120,0.18)',
+    unknown: 'rgba(255,255,255,0.08)',
+  };
+  return `<span style="padding:1px 6px;border-radius:3px;background:${colors[status]};font-size:10px;text-transform:uppercase">${escapeHtml(status)}</span>`;
+}
+
+function readStoredTab(): Tab {
+  try {
+    const stored = localStorage.getItem(TAB_STORAGE_KEY);
+    if (stored === 'addresses' || stored === 'domains' || stored === 'lookup') return stored;
+  } catch { /* noop */ }
+  return 'addresses';
+}

--- a/src/components/RedditOsintPanel.ts
+++ b/src/components/RedditOsintPanel.ts
@@ -1,0 +1,235 @@
+import { Panel } from './Panel';
+import { escapeHtml } from '@/utils/sanitize';
+import {
+  buildKeywordMatcher,
+  DEFAULT_SUBREDDITS,
+  fetchRedditFeed,
+  formatTimeAgo,
+  loadSavedKeywords,
+  saveSavedKeywords,
+  type RedditFeed,
+  type RedditPost,
+} from '@/services/osint/reddit-service';
+
+const SUBREDDIT_FILTER_KEY = 'cb:reddit-osint-active-subreddits';
+
+interface VisibleFilter {
+  /** lowercased subreddit names; empty set means "all subreddits". */
+  subs: Set<string>;
+  matchesOnly: boolean;
+}
+
+export class RedditOsintPanel extends Panel {
+  private feed: RedditFeed | null = null;
+  private feedLoading = false;
+  private keywords: string[] = loadSavedKeywords();
+  private keywordsDraft = '';
+  private filter: VisibleFilter = { subs: loadStoredSubs(), matchesOnly: false };
+
+  constructor() {
+    super({
+      id: 'reddit-osint',
+      title: 'Reddit OSINT',
+      showCount: true,
+      trackActivity: true,
+      infoTooltip: 'Multi-subreddit OSINT feed (r/netsec, r/cybersecurity, r/worldnews, …). 15-min cache per subreddit.',
+    });
+    this.keywordsDraft = this.keywords.join(', ');
+    this.render();
+    queueMicrotask(() => { void this.loadFeed(); });
+  }
+
+  private async loadFeed(): Promise<void> {
+    if (this.feedLoading) return;
+    this.feedLoading = true;
+    try {
+      this.feed = await fetchRedditFeed({ subreddits: DEFAULT_SUBREDDITS, limit: 25 });
+      this.setCount(this.feed.posts.length);
+    } finally {
+      this.feedLoading = false;
+      this.render();
+    }
+  }
+
+  private visiblePosts(): { post: RedditPost; match: string | null }[] {
+    const posts = this.feed?.posts ?? [];
+    const matcher = buildKeywordMatcher(this.keywords);
+    const out: { post: RedditPost; match: string | null }[] = [];
+    for (const post of posts) {
+      if (this.filter.subs.size > 0 && !this.filter.subs.has(post.subreddit.toLowerCase())) continue;
+      const match = matcher(post);
+      if (this.filter.matchesOnly && match === null) continue;
+      out.push({ post, match });
+    }
+    return out;
+  }
+
+  private renderSubredditChips(): string {
+    const subs = (this.feed?.subreddits ?? DEFAULT_SUBREDDITS).map((s) => s.toLowerCase());
+    const unique = [...new Set(subs)];
+    const allActive = this.filter.subs.size === 0;
+    const chips = unique.map((sub) => {
+      const active = allActive || this.filter.subs.has(sub);
+      return `<button class="reddit-sub-chip" data-sub="${escapeHtml(sub)}" type="button"
+        style="padding:2px 8px;border:1px solid rgba(255,255,255,0.12);background:${active ? 'rgba(96,165,250,0.20)' : 'transparent'};color:${active ? 'inherit' : 'rgba(255,255,255,0.5)'};border-radius:999px;cursor:pointer;font-size:11px;font-family:monospace">r/${escapeHtml(sub)}</button>`;
+    }).join('');
+    const reset = `<button class="reddit-sub-reset" type="button" style="padding:2px 8px;background:transparent;border:1px dashed rgba(255,255,255,0.18);color:rgba(255,255,255,0.6);border-radius:999px;cursor:pointer;font-size:11px">show all</button>`;
+    return `<div class="reddit-sub-chips" style="display:flex;flex-wrap:wrap;gap:4px;align-items:center">${chips}${this.filter.subs.size > 0 ? reset : ''}</div>`;
+  }
+
+  private renderKeywordPanel(): string {
+    const valueAttr = escapeHtml(this.keywordsDraft);
+    const matchesOnly = this.filter.matchesOnly;
+    return `<div class="reddit-keyword-panel" style="display:flex;flex-direction:column;gap:6px;margin:8px 0">
+      <div style="display:flex;gap:6px;align-items:center">
+        <input type="text" class="reddit-keyword-input" placeholder="Highlight keywords (comma-separated): breach, ransomware, earthquake" value="${valueAttr}"
+          style="flex:1;padding:4px 8px;background:rgba(255,255,255,0.04);color:inherit;border:1px solid rgba(255,255,255,0.12);border-radius:4px;font-size:12px" />
+        <button class="reddit-keyword-save" type="button"
+          style="padding:4px 10px;border:1px solid rgba(96,165,250,0.4);background:rgba(96,165,250,0.18);color:inherit;border-radius:4px;cursor:pointer;font-size:11px">Save</button>
+      </div>
+      <label style="display:flex;align-items:center;gap:4px;font-size:11px;opacity:0.85;cursor:pointer">
+        <input type="checkbox" class="reddit-matches-only" ${matchesOnly ? 'checked' : ''} />
+        Show only keyword matches
+      </label>
+    </div>`;
+  }
+
+  private renderPostRow({ post, match }: { post: RedditPost; match: string | null }): string {
+    const highlightStyle = match
+      ? 'background:rgba(245,158,11,0.10);border-left:3px solid #f59e0b;padding-left:7px'
+      : 'border-left:3px solid transparent;padding-left:7px';
+    const flair = post.flair
+      ? `<span style="padding:0 5px;margin-left:4px;border-radius:3px;background:rgba(124,58,237,0.18);font-size:10px">${escapeHtml(post.flair)}</span>`
+      : '';
+    const matchTag = match
+      ? `<span style="padding:0 5px;margin-left:4px;border-radius:3px;background:rgba(245,158,11,0.22);font-size:10px;color:#fde68a">${escapeHtml(match)}</span>`
+      : '';
+    const titleAttr = escapeHtml(post.title);
+    return `<div class="reddit-post" style="padding:6px 0 6px 4px;${highlightStyle};border-bottom:1px solid rgba(255,255,255,0.06)">
+      <div style="display:flex;justify-content:space-between;gap:8px;align-items:baseline">
+        <span style="padding:1px 6px;border-radius:3px;background:rgba(96,165,250,0.18);font-size:10px;font-family:monospace">r/${escapeHtml(post.subreddit)}</span>
+        <span style="font-size:11px;opacity:0.6">${formatTimeAgo(post.createdUtc)}</span>
+      </div>
+      <div style="margin-top:4px">
+        <a href="${escapeHtml(post.permalink)}" target="_blank" rel="noopener noreferrer" title="${titleAttr}"
+          style="color:inherit;text-decoration:none;font-size:13px;line-height:1.3">${escapeHtml(post.title)}</a>
+        ${flair}${matchTag}
+      </div>
+      <div style="margin-top:4px;font-size:11px;opacity:0.6;display:flex;gap:12px">
+        <span>↑ ${post.score.toLocaleString()}</span>
+        <span>💬 ${post.numComments.toLocaleString()}</span>
+        <span>u/${escapeHtml(post.author)}</span>
+        ${post.domain ? `<span style="opacity:0.7">${escapeHtml(post.domain)}</span>` : ''}
+      </div>
+    </div>`;
+  }
+
+  private renderFooter(): string {
+    if (!this.feed || this.feed.generatedAt.startsWith('1970')) {
+      const msg = this.placeholderMessage();
+      return `<div style="margin-top:6px;font-size:11px;opacity:0.6">${msg}</div>`;
+    }
+    const degradedSuffix = this.feed.degraded ? ' (degraded)' : '';
+    return `<div style="margin-top:6px;font-size:11px;opacity:0.6;display:flex;justify-content:space-between;gap:8px">
+      <span>${this.feed.subreddits.length} subreddits${degradedSuffix}</span>
+      <span>Generated ${escapeHtml(this.feed.generatedAt)}</span>
+    </div>`;
+  }
+
+  private placeholderMessage(): string {
+    if (this.feedLoading) return 'Loading…';
+    const reason = this.feed?.reason;
+    if (reason) return `Degraded: ${escapeHtml(reason)}`;
+    return 'Awaiting first refresh';
+  }
+
+  private render(): void {
+    const chips = this.renderSubredditChips();
+    const keywords = this.renderKeywordPanel();
+    const visible = this.visiblePosts();
+    let body: string;
+    if (this.feedLoading && !this.feed) {
+      body = `<div class="panel-empty" style="padding:16px 0;text-align:center;opacity:0.7">Loading reddit feed…</div>`;
+    } else if (visible.length === 0) {
+      body = `<div class="panel-empty" style="padding:16px 0;text-align:center;opacity:0.7">${this.filter.matchesOnly ? 'No posts match your keywords.' : 'No posts after filter.'}</div>`;
+    } else {
+      body = visible.slice(0, 200).map((entry) => this.renderPostRow(entry)).join('');
+    }
+    this.setContent(`${chips}${keywords}${body}${this.renderFooter()}`);
+    this.wireHandlers();
+  }
+
+  private wireHandlers(): void {
+    const root = this.getElement();
+    if (!root) return;
+    for (const chip of root.querySelectorAll<HTMLButtonElement>('.reddit-sub-chip')) {
+      chip.addEventListener('click', () => {
+        const sub = chip.dataset.sub;
+        if (!sub) return;
+        if (this.filter.subs.size === 0) {
+          // All-active → click selects only this one.
+          this.filter.subs = new Set([sub]);
+        } else if (this.filter.subs.has(sub)) {
+          this.filter.subs.delete(sub);
+        } else {
+          this.filter.subs.add(sub);
+        }
+        persistSubs(this.filter.subs);
+        this.render();
+      });
+    }
+    const reset = root.querySelector<HTMLButtonElement>('.reddit-sub-reset');
+    if (reset) {
+      reset.addEventListener('click', () => {
+        this.filter.subs = new Set();
+        persistSubs(this.filter.subs);
+        this.render();
+      });
+    }
+    const matchesOnly = root.querySelector<HTMLInputElement>('.reddit-matches-only');
+    if (matchesOnly) {
+      matchesOnly.addEventListener('change', () => {
+        this.filter.matchesOnly = matchesOnly.checked;
+        this.render();
+      });
+    }
+    const keywordInput = root.querySelector<HTMLInputElement>('.reddit-keyword-input');
+    const keywordSave = root.querySelector<HTMLButtonElement>('.reddit-keyword-save');
+    if (keywordInput) {
+      keywordInput.addEventListener('input', () => { this.keywordsDraft = keywordInput.value; });
+    }
+    if (keywordSave) {
+      keywordSave.addEventListener('click', () => {
+        const next = this.keywordsDraft
+          .split(',').map((k) => k.trim()).filter((k) => k.length > 0);
+        this.keywords = next;
+        saveSavedKeywords(next);
+        this.render();
+      });
+    }
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────
+
+function loadStoredSubs(): Set<string> {
+  try {
+    const raw = localStorage.getItem(SUBREDDIT_FILTER_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return new Set();
+    const out = new Set<string>();
+    for (const item of parsed) {
+      if (typeof item === 'string' && item.length > 0) out.add(item.toLowerCase());
+    }
+    return out;
+  } catch {
+    return new Set();
+  }
+}
+
+function persistSubs(subs: Set<string>): void {
+  try {
+    localStorage.setItem(SUBREDDIT_FILTER_KEY, JSON.stringify([...subs]));
+  } catch { /* noop */ }
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -133,3 +133,7 @@ export { CorrelationMatrixPanel } from './CorrelationMatrixPanel';
 export { CascadeSimulatorPanel } from './CascadeSimulatorPanel';
 export { EmergencyBroadcastPanel } from './EmergencyBroadcastPanel';
 export { SatelliteChangePanel } from './SatelliteChangePanel';
+
+// New OSINT + crypto panels
+export { BitcoinAbusePanel } from './BitcoinAbusePanel';
+export { RedditOsintPanel } from './RedditOsintPanel';

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -80,6 +80,8 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'security-advisories': { name: 'Security Advisories', enabled: true, priority: 2 },
   'cve-tracker': { name: 'CVE Tracker', enabled: true, priority: 2 },
   'vulners-cve': { name: 'Vulners CVE', enabled: true, priority: 2 },
+  'bitcoin-abuse': { name: 'Bitcoin Abuse', enabled: true, priority: 2 },
+  'reddit-osint': { name: 'Reddit OSINT', enabled: true, priority: 2 },
   'network-rules': { name: 'Network Rules', enabled: true, priority: 3 },
   's2u-intel': { name: 'S2U Intelligence', enabled: true, priority: 1 },
   'synthesis': { name: 'Synthesis', enabled: true, priority: 1 },
@@ -1011,7 +1013,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   },
   dataTracking: {
  labelKey: 'header.panelCatDataTracking',
- panelKeys: ['monitors', 'cyber-threats', 'threat-inbox', 'local-ids', 'comms-health', 'power-grid', 'ucdp-events', 'nuclear-risk', 'airstrikes', 'displacement', 'security-advisories', 'network-rules', 's2u-intel', 'oref-sirens', 'space-weather', 'spaceflight-news', 'space-launches', 'population-exposure', 'internet-disruptions', 'air-traffic', 'threat-intel-hub', 'geo-intel', 'dark-web', 'anomaly-detection', 'financial-contagion', 'supply-chain-impact', 'nuclear-monitor', 'sigint-panel', 'dark-vessel', 'ics-ot-dashboard', 'ioc-manager', 'network-topology', 'stix-taxii', 'custom-geofence', 'sanctions-crossref', 'emergency-broadcast', 'satellite-change', 'ripe-ncc', 'ripe-atlas', 'aerospace-reentry', 'satellite-intel'],
+ panelKeys: ['monitors', 'cyber-threats', 'threat-inbox', 'local-ids', 'comms-health', 'power-grid', 'ucdp-events', 'nuclear-risk', 'airstrikes', 'displacement', 'security-advisories', 'bitcoin-abuse', 'reddit-osint', 'network-rules', 's2u-intel', 'oref-sirens', 'space-weather', 'spaceflight-news', 'space-launches', 'population-exposure', 'internet-disruptions', 'air-traffic', 'threat-intel-hub', 'geo-intel', 'dark-web', 'anomaly-detection', 'financial-contagion', 'supply-chain-impact', 'nuclear-monitor', 'sigint-panel', 'dark-vessel', 'ics-ot-dashboard', 'ioc-manager', 'network-topology', 'stix-taxii', 'custom-geofence', 'sanctions-crossref', 'emergency-broadcast', 'satellite-change', 'ripe-ncc', 'ripe-atlas', 'aerospace-reentry', 'satellite-intel'],
  variants: ['full'],
   },
   hazards: {

--- a/src/services/crypto/__tests__/bitcoin-abuse-service.test.mts
+++ b/src/services/crypto/__tests__/bitcoin-abuse-service.test.mts
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  formatSatoshisAsBtc,
+  isPlausibleBtcAddress,
+  normalizeCategory,
+  parseScamAddressesResponse,
+  parseScamDomainsResponse,
+  truncateAddress,
+} from '../bitcoin-abuse-service.ts';
+
+// ── normalizeCategory ──────────────────────────────────────────────────
+
+test('normalizeCategory: ransomware variants', () => {
+  assert.equal(normalizeCategory('Ransomware'), 'ransomware');
+  assert.equal(normalizeCategory('REvil ransomware payment'), 'ransomware');
+});
+
+test('normalizeCategory: scam / fraud / phishing / mixer / darknet / mining buckets', () => {
+  assert.equal(normalizeCategory('Phishing site'), 'phishing');
+  assert.equal(normalizeCategory('Bitcoin mixer'), 'mixer');
+  assert.equal(normalizeCategory('Darknet market'), 'darknet');
+  assert.equal(normalizeCategory('Bitcoin Mining Scam'), 'mining'); // 'mining' wins (most specific)
+  assert.equal(normalizeCategory('Fake exchange fraud'), 'scam');
+});
+
+test('normalizeCategory: unknown / non-string falls back to "other"', () => {
+  assert.equal(normalizeCategory('something weird'), 'other');
+  assert.equal(normalizeCategory(undefined), 'other');
+  assert.equal(normalizeCategory(42), 'other');
+});
+
+// ── parseScamAddressesResponse ─────────────────────────────────────────
+
+test('parseScamAddressesResponse: array form parses all records', () => {
+  const out = parseScamAddressesResponse({
+    success: true,
+    result: [
+      { address: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', subcategory: 'Ransomware', reports: 12 },
+      { address: '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy', subcategory: 'Phishing', reports: 3 },
+    ],
+  });
+  assert.equal(out.length, 2);
+  assert.equal(out[0]!.address, '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa');
+  assert.equal(out[0]!.category, 'ransomware');
+  assert.equal(out[0]!.reportCount, 12);
+});
+
+test('parseScamAddressesResponse: object-keyed (legacy) form parses records', () => {
+  const out = parseScamAddressesResponse({
+    success: true,
+    result: {
+      '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa': { subcategory: 'Scam', reports: 5 },
+    },
+  });
+  assert.equal(out.length, 1);
+  assert.equal(out[0]!.address, '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa');
+});
+
+test('parseScamAddressesResponse: drops non-BTC coins', () => {
+  const out = parseScamAddressesResponse({
+    result: [
+      { address: '0xabc', coin: 'ETH', subcategory: 'Scam' },
+      { address: '1ABC', coin: 'BTC', subcategory: 'Scam' },
+    ],
+  });
+  assert.equal(out.length, 1);
+  assert.equal(out[0]!.address, '1ABC');
+});
+
+test('parseScamAddressesResponse: missing reports defaults to 1', () => {
+  const out = parseScamAddressesResponse({
+    result: [{ address: '1ABC', subcategory: 'Scam' }],
+  });
+  assert.equal(out[0]!.reportCount, 1);
+});
+
+test('parseScamAddressesResponse: malformed → empty array', () => {
+  assert.deepEqual(parseScamAddressesResponse(null), []);
+  assert.deepEqual(parseScamAddressesResponse('not json'), []);
+  assert.deepEqual(parseScamAddressesResponse({}), []);
+});
+
+// ── parseScamDomainsResponse ───────────────────────────────────────────
+
+test('parseScamDomainsResponse: strips protocol + trailing slash', () => {
+  const out = parseScamDomainsResponse({
+    result: [{ url: 'https://example-scam.com/', subcategory: 'Phishing', status: 'Active' }],
+  });
+  assert.equal(out.length, 1);
+  assert.equal(out[0]!.domain, 'example-scam.com');
+  assert.equal(out[0]!.status, 'active');
+  assert.equal(out[0]!.category, 'phishing');
+});
+
+test('parseScamDomainsResponse: status normalises offline / dead / unknown', () => {
+  const out = parseScamDomainsResponse({
+    result: [
+      { url: 'a.com', status: 'Offline' },
+      { url: 'b.com', status: 'dead' },
+      { url: 'c.com', status: 'something weird' },
+    ],
+  });
+  assert.equal(out[0]!.status, 'inactive');
+  assert.equal(out[1]!.status, 'inactive');
+  assert.equal(out[2]!.status, 'unknown');
+});
+
+// ── isPlausibleBtcAddress ──────────────────────────────────────────────
+
+test('isPlausibleBtcAddress: accepts legacy + P2SH + bech32', () => {
+  assert.ok(isPlausibleBtcAddress('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'));
+  assert.ok(isPlausibleBtcAddress('3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy'));
+  assert.ok(isPlausibleBtcAddress('bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq'));
+});
+
+test('isPlausibleBtcAddress: rejects ETH addresses + obvious typos', () => {
+  assert.equal(isPlausibleBtcAddress('0x742d35Cc6634C0532925a3b8D40Eaa4cb04D3F73'), false);
+  assert.equal(isPlausibleBtcAddress('not-an-address'), false);
+  assert.equal(isPlausibleBtcAddress(''), false);
+  assert.equal(isPlausibleBtcAddress('1' + 'A'.repeat(120)), false);
+});
+
+// ── formatting helpers ─────────────────────────────────────────────────
+
+test('truncateAddress: middle ellipsis with default 6+6', () => {
+  assert.equal(
+    truncateAddress('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'),
+    '1A1zP1…DivfNa',
+  );
+});
+
+test('truncateAddress: short addresses pass through', () => {
+  assert.equal(truncateAddress('1ABC'), '1ABC');
+});
+
+test('formatSatoshisAsBtc: converts to 8-decimal BTC', () => {
+  assert.equal(formatSatoshisAsBtc(123_456_789), '1.23456789 BTC');
+  assert.equal(formatSatoshisAsBtc(0), '0.00000000 BTC');
+  assert.equal(formatSatoshisAsBtc(null), '—');
+});

--- a/src/services/crypto/bitcoin-abuse-service.ts
+++ b/src/services/crypto/bitcoin-abuse-service.ts
@@ -1,0 +1,322 @@
+/**
+ * Bitcoin Abuse intelligence service.
+ *
+ * Pure-deterministic helpers + thin renderer-side fetch wrappers around
+ * `/api/crypto/bitcoin-abuse` and `/api/crypto/bitcoin-abuse/check`.
+ *
+ * Data sources (sidecar resolves these — module is renderer-safe):
+ *   - CryptoScamDB v1   (no key) for scam addresses + scam domains
+ *   - blockchain.info   (no key) for balance / tx_count on a single address
+ *   - Bitcoin Abuse DB  (key-gated, optional) for crowd-sourced reports
+ *
+ * No DOM, no globals at import time. Fetch only inside the public
+ * loaders — pure helpers can be unit-tested on fixture JSON.
+ */
+
+import { getApiBaseUrl } from '../runtime';
+
+// ── Public types ───────────────────────────────────────────────────────
+
+export type ScamAddressCategory =
+  | 'scam'
+  | 'ransomware'
+  | 'darknet'
+  | 'mining'
+  | 'phishing'
+  | 'mixer'
+  | 'other';
+
+export interface ScamAddressEntry {
+  address: string;
+  /** Normalised category — CryptoScamDB calls the field `subcategory` or
+   *  `category` depending on payload shape. */
+  category: ScamAddressCategory;
+  /** Number of reports / mentions backing this entry. Defaults to 1
+   *  when the upstream payload doesn't expose a count. */
+  reportCount: number;
+  /** Optional human-readable name (e.g. "BitConnect"). */
+  name?: string;
+  /** ISO timestamp of the last reported activity, when known. */
+  lastReportedAt?: string;
+}
+
+export type ScamDomainStatus = 'active' | 'inactive' | 'unknown';
+
+export interface ScamDomainEntry {
+  domain: string;
+  category: ScamAddressCategory;
+  status: ScamDomainStatus;
+  name?: string;
+  reportedAt?: string;
+}
+
+export interface BitcoinAbuseFeed {
+  addresses: ScamAddressEntry[];
+  domains: ScamDomainEntry[];
+  /** Set when the upstream returned a degraded response (e.g. rate
+   *  limit, optional key missing). Renderer surfaces this so users
+   *  understand a low result count is provenance, not a bug. */
+  degraded: boolean;
+  /** Free-form provenance string the panel surfaces in the footer. */
+  source: string;
+  /** Sidecar cache freshness — ISO timestamp the snapshot was built. */
+  generatedAt: string;
+}
+
+export interface AddressCheckResult {
+  address: string;
+  /** True when the address appears in any ingested scam DB. */
+  scamMatch: ScamAddressEntry | null;
+  /** Blockchain.info balance, satoshis. `null` when chain lookup failed. */
+  balanceSat: number | null;
+  /** Total tx count from chain lookup. `null` when chain lookup failed. */
+  txCount: number | null;
+  /** Free-form provenance string for the footer. */
+  source: string;
+  fetchedAt: string;
+}
+
+// ── Pure parsers ───────────────────────────────────────────────────────
+
+const VALID_CATEGORIES: ReadonlySet<ScamAddressCategory> = new Set([
+  'scam', 'ransomware', 'darknet', 'mining', 'phishing', 'mixer', 'other',
+]);
+
+/** Coerce arbitrary upstream category strings to one of our enum values.
+ *  Cryptoscamdb has a free-form `subcategory` field — we map the common
+ *  cases and bucket the rest as 'other'. */
+export function normalizeCategory(raw: unknown): ScamAddressCategory {
+  if (typeof raw !== 'string') return 'other';
+  const lower = raw.toLowerCase();
+  if (lower.includes('ransom')) return 'ransomware';
+  if (lower.includes('phish')) return 'phishing';
+  if (lower.includes('mixer') || lower.includes('tumbler')) return 'mixer';
+  if (lower.includes('darknet') || lower.includes('dark net') || lower.includes('darkmarket')) return 'darknet';
+  if (lower.includes('mining') || lower.includes('miner')) return 'mining';
+  if (lower.includes('scam') || lower.includes('fraud') || lower.includes('fake')) return 'scam';
+  return VALID_CATEGORIES.has(lower as ScamAddressCategory) ? (lower as ScamAddressCategory) : 'other';
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+interface CryptoScamRecord {
+  address?: unknown;
+  name?: unknown;
+  category?: unknown;
+  subcategory?: unknown;
+  url?: unknown;
+  reportedaddresses?: unknown;
+  reports?: unknown;
+  /** CryptoScamDB sometimes uses `coin` to disambiguate; we only keep BTC. */
+  coin?: unknown;
+}
+
+interface KeyedRecord<T> { key: string | null; record: T }
+
+/** Split a CryptoScamDB-shaped envelope into per-record entries.
+ *  Handles both the legacy object-keyed form and the array form. */
+function recordsFromResult<T extends object>(raw: unknown): KeyedRecord<T>[] {
+  if (!raw || typeof raw !== 'object') return [];
+  const result = (raw as Record<string, unknown>).result;
+  if (Array.isArray(result)) return arrayResultToRecords<T>(result);
+  if (result && typeof result === 'object') return objectResultToRecords<T>(result as Record<string, unknown>);
+  return [];
+}
+
+function arrayResultToRecords<T extends object>(arr: readonly unknown[]): KeyedRecord<T>[] {
+  const out: KeyedRecord<T>[] = [];
+  for (const r of arr) {
+    if (r && typeof r === 'object') out.push({ key: null, record: r as T });
+  }
+  return out;
+}
+
+function objectResultToRecords<T extends object>(obj: Record<string, unknown>): KeyedRecord<T>[] {
+  const out: KeyedRecord<T>[] = [];
+  for (const [key, value] of Object.entries(obj)) {
+    if (value && typeof value === 'object') out.push({ key, record: value as T });
+  }
+  return out;
+}
+
+/**
+ * Parse CryptoScamDB `/v1/addresses` response. Accepts both shapes the
+ * API has used over the years — the legacy object-keyed-by-address form
+ * `{ success, result: { "addr1": {...}, ... } }` and the newer array
+ * form `{ success, result: [...] }`. Returns a normalised list with
+ * non-BTC entries dropped.
+ */
+export function parseScamAddressesResponse(raw: unknown): ScamAddressEntry[] {
+  const out: ScamAddressEntry[] = [];
+  for (const { key, record } of recordsFromResult<CryptoScamRecord>(raw)) {
+    const entry = toScamAddressEntry(key, record);
+    if (entry) out.push(entry);
+  }
+  return out;
+}
+
+function toScamAddressEntry(
+  key: string | null,
+  record: CryptoScamRecord,
+): ScamAddressEntry | null {
+  const coin = asString(record.coin);
+  if (coin && coin.toUpperCase() !== 'BTC') return null;
+  const address = asString(record.address) ?? key ?? null;
+  if (!address) return null;
+  return {
+    address,
+    category: normalizeCategory(record.subcategory ?? record.category),
+    reportCount: asNumber(record.reports) ?? asNumber(record.reportedaddresses) ?? 1,
+    name: asString(record.name),
+  };
+}
+
+interface CryptoScamDomainRecord {
+  url?: unknown;
+  domain?: unknown;
+  name?: unknown;
+  category?: unknown;
+  subcategory?: unknown;
+  status?: unknown;
+  reported?: unknown;
+}
+
+function normaliseDomainStatus(raw: unknown): ScamDomainStatus {
+  if (typeof raw !== 'string') return 'unknown';
+  const lower = raw.toLowerCase();
+  if (lower.includes('offline') || lower.includes('inactive') || lower === 'dead') return 'inactive';
+  if (lower.includes('active') || lower === 'online') return 'active';
+  return 'unknown';
+}
+
+/** Parse CryptoScamDB `/v1/domains` response. Mirrors
+ *  `parseScamAddressesResponse` — handles array + object payload shapes
+ *  and accepts either `url` or `domain` as the primary key. */
+export function parseScamDomainsResponse(raw: unknown): ScamDomainEntry[] {
+  const out: ScamDomainEntry[] = [];
+  for (const { key, record } of recordsFromResult<CryptoScamDomainRecord>(raw)) {
+    const entry = toScamDomainEntry(key, record);
+    if (entry) out.push(entry);
+  }
+  return out;
+}
+
+function toScamDomainEntry(
+  key: string | null,
+  record: CryptoScamDomainRecord,
+): ScamDomainEntry | null {
+  const domain = asString(record.domain) ?? asString(record.url) ?? key ?? null;
+  if (!domain) return null;
+  return {
+    domain: stripProtocol(domain),
+    category: normalizeCategory(record.subcategory ?? record.category),
+    status: normaliseDomainStatus(record.status),
+    name: asString(record.name),
+    reportedAt: asString(record.reported),
+  };
+}
+
+function stripProtocol(value: string): string {
+  return value.replace(/^https?:\/\//i, '').replace(/\/$/, '');
+}
+
+/**
+ * Lightweight Bitcoin address shape check — exact validation would
+ * require base58/bech32 decoding (and is not part of the spec). We
+ * accept legacy P2PKH (`1...`), P2SH (`3...`), and bech32 (`bc1...`)
+ * by prefix + length so the panel can reject obvious typos before
+ * sending the request to the sidecar.
+ */
+export function isPlausibleBtcAddress(value: string): boolean {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (trimmed.length < 26 || trimmed.length > 90) return false;
+  if (/^bc1[ac-hj-np-z02-9]+$/i.test(trimmed)) return true;
+  if (/^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$/.test(trimmed)) return true;
+  return false;
+}
+
+// ── Renderer-side fetch wrappers ───────────────────────────────────────
+
+const FEED_PATH = '/api/crypto/bitcoin-abuse';
+const CHECK_PATH = '/api/crypto/bitcoin-abuse/check';
+
+export async function fetchBitcoinAbuseFeed(): Promise<BitcoinAbuseFeed> {
+  try {
+    const res = await fetch(`${getApiBaseUrl()}${FEED_PATH}`);
+    if (!res.ok) return emptyFeed(`HTTP ${res.status}`);
+    const data = (await res.json()) as Partial<BitcoinAbuseFeed>;
+    return {
+      addresses: Array.isArray(data.addresses) ? data.addresses : [],
+      domains: Array.isArray(data.domains) ? data.domains : [],
+      degraded: data.degraded === true,
+      source: typeof data.source === 'string' ? data.source : 'CryptoScamDB',
+      generatedAt: typeof data.generatedAt === 'string' ? data.generatedAt : new Date(0).toISOString(),
+    };
+  } catch (error) {
+    return emptyFeed(error instanceof Error ? error.message : String(error));
+  }
+}
+
+export async function fetchBitcoinAddressCheck(address: string): Promise<AddressCheckResult> {
+  const fallback: AddressCheckResult = {
+    address,
+    scamMatch: null,
+    balanceSat: null,
+    txCount: null,
+    source: 'lookup-failed',
+    fetchedAt: new Date().toISOString(),
+  };
+  if (!isPlausibleBtcAddress(address)) {
+    return { ...fallback, source: 'invalid-address-format' };
+  }
+  try {
+    const url = `${getApiBaseUrl()}${CHECK_PATH}?address=${encodeURIComponent(address.trim())}`;
+    const res = await fetch(url);
+    if (!res.ok) return { ...fallback, source: `HTTP ${res.status}` };
+    const data = (await res.json()) as Partial<AddressCheckResult>;
+    return {
+      address: data.address ?? address,
+      scamMatch: data.scamMatch ?? null,
+      balanceSat: typeof data.balanceSat === 'number' ? data.balanceSat : null,
+      txCount: typeof data.txCount === 'number' ? data.txCount : null,
+      source: typeof data.source === 'string' ? data.source : 'unknown',
+      fetchedAt: typeof data.fetchedAt === 'string' ? data.fetchedAt : new Date().toISOString(),
+    };
+  } catch (error) {
+    return { ...fallback, source: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function emptyFeed(reason: string): BitcoinAbuseFeed {
+  return {
+    addresses: [],
+    domains: [],
+    degraded: true,
+    source: reason,
+    generatedAt: new Date(0).toISOString(),
+  };
+}
+
+// ── Formatting helpers (panel surfaces) ────────────────────────────────
+
+export function truncateAddress(address: string, head = 6, tail = 6): string {
+  if (address.length <= head + tail + 1) return address;
+  return `${address.slice(0, head)}…${address.slice(-tail)}`;
+}
+
+export function formatSatoshisAsBtc(sats: number | null): string {
+  if (sats === null || !Number.isFinite(sats)) return '—';
+  return `${(sats / 100_000_000).toFixed(8)} BTC`;
+}

--- a/src/services/osint/__tests__/reddit-service.test.mts
+++ b/src/services/osint/__tests__/reddit-service.test.mts
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildKeywordMatcher,
+  DEFAULT_KEYWORDS,
+  DEFAULT_SUBREDDITS,
+  formatTimeAgo,
+  parseRedditListing,
+  parseSubredditList,
+  type RedditPost,
+} from '../reddit-service.ts';
+
+const NOW = 1_715_000_000_000;
+
+function post(overrides: Partial<RedditPost> = {}): RedditPost {
+  return {
+    id: 'abc',
+    subreddit: 'netsec',
+    title: 'A title',
+    url: 'https://example.com',
+    permalink: 'https://www.reddit.com/r/netsec/comments/abc/',
+    score: 100,
+    numComments: 10,
+    createdUtc: Math.floor(NOW / 1000) - 60,
+    flair: null,
+    author: 'alice',
+    domain: 'example.com',
+    over18: false,
+    ...overrides,
+  };
+}
+
+// ── parseSubredditList ─────────────────────────────────────────────────
+
+test('parseSubredditList: trims, strips r/ prefix, dedupes', () => {
+  assert.deepEqual(
+    parseSubredditList(' r/netsec , Cybersecurity , netsec ,r/RBI '),
+    ['netsec', 'Cybersecurity', 'RBI'],
+  );
+});
+
+test('parseSubredditList: rejects invalid characters and lengths', () => {
+  assert.deepEqual(parseSubredditList('a, valid_name, with space, x'), ['valid_name']);
+});
+
+test('parseSubredditList: non-string returns empty', () => {
+  assert.deepEqual(parseSubredditList(undefined), []);
+  assert.deepEqual(parseSubredditList(null), []);
+});
+
+// ── parseRedditListing ─────────────────────────────────────────────────
+
+test('parseRedditListing: extracts core fields from t3 children', () => {
+  const out = parseRedditListing({
+    kind: 'Listing',
+    data: {
+      children: [
+        {
+          kind: 't3',
+          data: {
+            id: 'p1', subreddit: 'netsec', title: 'New CVE',
+            url: 'https://x.com', permalink: '/r/netsec/comments/p1/cve/',
+            score: 42, num_comments: 7, created_utc: 1_715_000_000,
+            link_flair_text: 'Vulnerability', author: 'bob', domain: 'x.com',
+            over_18: false, stickied: false,
+          },
+        },
+      ],
+    },
+  });
+  assert.equal(out.length, 1);
+  assert.equal(out[0]!.id, 'p1');
+  assert.equal(out[0]!.subreddit, 'netsec');
+  assert.equal(out[0]!.flair, 'Vulnerability');
+  assert.equal(out[0]!.permalink, 'https://www.reddit.com/r/netsec/comments/p1/cve/');
+});
+
+test('parseRedditListing: drops stickied posts', () => {
+  const out = parseRedditListing({
+    data: {
+      children: [
+        { kind: 't3', data: { id: '1', title: 'pinned', stickied: true } },
+        { kind: 't3', data: { id: '2', title: 'real post' } },
+      ],
+    },
+  });
+  assert.equal(out.length, 1);
+  assert.equal(out[0]!.id, '2');
+});
+
+test('parseRedditListing: skips children with wrong kind or missing id/title', () => {
+  const out = parseRedditListing({
+    data: {
+      children: [
+        { kind: 't1', data: { id: 'c1', title: 'comment' } }, // wrong kind
+        { kind: 't3', data: { id: 'no-title' } },
+        { kind: 't3', data: { title: 'no-id' } },
+        { kind: 't3', data: { id: 'ok', title: 'kept' } },
+      ],
+    },
+  });
+  assert.equal(out.length, 1);
+  assert.equal(out[0]!.id, 'ok');
+});
+
+test('parseRedditListing: missing optional fields get defaults', () => {
+  const out = parseRedditListing({
+    data: { children: [{ kind: 't3', data: { id: 'x', title: 't' } }] },
+  });
+  assert.equal(out[0]!.score, 0);
+  assert.equal(out[0]!.numComments, 0);
+  assert.equal(out[0]!.author, '[deleted]');
+  assert.equal(out[0]!.flair, null);
+});
+
+test('parseRedditListing: malformed input → []', () => {
+  assert.deepEqual(parseRedditListing(null), []);
+  assert.deepEqual(parseRedditListing({}), []);
+  assert.deepEqual(parseRedditListing({ data: {} }), []);
+});
+
+// ── buildKeywordMatcher ────────────────────────────────────────────────
+
+test('buildKeywordMatcher: case-insensitive match on title', () => {
+  const match = buildKeywordMatcher(['breach', 'CVE-']);
+  assert.equal(match(post({ title: 'Massive data BREACH at corp' })), 'breach');
+  assert.equal(match(post({ title: 'Critical CVE-2025-9999 dropped' })), 'cve-');
+});
+
+test('buildKeywordMatcher: matches against flair and domain', () => {
+  const match = buildKeywordMatcher(['ransomware']);
+  assert.equal(match(post({ title: 'unrelated', flair: 'Ransomware', domain: 'x.com' })), 'ransomware');
+  assert.equal(match(post({ title: 'unrelated', flair: null, domain: 'ransomware-news.com' })), 'ransomware');
+});
+
+test('buildKeywordMatcher: empty keyword list always returns null', () => {
+  const match = buildKeywordMatcher([]);
+  assert.equal(match(post({ title: 'anything' })), null);
+});
+
+test('buildKeywordMatcher: trims whitespace and ignores empty entries', () => {
+  const match = buildKeywordMatcher(['  ', 'leak ', '']);
+  assert.equal(match(post({ title: 'big leak from x' })), 'leak');
+});
+
+// ── formatTimeAgo ──────────────────────────────────────────────────────
+
+test('formatTimeAgo: seconds, minutes, hours, days', () => {
+  const nowSec = NOW / 1000;
+  assert.equal(formatTimeAgo(nowSec - 30, NOW), '30s');
+  assert.equal(formatTimeAgo(nowSec - 5 * 60, NOW), '5m');
+  assert.equal(formatTimeAgo(nowSec - 3 * 3600, NOW), '3h');
+  assert.equal(formatTimeAgo(nowSec - 4 * 86_400, NOW), '4d');
+});
+
+test('formatTimeAgo: invalid input → "—"', () => {
+  assert.equal(formatTimeAgo(0, NOW), '—');
+  assert.equal(formatTimeAgo(Number.NaN, NOW), '—');
+});
+
+// ── Defaults ──────────────────────────────────────────────────────────
+
+test('DEFAULT_SUBREDDITS includes the threat-relevant set called out by spec', () => {
+  for (const s of ['netsec', 'cybersecurity', 'worldnews', 'geopolitics', 'RBI', 'EmergencyManagement']) {
+    assert.ok(DEFAULT_SUBREDDITS.includes(s), `missing ${s}`);
+  }
+});
+
+test('DEFAULT_KEYWORDS includes spec-called-out terms', () => {
+  for (const k of ['breach', 'ransomware', 'earthquake']) {
+    assert.ok(DEFAULT_KEYWORDS.includes(k), `missing ${k}`);
+  }
+});

--- a/src/services/osint/reddit-service.ts
+++ b/src/services/osint/reddit-service.ts
@@ -1,0 +1,267 @@
+/**
+ * Reddit OSINT service.
+ *
+ * Pure-deterministic helpers + thin renderer-side fetch wrapper around
+ * `/api/osint/reddit`. The sidecar handles the actual reddit.com HTTPS
+ * call (User-Agent rule + per-subreddit caching) — this module owns
+ * the JSON-shape parsers and keyword-match scaffolding so they can be
+ * unit-tested on fixtures.
+ *
+ * No DOM, no globals at import time.
+ */
+
+import { getApiBaseUrl } from '../runtime';
+
+// ── Public types ───────────────────────────────────────────────────────
+
+export interface RedditPost {
+  id: string;
+  subreddit: string;
+  title: string;
+  url: string;
+  permalink: string;
+  score: number;
+  numComments: number;
+  /** Seconds since epoch. */
+  createdUtc: number;
+  flair: string | null;
+  author: string;
+  /** "self.netsec" for self-posts, otherwise the linked-out hostname. */
+  domain: string | null;
+  /** True when Reddit flagged the post as 18+ — we surface but don't
+   *  hide; OSINT users need access to anything that might be relevant. */
+  over18: boolean;
+}
+
+export interface RedditFeed {
+  posts: RedditPost[];
+  /** Subreddits actually fetched (subset of requested, in case any
+   *  returned a permanent 4xx). */
+  subreddits: string[];
+  /** Set when one or more subreddits returned a non-200 / 429. */
+  degraded: boolean;
+  /** ISO timestamp of the snapshot. */
+  generatedAt: string;
+  /** Sidecar-supplied error string when `degraded` — null otherwise. */
+  reason: string | null;
+}
+
+/** Default subreddits the panel polls — threat-relevant feeds. The
+ *  spec calls out these six explicitly. Mutable allowlists live in
+ *  localStorage on the renderer side. */
+export const DEFAULT_SUBREDDITS: readonly string[] = [
+  'netsec',
+  'cybersecurity',
+  'worldnews',
+  'geopolitics',
+  'RBI',
+  'EmergencyManagement',
+];
+
+const VALID_SUBREDDIT = /^[a-z0-9][a-z0-9_]{1,20}$/i;
+
+/** Filter a free-form comma-separated list into valid subreddit names.
+ *  Reddit subreddit names are alphanumeric + underscore, 2..21 chars,
+ *  must start with a letter or digit. */
+export function parseSubredditList(raw: unknown): string[] {
+  if (typeof raw !== 'string') return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const token of raw.split(',')) {
+    const trimmed = token.trim().replace(/^r\//i, '');
+    if (!VALID_SUBREDDIT.test(trimmed)) continue;
+    const lower = trimmed.toLowerCase();
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+// ── Pure parsers ───────────────────────────────────────────────────────
+
+interface RedditApiChild {
+  kind?: unknown;
+  data?: unknown;
+}
+
+interface RedditApiPostData {
+  id?: unknown;
+  subreddit?: unknown;
+  title?: unknown;
+  url?: unknown;
+  permalink?: unknown;
+  score?: unknown;
+  num_comments?: unknown;
+  created_utc?: unknown;
+  link_flair_text?: unknown;
+  author?: unknown;
+  domain?: unknown;
+  over_18?: unknown;
+  stickied?: unknown;
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Parse the Reddit JSON listing payload. Reddit's `t3` (link) records
+ * are wrapped in `data.children[].data` — we drop stickied posts
+ * (announcements / pinned megathreads) and skip anything missing an
+ * id / title.
+ */
+export function parseRedditListing(raw: unknown, defaultSubreddit = ''): RedditPost[] {
+  if (!raw || typeof raw !== 'object') return [];
+  const obj = raw as Record<string, unknown>;
+  const dataNode = obj.data as Record<string, unknown> | undefined;
+  const children = dataNode && Array.isArray(dataNode.children) ? dataNode.children : [];
+  const out: RedditPost[] = [];
+  for (const child of children as RedditApiChild[]) {
+    if (!child?.data || typeof child.data !== 'object') continue;
+    if (child.kind !== undefined && child.kind !== 't3') continue;
+    const p = child.data as RedditApiPostData;
+    if (p.stickied === true) continue;
+    const id = asString(p.id);
+    const title = asString(p.title);
+    if (!id || !title) continue;
+    const subreddit = asString(p.subreddit) ?? defaultSubreddit;
+    const permalinkPath = asString(p.permalink) ?? `/r/${subreddit}/comments/${id}`;
+    out.push({
+      id,
+      subreddit,
+      title,
+      url: asString(p.url) ?? `https://www.reddit.com${permalinkPath}`,
+      permalink: `https://www.reddit.com${permalinkPath}`,
+      score: asNumber(p.score) ?? 0,
+      numComments: asNumber(p.num_comments) ?? 0,
+      createdUtc: asNumber(p.created_utc) ?? 0,
+      flair: asString(p.link_flair_text) ?? null,
+      author: asString(p.author) ?? '[deleted]',
+      domain: asString(p.domain) ?? null,
+      over18: p.over_18 === true,
+    });
+  }
+  return out;
+}
+
+// ── Keyword highlight scaffolding ──────────────────────────────────────
+
+const KEYWORDS_STORAGE_KEY = 'cb:reddit-osint-keywords';
+
+/** Default keywords seeded when the user has nothing saved. The spec
+ *  calls out "breach, ransomware, earthquake" — we add a few more that
+ *  are obviously action-worthy. */
+export const DEFAULT_KEYWORDS: readonly string[] = [
+  'breach', 'ransomware', 'earthquake', 'zero-day', 'critical', 'CVE-',
+];
+
+export function loadSavedKeywords(): string[] {
+  try {
+    const raw = localStorage.getItem(KEYWORDS_STORAGE_KEY);
+    if (!raw) return [...DEFAULT_KEYWORDS];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [...DEFAULT_KEYWORDS];
+    const out: string[] = [];
+    for (const item of parsed) {
+      if (typeof item === 'string' && item.trim().length > 0) out.push(item.trim());
+    }
+    return out.length > 0 ? out : [...DEFAULT_KEYWORDS];
+  } catch {
+    return [...DEFAULT_KEYWORDS];
+  }
+}
+
+export function saveSavedKeywords(keywords: readonly string[]): void {
+  try {
+    localStorage.setItem(KEYWORDS_STORAGE_KEY, JSON.stringify([...keywords]));
+  } catch { /* quota / unavailable storage */ }
+}
+
+/** Build a case-insensitive matcher that tells the panel which keyword
+ *  (if any) matched a given post — used both for highlighting and for
+ *  the "only show matches" filter. Empty list → returns null match. */
+export function buildKeywordMatcher(
+  keywords: readonly string[],
+): (post: RedditPost) => string | null {
+  const normalised = keywords
+    .map((k) => k.trim().toLowerCase())
+    .filter((k) => k.length > 0);
+  if (normalised.length === 0) return () => null;
+  return (post: RedditPost) => {
+    const haystack = `${post.title} ${post.flair ?? ''} ${post.domain ?? ''}`.toLowerCase();
+    for (const keyword of normalised) {
+      if (haystack.includes(keyword)) return keyword;
+    }
+    return null;
+  };
+}
+
+// ── Time-ago formatting ────────────────────────────────────────────────
+
+export function formatTimeAgo(createdUtc: number, nowMs: number = Date.now()): string {
+  if (!Number.isFinite(createdUtc) || createdUtc <= 0) return '—';
+  const seconds = Math.max(0, Math.floor(nowMs / 1000 - createdUtc));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+// ── Renderer-side fetch wrapper ────────────────────────────────────────
+
+export interface FetchRedditFeedOptions {
+  subreddits?: readonly string[];
+  limit?: number;
+}
+
+const FEED_PATH = '/api/osint/reddit';
+const DEFAULT_LIMIT = 25;
+
+export async function fetchRedditFeed(opts: FetchRedditFeedOptions = {}): Promise<RedditFeed> {
+  const subreddits = opts.subreddits && opts.subreddits.length > 0
+    ? [...opts.subreddits]
+    : [...DEFAULT_SUBREDDITS];
+  const limit = typeof opts.limit === 'number' && opts.limit > 0 ? Math.min(100, Math.floor(opts.limit)) : DEFAULT_LIMIT;
+
+  try {
+    const params = new URLSearchParams();
+    params.set('subreddits', subreddits.join(','));
+    params.set('limit', String(limit));
+    const url = `${getApiBaseUrl()}${FEED_PATH}?${params.toString()}`;
+    const res = await fetch(url);
+    if (!res.ok) return emptyFeed(subreddits, `HTTP ${res.status}`);
+    const data = (await res.json()) as Partial<RedditFeed>;
+    return {
+      posts: Array.isArray(data.posts) ? data.posts : [],
+      subreddits: Array.isArray(data.subreddits) ? data.subreddits : subreddits,
+      degraded: data.degraded === true,
+      generatedAt: typeof data.generatedAt === 'string' ? data.generatedAt : new Date(0).toISOString(),
+      reason: typeof data.reason === 'string' ? data.reason : null,
+    };
+  } catch (error) {
+    return emptyFeed(subreddits, error instanceof Error ? error.message : String(error));
+  }
+}
+
+function emptyFeed(subreddits: string[], reason: string): RedditFeed {
+  return {
+    posts: [],
+    subreddits,
+    degraded: true,
+    generatedAt: new Date(0).toISOString(),
+    reason,
+  };
+}


### PR DESCRIPTION
Two new threat-intel panels following the established service / sidecar / panel pattern (modeled on `SanctionsPanel.ts`).

## Bitcoin Abuse — `bitcoin-abuse`

**Service** (`src/services/crypto/bitcoin-abuse-service.ts`): pure parsers + helpers.
- `parseScamAddressesResponse` / `parseScamDomainsResponse` — accept **both** CryptoScamDB response shapes (legacy object-keyed-by-address `{ result: { addr: {...} } }` and the newer array form). Splitting via a shared `recordsFromResult` helper.
- `normalizeCategory` — maps free-form CryptoScamDB `subcategory` strings into a fixed enum (scam / ransomware / darknet / phishing / mixer / mining / other).
- `isPlausibleBtcAddress` — prefix + length check for P2PKH / P2SH / bech32 so the panel can reject obvious typos before hitting the network.
- `truncateAddress` + `formatSatoshisAsBtc` — display helpers shared with the panel.

**Sidecar**:
- `GET /api/crypto/bitcoin-abuse` — pulls `cryptoscamdb.org/v1/addresses` + `/v1/domains` in parallel, 6h cache, no key required, fail-soft `degraded:true` when either upstream errors.
- `GET /api/crypto/bitcoin-abuse/check?address=…` — membership check against the cached scam feed + `blockchain.info/rawaddr` for balance + tx count. Returns `scamMatch | null`.

**Panel** (`src/components/BitcoinAbusePanel.ts`): 3 tabs (Scam Addresses / Scam Domains / Address Lookup), localStorage-persisted active tab.

## Reddit OSINT — `reddit-osint`

**Service** (`src/services/osint/reddit-service.ts`):
- `parseRedditListing` — handles Reddit's `t3` `{ kind, data }` wrapper, drops stickied/pinned posts, skips entries missing id/title, sets sensible defaults.
- `parseSubredditList` — validates user-typed lists (`a-z0-9_` 2..21 chars), strips `r/` prefix, dedupes.
- `buildKeywordMatcher` — case-insensitive matcher across `title + flair + domain`. Returns the matched keyword (for badge surfacing) or `null`.
- `loadSavedKeywords` / `saveSavedKeywords` — localStorage persistence; seeded with `breach, ransomware, earthquake, zero-day, critical, CVE-` on first load.
- `formatTimeAgo` — compact `s/m/h/d` formatter.

**Sidecar**: `GET /api/osint/reddit?subreddits=&limit=` — fans out to up to ~6 subreddits in parallel, 15-min per-`(sub, limit)` cache, sets the `User-Agent: CrystalBall/2.13 (threat intelligence aggregator)` header per Reddit guidance, returns degraded info per failed subreddit.

**Panel** (`src/components/RedditOsintPanel.ts`): chronological multi-subreddit feed. Clickable subreddit chips for include/exclude filtering. Keyword highlight panel + 'show only matches' toggle. Saved filter + keywords persist across reloads.

**Defaults** (per spec): `netsec, cybersecurity, worldnews, geopolitics, RBI, EmergencyManagement`.

## Registration

- Both panel IDs added to `FULL_PANELS` in `src/config/panels.ts` and the cyber category panelKeys list.
- Instantiated + mounted in `src/app/panel-layout.ts` next to `SanctionsPanel`.
- Re-exported from `src/components/index.ts`.

## Tests

- 14 tests for the Bitcoin Abuse service (parser shape robustness, category map, status normalisation, address validation, formatters).
- 17 tests for the Reddit service (listing parser, sticky-post filter, keyword matcher, time-ago, subreddit-name validation, defaults).

```
npm run test:crypto    # 14 / 14
npm run test:osint     # 17 / 17
npm run typecheck:all  # clean
```