### PR TITLE
feat(diagnostics): diagnostic export upgrade + feed-health → mission-state mapping

### DIFF
--- a/api/__tests__/diagnostics-mission-state.test.mjs
+++ b/api/__tests__/diagnostics-mission-state.test.mjs
@@ -1,0 +1,139 @@
+/**
+ * Tests for api/diagnostics/mission-state.js
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { invokeHandler, mockFetch } from './_test-utils.mjs';
+
+let handler;
+let missionStateCache;
+try {
+  const mod = await import('../diagnostics/mission-state.js');
+  handler = mod.default;
+  missionStateCache = mod.cache;
+} catch (err) {
+  console.warn('Handler diagnostics/mission-state.js failed to import:', err.message);
+  handler = null;
+}
+
+function allReachable() {
+  return new Map([
+    ['earthquake.usgs.gov', { status: 200 }],
+    ['api.weather.gov', { status: 200 }],
+    ['firms.modaps.eosdis.nasa.gov', { status: 200 }],
+    ['marinetraffic.com', { status: 200 }],
+    ['services.swpc.noaa.gov', { status: 200 }],
+  ]);
+}
+
+function allDown() {
+  return new Map([
+    ['earthquake.usgs.gov', { status: 503 }],
+    ['api.weather.gov', { status: 503 }],
+    ['firms.modaps.eosdis.nasa.gov', { status: 503 }],
+    ['marinetraffic.com', { status: 503 }],
+    ['services.swpc.noaa.gov', { status: 503 }],
+  ]);
+}
+
+test('returns 200 with NOMINAL when all feeds reachable', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  missionStateCache?.clear();
+  const restore = mockFetch(allReachable());
+  try {
+    const { res } = await invokeHandler(handler);
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.state, 'NOMINAL');
+    assert.equal(res.body.downCount, 0);
+  } finally { restore(); }
+});
+
+test('returns DEGRADED when 2 feeds are down', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  missionStateCache?.clear();
+  const partial = new Map([
+    ['earthquake.usgs.gov', { status: 200 }],
+    ['api.weather.gov', { status: 503 }],
+    ['firms.modaps.eosdis.nasa.gov', { status: 503 }],
+    ['marinetraffic.com', { status: 200 }],
+    ['services.swpc.noaa.gov', { status: 200 }],
+  ]);
+  const restore = mockFetch(partial);
+  try {
+    const { res } = await invokeHandler(handler);
+    assert.equal(res.body.state, 'DEGRADED');
+    assert.equal(res.body.downCount, 2);
+  } finally { restore(); }
+});
+
+test('returns CRITICAL when 3 or more feeds are down', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  missionStateCache?.clear();
+  const restore = mockFetch(allDown());
+  try {
+    const { res } = await invokeHandler(handler);
+    assert.equal(res.body.state, 'CRITICAL');
+    assert.equal(res.body.downCount, 5);
+  } finally { restore(); }
+});
+
+test('response includes feeds array with id and label fields', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  missionStateCache?.clear();
+  const restore = mockFetch(allReachable());
+  try {
+    const { res } = await invokeHandler(handler);
+    assert.ok(Array.isArray(res.body.feeds));
+    assert.equal(res.body.feeds.length, 5);
+    for (const feed of res.body.feeds) {
+      assert.ok('id' in feed, 'feed should have id');
+      assert.ok('label' in feed, 'feed should have label');
+      assert.ok('reachable' in feed, 'feed should have reachable');
+    }
+  } finally { restore(); }
+});
+
+test('response includes generatedAt ISO timestamp', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  missionStateCache?.clear();
+  const restore = mockFetch(allReachable());
+  try {
+    const { res } = await invokeHandler(handler);
+    assert.ok(typeof res.body.generatedAt === 'string');
+    assert.ok(!Number.isNaN(Date.parse(res.body.generatedAt)));
+  } finally { restore(); }
+});
+
+test('rejects non-GET methods with 405', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  const { res } = await invokeHandler(handler, { method: 'POST' });
+  assert.equal(res.statusCode, 405);
+});
+
+test('serves cached response within TTL', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  missionStateCache?.clear();
+  let callCount = 0;
+  const countingFetch = new Map([
+    ['earthquake.usgs.gov', { status: 200 }],
+    ['api.weather.gov', { status: 200 }],
+    ['firms.modaps.eosdis.nasa.gov', { status: 200 }],
+    ['marinetraffic.com', { status: 200 }],
+    ['services.swpc.noaa.gov', { status: 200 }],
+  ]);
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, ...args) => {
+    callCount++;
+    return originalFetch(url, ...args);
+  };
+  const restore = mockFetch(countingFetch);
+  try {
+    await invokeHandler(handler);
+    const priorCount = callCount;
+    await invokeHandler(handler); // should hit cache
+    assert.equal(callCount, priorCount, 'second call should use cache, not re-fetch');
+  } finally {
+    restore();
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/api/diagnostics/mission-state.js
+++ b/api/diagnostics/mission-state.js
@@ -1,0 +1,97 @@
+/**
+ * Mission state probe — checks reachability of the five critical
+ * upstream data feeds and computes an overall NOMINAL/DEGRADED/CRITICAL
+ * posture from the sidecar's perspective.
+ *
+ * Rules (mirroring the frontend mission-state-service):
+ *   - ≥3 critical feeds unreachable → CRITICAL
+ *   - ≥2 critical feeds unreachable → DEGRADED
+ *   - otherwise                     → NOMINAL
+ *
+ * No API key required. Results cached for 60 s.
+ */
+
+import { getCorsHeaders, isDisallowedOrigin } from '../_cors.js';
+
+export const config = { runtime: 'edge' };
+
+const CACHE_TTL_MS = 60 * 1000;
+
+const CRITICAL_FEEDS = [
+  {
+    id: 'usgs-earthquake',
+    label: 'USGS Earthquakes',
+    url: 'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_hour.geojson',
+  },
+  {
+    id: 'nws-weather',
+    label: 'NWS Alerts',
+    url: 'https://api.weather.gov/',
+  },
+  {
+    id: 'nifc-wildfire',
+    label: 'NASA FIRMS Wildfire',
+    url: 'https://firms.modaps.eosdis.nasa.gov/',
+  },
+  {
+    id: 'ais-stream',
+    label: 'AIS Maritime',
+    url: 'https://www.marinetraffic.com/',
+  },
+  {
+    id: 'spaceweather-noaa',
+    label: 'NOAA Space Weather',
+    url: 'https://services.swpc.noaa.gov/json/solar-wind/mag-5-minute.json',
+  },
+];
+
+export const cache = new Map();
+
+const j = (payload, status, cors) =>
+  Response.json(payload, {
+    status,
+    headers: { 'content-type': 'application/json; charset=utf-8', ...cors },
+  });
+
+async function probeOne(feed) {
+  try {
+    const r = await fetch(feed.url, {
+      method: 'HEAD',
+      signal: AbortSignal.timeout(5000),
+    });
+    return { id: feed.id, label: feed.label, reachable: r.ok || r.status < 500 };
+  } catch {
+    return { id: feed.id, label: feed.label, reachable: false };
+  }
+}
+
+export default async function handler(req) {
+  const cors = getCorsHeaders(req, 'GET, OPTIONS');
+  if (isDisallowedOrigin(req)) return j({ error: 'Origin not allowed' }, 403, cors);
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
+  if (req.method !== 'GET') return j({ error: 'Method not allowed' }, 405, cors);
+
+  const cached = cache.get('mission-state');
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) return j(cached.payload, 200, cors);
+
+  const results = await Promise.all(CRITICAL_FEEDS.map((f) => probeOne(f)));
+  const downCount = results.filter((r) => !r.reachable).length;
+
+  let state;
+  if (downCount >= 3) {
+    state = 'CRITICAL';
+  } else if (downCount >= 2) {
+    state = 'DEGRADED';
+  } else {
+    state = 'NOMINAL';
+  }
+
+  const payload = {
+    state,
+    downCount,
+    feeds: results,
+    generatedAt: new Date().toISOString(),
+  };
+  cache.set('mission-state', { at: Date.now(), payload });
+  return j(payload, 200, cors);
+}

--- a/src/components/SystemDiagnosticPanel.ts
+++ b/src/components/SystemDiagnosticPanel.ts
@@ -48,6 +48,10 @@ import type {
   PanelHealth,
 } from '@/services/diagnostics/system-health-types';
 import { escapeHtml } from '@/utils/sanitize';
+import {
+  getMissionState,
+  type MissionState,
+} from '@/services/diagnostics/mission-state-service';
 
 const REFRESH_MS = 5000;
 
@@ -172,13 +176,19 @@ export class SystemDiagnosticPanel extends Panel {
   private renderHeader(ctx: DiagnosticContext): string {
     const status = ctx.report.status;
     const color = STATUS_COLOR[status];
+    const ms = getMissionState();
+    const msBadgeColor = missionStateColor(ms);
     return `<div class="syd-header" style="padding:8px 12px;border-bottom:1px solid var(--border-subtle,#333);display:flex;justify-content:space-between;align-items:center;">
       <div style="display:flex;align-items:center;gap:8px;">
         <span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:${color};"></span>
         <span style="font-weight:700;color:${color};text-transform:uppercase;font-size:12px;">${status}</span>
         <span style="color:var(--text-secondary,#aaa);font-size:12px;">${escapeHtml(ctx.report.summary)}</span>
+        <span class="syd-mission-badge" title="Feed-staleness mission state" style="font-size:9px;padding:2px 5px;background:${msBadgeColor};color:#fff;border-radius:3px;text-transform:uppercase;letter-spacing:0.05em;">${escapeHtml(ms)}</span>
       </div>
-      <button class="syd-refresh" style="font-size:11px;padding:3px 8px;background:transparent;color:var(--text-secondary,#aaa);border:1px solid var(--border-subtle,#333);border-radius:3px;cursor:pointer;">Refresh</button>
+      <div style="display:flex;gap:6px;align-items:center;">
+        <button class="syd-export" style="font-size:11px;padding:3px 8px;background:transparent;color:var(--text-secondary,#aaa);border:1px solid var(--border-subtle,#333);border-radius:3px;cursor:pointer;">Export JSON</button>
+        <button class="syd-refresh" style="font-size:11px;padding:3px 8px;background:transparent;color:var(--text-secondary,#aaa);border:1px solid var(--border-subtle,#333);border-radius:3px;cursor:pointer;">Refresh</button>
+      </div>
     </div>`;
   }
 
@@ -503,6 +513,32 @@ export class SystemDiagnosticPanel extends Panel {
     return '#9e9e9e';
   }
 
+  private async exportDiagnosticsJson(): Promise<void> {
+    try {
+      const { composeFrontendDiagnosticsExport } = await import(
+        '@/services/diagnostics/frontend-export-composer'
+      );
+      const g = globalThis as unknown as { __APP_VERSION__?: string; __APP_VARIANT__?: string; __TAURI_INTERNALS__?: unknown };
+      const app = {
+        variant: g.__APP_VARIANT__ ?? 'full',
+        version: g.__APP_VERSION__ ?? '0.0.0',
+        runtime: (g.__TAURI_INTERNALS__ === undefined ? 'web' : 'desktop') as 'web' | 'desktop',
+      };
+      const { bundle } = composeFrontendDiagnosticsExport({ app });
+      const { exportBundleToJson } = await import('@/services/diagnostics/export-bundle');
+      const json = exportBundleToJson(bundle);
+      const blob = new Blob([json], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `crystal-ball-diagnostics-${new Date().toISOString().slice(0, 19).replace(/[T:]/g, '-')}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.warn('[SystemDiagnosticPanel] export failed:', error);
+    }
+  }
+
   private wireHandlers(): void {
     const root = this.getContentElement();
     for (const tabBtn of root.querySelectorAll<HTMLButtonElement>('.syd-tab')) {
@@ -542,7 +578,8 @@ export class SystemDiagnosticPanel extends Panel {
         this.render();
       }
     });
-
+    const exportBtn = root.querySelector<HTMLButtonElement>('.syd-export');
+    exportBtn?.addEventListener('click', () => void this.exportDiagnosticsJson());
     const stBtn = root.querySelector<HTMLButtonElement>('.syd-self-test');
     stBtn?.addEventListener('click', async () => {
       if (this.selfTestRunning) return;
@@ -641,3 +678,10 @@ function formatAge(ms: number): string {
   if (ms < 24 * 60 * 60_000) return `${(ms / (60 * 60_000)).toFixed(1)}h ago`;
   return `${(ms / (24 * 60 * 60_000)).toFixed(1)}d ago`;
 }
+
+function missionStateColor(state: MissionState): string {
+  if (state === 'CRITICAL') return '#d50000';
+  if (state === 'DEGRADED') return '#ff8800';
+  return '#2e7d32';
+}
+

--- a/src/services/diagnostics/__tests__/mission-state-service.test.mts
+++ b/src/services/diagnostics/__tests__/mission-state-service.test.mts
@@ -1,0 +1,242 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  getMissionState,
+  getMissionStateDetail,
+  _resetMissionState,
+  _setSourcesOverride,
+  type MissionState,
+  type MissionStateChangedDetail,
+} from '../mission-state-service.ts';
+import type { DataSourceState } from '@/services/data-freshness';
+
+// ── Document mock (Node.js has no document) ───────────────────────────
+
+function makeMockDocument(events: CustomEvent[]) {
+  const listeners = new Map<string, Set<EventListener>>();
+  return {
+    addEventListener(type: string, fn: EventListener) {
+      const set = listeners.get(type) ?? new Set();
+      set.add(fn);
+      listeners.set(type, set);
+    },
+    removeEventListener(type: string, fn: EventListener) {
+      listeners.get(type)?.delete(fn);
+    },
+    dispatchEvent(event: Event) {
+      events.push(event as CustomEvent);
+      for (const fn of listeners.get(event.type) ?? []) fn(event);
+      return true;
+    },
+  };
+}
+
+function withMockDocument(mock: ReturnType<typeof makeMockDocument>, fn: () => void): void {
+  const g = globalThis as unknown as { document?: unknown };
+  const prev = g.document;
+  g.document = mock;
+  try { fn(); } finally { g.document = prev; }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+const NOW = 1_745_000_000_000;
+
+type PartialSource = Partial<DataSourceState> & Pick<DataSourceState, 'id' | 'status'>;
+
+function src(id: string, status: DataSourceState['status'], name = id): DataSourceState {
+  return {
+    id: id as DataSourceState['id'],
+    name,
+    lastUpdate: status === 'fresh' ? new Date(NOW) : null,
+    lastError: status === 'error' ? 'err' : null,
+    itemCount: 0,
+    enabled: status !== 'disabled',
+    status,
+    requiredForRisk: false,
+  } satisfies DataSourceState;
+}
+
+function freshSources(count = 20): DataSourceState[] {
+  return Array.from({ length: count }, (_, i) => src(`feed-${i}`, 'fresh', `Feed ${i}`));
+}
+
+function withCritical(extras: PartialSource[]): DataSourceState[] {
+  const base = freshSources(20);
+  for (const e of extras) {
+    const idx = base.findIndex((s) => s.id === e.id);
+    const replacement = { ...src(e.id, e.status, e.name ?? e.id), ...e };
+    if (idx >= 0) {
+      base[idx] = replacement;
+    } else {
+      base.push(replacement);
+    }
+  }
+  return base;
+}
+
+function setup(sources: DataSourceState[]) {
+  _resetMissionState();
+  _setSourcesOverride(() => sources);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+test('NOMINAL when all feeds are fresh', () => {
+  setup(freshSources(20));
+  assert.equal(getMissionState(), 'NOMINAL');
+});
+
+test('NOMINAL when fewer than 5 feeds stale and fewer than 3 critical stale', () => {
+  setup(withCritical([
+    { id: 'feed-0', status: 'stale' },
+    { id: 'feed-1', status: 'error' },
+  ]));
+  assert.equal(getMissionState(), 'NOMINAL');
+});
+
+test('DEGRADED when ≥5 non-critical feeds are stale', () => {
+  const sources = freshSources(20).map((s, i) =>
+    i < 5 ? { ...s, status: 'stale' as const } : s,
+  );
+  setup(sources);
+  assert.equal(getMissionState(), 'DEGRADED');
+});
+
+test('CRITICAL when ≥3 critical feeds are stale', () => {
+  setup(withCritical([
+    { id: 'usgs', status: 'stale' },
+    { id: 'nws-alerts', status: 'error' },
+    { id: 'firms', status: 'no_data' },
+  ]));
+  assert.equal(getMissionState(), 'CRITICAL');
+});
+
+test('CRITICAL takes precedence when both ≥3 critical and ≥5 total stale', () => {
+  const base = freshSources(20).map((s, i) =>
+    i < 6 ? { ...s, status: 'stale' as const } : s,
+  );
+  setup(withCritical([
+    { id: 'usgs', status: 'stale' },
+    { id: 'nws-alerts', status: 'error' },
+    { id: 'firms', status: 'very_stale' },
+    ...base,
+  ]));
+  assert.equal(getMissionState(), 'CRITICAL');
+});
+
+test('getMissionStateDetail returns correct counts for NOMINAL', () => {
+  setup(withCritical([{ id: 'feed-0', status: 'stale' }]));
+  const detail = getMissionStateDetail();
+  assert.equal(detail.state, 'NOMINAL');
+  assert.equal(detail.staleFeedCount, 1);
+  assert.equal(detail.criticalStaleFeedCount, 0);
+  assert.ok(detail.staleFeedNames.includes('feed-0'));
+});
+
+test('getMissionStateDetail counts only critical-feed-id stale sources', () => {
+  setup(withCritical([
+    { id: 'usgs', status: 'error', name: 'USGS Earthquakes' },
+    { id: 'ais', status: 'stale', name: 'AIS' },
+  ]));
+  const detail = getMissionStateDetail();
+  assert.equal(detail.criticalStaleFeedCount, 2);
+  assert.ok(detail.staleFeedNames.includes('USGS Earthquakes'));
+});
+
+test('disabled feeds are excluded from stale count', () => {
+  const sources = freshSources(20).map((s, i) =>
+    i < 8 ? { ...s, status: 'disabled' as const } : s,
+  );
+  setup(sources);
+  const detail = getMissionStateDetail();
+  assert.equal(detail.staleFeedCount, 0);
+  assert.equal(detail.state, 'NOMINAL');
+});
+
+test('no event dispatched on first call (no previous state)', () => {
+  const events: CustomEvent[] = [];
+  const mockDoc = makeMockDocument(events);
+  withMockDocument(mockDoc, () => {
+    _resetMissionState();
+    _setSourcesOverride(() => freshSources());
+    getMissionStateDetail();
+  });
+  assert.equal(events.length, 0);
+});
+
+test('event dispatched on state transition', () => {
+  const events: CustomEvent[] = [];
+  const mockDoc = makeMockDocument(events);
+  withMockDocument(mockDoc, () => {
+    // First call: NOMINAL (sets lastState = NOMINAL, no event)
+    _resetMissionState();
+    _setSourcesOverride(() => freshSources());
+    getMissionStateDetail();
+
+    // Second call: DEGRADED (transition → event)
+    _setSourcesOverride(() =>
+      freshSources(20).map((s, i) => (i < 5 ? { ...s, status: 'stale' as const } : s)),
+    );
+    getMissionStateDetail();
+  });
+
+  assert.equal(events.length, 1);
+  const detail = (events[0] as CustomEvent<MissionStateChangedDetail>).detail;
+  assert.equal(detail.state, 'DEGRADED');
+  assert.equal(detail.previous, 'NOMINAL');
+});
+
+test('no event when state unchanged across calls', () => {
+  const events: CustomEvent[] = [];
+  const mockDoc = makeMockDocument(events);
+  withMockDocument(mockDoc, () => {
+    _resetMissionState();
+    _setSourcesOverride(() => freshSources());
+    getMissionStateDetail(); // sets NOMINAL
+    getMissionStateDetail(); // still NOMINAL, no event
+    getMissionStateDetail(); // still NOMINAL, no event
+  });
+  assert.equal(events.length, 0);
+});
+
+test('CRITICAL requires exactly 3 or more critical feeds stale, not fewer', () => {
+  // Only 2 critical feeds stale → not CRITICAL
+  setup(withCritical([
+    { id: 'usgs', status: 'stale' },
+    { id: 'nws-alerts', status: 'error' },
+  ]));
+  assert.notEqual(getMissionState(), 'CRITICAL');
+});
+
+test('very_stale counts as stale for critical-feed threshold', () => {
+  setup(withCritical([
+    { id: 'usgs', status: 'very_stale' },
+    { id: 'nws-alerts', status: 'very_stale' },
+    { id: 'space-weather', status: 'very_stale' },
+  ]));
+  assert.equal(getMissionState(), 'CRITICAL');
+});
+
+test('getMissionState() is a shortcut for getMissionStateDetail().state', () => {
+  setup(freshSources());
+  _resetMissionState();
+  _setSourcesOverride(() => freshSources());
+  const fromDetail = getMissionStateDetail().state;
+  _resetMissionState();
+  _setSourcesOverride(() => freshSources());
+  const fromShortcut = getMissionState();
+  assert.equal(fromShortcut, fromDetail);
+});
+
+test('staleFeedNames array matches stale source names', () => {
+  setup(withCritical([
+    { id: 'feed-3', status: 'error', name: 'Alpha Feed' },
+    { id: 'feed-4', status: 'stale', name: 'Beta Feed' },
+  ]));
+  const { staleFeedNames } = getMissionStateDetail();
+  assert.ok(staleFeedNames.includes('Alpha Feed'), 'should include Alpha Feed');
+  assert.ok(staleFeedNames.includes('Beta Feed'), 'should include Beta Feed');
+  assert.equal(staleFeedNames.length, 2);
+});

--- a/src/services/diagnostics/export-bundle.ts
+++ b/src/services/diagnostics/export-bundle.ts
@@ -41,6 +41,7 @@ import type { DebtItem } from '@/services/quality/quality-debt';
 import type { ImprovementReport } from '@/services/quality/self-improvement-scheduler';
 import type { TrustBudgetReport } from '@/services/ops/trust-budget';
 import type { ScenarioCoverage } from '@/services/scenarios/scenario-library';
+import type { MissionState } from './mission-state-service';
 
 // Imported from PR 7 self-test runner. Kept as a structural type so
 // this module doesn't hard-depend on self-test.ts when self-test
@@ -59,6 +60,39 @@ export interface SelfTestReportShape {
   counts: Record<string, number>;
   totalDurationMs: number;
   summary: string;
+}
+
+// ── New field types (Phase 2: diagnostic completeness) ──────────────────
+
+export interface AlgorithmCalibrationSummary {
+  algorithmId: string;
+  domain: string;
+  graded: number;
+  hitRate: number;
+  weightedHitRate: number;
+  meanDurationMs: number;
+}
+
+export interface MissionStateSummary {
+  state: MissionState;
+  staleFeedCount: number;
+  criticalStaleFeedCount: number;
+}
+
+export interface FeedHealthEntry {
+  id: string;
+  name: string;
+  status: string;
+  lastUpdateIso: string | null;
+}
+
+export interface SystemInfo {
+  appVersion: string;
+  buildHash?: string;
+  /** ms since page load (performance.now()). */
+  uptimeMs?: number;
+  /** JS heap used bytes if available. */
+  memoryUsedBytes?: number;
 }
 
 // ── Public API ──────────────────────────────────────────────────────────
@@ -111,6 +145,14 @@ export interface DiagnosticsExportBundle {
   improvementPlan?: ImprovementReport;
   /** Scenario library coverage by domain + category. */
   scenarioCoverage?: ScenarioCoverage;
+  /** Per-algorithm calibration summaries from the evaluation ledger. */
+  algorithmState?: readonly AlgorithmCalibrationSummary[];
+  /** Overall mission state computed from feed-staleness rules. */
+  missionState?: MissionStateSummary;
+  /** Per-feed freshness snapshot (id, name, status, last update). */
+  feedHealth?: readonly FeedHealthEntry[];
+  /** System runtime info: version, uptime, memory. */
+  systemInfo?: SystemInfo;
   /** Anything truncated for size, recorded so the consumer knows what
    *  was dropped. */
   truncations: ExportTruncationNote[];
@@ -147,6 +189,10 @@ export interface BuildExportBundleInput {
   trustBudget?: TrustBudgetReport;
   improvementPlan?: ImprovementReport;
   scenarioCoverage?: ScenarioCoverage;
+  algorithmState?: readonly AlgorithmCalibrationSummary[];
+  missionState?: MissionStateSummary;
+  feedHealth?: readonly FeedHealthEntry[];
+  systemInfo?: SystemInfo;
   /** Caps; see DEFAULTS below. */
   caps?: Partial<{
     maxNotificationTraces: number;
@@ -242,6 +288,10 @@ export function buildExportBundle(input: BuildExportBundleInput): DiagnosticsExp
     trustBudget: redactStrategicSection(input.trustBudget),
     improvementPlan: redactStrategicSection(input.improvementPlan),
     scenarioCoverage: redactStrategicSection(input.scenarioCoverage),
+    algorithmState: input.algorithmState ? [...input.algorithmState] : undefined,
+    missionState: input.missionState ? { ...input.missionState } : undefined,
+    feedHealth: input.feedHealth ? [...input.feedHealth] : undefined,
+    systemInfo: input.systemInfo ? { ...input.systemInfo } : undefined,
     truncations,
   };
 

--- a/src/services/diagnostics/frontend-export-composer.ts
+++ b/src/services/diagnostics/frontend-export-composer.ts
@@ -19,9 +19,12 @@ import { aggregateSystemHealth, contextFromSnapshots } from './system-health';
 import {
   buildExportBundle,
   exportBundleToMarkdown,
+  type AlgorithmCalibrationSummary,
   type DiagnosticsExportBundle,
   type ExportBundleAppMeta,
   type ExportBundleEnvHints,
+  type FeedHealthEntry,
+  type SystemInfo,
 } from './export-bundle';
 import { getLiveDiagnosticsSnapshot } from './live-diagnostics-snapshot';
 import {
@@ -30,6 +33,12 @@ import {
 } from './diagnostics-state';
 import { summarizeScenarioCoverage } from '@/services/scenarios/scenario-library';
 import { getActiveQualityDebt } from '@/services/quality/quality-debt-state';
+import { getMissionStateDetail } from './mission-state-service';
+import { dataFreshness } from '@/services/data-freshness';
+import {
+  getAlgorithmEvaluationLedger,
+} from '@/services/algorithms/algorithms-state';
+import { summarizeCalibration } from '@/services/algorithms/algorithm-evaluation-ledger';
 
 // ── Public API ──────────────────────────────────────────────────────────
 
@@ -75,11 +84,54 @@ export function composeFrontendDiagnosticsExport(
     sidecar: snapshot.sidecar,
   });
 
-  // Strategic sections — best-effort. Failure on any one section does
-  // not block the overall export; the missing field just stays
-  // undefined and the consumer will see only what was available.
+  // Strategic + diagnostic sections — best-effort. Failure on any one
+  // section does not block the overall export.
   const scenarioCoverage = safe(() => summarizeScenarioCoverage());
   const qualityDebt = safe(() => getActiveQualityDebt());
+  const missionStateDetail = safe(() => getMissionStateDetail());
+  const missionState = missionStateDetail
+    ? {
+        state: missionStateDetail.state,
+        staleFeedCount: missionStateDetail.staleFeedCount,
+        criticalStaleFeedCount: missionStateDetail.criticalStaleFeedCount,
+      }
+    : undefined;
+
+  const feedHealth = safe((): FeedHealthEntry[] =>
+    dataFreshness.getAllSources().map((s) => ({
+      id: s.id,
+      name: s.name,
+      status: s.status,
+      lastUpdateIso: s.lastUpdate ? s.lastUpdate.toISOString() : null,
+    })),
+  );
+
+  const algorithmState = safe((): AlgorithmCalibrationSummary[] => {
+    const ledger = getAlgorithmEvaluationLedger();
+    return summarizeCalibration(ledger.all()).map((c) => ({
+      algorithmId: c.algorithmId,
+      domain: c.domain,
+      graded: c.graded,
+      hitRate: Number.isNaN(c.hitRate) ? 0 : c.hitRate,
+      weightedHitRate: Number.isNaN(c.weightedHitRate) ? 0 : c.weightedHitRate,
+      meanDurationMs: Number.isNaN(c.meanDurationMs) ? 0 : c.meanDurationMs,
+    }));
+  });
+
+  const systemInfo = safe((): SystemInfo => {
+    const g = globalThis as unknown as {
+      __APP_VERSION__?: string;
+      performance?: { now(): number };
+      // Chrome-only memory API
+      memory?: { usedJSHeapSize?: number };
+    };
+    return {
+      appVersion: input.app.version,
+      buildHash: input.app.buildHash,
+      uptimeMs: g.performance ? Math.round(g.performance.now()) : undefined,
+      memoryUsedBytes: g.memory?.usedJSHeapSize,
+    };
+  });
 
   const bundle = buildExportBundle({
     now,
@@ -92,6 +144,10 @@ export function composeFrontendDiagnosticsExport(
     events: { snapshot: [...snapshot.recentEvents] },
     scenarioCoverage,
     qualityDebt,
+    missionState,
+    feedHealth,
+    algorithmState,
+    systemInfo,
   });
 
   let markdown = exportBundleToMarkdown(bundle);

--- a/src/services/diagnostics/mission-state-service.ts
+++ b/src/services/diagnostics/mission-state-service.ts
@@ -1,0 +1,113 @@
+/**
+ * Mission State Service — maps feed staleness to an overall
+ * operational posture: NOMINAL / DEGRADED / CRITICAL.
+ *
+ * Rules:
+ *   - ≥3 critical feeds stale  → CRITICAL
+ *   - ≥5 any feeds stale       → DEGRADED
+ *   - otherwise                → NOMINAL
+ *
+ * Critical feeds are the five highest-impact data sources:
+ *   usgs (earthquakes), nws-alerts, firms (wildfire),
+ *   ais (vessels), space-weather.
+ *
+ * Reads from the shared dataFreshness singleton — no fetch, no DOM.
+ * Dispatches `wm:mission-state-changed` on the document when state
+ * transitions (browser-only; safe to call from SSR / Node tests).
+ */
+
+import { dataFreshness, type DataSourceId, type DataSourceState } from '@/services/data-freshness';
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+export type MissionState = 'NOMINAL' | 'DEGRADED' | 'CRITICAL';
+
+export interface MissionStateDetail {
+  state: MissionState;
+  staleFeedCount: number;
+  criticalStaleFeedCount: number;
+  /** Display names of all stale feeds (not just the critical ones). */
+  staleFeedNames: string[];
+}
+
+export interface MissionStateChangedDetail {
+  state: MissionState;
+  previous: MissionState;
+}
+
+// ── Constants ────────────────────────────────────────────────────────────
+
+const CRITICAL_FEED_IDS = new Set<DataSourceId>([
+  'usgs',
+  'nws-alerts',
+  'firms',
+  'ais',
+  'space-weather',
+]);
+
+const STALE_STATUSES = new Set(['stale', 'very_stale', 'no_data', 'error']);
+
+// ── Module state ─────────────────────────────────────────────────────────
+
+let lastState: MissionState | undefined;
+let _sourcesOverride: (() => DataSourceState[]) | undefined;
+
+// ── Public API ───────────────────────────────────────────────────────────
+
+export function getMissionStateDetail(): MissionStateDetail {
+  const sources = (_sourcesOverride ?? (() => dataFreshness.getAllSources()))();
+
+  const staleCritical = sources.filter(
+    (s) => CRITICAL_FEED_IDS.has(s.id) && STALE_STATUSES.has(s.status),
+  );
+  const staleAll = sources.filter(
+    (s) => s.status !== 'disabled' && STALE_STATUSES.has(s.status),
+  );
+
+  let state: MissionState;
+  if (staleCritical.length >= 3) {
+    state = 'CRITICAL';
+  } else if (staleAll.length >= 5) {
+    state = 'DEGRADED';
+  } else {
+    state = 'NOMINAL';
+  }
+
+  if (lastState !== undefined && state !== lastState) {
+    _dispatchStateChange(state, lastState);
+  }
+  lastState = state;
+
+  return {
+    state,
+    staleFeedCount: staleAll.length,
+    criticalStaleFeedCount: staleCritical.length,
+    staleFeedNames: staleAll.map((s) => s.name),
+  };
+}
+
+export function getMissionState(): MissionState {
+  return getMissionStateDetail().state;
+}
+
+/** Reset module state. Tests only. */
+export function _resetMissionState(): void {
+  lastState = undefined;
+  _sourcesOverride = undefined;
+}
+
+/** Override the sources provider. Tests only. */
+export function _setSourcesOverride(fn: (() => DataSourceState[]) | undefined): void {
+  _sourcesOverride = fn;
+}
+
+// ── Internal ─────────────────────────────────────────────────────────────
+
+function _dispatchStateChange(state: MissionState, previous: MissionState): void {
+  if (typeof document === 'undefined') return;
+  document.dispatchEvent(
+    new CustomEvent<MissionStateChangedDetail>('wm:mission-state-changed', {
+      detail: { state, previous },
+    }),
+  );
+}


### PR DESCRIPTION
## Summary

Implements diagnostic completeness improvements: a feed-health → mission-state mapping service, an upgraded export bundle, and UI wiring into the System Diagnostic Panel.

### MissionStateService (`src/services/diagnostics/mission-state-service.ts`)
- Reads `dataFreshness.getAllSources()` to check the 5 critical feeds: `usgs`, `nws-alerts`, `firms`, `ais`, `space-weather`
- Rules: ≥3 critical stale → CRITICAL; ≥5 any stale → DEGRADED; else NOMINAL
- Exports `getMissionState()` and `getMissionStateDetail()`
- Emits `wm:mission-state-changed` custom event on state transitions (browser-safe guard)

### Sidecar route (`api/diagnostics/mission-state.js`)
- `GET /api/diagnostics/mission-state` — probes 5 critical upstream endpoints with HEAD requests (5 s timeout, parallel)
- Computes NOMINAL/DEGRADED/CRITICAL independently of frontend state
- 60-second result cache; no API key required

### Export bundle upgrade
- Added 4 new optional fields to `DiagnosticsExportBundle` and `BuildExportBundleInput`: `algorithmState`, `missionState`, `feedHealth`, `systemInfo`
- `frontend-export-composer.ts` populates all 4 via best-effort `safe()` wrappers

### SystemDiagnosticPanel UI
- **Mission state badge** in header: NOMINAL (green) / DEGRADED (amber) / CRITICAL (red)
- **Export JSON button**: downloads a timestamped `crystal-ball-diagnostics-*.json` file

### Tests (22 total)
- 15 unit tests for `mission-state-service`: thresholds, transition events, disabled-feed exclusion
- 7 integration tests for the sidecar route: NOMINAL/DEGRADED/CRITICAL probes, 405, cache

---

Cross-agent review: claude reviewed on 2026-05-11; outcome: pass