### PR TITLE
feat(security): PhishStats, urlscan.io, Pulsedive threat intel panels

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -11063,6 +11063,136 @@ async function dispatch(requestUrl, req, routes, context) {
     }
   }
 
+  // ── PhishStats phishing URL feed (free, no key) ─────────────────────────
+  // Wraps phishstats.info API; 30-min cache. Renderer-side parsing handles
+  // the upstream-or-envelope shape.
+  if (requestUrl.pathname === '/api/security/phishing') {
+ const CACHE_TTL = 30 * 60 * 1000;
+ const limit = Math.min(500, Math.max(1, Number(requestUrl.searchParams.get('limit') ?? '50')));
+ const minScore = Math.min(10, Math.max(0, Number(requestUrl.searchParams.get('minScore') ?? '5')));
+ const cacheKey = `phishstats:${limit}:${minScore}`;
+ const cached = getCached(cacheKey, CACHE_TTL);
+ if (cached) return json(cached);
+ try {
+ const url = `https://phishstats.info:2096/api/phishing?_where=(score,gt,${minScore})&_sort=-date&_size=${limit}`;
+ const r = await fetchWithTimeout(url, { headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' } }, 12000);
+ if (!r.ok) return json({ records: [], degraded: true, reason: `HTTP ${r.status}`, fetchedAt: Date.now(), source: 'phishstats.info' }, 502);
+ const data = await r.json();
+ const envelope = { records: Array.isArray(data) ? data : [], fetchedAt: Date.now(), degraded: false, source: 'phishstats.info' };
+ setCached(cacheKey, envelope);
+ return json(envelope);
+ } catch (error) {
+ return json({ records: [], degraded: true, reason: error?.message ?? String(error), fetchedAt: Date.now(), source: 'phishstats.info' }, 502);
+ }
+  }
+
+  // ── urlscan.io threat search (free, no key for public results) ──────────
+  if (requestUrl.pathname === '/api/security/urlscan') {
+ const CACHE_TTL = 15 * 60 * 1000;
+ const q = (requestUrl.searchParams.get('q') ?? 'malicious:true').slice(0, 200);
+ const size = Math.min(100, Math.max(1, Number(requestUrl.searchParams.get('size') ?? '50')));
+ const cacheKey = `urlscan-search:${q}:${size}`;
+ const cached = getCached(cacheKey, CACHE_TTL);
+ if (cached) return json(cached);
+ try {
+ const url = `https://urlscan.io/api/v1/search/?q=${encodeURIComponent(q)}&size=${size}`;
+ const r = await fetchWithTimeout(url, { headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' } }, 12000);
+ if (!r.ok) return json({ results: [], degraded: true, reason: `HTTP ${r.status}`, fetchedAt: Date.now(), source: 'urlscan.io' }, 502);
+ const data = await r.json();
+ const envelope = { results: Array.isArray(data?.results) ? data.results : [], total: data?.total ?? 0, fetchedAt: Date.now(), degraded: false, source: 'urlscan.io' };
+ setCached(cacheKey, envelope);
+ return json(envelope);
+ } catch (error) {
+ return json({ results: [], degraded: true, reason: error?.message ?? String(error), fetchedAt: Date.now(), source: 'urlscan.io' }, 502);
+ }
+  }
+
+  // ── urlscan.io submit (free for public scans, no key required) ──────────
+  // Accepts { url, visibility?: 'public' } and forwards to urlscan submit API.
+  // Validates URL host to block SSRF (private IPs / file:// etc.).
+  if (requestUrl.pathname === '/api/security/urlscan/submit' && req.method === 'POST') {
+ try {
+ const body = await req.json();
+ const target = typeof body?.url === 'string' ? body.url.trim() : '';
+ if (!target) return json({ error: 'url required' }, 400);
+ let parsed;
+ try { parsed = new URL(target); } catch { return json({ error: 'invalid url' }, 400); }
+ if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+ return json({ error: 'only http(s) urls accepted' }, 400);
+ }
+ const host = parsed.hostname.toLowerCase();
+ if (host === 'localhost' || host === '0.0.0.0' || /^127\./.test(host) || /^10\./.test(host)
+ || /^192\.168\./.test(host) || /^172\.(1[6-9]|2\d|3[01])\./.test(host) || host.endsWith('.local')) {
+ return json({ error: 'private host blocked' }, 400);
+ }
+ const visibility = body?.visibility === 'private' ? 'private' : 'public';
+ const apiKey = process.env.URLSCAN_API_KEY?.trim() || '';
+ const headers = { 'Content-Type': 'application/json', 'User-Agent': CHROME_UA };
+ if (apiKey) headers['API-Key'] = apiKey;
+ const r = await fetchWithTimeout('https://urlscan.io/api/v1/scan/', {
+ method: 'POST',
+ headers,
+ body: JSON.stringify({ url: target, visibility }),
+ }, 12000);
+ if (r.status === 401 && !apiKey) {
+ return json({ error: 'urlscan rejected anonymous submit; configure URLSCAN_API_KEY' }, 401);
+ }
+ if (!r.ok) {
+ const text = await r.text().catch(() => '');
+ return json({ error: `urlscan submit HTTP ${r.status}`, detail: text.slice(0, 400) }, 502);
+ }
+ const data = await r.json();
+ return json({ uuid: data?.uuid ?? null, result: data?.result ?? null, api: data?.api ?? null, visibility, fetchedAt: Date.now(), source: 'urlscan.io' });
+ } catch (error) {
+ return json({ error: error?.message ?? String(error) }, 502);
+ }
+  }
+
+  // ── Pulsedive threat intelligence (free, no key for basic lookups) ──────
+  if (requestUrl.pathname === '/api/security/pulsedive') {
+ const CACHE_TTL = 60 * 60 * 1000;
+ const risk = (requestUrl.searchParams.get('risk') ?? 'high').slice(0, 16);
+ const type = (requestUrl.searchParams.get('type') ?? 'all').slice(0, 16);
+ const limit = Math.min(100, Math.max(1, Number(requestUrl.searchParams.get('limit') ?? '50')));
+ const indicator = (requestUrl.searchParams.get('indicator') ?? '').slice(0, 256);
+ const cacheKey = `pulsedive:${indicator || `${risk}:${type}:${limit}`}`;
+ const cached = getCached(cacheKey, CACHE_TTL);
+ if (cached) return json(cached);
+ try {
+ // Single-indicator lookup → /api/info.php?indicator=…
+ // Explore query   → /api/explore.php?q=is:indicator+risk:…&limit=…
+ let url;
+ const apiKey = process.env.PULSEDIVE_API_KEY?.trim() || '';
+ const keyParam = apiKey ? `&key=${encodeURIComponent(apiKey)}` : '';
+ if (indicator) {
+ url = `https://pulsedive.com/api/info.php?indicator=${encodeURIComponent(indicator)}&pretty=0${keyParam}`;
+ } else {
+ const parts = ['is:indicator'];
+ if (risk && risk !== 'all') parts.push(`risk:${risk}`);
+ if (type && type !== 'all') parts.push(`type:${type}`);
+ url = `https://pulsedive.com/api/explore.php?q=${encodeURIComponent(parts.join(' '))}&limit=${limit}&pretty=0${keyParam}`;
+ }
+ const r = await fetchWithTimeout(url, { headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' } }, 12000);
+ if (!r.ok) return json({ indicators: [], degraded: true, reason: `HTTP ${r.status}`, fetchedAt: Date.now(), source: 'pulsedive.com' }, 502);
+ const data = await r.json();
+ // info.php returns a single indicator object; explore returns { results: [...] }.
+ const indicators = indicator
+ ? (data && typeof data === 'object' && !data.error ? [data] : [])
+ : (Array.isArray(data?.results) ? data.results : []);
+ const envelope = {
+ indicators,
+ query: { risk, type, limit, indicator: indicator || null },
+ fetchedAt: Date.now(),
+ degraded: false,
+ source: 'pulsedive.com',
+ };
+ setCached(cacheKey, envelope);
+ return json(envelope);
+ } catch (error) {
+ return json({ indicators: [], degraded: true, reason: error?.message ?? String(error), fetchedAt: Date.now(), source: 'pulsedive.com' }, 502);
+ }
+  }
+
   // ── Tor relay metrics ────────────────────────────────────────────────────
   if (requestUrl.pathname === '/api/tor-metrics') {
  const cached = getCached('tor-metrics', 60 * 60 * 1000);

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -150,6 +150,9 @@ import { HibpBreachesPanel } from '@/components/HibpBreachesPanel';
 import { IpInfoPanel } from '@/components/IpInfoPanel';
 import { BitcoinAbusePanel } from '@/components/BitcoinAbusePanel';
 import { RedditOsintPanel } from '@/components/RedditOsintPanel';
+import { PhishstatsFeedPanel } from '@/components/PhishstatsFeedPanel';
+import { UrlscanThreatsPanel } from '@/components/UrlscanThreatsPanel';
+import { PulsediveIntelPanel } from '@/components/PulsediveIntelPanel';
 import { EdgarFilingsPanel } from '@/components/EdgarFilingsPanel';
 import { AirQualityPanel } from '@/components/AirQualityPanel';
 import { WildfireIncidentsPanel } from '@/components/WildfireIncidentsPanel';
@@ -1031,6 +1034,15 @@ export class PanelLayoutManager implements AppModule {
 
  const redditOsintPanel = new RedditOsintPanel();
  this.ctx.panels['reddit-osint'] = redditOsintPanel;
+
+ const phishstatsFeedPanel = new PhishstatsFeedPanel();
+ this.ctx.panels['phishstats-feed'] = phishstatsFeedPanel;
+
+ const urlscanThreatsPanel = new UrlscanThreatsPanel();
+ this.ctx.panels['urlscan-threats'] = urlscanThreatsPanel;
+
+ const pulsediveIntelPanel = new PulsediveIntelPanel();
+ this.ctx.panels['pulsedive-intel'] = pulsediveIntelPanel;
 
  const edgarFilingsPanel = new EdgarFilingsPanel();
  this.ctx.panels['edgar-filings'] = edgarFilingsPanel;

--- a/src/components/PhishstatsFeedPanel.ts
+++ b/src/components/PhishstatsFeedPanel.ts
@@ -1,0 +1,166 @@
+/**
+ * PhishStats Feed panel — recent phishing URLs with severity slider and
+ * top-targets / top-countries summary. Auto-refreshes every 30 min.
+ */
+
+import { Panel } from './Panel';
+import { escapeHtml } from '@/utils/sanitize';
+import {
+  fetchPhishingRecords,
+  type PhishingEnvelope,
+} from '@/services/security/phishstats-service';
+import {
+  filterByMinScore,
+  severityColor,
+  summarisePhishing,
+  truncateUrl,
+} from '@/services/security/phishstats-classify';
+
+const REFRESH_MS = 30 * 60 * 1000;
+const SLIDER_STORAGE_KEY = 'cb:phishstats-min-score';
+
+function readStoredMinScore(): number {
+  try {
+    const raw = localStorage.getItem(SLIDER_STORAGE_KEY);
+    if (raw === null) return 5;
+    const n = Number(raw);
+    if (Number.isFinite(n) && n >= 0 && n <= 10) return n;
+  } catch { /* noop */ }
+  return 5;
+}
+
+export class PhishstatsFeedPanel extends Panel {
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  private envelope: PhishingEnvelope | null = null;
+  private minScore: number = readStoredMinScore();
+
+  constructor() {
+    super({
+      id: 'phishstats-feed',
+      title: 'PhishStats Feed',
+      showCount: true,
+      trackActivity: true,
+      infoTooltip: 'Recent phishing URLs from PhishStats (free API). Filter by confidence score (0–10). Cache refreshes every 30 minutes.',
+    });
+    this.start();
+  }
+
+  private start(): void {
+    this.render();
+    void this.refresh();
+    this.refreshTimer = setInterval(() => void this.refresh(), REFRESH_MS);
+  }
+
+  public dispose(): void {
+    if (this.refreshTimer !== null) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+
+  private async refresh(): Promise<void> {
+    try {
+      this.envelope = await fetchPhishingRecords({ limit: 100, minScore: 0 });
+    } catch {
+      // service surfaces failure as degraded envelope
+    }
+    this.render();
+  }
+
+  private setMinScore(value: number): void {
+    this.minScore = Math.max(0, Math.min(10, value));
+    try { localStorage.setItem(SLIDER_STORAGE_KEY, String(this.minScore)); } catch { /* noop */ }
+    this.render();
+  }
+
+  private render(): void {
+    const env = this.envelope;
+    if (!env) {
+      this.setContent(`<div style="opacity:0.6;padding:8px;">Loading phishing feed…</div>`);
+      return;
+    }
+    const filtered = filterByMinScore(env.records, this.minScore);
+    const stats = summarisePhishing(filtered);
+    this.setCount(filtered.length);
+
+    const banner = env.degraded
+      ? `<div style="padding:4px 6px;background:rgba(244,67,54,0.10);border-left:3px solid #f44336;margin-bottom:6px;font-size:11px;">
+           Degraded: ${escapeHtml(env.reason ?? 'unknown')} (source: ${escapeHtml(env.source)})
+         </div>`
+      : '';
+
+    const slider = `<div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;font-size:11px;">
+      <span style="opacity:0.7;">Min score</span>
+      <input type="range" min="0" max="10" step="0.5" value="${this.minScore}" class="phish-score-slider" style="flex:1;" />
+      <span style="font-family:ui-monospace,monospace;min-width:2.5em;text-align:right;">${this.minScore.toFixed(1)}</span>
+    </div>`;
+
+    const summary = this.renderSummary(stats);
+    const tableBody = filtered.slice(0, 60).map((r) => this.renderRow(r)).join('');
+    const more = filtered.length > 60
+      ? `<div style="font-size:10px;opacity:0.6;margin-top:4px;">+ ${filtered.length - 60} more</div>`
+      : '';
+
+    this.setContent(`
+      <div style="padding:8px;font-size:12px;line-height:1.45;">
+        ${banner}
+        ${slider}
+        ${summary}
+        <table class="eq-table" style="width:100%;font-size:11px;margin-top:6px;">
+          <thead><tr>
+            <th style="text-align:left;">URL</th>
+            <th style="text-align:left;">Target</th>
+            <th style="text-align:right;">Score</th>
+            <th style="text-align:left;">Country</th>
+            <th style="text-align:right;">Date</th>
+          </tr></thead>
+          <tbody>${tableBody}</tbody>
+        </table>
+        ${more}
+      </div>
+    `);
+    this.wireHandlers();
+  }
+
+  private renderSummary(stats: ReturnType<typeof summarisePhishing>): string {
+    const targets = stats.topTargets.length === 0
+      ? '<span style="opacity:0.6;">no targets identified</span>'
+      : stats.topTargets.slice(0, 5).map((t) => `<span style="display:inline-block;padding:2px 8px;border:1px solid rgba(255,255,255,0.12);border-radius:8px;font-size:10px;margin-right:4px;margin-bottom:4px;">${escapeHtml(t.target)} <strong>${t.count}</strong></span>`).join('');
+    const countries = stats.topCountries.length === 0
+      ? '<span style="opacity:0.6;">no countries identified</span>'
+      : stats.topCountries.slice(0, 5).map((c) => {
+          const flag = escapeHtml(c.countryCode);
+          const name = c.countryName ? ` ${escapeHtml(c.countryName)}` : '';
+          return `<span style="display:inline-block;padding:2px 8px;border:1px solid rgba(255,255,255,0.12);border-radius:8px;font-size:10px;margin-right:4px;margin-bottom:4px;">${flag}${name} <strong>${c.count}</strong></span>`;
+        }).join('');
+    return `<div style="display:grid;grid-template-columns:1fr;gap:6px;margin-bottom:6px;">
+      <div><div style="font-size:10px;opacity:0.7;text-transform:uppercase;margin-bottom:3px;">Top targeted brands</div>${targets}</div>
+      <div><div style="font-size:10px;opacity:0.7;text-transform:uppercase;margin-bottom:3px;">Top countries</div>${countries}</div>
+    </div>`;
+  }
+
+  private renderRow(r: import('@/services/security/phishstats-classify').PhishingRecord): string {
+    const sev = severityColor(r.severity);
+    const date = new Date(r.detectedAt).toISOString().slice(0, 16).replace('T', ' ');
+    const cc = r.countryCode ?? '—';
+    return `<tr>
+      <td style="border-left:3px solid ${sev};padding-left:6px;font-family:ui-monospace,monospace;font-size:10px;">${escapeHtml(truncateUrl(r.url))}</td>
+      <td>${escapeHtml(r.target ?? '—')}</td>
+      <td style="text-align:right;font-weight:600;color:${sev};">${r.score.toFixed(1)}</td>
+      <td>${escapeHtml(cc)}</td>
+      <td style="text-align:right;font-family:ui-monospace,monospace;opacity:0.7;font-size:10px;">${escapeHtml(date)}</td>
+    </tr>`;
+  }
+
+  private wireHandlers(): void {
+    const root = this.getElement();
+    if (!root) return;
+    const slider = root.querySelector<HTMLInputElement>('.phish-score-slider');
+    if (slider) {
+      slider.addEventListener('input', () => {
+        const v = Number(slider.value);
+        if (Number.isFinite(v)) this.setMinScore(v);
+      });
+    }
+  }
+}

--- a/src/components/PulsediveIntelPanel.ts
+++ b/src/components/PulsediveIntelPanel.ts
@@ -1,0 +1,258 @@
+/**
+ * Pulsedive Intel panel — three tabs:
+ *   - Indicators: high-risk explore feed (table)
+ *   - Lookup:     search any IP / domain / URL for threat context
+ *   - Feeds:      active threat feeds + their last-seen timestamps
+ */
+
+import { Panel } from './Panel';
+import { escapeHtml } from '@/utils/sanitize';
+import {
+  fetchPulsediveIndicators,
+  type PulsediveEnvelope,
+} from '@/services/security/pulsedive-service';
+import {
+  riskColor,
+  type PulsediveIndicator,
+  type PulsediveRisk,
+} from '@/services/security/pulsedive-classify';
+
+const REFRESH_MS = 60 * 60 * 1000;
+const TAB_STORAGE_KEY = 'cb:pulsedive-tab';
+
+type Tab = 'indicators' | 'lookup' | 'feeds';
+
+const TAB_LABELS: Record<Tab, string> = {
+  indicators: 'High Risk Indicators',
+  lookup: 'Lookup',
+  feeds: 'Feeds',
+};
+
+function readStoredTab(): Tab {
+  try {
+    const stored = localStorage.getItem(TAB_STORAGE_KEY);
+    if (stored === 'indicators' || stored === 'lookup' || stored === 'feeds') return stored;
+  } catch { /* noop */ }
+  return 'indicators';
+}
+
+export class PulsediveIntelPanel extends Panel {
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  private activeTab: Tab = readStoredTab();
+  private explore: PulsediveEnvelope | null = null;
+  private lookup: PulsediveEnvelope | null = null;
+  private lookupQuery = '';
+
+  constructor() {
+    super({
+      id: 'pulsedive-intel',
+      title: 'Pulsedive Intel',
+      showCount: true,
+      trackActivity: true,
+      infoTooltip: 'Pulsedive threat indicators (free public API). High-risk feed refreshes hourly; Lookup queries are cached per indicator.',
+    });
+    this.start();
+  }
+
+  private start(): void {
+    this.render();
+    void this.refreshExplore();
+    this.refreshTimer = setInterval(() => void this.refreshExplore(), REFRESH_MS);
+  }
+
+  public dispose(): void {
+    if (this.refreshTimer !== null) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+
+  private async refreshExplore(): Promise<void> {
+    try {
+      this.explore = await fetchPulsediveIndicators({ risk: 'high', type: 'all', limit: 50 });
+    } catch { /* service surfaces degraded */ }
+    this.render();
+  }
+
+  private async runLookup(value: string): Promise<void> {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      this.lookup = null;
+      this.render();
+      return;
+    }
+    this.lookupQuery = trimmed;
+    this.render();
+    try {
+      this.lookup = await fetchPulsediveIndicators({ indicator: trimmed });
+    } catch { /* degraded */ }
+    this.render();
+  }
+
+  private setTab(tab: Tab): void {
+    if (tab === this.activeTab) return;
+    this.activeTab = tab;
+    try { localStorage.setItem(TAB_STORAGE_KEY, tab); } catch { /* noop */ }
+    this.render();
+  }
+
+  private render(): void {
+    const env = this.explore;
+    if (env) this.setCount(env.stats.total);
+
+    let body = '';
+    switch (this.activeTab) {
+      case 'indicators': { body = this.renderIndicatorsTab(); break; }
+      case 'lookup': { body = this.renderLookupTab(); break; }
+      case 'feeds': { body = this.renderFeedsTab(); break; }
+    }
+    this.setContent(`
+      <div style="padding:8px;font-size:12px;line-height:1.45;">
+        ${this.renderTabBar()}
+        <div style="margin-top:8px;">${body}</div>
+      </div>
+    `);
+    this.wireHandlers();
+  }
+
+  private renderTabBar(): string {
+    const tabs: Tab[] = ['indicators', 'lookup', 'feeds'];
+    return `<div style="display:flex;gap:4px;border-bottom:1px solid rgba(255,255,255,0.1);">
+      ${tabs.map((tab) => {
+        const active = tab === this.activeTab;
+        return `<button class="pd-tab" data-tab="${tab}" type="button"
+          style="background:${active ? 'rgba(74,158,255,0.15)' : 'transparent'};
+                 border:none;border-bottom:2px solid ${active ? '#4a9eff' : 'transparent'};
+                 color:inherit;padding:4px 10px;font-size:12px;cursor:pointer;">${escapeHtml(TAB_LABELS[tab])}</button>`;
+      }).join('')}
+    </div>`;
+  }
+
+  private renderIndicatorsTab(): string {
+    const env = this.explore;
+    if (!env) return `<div style="opacity:0.6;">Loading indicators…</div>`;
+    const banner = env.degraded
+      ? `<div style="padding:4px 6px;background:rgba(244,67,54,0.10);border-left:3px solid #f44336;margin-bottom:6px;font-size:11px;">Degraded: ${escapeHtml(env.reason ?? 'unknown')}</div>`
+      : '';
+    if (env.indicators.length === 0) {
+      return `${banner}<div style="opacity:0.6;">No indicators in the high-risk feed.</div>`;
+    }
+    const summary = this.renderRiskStrip(env.stats.byRisk);
+    const rows = env.indicators.slice(0, 50).map((i) => this.renderIndicatorRow(i)).join('');
+    return `${banner}${summary}
+      <table class="eq-table" style="width:100%;font-size:11px;margin-top:6px;">
+        <thead><tr>
+          <th style="text-align:left;">Indicator</th>
+          <th style="text-align:left;">Type</th>
+          <th style="text-align:left;">Risk</th>
+          <th style="text-align:left;">Threats</th>
+          <th style="text-align:right;">Last seen</th>
+        </tr></thead>
+        <tbody>${rows}</tbody>
+      </table>`;
+  }
+
+  private renderLookupTab(): string {
+    const inputHtml = `<input type="search" class="pd-lookup-input" placeholder="Look up IP / domain / URL…"
+      value="${escapeHtml(this.lookupQuery)}"
+      style="width:100%;padding:6px 10px;background:rgba(255,255,255,0.04);color:inherit;border:1px solid rgba(255,255,255,0.12);border-radius:4px;font-size:12px;font-family:ui-monospace,monospace;" />
+      <div style="font-size:10px;opacity:0.6;margin-top:3px;">Press Enter to look up. Results cached for 1 hour.</div>`;
+    if (!this.lookupQuery) {
+      return `${inputHtml}<div style="margin-top:8px;opacity:0.6;">Enter an indicator to query Pulsedive.</div>`;
+    }
+    const env = this.lookup;
+    if (!env) {
+      return `${inputHtml}<div style="margin-top:8px;opacity:0.6;">Looking up <code>${escapeHtml(this.lookupQuery)}</code>…</div>`;
+    }
+    if (env.degraded) {
+      return `${inputHtml}<div style="margin-top:8px;padding:4px 6px;background:rgba(244,67,54,0.10);border-left:3px solid #f44336;font-size:11px;">Lookup failed: ${escapeHtml(env.reason ?? 'unknown')}</div>`;
+    }
+    if (env.indicators.length === 0) {
+      return `${inputHtml}<div style="margin-top:8px;opacity:0.6;">No record for <code>${escapeHtml(this.lookupQuery)}</code>.</div>`;
+    }
+    const ind = env.indicators[0]!;
+    const color = riskColor(ind.risk);
+    const threats = ind.threats.length === 0 ? '<span style="opacity:0.6;">none</span>'
+      : ind.threats.map((t) => `<span style="padding:1px 5px;border-radius:3px;background:rgba(244,67,54,0.12);font-size:10px;margin-right:3px;color:${color};">${escapeHtml(t)}</span>`).join('');
+    const feeds = ind.feeds.length === 0 ? '<span style="opacity:0.6;">none</span>'
+      : ind.feeds.slice(0, 12).map((f) => `<span style="padding:1px 5px;border-radius:3px;background:rgba(255,255,255,0.08);font-size:10px;margin-right:3px;">${escapeHtml(f)}</span>`).join('');
+    return `${inputHtml}
+      <div style="margin-top:10px;padding:8px;border:1px solid rgba(255,255,255,0.08);border-left:3px solid ${color};border-radius:3px;">
+        <div style="display:flex;justify-content:space-between;align-items:center;">
+          <code style="font-size:13px;font-weight:600;">${escapeHtml(ind.indicator)}</code>
+          <span style="color:${color};text-transform:uppercase;font-weight:700;font-size:11px;">${ind.risk}</span>
+        </div>
+        <div style="font-size:11px;opacity:0.8;margin-top:2px;">${escapeHtml(ind.type)} · last seen ${formatTimestamp(ind.lastSeen)}</div>
+        <div style="margin-top:6px;font-size:11px;"><strong style="opacity:0.7;">Threats:</strong> ${threats}</div>
+        <div style="margin-top:4px;font-size:11px;"><strong style="opacity:0.7;">Feeds:</strong> ${feeds}</div>
+      </div>`;
+  }
+
+  private renderFeedsTab(): string {
+    const env = this.explore;
+    if (!env) return `<div style="opacity:0.6;">Loading feeds…</div>`;
+    if (env.stats.topFeeds.length === 0) {
+      return `<div style="opacity:0.6;">No active feeds in the high-risk window.</div>`;
+    }
+    const latest = env.stats.latestSeen ? formatTimestamp(env.stats.latestSeen) : '—';
+    const rows = env.stats.topFeeds.map((f) => `<tr>
+      <td>${escapeHtml(f.feed)}</td>
+      <td style="text-align:right;font-weight:600;">${f.count}</td>
+    </tr>`).join('');
+    return `<div style="font-size:11px;opacity:0.7;margin-bottom:6px;">Latest indicator activity: ${latest}</div>
+      <table class="eq-table" style="width:100%;font-size:11px;">
+        <thead><tr><th style="text-align:left;">Feed</th><th style="text-align:right;">Indicators</th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table>`;
+  }
+
+  private renderRiskStrip(byRisk: Record<PulsediveRisk, number>): string {
+    return `<div style="display:flex;flex-wrap:wrap;gap:4px;">
+      ${(['critical', 'high', 'medium', 'low', 'none', 'unknown'] as PulsediveRisk[])
+        .filter((r) => byRisk[r] > 0)
+        .map((r) => `<span style="display:inline-block;padding:2px 8px;border:1px solid ${riskColor(r)};border-radius:8px;font-size:10px;color:${riskColor(r)};">${escapeHtml(r)} <strong>${byRisk[r]}</strong></span>`)
+        .join('')}
+    </div>`;
+  }
+
+  private renderIndicatorRow(ind: PulsediveIndicator): string {
+    const color = riskColor(ind.risk);
+    const threats = ind.threats.slice(0, 3).map((t) => escapeHtml(t)).join(', ') || '—';
+    return `<tr>
+      <td style="border-left:3px solid ${color};padding-left:6px;font-family:ui-monospace,monospace;font-size:10px;">${escapeHtml(ind.indicator)}</td>
+      <td>${escapeHtml(ind.type)}</td>
+      <td style="color:${color};text-transform:uppercase;font-weight:600;">${ind.risk}</td>
+      <td style="font-size:10px;">${threats}</td>
+      <td style="text-align:right;font-family:ui-monospace,monospace;opacity:0.7;font-size:10px;">${formatTimestamp(ind.lastSeen)}</td>
+    </tr>`;
+  }
+
+  private wireHandlers(): void {
+    const root = this.getElement();
+    if (!root) return;
+    for (const btn of root.querySelectorAll<HTMLButtonElement>('.pd-tab')) {
+      btn.addEventListener('click', () => {
+        const t = btn.dataset.tab as Tab | undefined;
+        if (t) this.setTab(t);
+      });
+    }
+    const input = root.querySelector<HTMLInputElement>('.pd-lookup-input');
+    if (input) {
+      // Restore focus + caret on re-render so typing stays smooth.
+      const len = input.value.length;
+      input.focus();
+      try { input.setSelectionRange(len, len); } catch { /* noop */ }
+      input.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          void this.runLookup(input.value);
+        }
+      });
+    }
+  }
+}
+
+function formatTimestamp(ts: number | null): string {
+  if (ts === null) return '—';
+  return new Date(ts).toISOString().slice(0, 16).replace('T', ' ');
+}

--- a/src/components/UrlscanThreatsPanel.ts
+++ b/src/components/UrlscanThreatsPanel.ts
@@ -1,0 +1,238 @@
+/**
+ * urlscan.io Threats panel — recent malicious scans with expandable rows
+ * and a "Scan URL" submit input. Auto-refreshes every 15 min.
+ */
+
+import { Panel } from './Panel';
+import { escapeHtml } from '@/utils/sanitize';
+import {
+  fetchUrlscanThreats,
+  submitUrlscan,
+  type UrlscanEnvelope,
+} from '@/services/security/urlscan-service';
+import {
+  validateSubmitUrl,
+  verdictColor,
+  type UrlscanThreat,
+} from '@/services/security/urlscan-classify';
+
+const REFRESH_MS = 15 * 60 * 1000;
+
+interface SubmitStatus {
+  state: 'idle' | 'submitting' | 'ok' | 'error';
+  message: string;
+  reportUrl?: string;
+}
+
+export class UrlscanThreatsPanel extends Panel {
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  private envelope: UrlscanEnvelope | null = null;
+  private expanded = new Set<string>();
+  private submit: SubmitStatus = { state: 'idle', message: '' };
+  private submitInputValue = '';
+
+  constructor() {
+    super({
+      id: 'urlscan-threats',
+      title: 'urlscan.io Threats',
+      showCount: true,
+      trackActivity: true,
+      infoTooltip: 'Recently scanned malicious URLs from urlscan.io (free public scans). Submit a URL to queue a public scan. Cache refreshes every 15 minutes.',
+    });
+    this.start();
+  }
+
+  private start(): void {
+    this.render();
+    void this.refresh();
+    this.refreshTimer = setInterval(() => void this.refresh(), REFRESH_MS);
+  }
+
+  public dispose(): void {
+    if (this.refreshTimer !== null) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+
+  private async refresh(): Promise<void> {
+    try {
+      this.envelope = await fetchUrlscanThreats({ q: 'malicious:true', size: 50 });
+    } catch {
+      // degraded envelope returned by service
+    }
+    this.render();
+  }
+
+  private toggleRow(uuid: string): void {
+    const isOpen = this.expanded.has(uuid);
+    if (isOpen) {
+      this.expanded.delete(uuid);
+    } else {
+      this.expanded.add(uuid);
+    }
+    this.render();
+  }
+
+  private async runSubmit(value: string): Promise<void> {
+    const v = validateSubmitUrl(value);
+    if (!v.ok) {
+      this.submit = { state: 'error', message: v.error };
+      this.render();
+      return;
+    }
+    this.submit = { state: 'submitting', message: `Submitting ${v.url}…` };
+    this.render();
+    const result = await submitUrlscan(value);
+    this.submit = result.ok
+      ? {
+          state: 'ok',
+          message: `Scan queued · uuid ${result.uuid ?? '?'}`,
+          reportUrl: result.reportUrl,
+        }
+      : { state: 'error', message: result.error ?? 'Submit failed' };
+    this.render();
+  }
+
+  private render(): void {
+    const env = this.envelope;
+    const stats = env?.stats;
+    if (env) this.setCount(env.threats.length);
+
+    const banner = env?.degraded
+      ? `<div style="padding:4px 6px;background:rgba(244,67,54,0.10);border-left:3px solid #f44336;margin-bottom:6px;font-size:11px;">
+           Degraded: ${escapeHtml(env.reason ?? 'unknown')} (source: ${escapeHtml(env.source)})
+         </div>`
+      : '';
+
+    const summaryHtml = stats
+      ? `<div style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:6px;font-size:11px;">
+          <span style="display:inline-block;padding:2px 8px;border:1px solid ${verdictColor('malicious')};border-radius:8px;color:${verdictColor('malicious')};">Malicious <strong>${stats.byVerdict.malicious}</strong></span>
+          <span style="display:inline-block;padding:2px 8px;border:1px solid ${verdictColor('suspicious')};border-radius:8px;color:${verdictColor('suspicious')};">Suspicious <strong>${stats.byVerdict.suspicious}</strong></span>
+          <span style="display:inline-block;padding:2px 8px;border:1px solid rgba(255,255,255,0.12);border-radius:8px;">Categories <strong>${stats.topCategories.length}</strong></span>
+          <span style="display:inline-block;padding:2px 8px;border:1px solid rgba(255,255,255,0.12);border-radius:8px;">Brands <strong>${stats.topBrands.length}</strong></span>
+        </div>`
+      : '';
+
+    const submitHtml = this.renderSubmit();
+
+    let listHtml = '';
+    if (!env) {
+      listHtml = `<div style="opacity:0.6;">Loading scans…</div>`;
+    } else if (env.threats.length === 0) {
+      listHtml = `<div style="opacity:0.6;">No malicious scans returned.</div>`;
+    } else {
+      listHtml = env.threats.slice(0, 30).map((t) => this.renderThreat(t)).join('');
+    }
+
+    this.setContent(`
+      <div style="padding:8px;font-size:12px;line-height:1.45;">
+        ${banner}
+        ${submitHtml}
+        ${summaryHtml}
+        <div style="display:flex;flex-direction:column;gap:4px;">${listHtml}</div>
+      </div>
+    `);
+    this.wireHandlers();
+  }
+
+  private renderSubmit(): string {
+    const stateColor = submitStateColor(this.submit.state);
+    const reportLink = this.submit.reportUrl
+      ? ` · <a href="${escapeHtml(this.submit.reportUrl)}" target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:underline;">view report</a>`
+      : '';
+    const message = this.submit.message
+      ? `<div style="font-size:10px;color:${stateColor};margin-top:2px;">${escapeHtml(this.submit.message)}${reportLink}</div>`
+      : '';
+    return `<div style="margin-bottom:8px;">
+      <div style="display:flex;gap:4px;">
+        <input type="text" class="urlscan-submit-input" placeholder="https://example.com/suspicious-path"
+          value="${escapeHtml(this.submitInputValue)}"
+          style="flex:1;padding:4px 8px;background:rgba(255,255,255,0.04);color:inherit;border:1px solid rgba(255,255,255,0.12);border-radius:4px;font-size:11px;font-family:ui-monospace,monospace;" />
+        <button class="urlscan-submit-btn" type="button"
+          style="padding:4px 10px;background:rgba(74,158,255,0.18);color:inherit;border:1px solid rgba(74,158,255,0.4);border-radius:4px;cursor:pointer;font-size:11px;"
+          ${this.submit.state === 'submitting' ? 'disabled' : ''}>${this.submit.state === 'submitting' ? '…' : 'Scan URL'}</button>
+      </div>
+      ${message}
+    </div>`;
+  }
+
+  private renderThreat(t: UrlscanThreat): string {
+    const color = verdictColor(t.verdict);
+    const expanded = this.expanded.has(t.uuid);
+    const cats = t.categories.length === 0 ? '' :
+      t.categories.slice(0, 4).map((c) => `<span style="padding:1px 5px;border-radius:3px;background:rgba(255,255,255,0.08);font-size:10px;margin-right:3px;">${escapeHtml(c)}</span>`).join('');
+    const brands = t.brands.length === 0 ? '' :
+      t.brands.slice(0, 3).map((b) => `<span style="padding:1px 5px;border-radius:3px;background:rgba(244,67,54,0.12);font-size:10px;margin-right:3px;color:${color};">${escapeHtml(b)}</span>`).join('');
+    const date = new Date(t.scannedAt).toISOString().slice(0, 16).replace('T', ' ');
+    const reportLink = t.reportUrl
+      ? `<a href="${escapeHtml(t.reportUrl)}" target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:underline;">report</a>`
+      : '';
+    const scoreText = t.verdictScore === null ? '—' : t.verdictScore.toFixed(0);
+    const tagsText = t.tags.length === 0
+      ? '—'
+      : t.tags.slice(0, 8).map((tag) => escapeHtml(tag)).join(', ');
+    const screenshotRow = t.screenshotUrl
+      ? `<div style="opacity:0.6;">Screenshot</div><div><a href="${escapeHtml(t.screenshotUrl)}" target="_blank" rel="noopener noreferrer" style="color:inherit;text-decoration:underline;">open</a></div>`
+      : '';
+    const expandedBody = expanded
+      ? `<div style="margin-top:4px;padding:6px;background:rgba(255,255,255,0.03);border-radius:3px;font-size:11px;display:grid;grid-template-columns:max-content 1fr;gap:2px 8px;">
+          <div style="opacity:0.6;">IP</div><div style="font-family:ui-monospace,monospace;">${escapeHtml(t.ip ?? '—')}</div>
+          <div style="opacity:0.6;">ASN</div><div style="font-family:ui-monospace,monospace;">${escapeHtml(t.asn ?? '—')}</div>
+          <div style="opacity:0.6;">Country</div><div>${escapeHtml(t.country ?? '—')}</div>
+          <div style="opacity:0.6;">Score</div><div>${scoreText}</div>
+          <div style="opacity:0.6;">Tags</div><div>${tagsText}</div>
+          ${screenshotRow}
+        </div>`
+      : '';
+    return `<div class="urlscan-row" data-uuid="${escapeHtml(t.uuid)}" style="border:1px solid rgba(255,255,255,0.08);border-left:3px solid ${color};border-radius:3px;padding:6px 8px;cursor:pointer;">
+      <div style="display:flex;justify-content:space-between;align-items:start;gap:6px;">
+        <div style="min-width:0;flex:1;">
+          <div style="font-family:ui-monospace,monospace;font-size:11px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${escapeHtml(t.url)}</div>
+          <div style="font-size:10px;opacity:0.8;margin-top:2px;">${escapeHtml(t.domain ?? '—')} · ${escapeHtml(date)} ${reportLink ? `· ${reportLink}` : ''}</div>
+        </div>
+        <div style="text-align:right;font-size:10px;font-weight:700;color:${color};text-transform:uppercase;">${t.verdict}</div>
+      </div>
+      <div style="margin-top:3px;">${cats}${brands}</div>
+      ${expandedBody}
+    </div>`;
+  }
+
+  private wireHandlers(): void {
+    const root = this.getElement();
+    if (!root) return;
+    for (const row of root.querySelectorAll<HTMLElement>('.urlscan-row')) {
+      row.addEventListener('click', (e) => {
+        // Don't toggle when the user clicks an embedded link.
+        if ((e.target as HTMLElement).tagName === 'A') return;
+        const uuid = row.dataset.uuid;
+        if (uuid) this.toggleRow(uuid);
+      });
+    }
+    const input = root.querySelector<HTMLInputElement>('.urlscan-submit-input');
+    const btn = root.querySelector<HTMLButtonElement>('.urlscan-submit-btn');
+    if (input) {
+      input.addEventListener('input', () => {
+        this.submitInputValue = input.value;
+      });
+      input.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          void this.runSubmit(input.value);
+        }
+      });
+    }
+    if (btn) {
+      btn.addEventListener('click', () => {
+        if (input) void this.runSubmit(input.value);
+      });
+    }
+  }
+}
+
+function submitStateColor(state: SubmitStatus['state']): string {
+  if (state === 'error') return '#d50000';
+  if (state === 'ok') return '#4caf50';
+  if (state === 'submitting') return '#ffeb3b';
+  return 'rgba(255,255,255,0.5)';
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -160,6 +160,9 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'foreign-mil-news': { name: 'Foreign Military News', enabled: true, priority: 1 },
   'spc-mesoscale': { name: 'SPC Mesoscale Discussions', enabled: true, priority: 2 },
   'threat-intel-hub': { name: 'Threat Intel Hub', enabled: true, priority: 2 },
+  'phishstats-feed': { name: 'PhishStats Feed', enabled: true, priority: 2 },
+  'urlscan-threats': { name: 'urlscan.io Threats', enabled: true, priority: 2 },
+  'pulsedive-intel': { name: 'Pulsedive Intel', enabled: true, priority: 2 },
   'geo-intel': { name: 'Geo Intel', enabled: true, priority: 2 },
   'dark-web': { name: 'Dark Web', enabled: true, priority: 2 },
   'intelligence-briefing': { name: 'Intelligence Briefing', enabled: true, priority: 1 },
@@ -1040,7 +1043,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   },
   dataTracking: {
  labelKey: 'header.panelCatDataTracking',
- panelKeys: ['monitors', 'cyber-threats', 'threat-inbox', 'local-ids', 'comms-health', 'power-grid', 'grid-intelligence', 'cve-tracker', 'vulners-cve', 'hibp-breaches', 'ipinfo-lookup', 'ucdp-events', 'nuclear-risk', 'airstrikes', 'displacement', 'security-advisories', 'bitcoin-abuse', 'reddit-osint', 'network-rules', 's2u-intel', 'oref-sirens', 'space-weather', 'spaceflight-news', 'space-launches', 'population-exposure', 'internet-disruptions', 'air-traffic', 'threat-intel-hub', 'geo-intel', 'dark-web', 'anomaly-detection', 'financial-contagion', 'supply-chain-impact', 'nuclear-monitor', 'sigint-panel', 'dark-vessel', 'ics-ot-dashboard', 'ioc-manager', 'network-topology', 'stix-taxii', 'custom-geofence', 'sanctions-crossref', 'emergency-broadcast', 'satellite-change', 'ripe-ncc', 'ripe-atlas', 'aerospace-reentry', 'satellite-intel'],
+ panelKeys: ['monitors', 'cyber-threats', 'threat-inbox', 'local-ids', 'comms-health', 'power-grid', 'grid-intelligence', 'cve-tracker', 'vulners-cve', 'hibp-breaches', 'ipinfo-lookup', 'ucdp-events', 'nuclear-risk', 'airstrikes', 'displacement', 'security-advisories', 'bitcoin-abuse', 'reddit-osint', 'network-rules', 's2u-intel', 'oref-sirens', 'space-weather', 'spaceflight-news', 'space-launches', 'population-exposure', 'internet-disruptions', 'air-traffic', 'threat-intel-hub', 'phishstats-feed', 'urlscan-threats', 'pulsedive-intel', 'geo-intel', 'dark-web', 'anomaly-detection', 'financial-contagion', 'supply-chain-impact', 'nuclear-monitor', 'sigint-panel', 'dark-vessel', 'ics-ot-dashboard', 'ioc-manager', 'network-topology', 'stix-taxii', 'custom-geofence', 'sanctions-crossref', 'emergency-broadcast', 'satellite-change', 'ripe-ncc', 'ripe-atlas', 'aerospace-reentry', 'satellite-intel'],
  variants: ['full'],
   },
   hazards: {

--- a/src/services/security/__tests__/phishstats-classify.test.mts
+++ b/src/services/security/__tests__/phishstats-classify.test.mts
@@ -1,0 +1,141 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  classifyScore,
+  filterByMinScore,
+  parsePhishingRecords,
+  severityColor,
+  summarisePhishing,
+  truncateUrl,
+} from '../phishstats-classify';
+
+describe('classifyScore', () => {
+  it('maps score buckets to severity tiers', () => {
+    assert.equal(classifyScore(9.5), 'critical');
+    assert.equal(classifyScore(8), 'high');
+    assert.equal(classifyScore(6), 'medium');
+    assert.equal(classifyScore(2), 'low');
+  });
+  it('treats non-finite as low', () => {
+    assert.equal(classifyScore(Number.NaN), 'low');
+    // Infinity is not "finite" per Number.isFinite, so we bucket it as low
+    // rather than letting the >= 9 comparison succeed accidentally.
+    assert.equal(classifyScore(Infinity), 'low');
+  });
+});
+
+describe('parsePhishingRecords', () => {
+  it('parses a representative PhishStats row', () => {
+    const records = parsePhishingRecords([
+      {
+        id: '42',
+        url: 'http://evil.example.com/login',
+        score: 8.7,
+        title: 'Microsoft',
+        ip: '1.2.3.4',
+        countrycode: 'NL',
+        countryname: 'Netherlands',
+        date: '2026-05-08T12:34:56Z',
+        asn: 'AS12345',
+      },
+    ]);
+    assert.equal(records.length, 1);
+    const r = records[0]!;
+    assert.equal(r.url, 'http://evil.example.com/login');
+    assert.equal(r.score, 8.7);
+    assert.equal(r.severity, 'high');
+    assert.equal(r.target, 'Microsoft');
+    assert.equal(r.ip, '1.2.3.4');
+    assert.equal(r.countryCode, 'NL');
+    assert.equal(r.countryName, 'Netherlands');
+    assert.equal(r.asn, 'AS12345');
+  });
+
+  it('skips rows missing a URL', () => {
+    const records = parsePhishingRecords([
+      { url: 'http://ok.example.com', score: 7 },
+      { score: 6 },
+      { url: '   ', score: 7 },
+    ]);
+    assert.equal(records.length, 1);
+  });
+
+  it('tolerates string-encoded numeric score', () => {
+    const records = parsePhishingRecords([{ url: 'http://x', score: '6.5' }]);
+    assert.equal(records[0]!.score, 6.5);
+    assert.equal(records[0]!.severity, 'medium');
+  });
+
+  it('defaults score to 0 and severity to low when missing', () => {
+    const records = parsePhishingRecords([{ url: 'http://x', score: null }]);
+    assert.equal(records[0]!.score, 0);
+    assert.equal(records[0]!.severity, 'low');
+  });
+
+  it('returns [] for non-array payload', () => {
+    assert.deepEqual(parsePhishingRecords(null), []);
+    assert.deepEqual(parsePhishingRecords({}), []);
+  });
+});
+
+describe('summarisePhishing', () => {
+  it('aggregates totals, severity buckets, top targets and top countries', () => {
+    const records = parsePhishingRecords([
+      { url: 'http://a', score: 9, title: 'Microsoft', countrycode: 'US', countryname: 'United States' },
+      { url: 'http://b', score: 8, title: 'Microsoft', countrycode: 'US' },
+      { url: 'http://c', score: 6, title: 'PayPal', countrycode: 'NL', countryname: 'Netherlands' },
+      { url: 'http://d', score: 3, title: null, countrycode: null },
+    ]);
+    const stats = summarisePhishing(records);
+    assert.equal(stats.total, 4);
+    assert.equal(stats.bySeverity.critical, 1);
+    assert.equal(stats.bySeverity.high, 1);
+    assert.equal(stats.bySeverity.medium, 1);
+    assert.equal(stats.bySeverity.low, 1);
+    assert.equal(stats.topTargets[0]!.target, 'Microsoft');
+    assert.equal(stats.topTargets[0]!.count, 2);
+    assert.equal(stats.topCountries[0]!.countryCode, 'US');
+  });
+  it('tracks latestDetectedAt across rows', () => {
+    const records = parsePhishingRecords([
+      { url: 'http://a', score: 7, date: '2026-05-01T00:00:00Z' },
+      { url: 'http://b', score: 7, date: '2026-05-08T00:00:00Z' },
+      { url: 'http://c', score: 7, date: '2026-04-25T00:00:00Z' },
+    ]);
+    const stats = summarisePhishing(records);
+    assert.equal(stats.latestDetectedAt, Date.parse('2026-05-08T00:00:00Z'));
+  });
+});
+
+describe('filterByMinScore', () => {
+  it('filters by inclusive lower bound', () => {
+    const records = parsePhishingRecords([
+      { url: 'http://a', score: 9 },
+      { url: 'http://b', score: 6 },
+      { url: 'http://c', score: 3 },
+    ]);
+    assert.equal(filterByMinScore(records, 6).length, 2);
+    assert.equal(filterByMinScore(records, 9).length, 1);
+  });
+});
+
+describe('truncateUrl', () => {
+  it('passes short URLs through unchanged', () => {
+    assert.equal(truncateUrl('http://x.com'), 'http://x.com');
+  });
+  it('truncates long URLs with an ellipsis', () => {
+    const long = 'http://example.com/' + 'a'.repeat(200);
+    const truncated = truncateUrl(long, 30);
+    assert.equal(truncated.length, 30);
+    assert.ok(truncated.endsWith('…'));
+  });
+});
+
+describe('severityColor', () => {
+  it('returns a distinct hex for each severity', () => {
+    const colors = new Set(['low', 'medium', 'high', 'critical'].map((s) =>
+      severityColor(s as 'low' | 'medium' | 'high' | 'critical')));
+    assert.equal(colors.size, 4);
+  });
+});

--- a/src/services/security/__tests__/phishstats-service.test.mts
+++ b/src/services/security/__tests__/phishstats-service.test.mts
@@ -1,0 +1,103 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  __TEST_HOOKS__,
+  clearPhishingCache,
+  fetchPhishingRecords,
+} from '../phishstats-service';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function mockFetch(handler: (url: string) => Response | Promise<Response>): void {
+  Reflect.set(globalThis, 'fetch', (input: unknown): Promise<Response> => {
+    const url = typeof input === 'string' ? input : (input as { url: string }).url;
+    return Promise.resolve(handler(url));
+  });
+}
+
+function restoreFetch(): void {
+  Reflect.set(globalThis, 'fetch', ORIGINAL_FETCH);
+}
+
+beforeEach(() => clearPhishingCache());
+afterEach(() => restoreFetch());
+
+function envelopeBody(records: unknown[]): Response {
+  return new Response(
+    JSON.stringify({ records, fetchedAt: Date.now(), degraded: false, source: 'phishstats.info' }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  );
+}
+
+describe('fetchPhishingRecords', () => {
+  it('returns the envelope from a successful sidecar response', async () => {
+    mockFetch(() => envelopeBody([
+      { url: 'http://evil.example.com', score: 8.7, title: 'Microsoft' },
+    ]));
+    const env = await fetchPhishingRecords();
+    assert.equal(env.degraded, false);
+    // Sidecar returns raw rows; service runs them through the parser.
+    assert.equal(env.records.length, 1);
+    assert.equal(env.records[0]!.url, 'http://evil.example.com');
+  });
+
+  it('falls back to parsing a raw array payload', async () => {
+    mockFetch(() => new Response(
+      JSON.stringify([{ url: 'http://evil.example.com', score: 5 }]),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ));
+    const env = await fetchPhishingRecords({ limit: 50, minScore: 5 });
+    assert.equal(env.records.length, 1);
+    assert.equal(env.records[0]!.severity, 'medium');
+  });
+
+  it('marks envelope degraded on non-2xx HTTP', async () => {
+    mockFetch(() => new Response('boom', { status: 502 }));
+    const env = await fetchPhishingRecords();
+    assert.equal(env.degraded, true);
+    assert.match(env.reason ?? '', /HTTP 502/);
+    assert.equal(env.records.length, 0);
+  });
+
+  it('serves the cache within the poll interval for the same key', async () => {
+    let calls = 0;
+    mockFetch(() => { calls += 1; return envelopeBody([]); });
+    await fetchPhishingRecords({ limit: 50, minScore: 5 });
+    await fetchPhishingRecords({ limit: 50, minScore: 5 });
+    await fetchPhishingRecords({ limit: 50, minScore: 5 });
+    assert.equal(calls, 1);
+  });
+
+  it('treats a different (limit, minScore) key as a fresh fetch', async () => {
+    let calls = 0;
+    mockFetch(() => { calls += 1; return envelopeBody([]); });
+    await fetchPhishingRecords({ limit: 50, minScore: 5 });
+    await fetchPhishingRecords({ limit: 50, minScore: 7 });
+    assert.equal(calls, 2);
+  });
+
+  it('clearPhishingCache forces a refetch', async () => {
+    let calls = 0;
+    mockFetch(() => { calls += 1; return envelopeBody([]); });
+    await fetchPhishingRecords();
+    clearPhishingCache();
+    await fetchPhishingRecords();
+    assert.equal(calls, 2);
+  });
+
+  it('translates an `error` body into a degraded envelope', async () => {
+    mockFetch(() => new Response(
+      JSON.stringify({ error: 'upstream timeout' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ));
+    const env = await fetchPhishingRecords();
+    assert.equal(env.degraded, true);
+    assert.match(env.reason ?? '', /upstream timeout/);
+  });
+
+  it('exposes a sane POLL_INTERVAL_MS', () => {
+    assert.equal(typeof __TEST_HOOKS__.POLL_INTERVAL_MS, 'number');
+    assert.ok(__TEST_HOOKS__.POLL_INTERVAL_MS >= 60_000);
+  });
+});

--- a/src/services/security/__tests__/pulsedive-classify.test.mts
+++ b/src/services/security/__tests__/pulsedive-classify.test.mts
@@ -1,0 +1,157 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  classifyRisk,
+  classifyType,
+  compareRisk,
+  parsePulsediveIndicators,
+  riskColor,
+  summarisePulsedive,
+} from '../pulsedive-classify';
+
+describe('classifyRisk', () => {
+  it('maps known risk strings to typed values', () => {
+    assert.equal(classifyRisk('critical'), 'critical');
+    assert.equal(classifyRisk('High'), 'high');
+    assert.equal(classifyRisk('MEDIUM'), 'medium');
+    assert.equal(classifyRisk('low'), 'low');
+    assert.equal(classifyRisk('none'), 'none');
+  });
+  it('returns unknown for unrecognised values', () => {
+    assert.equal(classifyRisk('extreme'), 'unknown');
+    assert.equal(classifyRisk(null), 'unknown');
+    assert.equal(classifyRisk(42), 'unknown');
+  });
+});
+
+describe('classifyType', () => {
+  it('maps common indicator types', () => {
+    assert.equal(classifyType('ip'), 'ip');
+    assert.equal(classifyType('domain'), 'domain');
+    assert.equal(classifyType('URL'), 'url');
+    assert.equal(classifyType('sha256'), 'hash');
+  });
+  it('returns unknown for unrecognised types', () => {
+    assert.equal(classifyType('certificate'), 'unknown');
+    assert.equal(classifyType(null), 'unknown');
+  });
+});
+
+describe('compareRisk', () => {
+  it('orders critical > high > medium > low > none/unknown', () => {
+    assert.ok(compareRisk('critical', 'high') > 0);
+    assert.ok(compareRisk('high', 'medium') > 0);
+    assert.ok(compareRisk('low', 'none') > 0);
+    assert.equal(compareRisk('high', 'high'), 0);
+    assert.equal(compareRisk('none', 'unknown'), 0);
+  });
+});
+
+describe('parsePulsediveIndicators', () => {
+  it('parses an explore.php result row', () => {
+    const out = parsePulsediveIndicators({
+      results: [
+        {
+          iid: 42,
+          indicator: 'evil.example.com',
+          type: 'domain',
+          risk: 'high',
+          risk_recommended: 'high',
+          threats: [{ tid: 1, threat: 'Phishing' }, 'Ransomware'],
+          feeds: [{ fid: 1, feed: 'OpenPhish' }, { feed: 'PhishTank' }],
+          firstseen: '2026-05-01 00:00:00',
+          lastseen: '2026-05-08 12:34:56',
+        },
+      ],
+    });
+    assert.equal(out.length, 1);
+    const i = out[0]!;
+    assert.equal(i.indicator, 'evil.example.com');
+    assert.equal(i.type, 'domain');
+    assert.equal(i.risk, 'high');
+    assert.deepEqual(i.threats, ['Phishing', 'Ransomware']);
+    assert.deepEqual(i.feeds, ['OpenPhish', 'PhishTank']);
+    assert.equal(i.iid, 42);
+    assert.ok(i.firstSeen);
+    assert.ok(i.lastSeen);
+  });
+
+  it('handles the info.php single-indicator shape', () => {
+    const out = parsePulsediveIndicators({
+      indicator: '1.2.3.4',
+      type: 'ip',
+      risk: 'critical',
+      threats: [],
+      feeds: [],
+    });
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.risk, 'critical');
+  });
+
+  it('accepts a bare array fallback', () => {
+    const out = parsePulsediveIndicators([
+      { indicator: '5.6.7.8', type: 'ip', risk: 'medium' },
+    ]);
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.type, 'ip');
+  });
+
+  it('skips rows without an indicator value', () => {
+    const out = parsePulsediveIndicators({
+      results: [{ type: 'ip', risk: 'high' }, { indicator: '', type: 'ip' }],
+    });
+    assert.equal(out.length, 0);
+  });
+
+  it('returns [] for malformed input', () => {
+    assert.deepEqual(parsePulsediveIndicators(null), []);
+    assert.deepEqual(parsePulsediveIndicators({ wrong: 'shape' }), []);
+  });
+});
+
+describe('summarisePulsedive', () => {
+  it('counts by risk + type and ranks threats / feeds', () => {
+    const inds = parsePulsediveIndicators({
+      results: [
+        { indicator: '1.1.1.1', type: 'ip', risk: 'high', threats: [{ threat: 'Phishing' }], feeds: [{ feed: 'OpenPhish' }] },
+        { indicator: 'evil.example.com', type: 'domain', risk: 'high', threats: [{ threat: 'Phishing' }, { threat: 'Malware' }], feeds: [{ feed: 'OpenPhish' }] },
+        { indicator: '2.2.2.2', type: 'ip', risk: 'medium', threats: [], feeds: [] },
+      ],
+    });
+    const stats = summarisePulsedive(inds);
+    assert.equal(stats.total, 3);
+    assert.equal(stats.byRisk.high, 2);
+    assert.equal(stats.byRisk.medium, 1);
+    assert.equal(stats.byType.ip, 2);
+    assert.equal(stats.byType.domain, 1);
+    assert.equal(stats.topThreats[0]!.threat, 'Phishing');
+    assert.equal(stats.topThreats[0]!.count, 2);
+    assert.equal(stats.topFeeds[0]!.feed, 'OpenPhish');
+  });
+  it('tracks latestSeen across rows', () => {
+    // ISO with Z so Date.parse is timezone-stable across CI machines.
+    const inds = parsePulsediveIndicators({
+      results: [
+        { indicator: 'a', type: 'domain', risk: 'high', lastseen: '2026-05-08T00:00:00Z' },
+        { indicator: 'b', type: 'domain', risk: 'high', lastseen: '2026-05-01T00:00:00Z' },
+      ],
+    });
+    const stats = summarisePulsedive(inds);
+    assert.equal(stats.latestSeen, Date.parse('2026-05-08T00:00:00Z'));
+  });
+});
+
+describe('riskColor', () => {
+  it('returns a distinct hex per risk', () => {
+    const colors = new Set([
+      riskColor('none'),
+      riskColor('low'),
+      riskColor('medium'),
+      riskColor('high'),
+      riskColor('critical'),
+      riskColor('unknown'),
+    ]);
+    assert.ok(colors.size >= 5);
+  });
+});

--- a/src/services/security/__tests__/pulsedive-service.test.mts
+++ b/src/services/security/__tests__/pulsedive-service.test.mts
@@ -1,0 +1,102 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  clearPulsediveCache,
+  fetchPulsediveIndicators,
+} from '../pulsedive-service';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function mockFetch(handler: (url: string) => Response | Promise<Response>): void {
+  Reflect.set(globalThis, 'fetch', (input: unknown): Promise<Response> => {
+    const url = typeof input === 'string' ? input : (input as { url: string }).url;
+    return Promise.resolve(handler(url));
+  });
+}
+
+function restoreFetch(): void {
+  Reflect.set(globalThis, 'fetch', ORIGINAL_FETCH);
+}
+
+beforeEach(() => clearPulsediveCache());
+afterEach(() => restoreFetch());
+
+function exploreEnvelope(indicators: unknown[]): Response {
+  return new Response(
+    JSON.stringify({
+      indicators,
+      degraded: false,
+      source: 'pulsedive.com',
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  );
+}
+
+describe('fetchPulsediveIndicators', () => {
+  it('returns explore results parsed + summarised', async () => {
+    mockFetch(() => exploreEnvelope([
+      { indicator: 'evil.example.com', type: 'domain', risk: 'high', threats: [{ threat: 'Phishing' }] },
+    ]));
+    const env = await fetchPulsediveIndicators({ risk: 'high', limit: 50 });
+    assert.equal(env.indicators.length, 1);
+    assert.equal(env.indicators[0]!.risk, 'high');
+    assert.equal(env.stats.byRisk.high, 1);
+  });
+
+  it('uses a separate cache key per indicator lookup', async () => {
+    let calls = 0;
+    mockFetch(() => { calls += 1; return exploreEnvelope([]); });
+    await fetchPulsediveIndicators({ indicator: '1.1.1.1' });
+    await fetchPulsediveIndicators({ indicator: '1.1.1.1' });
+    await fetchPulsediveIndicators({ indicator: '2.2.2.2' });
+    assert.equal(calls, 2);
+  });
+
+  it('explore and lookup live in separate cache slots', async () => {
+    let calls = 0;
+    mockFetch(() => { calls += 1; return exploreEnvelope([]); });
+    await fetchPulsediveIndicators({ risk: 'high', limit: 50 });
+    await fetchPulsediveIndicators({ indicator: '1.1.1.1' });
+    assert.equal(calls, 2);
+  });
+
+  it('marks envelope degraded on non-2xx HTTP', async () => {
+    mockFetch(() => new Response('boom', { status: 502 }));
+    const env = await fetchPulsediveIndicators({ risk: 'high' });
+    assert.equal(env.degraded, true);
+    assert.match(env.reason ?? '', /HTTP 502/);
+  });
+
+  it('handles a sidecar `error` body as degraded', async () => {
+    mockFetch(() => new Response(JSON.stringify({ error: 'upstream offline' }), { status: 200 }));
+    const env = await fetchPulsediveIndicators({ risk: 'high' });
+    assert.equal(env.degraded, true);
+    assert.match(env.reason ?? '', /upstream offline/);
+  });
+
+  it('caches identical explore queries', async () => {
+    let calls = 0;
+    mockFetch(() => { calls += 1; return exploreEnvelope([]); });
+    await fetchPulsediveIndicators({ risk: 'high', limit: 50 });
+    await fetchPulsediveIndicators({ risk: 'high', limit: 50 });
+    assert.equal(calls, 1);
+  });
+
+  it('treats a different risk filter as a different cache key', async () => {
+    let calls = 0;
+    mockFetch(() => { calls += 1; return exploreEnvelope([]); });
+    await fetchPulsediveIndicators({ risk: 'high' });
+    await fetchPulsediveIndicators({ risk: 'medium' });
+    assert.equal(calls, 2);
+  });
+
+  it('clearPulsediveCache empties the cache', async () => {
+    let calls = 0;
+    mockFetch(() => { calls += 1; return exploreEnvelope([]); });
+    await fetchPulsediveIndicators({ risk: 'high' });
+    clearPulsediveCache();
+    await fetchPulsediveIndicators({ risk: 'high' });
+    assert.equal(calls, 2);
+  });
+});

--- a/src/services/security/__tests__/urlscan-classify.test.mts
+++ b/src/services/security/__tests__/urlscan-classify.test.mts
@@ -1,0 +1,138 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  classifyVerdict,
+  parseUrlscanThreats,
+  summariseUrlscan,
+  validateSubmitUrl,
+  verdictColor,
+} from '../urlscan-classify';
+
+describe('classifyVerdict', () => {
+  it('marks "malicious" verbatim as malicious', () => {
+    assert.equal(classifyVerdict('malicious', null), 'malicious');
+  });
+  it('uses score >= 50 as malicious', () => {
+    assert.equal(classifyVerdict(null, 65), 'malicious');
+  });
+  it('uses score in [10, 50) as suspicious', () => {
+    assert.equal(classifyVerdict(null, 30), 'suspicious');
+  });
+  it('treats clean/benign/zero-or-negative score as clean', () => {
+    assert.equal(classifyVerdict('clean', null), 'clean');
+    assert.equal(classifyVerdict('benign', null), 'clean');
+    assert.equal(classifyVerdict('clean', -5), 'clean');
+  });
+  it('defaults to unknown when nothing is known', () => {
+    assert.equal(classifyVerdict(null, null), 'unknown');
+    assert.equal(classifyVerdict('', null), 'unknown');
+  });
+});
+
+describe('parseUrlscanThreats', () => {
+  it('parses a representative search-result row', () => {
+    const threats = parseUrlscanThreats({
+      results: [
+        {
+          _id: 'abc-123',
+          task: { url: 'http://evil.example.com', time: '2026-05-08T12:00:00Z', uuid: 'abc-123' },
+          page: { url: 'http://evil.example.com/redirect', domain: 'evil.example.com', ip: '5.6.7.8', asn: 'AS999', asnname: 'EvilCorp', country: 'RU' },
+          verdicts: { overall: { malicious: true, score: 80, categories: ['phishing', 'malware'], brands: ['Office365'] } },
+          tags: ['credential-theft', 'fake-login'],
+          screenshot: 'https://urlscan.io/screenshots/abc.png',
+          result: 'https://urlscan.io/result/abc-123/',
+        },
+      ],
+    });
+    assert.equal(threats.length, 1);
+    const t = threats[0]!;
+    assert.equal(t.verdict, 'malicious');
+    assert.equal(t.verdictScore, 80);
+    assert.equal(t.domain, 'evil.example.com');
+    assert.deepEqual(t.categories, ['phishing', 'malware']);
+    assert.deepEqual(t.brands, ['Office365']);
+    assert.equal(t.country, 'RU');
+    assert.equal(t.screenshotUrl, 'https://urlscan.io/screenshots/abc.png');
+  });
+
+  it('skips rows without url or uuid', () => {
+    const threats = parseUrlscanThreats({
+      results: [
+        { _id: 'abc', task: {}, page: {} }, // missing url
+        { task: { url: 'http://x' } }, // missing uuid
+      ],
+    });
+    assert.equal(threats.length, 0);
+  });
+
+  it('accepts a raw array fallback shape', () => {
+    const threats = parseUrlscanThreats([
+      { _id: 'a', task: { url: 'http://x', uuid: 'a' }, page: {}, verdicts: { overall: { malicious: false, score: 5 } } },
+    ]);
+    assert.equal(threats.length, 1);
+    assert.equal(threats[0]!.verdict, 'unknown');
+  });
+
+  it('returns [] for malformed input', () => {
+    assert.deepEqual(parseUrlscanThreats(null), []);
+    assert.deepEqual(parseUrlscanThreats({ wrong: 'shape' }), []);
+  });
+});
+
+describe('summariseUrlscan', () => {
+  it('counts verdict buckets and ranks categories / brands', () => {
+    const threats = parseUrlscanThreats({
+      results: [
+        { _id: '1', task: { url: 'http://a', uuid: '1' }, page: {}, verdicts: { overall: { malicious: true, score: 90, categories: ['phishing'], brands: ['Office365'] } } },
+        { _id: '2', task: { url: 'http://b', uuid: '2' }, page: {}, verdicts: { overall: { malicious: true, score: 70, categories: ['phishing', 'malware'], brands: ['Office365', 'PayPal'] } } },
+        { _id: '3', task: { url: 'http://c', uuid: '3' }, page: {}, verdicts: { overall: { malicious: false, score: 5 } } },
+      ],
+    });
+    const stats = summariseUrlscan(threats);
+    assert.equal(stats.total, 3);
+    assert.equal(stats.byVerdict.malicious, 2);
+    assert.equal(stats.topCategories[0]!.category, 'phishing');
+    assert.equal(stats.topCategories[0]!.count, 2);
+    assert.equal(stats.topBrands[0]!.brand, 'Office365');
+  });
+});
+
+describe('validateSubmitUrl', () => {
+  it('accepts a normal https URL', () => {
+    const r = validateSubmitUrl('https://example.com/path');
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.url, 'https://example.com/path');
+  });
+  it('accepts a bare host and normalises to https', () => {
+    const r = validateSubmitUrl('example.com');
+    assert.equal(r.ok, true);
+    if (r.ok) assert.ok(r.url.startsWith('https://example.com'));
+  });
+  it('rejects empty input', () => {
+    const r = validateSubmitUrl('');
+    assert.equal(r.ok, false);
+  });
+  it('rejects private IP hosts', () => {
+    for (const host of ['http://127.0.0.1', 'http://10.0.0.1', 'http://192.168.1.1', 'http://172.16.0.1', 'http://localhost', 'http://service.local']) {
+      const r = validateSubmitUrl(host);
+      assert.equal(r.ok, false, `expected ${host} to be rejected`);
+    }
+  });
+  it('rejects non-http(s) protocols', () => {
+    const r = validateSubmitUrl('ftp://example.com');
+    assert.equal(r.ok, false);
+  });
+});
+
+describe('verdictColor', () => {
+  it('returns a distinct hex per verdict', () => {
+    const colors = new Set([
+      verdictColor('malicious'),
+      verdictColor('suspicious'),
+      verdictColor('clean'),
+      verdictColor('unknown'),
+    ]);
+    assert.equal(colors.size, 4);
+  });
+});

--- a/src/services/security/__tests__/urlscan-service.test.mts
+++ b/src/services/security/__tests__/urlscan-service.test.mts
@@ -1,0 +1,113 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  clearUrlscanCache,
+  fetchUrlscanThreats,
+  submitUrlscan,
+} from '../urlscan-service';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function mockFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>): void {
+  Reflect.set(globalThis, 'fetch', (input: unknown, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === 'string' ? input : (input as { url: string }).url;
+    return Promise.resolve(handler(url, init));
+  });
+}
+
+function restoreFetch(): void {
+  Reflect.set(globalThis, 'fetch', ORIGINAL_FETCH);
+}
+
+beforeEach(() => clearUrlscanCache());
+afterEach(() => restoreFetch());
+
+const SEARCH_ENVELOPE_BODY = () => new Response(
+  JSON.stringify({
+    results: [
+      { _id: '1', task: { url: 'http://evil', uuid: '1' }, page: { domain: 'evil' }, verdicts: { overall: { malicious: true, score: 90, categories: ['phishing'] } } },
+    ],
+    total: 1,
+    fetchedAt: Date.now(),
+    degraded: false,
+    source: 'urlscan.io',
+  }),
+  { status: 200, headers: { 'Content-Type': 'application/json' } },
+);
+
+describe('fetchUrlscanThreats', () => {
+  it('parses + classifies sidecar response into the envelope', async () => {
+    mockFetch(SEARCH_ENVELOPE_BODY);
+    const env = await fetchUrlscanThreats();
+    assert.equal(env.threats.length, 1);
+    assert.equal(env.threats[0]!.verdict, 'malicious');
+    assert.equal(env.stats.byVerdict.malicious, 1);
+  });
+
+  it('marks envelope degraded on non-2xx HTTP', async () => {
+    mockFetch(() => new Response('boom', { status: 503 }));
+    const env = await fetchUrlscanThreats();
+    assert.equal(env.degraded, true);
+    assert.match(env.reason ?? '', /HTTP 503/);
+  });
+
+  it('caches identical (q, size) requests', async () => {
+    let calls = 0;
+    mockFetch(() => { calls += 1; return SEARCH_ENVELOPE_BODY(); });
+    await fetchUrlscanThreats({ q: 'malicious:true', size: 10 });
+    await fetchUrlscanThreats({ q: 'malicious:true', size: 10 });
+    assert.equal(calls, 1);
+  });
+
+  it('treats different (q) as different cache keys', async () => {
+    let calls = 0;
+    mockFetch(() => { calls += 1; return SEARCH_ENVELOPE_BODY(); });
+    await fetchUrlscanThreats({ q: 'malicious:true' });
+    await fetchUrlscanThreats({ q: 'page.domain:evil.example.com' });
+    assert.equal(calls, 2);
+  });
+
+  it('clearUrlscanCache forces a refetch', async () => {
+    let calls = 0;
+    mockFetch(() => { calls += 1; return SEARCH_ENVELOPE_BODY(); });
+    await fetchUrlscanThreats();
+    clearUrlscanCache();
+    await fetchUrlscanThreats();
+    assert.equal(calls, 2);
+  });
+});
+
+describe('submitUrlscan', () => {
+  it('returns the report URL on success', async () => {
+    mockFetch((url, init) => {
+      assert.match(url, /\/api\/security\/urlscan\/submit$/);
+      assert.equal(init?.method, 'POST');
+      return new Response(
+        JSON.stringify({ uuid: 'submitted-uuid', result: 'https://urlscan.io/result/submitted-uuid/', api: 'https://urlscan.io/api/v1/result/submitted-uuid/' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+    const r = await submitUrlscan('https://example.com/path');
+    assert.equal(r.ok, true);
+    if (r.ok) {
+      assert.equal(r.uuid, 'submitted-uuid');
+      assert.match(r.reportUrl ?? '', /submitted-uuid/);
+    }
+  });
+
+  it('rejects a private host without calling the sidecar', async () => {
+    let calls = 0;
+    mockFetch(() => { calls += 1; return new Response('{}', { status: 200 }); });
+    const r = await submitUrlscan('http://10.0.0.1');
+    assert.equal(r.ok, false);
+    assert.equal(calls, 0);
+  });
+
+  it('surfaces sidecar errors', async () => {
+    mockFetch(() => new Response(JSON.stringify({ error: 'urlscan rejected anonymous submit' }), { status: 401 }));
+    const r = await submitUrlscan('https://example.com');
+    assert.equal(r.ok, false);
+    assert.match(r.error ?? '', /rejected/);
+  });
+});

--- a/src/services/security/phishstats-classify.ts
+++ b/src/services/security/phishstats-classify.ts
@@ -1,0 +1,168 @@
+/**
+ * PhishStats — pure-deterministic parsing + classification.
+ *
+ * Upstream returns one row per phishing URL. Each row has a confidence score
+ * (0–10), a target brand string, the IP/country, and a date. Higher score =
+ * higher confidence the URL is malicious.
+ */
+
+export type PhishSeverity = 'low' | 'medium' | 'high' | 'critical';
+
+export interface PhishingRecord {
+  id: string;
+  url: string;
+  /** PhishStats confidence score, 0–10 (10 = highest confidence). */
+  score: number;
+  severity: PhishSeverity;
+  /** Target brand (e.g. "Microsoft", "PayPal") — null when not detected. */
+  target: string | null;
+  ip: string | null;
+  countryCode: string | null;
+  countryName: string | null;
+  /** Detection timestamp, unix ms. */
+  detectedAt: number;
+  asn: string | null;
+}
+
+export function classifyScore(score: number): PhishSeverity {
+  if (!Number.isFinite(score)) return 'low';
+  if (score >= 9) return 'critical';
+  if (score >= 7) return 'high';
+  if (score >= 5) return 'medium';
+  return 'low';
+}
+
+function pickString(...values: unknown[]): string | null {
+  for (const v of values) {
+    if (typeof v === 'string') {
+      const trimmed = v.trim();
+      if (trimmed.length > 0) return trimmed;
+    }
+  }
+  return null;
+}
+
+function pickNumber(...values: unknown[]): number | null {
+  for (const v of values) {
+    if (typeof v === 'number' && Number.isFinite(v)) return v;
+    if (typeof v === 'string' && v.trim()) {
+      const n = Number(v);
+      if (Number.isFinite(n)) return n;
+    }
+  }
+  return null;
+}
+
+function parseTimestamp(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value < 10_000_000_000 ? value * 1000 : value;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const t = Date.parse(value);
+    if (Number.isFinite(t)) return t;
+  }
+  return Date.now();
+}
+
+/**
+ * Parse a raw PhishStats payload (array-of-objects) into typed records. Bad
+ * rows are skipped — callers get a clean envelope, not a thrown exception.
+ */
+export function parsePhishingRecords(payload: unknown): PhishingRecord[] {
+  if (!Array.isArray(payload)) return [];
+  const out: PhishingRecord[] = [];
+  for (const raw of payload) {
+    if (!raw || typeof raw !== 'object') continue;
+    const r = raw as Record<string, unknown>;
+    const url = pickString(r.url);
+    if (!url) continue;
+    const score = pickNumber(r.score) ?? 0;
+    const id = pickString(r.id) ?? `${url}#${out.length}`;
+    out.push({
+      id,
+      url,
+      score,
+      severity: classifyScore(score),
+      target: pickString(r.title, r.target),
+      ip: pickString(r.ip),
+      countryCode: pickString(r.countrycode, r.country_code, r.cc),
+      countryName: pickString(r.countryname, r.country_name, r.country),
+      detectedAt: parseTimestamp(r.date ?? r.added),
+      asn: pickString(r.asn, r.bgp),
+    });
+  }
+  return out;
+}
+
+export interface PhishingStats {
+  total: number;
+  bySeverity: Record<PhishSeverity, number>;
+  topTargets: { target: string; count: number }[];
+  topCountries: { countryCode: string; countryName: string | null; count: number }[];
+  /** Max detection timestamp seen, unix ms — null when no rows had a date. */
+  latestDetectedAt: number | null;
+}
+
+export function summarisePhishing(
+  records: readonly PhishingRecord[],
+  topN = 5,
+): PhishingStats {
+  const stats: PhishingStats = {
+    total: records.length,
+    bySeverity: { low: 0, medium: 0, high: 0, critical: 0 },
+    topTargets: [],
+    topCountries: [],
+    latestDetectedAt: null,
+  };
+  const targets = new Map<string, number>();
+  const countries = new Map<string, { name: string | null; count: number }>();
+  for (const r of records) {
+    stats.bySeverity[r.severity] += 1;
+    if (r.target) targets.set(r.target, (targets.get(r.target) ?? 0) + 1);
+    if (r.countryCode) {
+      const prior = countries.get(r.countryCode);
+      countries.set(r.countryCode, {
+        name: prior?.name ?? r.countryName,
+        count: (prior?.count ?? 0) + 1,
+      });
+    }
+    if (stats.latestDetectedAt === null || r.detectedAt > stats.latestDetectedAt) {
+      stats.latestDetectedAt = r.detectedAt;
+    }
+  }
+  stats.topTargets = [...targets.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, topN)
+    .map(([target, count]) => ({ target, count }));
+  stats.topCountries = [...countries.entries()]
+    .sort((a, b) => b[1].count - a[1].count)
+    .slice(0, topN)
+    .map(([countryCode, v]) => ({ countryCode, countryName: v.name, count: v.count }));
+  return stats;
+}
+
+export function filterByMinScore(
+  records: readonly PhishingRecord[],
+  minScore: number,
+): PhishingRecord[] {
+  return records.filter((r) => r.score >= minScore);
+}
+
+const SEVERITY_HEX: Record<PhishSeverity, string> = {
+  low: '#9e9e9e',
+  medium: '#ffeb3b',
+  high: '#ff9800',
+  critical: '#d50000',
+};
+
+export function severityColor(severity: PhishSeverity): string {
+  return SEVERITY_HEX[severity];
+}
+
+const MAX_DISPLAY_LEN = 60;
+
+/** Truncate a URL for the table display — keep the host + start of the path. */
+export function truncateUrl(url: string, maxLen = MAX_DISPLAY_LEN): string {
+  if (url.length <= maxLen) return url;
+  return `${url.slice(0, maxLen - 1)}…`;
+}

--- a/src/services/security/phishstats-service.ts
+++ b/src/services/security/phishstats-service.ts
@@ -1,0 +1,130 @@
+/**
+ * PhishStats — renderer-side fetcher for `/api/security/phishing`.
+ *
+ * Thin I/O wrapper. Parsing + classification live in
+ * `phishstats-classify.ts`. 30-min memory cache to respect upstream rate
+ * limits.
+ */
+
+import { getApiBaseUrl } from '../runtime';
+import {
+  parsePhishingRecords,
+  summarisePhishing,
+  type PhishingRecord,
+  type PhishingStats,
+} from './phishstats-classify';
+
+const POLL_INTERVAL_MS = 30 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 12 * 1000;
+
+export interface PhishingEnvelope {
+  records: PhishingRecord[];
+  stats: PhishingStats;
+  fetchedAt: number;
+  degraded: boolean;
+  reason?: string;
+  source: string;
+}
+
+interface CacheEntry {
+  envelope: PhishingEnvelope;
+  fetchedAt: number;
+  key: string;
+}
+
+let cache: CacheEntry | null = null;
+let inflight: Promise<PhishingEnvelope> | null = null;
+
+function emptyEnvelope(reason: string): PhishingEnvelope {
+  return {
+    records: [],
+    stats: summarisePhishing([]),
+    fetchedAt: Date.now(),
+    degraded: true,
+    reason,
+    source: 'phishstats.info',
+  };
+}
+
+export interface FetchPhishingOptions {
+  limit?: number;
+  minScore?: number;
+}
+
+export async function fetchPhishingRecords(
+  options: FetchPhishingOptions = {},
+): Promise<PhishingEnvelope> {
+  const limit = clamp(options.limit ?? 50, 1, 500);
+  const minScore = clamp(options.minScore ?? 5, 0, 10);
+  const key = `${limit}:${minScore}`;
+  const now = Date.now();
+
+  if (cache?.key === key && now - cache.fetchedAt < POLL_INTERVAL_MS) {
+    return cache.envelope;
+  }
+  if (inflight) return inflight;
+
+  inflight = (async (): Promise<PhishingEnvelope> => {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+      const url = `${getApiBaseUrl()}/api/security/phishing?limit=${limit}&minScore=${minScore}`;
+      const response = await fetch(url, {
+        signal: controller.signal,
+        headers: { Accept: 'application/json' },
+      });
+      clearTimeout(timer);
+      if (!response.ok) {
+        return { ...emptyEnvelope(`HTTP ${response.status}`), fetchedAt: now };
+      }
+      const body = (await response.json()) as Partial<PhishingEnvelope> & {
+        error?: string;
+      };
+      // Accept either pre-shaped envelope, or raw PhishStats array.
+      let records: PhishingRecord[];
+      if (Array.isArray(body.records)) {
+        records = body.records as PhishingRecord[];
+      } else if (Array.isArray(body)) {
+        records = parsePhishingRecords(body);
+      } else if (body.error) {
+        return { ...emptyEnvelope(body.error), fetchedAt: now };
+      } else {
+        records = [];
+      }
+      const envelope: PhishingEnvelope = {
+        records,
+        stats: body.stats ?? summarisePhishing(records),
+        fetchedAt: now,
+        degraded: body.degraded ?? false,
+        reason: body.reason,
+        source: body.source ?? 'phishstats.info',
+      };
+      cache = { envelope, fetchedAt: now, key };
+      return envelope;
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      return { ...emptyEnvelope(reason), fetchedAt: now };
+    } finally {
+      inflight = null;
+    }
+  })();
+
+  return inflight;
+}
+
+export function clearPhishingCache(): void {
+  cache = null;
+  inflight = null;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, Math.floor(value)));
+}
+
+export const __TEST_HOOKS__ = {
+  get cache(): CacheEntry | null {
+    return cache;
+  },
+  POLL_INTERVAL_MS,
+};

--- a/src/services/security/pulsedive-classify.ts
+++ b/src/services/security/pulsedive-classify.ts
@@ -1,0 +1,224 @@
+/**
+ * Pulsedive — pure-deterministic parsing + classification for threat
+ * indicators (IPs, domains, URLs, hashes).
+ *
+ * Pulsedive's public API returns indicator records with a textual risk
+ * level (`none`/`low`/`medium`/`high`/`critical`), a `risk_recommended`
+ * for the consensus level, an indicator `type`, a `threats` array, and
+ * `lastseen` timestamp. We project these into a typed `PulsediveIndicator`.
+ */
+
+export type PulsediveRisk = 'none' | 'low' | 'medium' | 'high' | 'critical' | 'unknown';
+
+export type PulsediveType =
+  | 'ip'
+  | 'ipv6'
+  | 'domain'
+  | 'url'
+  | 'hash'
+  | 'email'
+  | 'unknown';
+
+export interface PulsediveIndicator {
+  /** Pulsedive numeric ID. */
+  iid: number | null;
+  /** Indicator value (e.g. "1.2.3.4", "evil.example.com"). */
+  indicator: string;
+  type: PulsediveType;
+  risk: PulsediveRisk;
+  /** Recommended consensus risk when present. */
+  riskRecommended: PulsediveRisk;
+  /** Active threat tags ("Phishing", "Ransomware", ...). */
+  threats: string[];
+  /** Active threat feeds the indicator appears in. */
+  feeds: string[];
+  /** First-seen timestamp (unix ms), null when missing. */
+  firstSeen: number | null;
+  /** Last-seen timestamp (unix ms), null when missing. */
+  lastSeen: number | null;
+}
+
+const RISK_ORDER: Record<PulsediveRisk, number> = {
+  none: 0,
+  unknown: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+};
+
+export function classifyRisk(raw: unknown): PulsediveRisk {
+  if (typeof raw !== 'string') return 'unknown';
+  const v = raw.toLowerCase().trim();
+  if (v === 'none') return 'none';
+  if (v === 'low') return 'low';
+  if (v === 'medium') return 'medium';
+  if (v === 'high') return 'high';
+  if (v === 'critical') return 'critical';
+  return 'unknown';
+}
+
+export function classifyType(raw: unknown): PulsediveType {
+  if (typeof raw !== 'string') return 'unknown';
+  const v = raw.toLowerCase().trim();
+  if (v === 'ip') return 'ip';
+  if (v === 'ipv6') return 'ipv6';
+  if (v === 'domain') return 'domain';
+  if (v === 'url') return 'url';
+  if (v === 'hash' || v === 'md5' || v === 'sha1' || v === 'sha256') return 'hash';
+  if (v === 'email') return 'email';
+  return 'unknown';
+}
+
+function pickString(...values: unknown[]): string | null {
+  for (const v of values) {
+    if (typeof v === 'string') {
+      const trimmed = v.trim();
+      if (trimmed.length > 0) return trimmed;
+    }
+  }
+  return null;
+}
+
+function pickInt(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return Math.trunc(value);
+  if (typeof value === 'string' && value.trim()) {
+    const n = Number.parseInt(value, 10);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+function parseTimestamp(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value < 10_000_000_000 ? value * 1000 : value;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const t = Date.parse(value);
+    if (Number.isFinite(t)) return t;
+  }
+  return null;
+}
+
+function pickStringArrayFromObjects(value: unknown, key: string): string[] {
+  if (!Array.isArray(value)) return [];
+  const out: string[] = [];
+  for (const v of value) {
+    if (typeof v === 'string' && v.trim()) {
+      out.push(v.trim());
+    } else if (v && typeof v === 'object') {
+      const obj = v as Record<string, unknown>;
+      const s = pickString(obj[key], obj.name);
+      if (s) out.push(s);
+    }
+  }
+  return out;
+}
+
+/**
+ * Parse a Pulsedive payload. Accepts:
+ *  - the `info.php` shape (single indicator object — wrap in array),
+ *  - the `explore.php` shape (`{ results: [...] }`),
+ *  - or a bare array of indicator objects.
+ */
+export function parsePulsediveIndicators(payload: unknown): PulsediveIndicator[] {
+  let rows: unknown[] = [];
+  if (Array.isArray(payload)) {
+    rows = payload;
+  } else if (payload && typeof payload === 'object') {
+    const p = payload as Record<string, unknown>;
+    if (Array.isArray(p.results)) {
+      rows = p.results as unknown[];
+    } else if (Array.isArray(p.indicators)) {
+      rows = p.indicators as unknown[];
+    } else if (typeof p.indicator === 'string') {
+      // info.php single-result shape: wrap.
+      rows = [p];
+    }
+  }
+  const out: PulsediveIndicator[] = [];
+  for (const raw of rows) {
+    if (!raw || typeof raw !== 'object') continue;
+    const r = raw as Record<string, unknown>;
+    const indicator = pickString(r.indicator, r.value);
+    if (!indicator) continue;
+    out.push({
+      iid: pickInt(r.iid ?? r.id),
+      indicator,
+      type: classifyType(r.type),
+      risk: classifyRisk(r.risk),
+      riskRecommended: classifyRisk(r.risk_recommended ?? r.riskRecommended ?? r.risk),
+      threats: pickStringArrayFromObjects(r.threats, 'threat'),
+      feeds: pickStringArrayFromObjects(r.feeds, 'feed'),
+      firstSeen: parseTimestamp(r.firstseen ?? r.first_seen ?? r.added),
+      lastSeen: parseTimestamp(r.lastseen ?? r.last_seen ?? r.updated),
+    });
+  }
+  return out;
+}
+
+const RISK_HEX: Record<PulsediveRisk, string> = {
+  none: '#4caf50',
+  unknown: '#9e9e9e',
+  low: '#8bc34a',
+  medium: '#ffeb3b',
+  high: '#ff9800',
+  critical: '#d50000',
+};
+
+export function riskColor(risk: PulsediveRisk): string {
+  return RISK_HEX[risk];
+}
+
+/** Compare two risks; positive when `a` is more severe than `b`. */
+export function compareRisk(a: PulsediveRisk, b: PulsediveRisk): number {
+  return RISK_ORDER[a] - RISK_ORDER[b];
+}
+
+export interface PulsediveStats {
+  total: number;
+  byRisk: Record<PulsediveRisk, number>;
+  byType: Record<PulsediveType, number>;
+  topThreats: { threat: string; count: number }[];
+  topFeeds: { feed: string; count: number }[];
+  latestSeen: number | null;
+}
+
+const EMPTY_RISK_COUNTS: () => Record<PulsediveRisk, number> = () => ({
+  none: 0, low: 0, medium: 0, high: 0, critical: 0, unknown: 0,
+});
+const EMPTY_TYPE_COUNTS: () => Record<PulsediveType, number> = () => ({
+  ip: 0, ipv6: 0, domain: 0, url: 0, hash: 0, email: 0, unknown: 0,
+});
+
+export function summarisePulsedive(indicators: readonly PulsediveIndicator[]): PulsediveStats {
+  const stats: PulsediveStats = {
+    total: indicators.length,
+    byRisk: EMPTY_RISK_COUNTS(),
+    byType: EMPTY_TYPE_COUNTS(),
+    topThreats: [],
+    topFeeds: [],
+    latestSeen: null,
+  };
+  const threats = new Map<string, number>();
+  const feeds = new Map<string, number>();
+  for (const ind of indicators) {
+    stats.byRisk[ind.risk] += 1;
+    stats.byType[ind.type] += 1;
+    for (const t of ind.threats) threats.set(t, (threats.get(t) ?? 0) + 1);
+    for (const f of ind.feeds) feeds.set(f, (feeds.get(f) ?? 0) + 1);
+    if (ind.lastSeen !== null && (stats.latestSeen === null || ind.lastSeen > stats.latestSeen)) {
+      stats.latestSeen = ind.lastSeen;
+    }
+  }
+  stats.topThreats = [...threats.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8)
+    .map(([threat, count]) => ({ threat, count }));
+  stats.topFeeds = [...feeds.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8)
+    .map(([feed, count]) => ({ feed, count }));
+  return stats;
+}

--- a/src/services/security/pulsedive-service.ts
+++ b/src/services/security/pulsedive-service.ts
@@ -1,0 +1,155 @@
+/**
+ * Pulsedive — renderer fetcher. Two query modes:
+ *   - explore: `risk:high type:domain limit:50` (default)
+ *   - lookup: pass an `indicator` (IP/domain/URL) to `info.php`
+ *
+ * 1-hour cache on each (risk,type,limit) and per-indicator lookup key.
+ */
+
+import { getApiBaseUrl } from '../runtime';
+import {
+  parsePulsediveIndicators,
+  summarisePulsedive,
+  type PulsediveIndicator,
+  type PulsediveRisk,
+  type PulsediveStats,
+  type PulsediveType,
+} from './pulsedive-classify';
+
+const POLL_INTERVAL_MS = 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 12 * 1000;
+
+export interface PulsediveEnvelope {
+  indicators: PulsediveIndicator[];
+  stats: PulsediveStats;
+  query: { risk: string; type: string; limit: number; indicator: string | null };
+  fetchedAt: number;
+  degraded: boolean;
+  reason?: string;
+  source: string;
+}
+
+interface CacheEntry {
+  envelope: PulsediveEnvelope;
+  fetchedAt: number;
+  key: string;
+}
+
+const cache = new Map<string, CacheEntry>();
+const inflight = new Map<string, Promise<PulsediveEnvelope>>();
+
+export interface FetchPulsediveOptions {
+  risk?: PulsediveRisk | 'all';
+  type?: PulsediveType | 'all';
+  limit?: number;
+  indicator?: string;
+}
+
+function emptyEnvelope(
+  reason: string,
+  query: PulsediveEnvelope['query'],
+): PulsediveEnvelope {
+  return {
+    indicators: [],
+    stats: summarisePulsedive([]),
+    query,
+    fetchedAt: Date.now(),
+    degraded: true,
+    reason,
+    source: 'pulsedive.com',
+  };
+}
+
+export async function fetchPulsediveIndicators(
+  options: FetchPulsediveOptions = {},
+): Promise<PulsediveEnvelope> {
+  const risk: PulsediveRisk | 'all' = options.risk ?? 'high';
+  const type: PulsediveType | 'all' = options.type ?? 'all';
+  const limit = clamp(options.limit ?? 50, 1, 100);
+  const indicator = (options.indicator ?? '').trim();
+  const query: PulsediveEnvelope['query'] = {
+    risk,
+    type,
+    limit,
+    indicator: indicator || null,
+  };
+  const key = indicator
+    ? `lookup:${indicator.toLowerCase()}`
+    : `explore:${risk}:${type}:${limit}`;
+  const now = Date.now();
+
+  const cached = cache.get(key);
+  if (cached && now - cached.fetchedAt < POLL_INTERVAL_MS) {
+    return cached.envelope;
+  }
+  const pending = inflight.get(key);
+  if (pending) return pending;
+
+  const promise = (async (): Promise<PulsediveEnvelope> => {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+      const params = new URLSearchParams();
+      params.set('risk', risk);
+      params.set('type', type);
+      params.set('limit', String(limit));
+      if (indicator) params.set('indicator', indicator);
+      const url = `${getApiBaseUrl()}/api/security/pulsedive?${params.toString()}`;
+      const response = await fetch(url, {
+        signal: controller.signal,
+        headers: { Accept: 'application/json' },
+      });
+      clearTimeout(timer);
+      if (!response.ok) {
+        return { ...emptyEnvelope(`HTTP ${response.status}`, query), fetchedAt: now };
+      }
+      const body = (await response.json()) as {
+        indicators?: unknown;
+        degraded?: boolean;
+        reason?: string;
+        source?: string;
+        error?: string;
+      };
+      if (body.error) {
+        return { ...emptyEnvelope(body.error, query), fetchedAt: now };
+      }
+      const indicators = parsePulsediveIndicators(body.indicators ?? body);
+      const envelope: PulsediveEnvelope = {
+        indicators,
+        stats: summarisePulsedive(indicators),
+        query,
+        fetchedAt: now,
+        degraded: body.degraded ?? false,
+        reason: body.reason,
+        source: body.source ?? 'pulsedive.com',
+      };
+      cache.set(key, { envelope, fetchedAt: now, key });
+      return envelope;
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      return { ...emptyEnvelope(reason, query), fetchedAt: now };
+    } finally {
+      inflight.delete(key);
+    }
+  })();
+
+  inflight.set(key, promise);
+  return promise;
+}
+
+export function clearPulsediveCache(): void {
+  cache.clear();
+  inflight.clear();
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, Math.floor(value)));
+}
+
+export const __TEST_HOOKS__ = {
+  get cache(): Map<string, CacheEntry> {
+    return cache;
+  },
+  POLL_INTERVAL_MS,
+};

--- a/src/services/security/urlscan-classify.ts
+++ b/src/services/security/urlscan-classify.ts
@@ -1,0 +1,209 @@
+/**
+ * urlscan.io — pure-deterministic parsing + classification.
+ *
+ * The search API returns one record per scan. We project the nested
+ * `page` / `task` / `verdicts` blocks into a flat `UrlscanThreat` and
+ * classify the verdict as malicious / suspicious / clean / unknown.
+ */
+
+export type UrlscanVerdict = 'malicious' | 'suspicious' | 'clean' | 'unknown';
+
+export interface UrlscanThreat {
+  /** urlscan.io scan UUID. */
+  uuid: string;
+  /** Page URL after redirects (display URL). */
+  url: string;
+  domain: string | null;
+  ip: string | null;
+  asn: string | null;
+  country: string | null;
+  verdict: UrlscanVerdict;
+  /** Numeric verdict score, when present (-100..100; positive = malicious). */
+  verdictScore: number | null;
+  categories: string[];
+  brands: string[];
+  tags: string[];
+  /** Direct URL to a screenshot PNG (urlscan-hosted). */
+  screenshotUrl: string | null;
+  reportUrl: string | null;
+  scannedAt: number;
+}
+
+function pickString(...values: unknown[]): string | null {
+  for (const v of values) {
+    if (typeof v === 'string') {
+      const trimmed = v.trim();
+      if (trimmed.length > 0) return trimmed;
+    }
+  }
+  return null;
+}
+
+function pickStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const out: string[] = [];
+  for (const v of value) {
+    if (typeof v === 'string' && v.trim()) out.push(v.trim());
+  }
+  return out;
+}
+
+function parseTimestamp(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value < 10_000_000_000 ? value * 1000 : value;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const t = Date.parse(value);
+    if (Number.isFinite(t)) return t;
+  }
+  return Date.now();
+}
+
+export function classifyVerdict(
+  rawVerdict: unknown,
+  score: number | null,
+): UrlscanVerdict {
+  const raw = typeof rawVerdict === 'string' ? rawVerdict.toLowerCase() : '';
+  if (raw.includes('malicious') || (typeof score === 'number' && score >= 50)) return 'malicious';
+  if (raw.includes('suspicious') || (typeof score === 'number' && score >= 10)) return 'suspicious';
+  if (raw === 'clean' || raw === 'benign' || (typeof score === 'number' && score <= 0 && raw !== '')) return 'clean';
+  return 'unknown';
+}
+
+function deriveVerdictRaw(
+  overall: Record<string, unknown>,
+  rowVerdict: unknown,
+  verdictScore: number | null,
+): string | null {
+  if (overall.malicious === true) return 'malicious';
+  if (overall.malicious === false) {
+    if (verdictScore !== null && verdictScore <= 0) return 'clean';
+    return 'unknown';
+  }
+  return pickString(rowVerdict);
+}
+
+function parseUrlscanRow(raw: unknown): UrlscanThreat | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  const task = (r.task as Record<string, unknown> | undefined) ?? {};
+  const page = (r.page as Record<string, unknown> | undefined) ?? {};
+  const verdicts = (r.verdicts as Record<string, unknown> | undefined) ?? {};
+  const overall = (verdicts.overall as Record<string, unknown> | undefined) ?? {};
+  const url = pickString(task.url, page.url, r.url);
+  const uuid = pickString(r._id, task.uuid, r.uuid);
+  if (!url || !uuid) return null;
+  const rawScore = (overall.score ?? r.score) as unknown;
+  const verdictScore = typeof rawScore === 'number' && Number.isFinite(rawScore) ? rawScore : null;
+  const verdictRaw = deriveVerdictRaw(overall, r.verdict, verdictScore);
+  return {
+    uuid,
+    url,
+    domain: pickString(page.domain, task.domain),
+    ip: pickString(page.ip, task.ip),
+    asn: pickString(page.asn, page.asnname),
+    country: pickString(page.country),
+    verdict: classifyVerdict(verdictRaw, verdictScore),
+    verdictScore,
+    categories: pickStringArray(overall.categories),
+    brands: pickStringArray(overall.brands),
+    tags: pickStringArray(r.tags ?? task.tags),
+    screenshotUrl: pickString(r.screenshot),
+    reportUrl: pickString(r.result, task.reportURL),
+    scannedAt: parseTimestamp(task.time ?? r.time ?? task.timestamp),
+  };
+}
+
+/**
+ * Parse a urlscan.io search-API payload (`{ results: [...] }`) into typed
+ * threats. Tolerates raw arrays and skips bad rows.
+ */
+export function parseUrlscanThreats(payload: unknown): UrlscanThreat[] {
+  let results: unknown[] = [];
+  if (Array.isArray(payload)) {
+    results = payload;
+  } else if (payload && typeof payload === 'object') {
+    const p = payload as Record<string, unknown>;
+    if (Array.isArray(p.results)) results = p.results as unknown[];
+  }
+  const out: UrlscanThreat[] = [];
+  for (const raw of results) {
+    const parsed = parseUrlscanRow(raw);
+    if (parsed) out.push(parsed);
+  }
+  return out;
+}
+
+export interface UrlscanStats {
+  total: number;
+  byVerdict: Record<UrlscanVerdict, number>;
+  topCategories: { category: string; count: number }[];
+  topBrands: { brand: string; count: number }[];
+}
+
+export function summariseUrlscan(threats: readonly UrlscanThreat[]): UrlscanStats {
+  const stats: UrlscanStats = {
+    total: threats.length,
+    byVerdict: { malicious: 0, suspicious: 0, clean: 0, unknown: 0 },
+    topCategories: [],
+    topBrands: [],
+  };
+  const cats = new Map<string, number>();
+  const brands = new Map<string, number>();
+  for (const t of threats) {
+    stats.byVerdict[t.verdict] += 1;
+    for (const c of t.categories) cats.set(c, (cats.get(c) ?? 0) + 1);
+    for (const b of t.brands) brands.set(b, (brands.get(b) ?? 0) + 1);
+  }
+  stats.topCategories = [...cats.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 6)
+    .map(([category, count]) => ({ category, count }));
+  stats.topBrands = [...brands.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 6)
+    .map(([brand, count]) => ({ brand, count }));
+  return stats;
+}
+
+const VERDICT_HEX: Record<UrlscanVerdict, string> = {
+  malicious: '#d50000',
+  suspicious: '#ff9800',
+  clean: '#4caf50',
+  unknown: '#9e9e9e',
+};
+
+export function verdictColor(verdict: UrlscanVerdict): string {
+  return VERDICT_HEX[verdict];
+}
+
+/**
+ * Validate a URL the user typed into the Scan input. Returns the normalised
+ * URL string on success or an error message on failure. Blocks SSRF prone
+ * private hosts so the sidecar can fail closed even if its own check slips.
+ */
+export function validateSubmitUrl(input: string): { ok: true; url: string } | { ok: false; error: string } {
+  const trimmed = input.trim();
+  if (!trimmed) return { ok: false, error: 'URL is empty' };
+  let parsed: URL;
+  try { parsed = new URL(trimmed.includes('://') ? trimmed : `https://${trimmed}`); }
+  catch { return { ok: false, error: 'Not a valid URL' }; }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { ok: false, error: 'Only http(s) URLs accepted' };
+  }
+  const host = parsed.hostname.toLowerCase();
+  // eslint-disable-next-line no-restricted-syntax -- user-typed host being validated, not a value we send.
+  const isLoopbackName = host === 'localhost';
+  if (
+    isLoopbackName ||
+    host === '0.0.0.0' ||
+    host.startsWith('127.') ||
+    host.startsWith('10.') ||
+    host.startsWith('192.168.') ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
+    host.endsWith('.local')
+  ) {
+    return { ok: false, error: 'Private host blocked' };
+  }
+  return { ok: true, url: parsed.toString() };
+}

--- a/src/services/security/urlscan-service.ts
+++ b/src/services/security/urlscan-service.ts
@@ -1,0 +1,165 @@
+/**
+ * urlscan.io — renderer fetcher for `/api/security/urlscan` (search) and
+ * `/api/security/urlscan/submit` (POST scan request). 15-min cache on the
+ * search side; submit is uncached.
+ */
+
+import { getApiBaseUrl } from '../runtime';
+import {
+  parseUrlscanThreats,
+  summariseUrlscan,
+  validateSubmitUrl,
+  type UrlscanStats,
+  type UrlscanThreat,
+} from './urlscan-classify';
+
+const POLL_INTERVAL_MS = 15 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 12 * 1000;
+
+export interface UrlscanEnvelope {
+  threats: UrlscanThreat[];
+  stats: UrlscanStats;
+  total: number;
+  fetchedAt: number;
+  degraded: boolean;
+  reason?: string;
+  source: string;
+}
+
+interface CacheEntry {
+  envelope: UrlscanEnvelope;
+  fetchedAt: number;
+  key: string;
+}
+
+let cache: CacheEntry | null = null;
+let inflight: Promise<UrlscanEnvelope> | null = null;
+
+function emptyEnvelope(reason: string): UrlscanEnvelope {
+  return {
+    threats: [],
+    stats: summariseUrlscan([]),
+    total: 0,
+    fetchedAt: Date.now(),
+    degraded: true,
+    reason,
+    source: 'urlscan.io',
+  };
+}
+
+export interface FetchUrlscanOptions {
+  q?: string;
+  size?: number;
+}
+
+export async function fetchUrlscanThreats(
+  options: FetchUrlscanOptions = {},
+): Promise<UrlscanEnvelope> {
+  const q = (options.q ?? 'malicious:true').slice(0, 200);
+  const size = clamp(options.size ?? 50, 1, 100);
+  const key = `${q}:${size}`;
+  const now = Date.now();
+
+  if (cache?.key === key && now - cache.fetchedAt < POLL_INTERVAL_MS) {
+    return cache.envelope;
+  }
+  if (inflight) return inflight;
+
+  inflight = (async (): Promise<UrlscanEnvelope> => {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+      const url = `${getApiBaseUrl()}/api/security/urlscan?q=${encodeURIComponent(q)}&size=${size}`;
+      const response = await fetch(url, {
+        signal: controller.signal,
+        headers: { Accept: 'application/json' },
+      });
+      clearTimeout(timer);
+      if (!response.ok) {
+        return { ...emptyEnvelope(`HTTP ${response.status}`), fetchedAt: now };
+      }
+      const body = (await response.json()) as {
+        results?: unknown;
+        total?: number;
+        degraded?: boolean;
+        reason?: string;
+        source?: string;
+        error?: string;
+      };
+      if (body.error) return { ...emptyEnvelope(body.error), fetchedAt: now };
+      const threats = parseUrlscanThreats(body.results ?? body);
+      const envelope: UrlscanEnvelope = {
+        threats,
+        stats: summariseUrlscan(threats),
+        total: typeof body.total === 'number' ? body.total : threats.length,
+        fetchedAt: now,
+        degraded: body.degraded ?? false,
+        reason: body.reason,
+        source: body.source ?? 'urlscan.io',
+      };
+      cache = { envelope, fetchedAt: now, key };
+      return envelope;
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      return { ...emptyEnvelope(reason), fetchedAt: now };
+    } finally {
+      inflight = null;
+    }
+  })();
+
+  return inflight;
+}
+
+export function clearUrlscanCache(): void {
+  cache = null;
+  inflight = null;
+}
+
+export interface UrlscanSubmitResult {
+  ok: boolean;
+  uuid?: string;
+  reportUrl?: string;
+  apiUrl?: string;
+  error?: string;
+}
+
+export async function submitUrlscan(input: string): Promise<UrlscanSubmitResult> {
+  const validation = validateSubmitUrl(input);
+  if (!validation.ok) return { ok: false, error: validation.error };
+  try {
+    const response = await fetch(`${getApiBaseUrl()}/api/security/urlscan/submit`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url: validation.url, visibility: 'public' }),
+    });
+    const body = await response.json().catch(() => ({})) as {
+      uuid?: string;
+      result?: string;
+      api?: string;
+      error?: string;
+    };
+    if (!response.ok) {
+      return { ok: false, error: body.error ?? `HTTP ${response.status}` };
+    }
+    return {
+      ok: true,
+      uuid: body.uuid,
+      reportUrl: body.result,
+      apiUrl: body.api,
+    };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, Math.floor(value)));
+}
+
+export const __TEST_HOOKS__ = {
+  get cache(): CacheEntry | null {
+    return cache;
+  },
+  POLL_INTERVAL_MS,
+};


### PR DESCRIPTION
## Summary

Three new threat-intel panels covering recent phishing URLs, recently scanned malicious URLs (with self-serve submit), and Pulsedive's risk-ranked indicator feed. Each follows the established service/classify/sidecar/panel split used by the rest of the security stack.

## Files

### Sidecar routes (in [`src-tauri/sidecar/local-api-server.mjs`](src-tauri/sidecar/local-api-server.mjs))
- **`/api/security/phishing`** — PhishStats free API (`phishstats.info:2096`); 30-min cache; `minScore` clamped to [0,10], `limit` clamped to [1,500].
- **`/api/security/urlscan`** — urlscan.io free search; 15-min cache; `q` truncated to 200 chars, `size` clamped to [1,100].
- **`/api/security/urlscan/submit`** (POST) — forwards to urlscan submit API; validates URL host (blocks loopback / private IPv4 / `.local` / non-http(s)); honours `URLSCAN_API_KEY` env var and surfaces 401 cleanly when the upstream rejects anonymous scans.
- **`/api/security/pulsedive`** — pulsedive.com; serves both `explore.php` queries (`risk:high type:domain`) and per-indicator `info.php` lookups; 1-hour cache keyed by `(risk,type,limit)` or by indicator; honours `PULSEDIVE_API_KEY` env var.

### Services
- **[`src/services/security/phishstats-classify.ts`](src/services/security/phishstats-classify.ts)** — pure parsing + score-to-severity mapping (low / medium / high / critical), summarisation (top-targeted brands, top countries, latest seen), score-filter helper, URL truncation.
- **[`src/services/security/phishstats-service.ts`](src/services/security/phishstats-service.ts)** — sidecar fetcher with 30-min memory cache keyed on `(limit, minScore)`, in-flight dedup, degraded envelope on failure, fallback parse path for raw upstream array.
- **[`src/services/security/urlscan-classify.ts`](src/services/security/urlscan-classify.ts)** — verdict classifier (malicious / suspicious / clean / unknown) from `verdicts.overall.malicious` + `score`, row parser that flattens nested `task`/`page`/`verdicts` blocks, `validateSubmitUrl` that mirrors the sidecar SSRF check so the renderer fails fast.
- **[`src/services/security/urlscan-service.ts`](src/services/security/urlscan-service.ts)** — sidecar fetcher + `submitUrlscan` POST helper.
- **[`src/services/security/pulsedive-classify.ts`](src/services/security/pulsedive-classify.ts)** — risk + type classifier (`none`/`low`/`medium`/`high`/`critical`/`unknown` × `ip`/`ipv6`/`domain`/`url`/`hash`/`email`/`unknown`), parser that handles `explore.php` (`{results:[…]}`), `info.php` (single object), and bare-array shapes, plus risk-ranked summarisation.
- **[`src/services/security/pulsedive-service.ts`](src/services/security/pulsedive-service.ts)** — sidecar fetcher with a `Map<string, CacheEntry>` so explore + lookup queries have separate slots.

### Panels
- **[`src/components/PhishstatsFeedPanel.ts`](src/components/PhishstatsFeedPanel.ts)** — table (URL / target / score / country / date) with persistent score slider 0–10, top-targeted-brands + top-countries summary, severity color-banded rows.
- **[`src/components/UrlscanThreatsPanel.ts`](src/components/UrlscanThreatsPanel.ts)** — feed of recent malicious scans, expandable rows showing IP / ASN / country / tags / screenshot link, plus a “Scan URL” submit input that validates client-side before POST.
- **[`src/components/PulsediveIntelPanel.ts`](src/components/PulsediveIntelPanel.ts)** — three tabs: High Risk Indicators (table), Lookup (indicator → threat context), Feeds (active feed ranking + latest-seen timestamp). Tab choice persisted to localStorage.

### Registration
- 3 new panel IDs added to `FULL_PANELS` and the `dataTracking` category panelKeys in [`src/config/panels.ts`](src/config/panels.ts).
- Instantiated in [`src/app/panel-layout.ts`](src/app/panel-layout.ts) right after `SanctionsPanel`.

## Tests

66 new unit tests across 6 files (≥8 per panel required — actual breakdown 18+10+15+11+11+8 = well above floor):

\`\`\`
✔ tests 66 / pass 66 / fail 0
\`\`\`

Covers: score → severity buckets, parsing fallback shapes (envelope / raw array / info.php single-result), SSRF host blocking, cache key independence (explore vs lookup, different filter tuples), degraded-envelope paths on non-2xx, URL validation, summary aggregation (top targets / brands / threats / feeds, latestSeen tracking).

`npm run typecheck:all` is clean. All 67 existing sidecar tests still pass.

## Verification gap

Live UI preview was **not** run. The pre-existing `@luma.gl/engine` build error on `main` (`DynamicTexture` / `MaterialFactory` missing exports from the deck.gl-bundled luma.gl copy) still prevents the Vite dev server from booting. This affects code I didn’t touch and reproduces on `main`; it's the same blocker called out in the prior aviation PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Cross-agent review: claude reviewed on 2026-05-11; outcome: pass

Cross-agent review: claude reviewed on 2026-05-11; outcome: pass