### PR TITLE
feat(ux): command center saved-places tiles + live change tape

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -31,6 +31,7 @@ import {
   loadSmsConfig, saveSmsConfig,
   handleSmsCommand,
 } from './sms-command-parser.mjs';
+import { buildRecentChanges } from './recent-changes.mjs';
 
 let _smsConfig = loadSmsConfig();
 const _smsRateLimitMap = new Map();
@@ -4906,6 +4907,13 @@ async function dispatch(requestUrl, req, routes, context) {
         lastHourCount: 0, baselineRate: 0, surgeRatio: 0, surgeLevel: 'normal',
         totalSeen: 0, recent: [] }, 502);
     }
+  }
+
+  // ── Command Center: recent changes tape ──────────────────────────────────
+  if (requestUrl.pathname === '/api/command-center/recent-changes' && req.method === 'GET') {
+    const alertCache = getCachedStale('ipaws-active');
+    const feedSnapshots = getFeedSnapshots();
+    return json(buildRecentChanges(feedSnapshots, alertCache, Date.now()));
   }
 
   // ── CDC Acute Respiratory Illness by state (SODA, no auth) ──────────────

--- a/src-tauri/sidecar/recent-changes.mjs
+++ b/src-tauri/sidecar/recent-changes.mjs
@@ -1,0 +1,49 @@
+/**
+ * Pure helper — no side-effects, no fetch.
+ * Synthesises the "what changed in the last hour" tape from in-process data
+ * already available in the sidecar: the feed-health tracker and the IPAWS
+ * alert cache.
+ */
+
+const ALERT_WINDOW_MS = 60 * 60 * 1000;   // 60 min
+const STALE_FEED_THRESHOLD_MS = 30 * 60 * 1000; // 30 min without success
+
+/**
+ * @param {Array<{key: string, lastSuccessAt: number|null, lastError: string|null, lastAttemptAt: number|null}>} feedSnapshots
+ * @param {{alerts: Array<{event: string, headline: string, effective: string}>}|null} alertCache
+ * @param {number} nowMs
+ * @returns {{items: Array<{type: string, label: string, ageMs: number}>}}
+ */
+export function buildRecentChanges(feedSnapshots, alertCache, nowMs) {
+  const items = [];
+  collectAlerts(items, alertCache, nowMs);
+  collectStaleFeeds(items, feedSnapshots, nowMs);
+  items.sort((a, b) => a.ageMs - b.ageMs);
+  return { items };
+}
+
+function collectAlerts(items, alertCache, nowMs) {
+  if (!Array.isArray(alertCache?.alerts)) return;
+  for (const alert of alertCache.alerts) {
+    const effectiveMs = alert.effective ? Date.parse(alert.effective) : Number.NaN;
+    if (Number.isNaN(effectiveMs) || effectiveMs > nowMs) continue;
+    const ageMs = nowMs - effectiveMs;
+    if (ageMs > ALERT_WINDOW_MS) continue;
+    const label = alert.headline || alert.event || 'Alert';
+    items.push({ type: 'alert', label, ageMs });
+  }
+}
+
+function collectStaleFeeds(items, feedSnapshots, nowMs) {
+  if (!Array.isArray(feedSnapshots)) return;
+  for (const feed of feedSnapshots) {
+    if (!feed.lastError || feed.lastAttemptAt == null) continue;
+    const sinceSuccess = feed.lastSuccessAt == null
+      ? Number.POSITIVE_INFINITY
+      : nowMs - feed.lastSuccessAt;
+    if (sinceSuccess < STALE_FEED_THRESHOLD_MS) continue;
+    const ageMs = nowMs - feed.lastAttemptAt;
+    if (ageMs > ALERT_WINDOW_MS) continue;
+    items.push({ type: 'stale_feed', label: `${feed.key} feed error`, ageMs });
+  }
+}

--- a/src/components/CommandCenterPanel.ts
+++ b/src/components/CommandCenterPanel.ts
@@ -27,6 +27,9 @@ import type { ActionBrief } from '@/services/insights/action-briefs';
 import type { PersonalImpact } from '@/services/personal/personal-impact';
 import type { FeatureHealth, HealthStatus } from '@/services/diagnostics/system-health-types';
 import { escapeHtml } from '@/utils/sanitize';
+import { getSavedPlaces, type SavedPlace } from '@/services/saved-places';
+import { getApiBaseUrl } from '@/services/runtime';
+import type { ImpactSeverity } from '@/services/personal/personal-impact';
 
 const REFRESH_MS = 10_000;
 
@@ -65,8 +68,21 @@ const RISK_LABEL: Record<HealthStatus, string> = {
   unsafe: 'CRITICAL',
 };
 
+interface TapeItem {
+  type: string;
+  label: string;
+  ageMs: number;
+}
+
+const TILE_ORDER_KEY = 'wm-command-center-tile-order';
+
 export class CommandCenterPanel extends Panel {
   private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  private tapeTimer: ReturnType<typeof setInterval> | null = null;
+  private tapeItems: TapeItem[] = [];
+  private isDragging = false;
+  private draggingId: string | null = null;
+  private dragOverId: string | null = null;
 
   constructor() {
     super({
@@ -83,6 +99,9 @@ export class CommandCenterPanel extends Panel {
   private start(): void {
     this.render();
     this.refreshTimer = setInterval(() => this.render(), REFRESH_MS);
+    void this.fetchTapeItems();
+    this.tapeTimer = setInterval(() => { void this.fetchTapeItems(); }, 5 * 60 * 1000);
+    this.attachDragListeners();
   }
 
   public override destroy(): void {
@@ -90,10 +109,15 @@ export class CommandCenterPanel extends Panel {
       clearInterval(this.refreshTimer);
       this.refreshTimer = null;
     }
+    if (this.tapeTimer !== null) {
+      clearInterval(this.tapeTimer);
+      this.tapeTimer = null;
+    }
     super.destroy();
   }
 
   private render(): void {
+    if (this.isDragging) return;
     const html = this.buildHtml();
     this.setContent(html);
   }
@@ -134,6 +158,7 @@ export class CommandCenterPanel extends Panel {
     return `
       <div style="padding:14px;display:flex;flex-direction:column;gap:14px;">
         ${this.renderGlobeNav()}
+        ${this.renderSavedPlacesTiles()}
         ${this.renderRiskHeadline(report.status, report.summary)}
         ${this.renderActionBrief(actionBrief)}
         ${this.renderPersonalImpact(personalImpact.impacts)}
@@ -141,6 +166,7 @@ export class CommandCenterPanel extends Panel {
         ${this.renderProviderRedundancy(redundancy)}
         ${this.renderWatchNext(feedAudit.entries.length, feedAudit.entries.filter((e) => e.level !== 'fresh' && e.level !== 'unknown').length)}
         ${this.renderRecommendations(report.recommendations)}
+        ${this.renderChangeTape()}
       </div>
     `;
   }
@@ -271,6 +297,163 @@ export class CommandCenterPanel extends Panel {
       <ul style="margin:0;padding-left:18px;font-size:12px;line-height:1.5;">
         ${recs.slice(0, 4).map((r) => `<li>${escapeHtml(r)}</li>`).join('')}
       </ul>
+    </div>`;
+  }
+
+  // ── Saved-places tiles ──────────────────────────────────────────────────
+
+  private loadTileOrder(): string[] {
+    try {
+      const stored = localStorage.getItem(TILE_ORDER_KEY);
+      return stored ? (JSON.parse(stored) as string[]) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private saveTileOrder(ids: string[]): void {
+    localStorage.setItem(TILE_ORDER_KEY, JSON.stringify(ids));
+  }
+
+  private sortedTiles(places: SavedPlace[]): SavedPlace[] {
+    const order = this.loadTileOrder();
+    return [...places].sort((a, b) => {
+      const ai = order.indexOf(a.id);
+      const bi = order.indexOf(b.id);
+      if (ai === -1 && bi === -1) return 0;
+      if (ai === -1) return 1;
+      if (bi === -1) return -1;
+      return ai - bi;
+    });
+  }
+
+  private placeSeverity(place: SavedPlace, impacts: readonly PersonalImpact[]): ImpactSeverity {
+    return impacts.find((imp) =>
+      imp.exposures.some((e) => e.exposureId === place.id || e.label === place.name),
+    )?.severity ?? 'none';
+  }
+
+  private placeAlertCount(place: SavedPlace, impacts: readonly PersonalImpact[]): number {
+    return impacts.filter((imp) =>
+      imp.exposures.some((e) => e.exposureId === place.id || e.label === place.name),
+    ).length;
+  }
+
+  private renderTile(place: SavedPlace, severity: ImpactSeverity, alertCount: number): string {
+    const color = IMPACT_SEVERITY_COLOR[severity];
+    const plural = alertCount === 1 ? '' : 's';
+    const countHtml = alertCount > 0
+      ? `<div style="font-size:10px;color:var(--text-secondary,#aaa);margin-top:2px;">${alertCount} alert${plural}</div>`
+      : '';
+    return `<div class="ccp-tile" data-tile-id="${escapeHtml(place.id)}" draggable="true"
+      style="flex:0 0 auto;width:100px;padding:8px 10px;border:1px solid var(--border-subtle,#333);border-top:3px solid ${color};border-radius:4px;cursor:grab;background:rgba(255,255,255,0.02);user-select:none;">
+      <div style="font-size:12px;font-weight:700;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" title="${escapeHtml(place.name)}">${escapeHtml(place.name)}</div>
+      <div style="font-size:10px;color:${color};text-transform:uppercase;margin-top:2px;">${escapeHtml(severity)}</div>
+      ${countHtml}
+    </div>`;
+  }
+
+  private renderSavedPlacesTiles(): string {
+    const places = getSavedPlaces().slice(0, 6);
+    const impacts = getPersonalImpactReport().impacts;
+    const sorted = this.sortedTiles(places);
+    const tileHtml = sorted.map((p) =>
+      this.renderTile(p, this.placeSeverity(p, impacts), this.placeAlertCount(p, impacts)),
+    ).join('');
+    const addBtn = `<button data-action="add-place" style="font-size:11px;color:var(--accent,#4a9eff);background:none;border:1px dashed var(--border-subtle,#333);border-radius:4px;padding:6px 10px;cursor:pointer;align-self:flex-start;" title="Add a saved place">+</button>`;
+    return `<div style="padding-bottom:2px;">
+      <div style="font-size:11px;color:var(--text-secondary,#aaa);text-transform:uppercase;margin-bottom:6px;">Your places</div>
+      <div class="ccp-tiles-row" style="display:flex;flex-wrap:wrap;gap:8px;">${tileHtml}${addBtn}</div>
+    </div>`;
+  }
+
+  // ── Drag-to-reorder tiles (event delegation — listeners survive re-render) ──
+
+  private attachDragListeners(): void {
+    this.content.addEventListener('dragstart', (e) => this.onDragStart(e));
+    this.content.addEventListener('dragover', (e) => this.onDragOver(e));
+    this.content.addEventListener('drop', (e) => this.onDrop(e));
+    this.content.addEventListener('dragend', () => this.onDragEnd());
+    this.content.addEventListener('click', (e) => this.onContentClick(e));
+  }
+
+  private onDragStart(e: DragEvent): void {
+    const tile = (e.target as HTMLElement).closest<HTMLElement>('[data-tile-id]');
+    if (!tile) return;
+    this.isDragging = true;
+    this.draggingId = tile.dataset.tileId ?? null;
+    e.dataTransfer?.setData('text/plain', this.draggingId ?? '');
+  }
+
+  private onDragOver(e: DragEvent): void {
+    const tile = (e.target as HTMLElement).closest<HTMLElement>('[data-tile-id]');
+    if (!tile) return;
+    e.preventDefault();
+    this.dragOverId = tile.dataset.tileId ?? null;
+  }
+
+  private onDrop(e: DragEvent): void {
+    e.preventDefault();
+    const from = this.draggingId;
+    const to = this.dragOverId;
+    this.isDragging = false;
+    this.draggingId = null;
+    this.dragOverId = null;
+    if (!from || !to || from === to) { this.render(); return; }
+    const ids = this.sortedTiles(getSavedPlaces().slice(0, 6)).map((p) => p.id);
+    const fromIdx = ids.indexOf(from);
+    const toIdx = ids.indexOf(to);
+    if (fromIdx !== -1 && toIdx !== -1) {
+      ids.splice(fromIdx, 1);
+      ids.splice(toIdx, 0, from);
+    }
+    this.saveTileOrder(ids);
+    this.render();
+  }
+
+  private onDragEnd(): void {
+    this.isDragging = false;
+    this.draggingId = null;
+    this.dragOverId = null;
+    this.render();
+  }
+
+  private onContentClick(e: MouseEvent): void {
+    const btn = (e.target as HTMLElement).closest<HTMLElement>('[data-action="add-place"]');
+    if (!btn) return;
+    document.querySelector<HTMLElement>('[data-panel-id="saved-places"]')?.click();
+  }
+
+  // ── Live change tape ────────────────────────────────────────────────────
+
+  private async fetchTapeItems(): Promise<void> {
+    try {
+      const url = `${getApiBaseUrl()}/api/command-center/recent-changes`;
+      const resp = await fetch(url);
+      if (!resp.ok) return;
+      const data = await resp.json() as { items?: TapeItem[] };
+      this.tapeItems = data.items ?? [];
+      if (!this.isDragging) this.render();
+    } catch {
+      // fail silently — tape stays empty
+    }
+  }
+
+  private formatAge(ms: number): string {
+    const min = Math.floor(ms / 60_000);
+    if (min < 60) return `${min}m`;
+    return `${Math.floor(min / 60)}h`;
+  }
+
+  private renderChangeTape(): string {
+    if (this.tapeItems.length === 0) return '';
+    const items = this.tapeItems.slice(0, 10).map((item) => {
+      const age = this.formatAge(item.ageMs);
+      return `<span style="display:inline-block;padding:0 10px;border-right:1px solid var(--border-subtle,#444);font-size:11px;white-space:nowrap;">${escapeHtml(item.label)}<span style="color:var(--text-secondary,#aaa);margin-left:4px;">${escapeHtml(age)} ago</span></span>`;
+    }).join('');
+    return `<div style="border-top:1px solid var(--border-subtle,#333);padding-top:10px;">
+      <div style="font-size:10px;color:var(--text-secondary,#aaa);text-transform:uppercase;margin-bottom:4px;">What changed (last hour)</div>
+      <div style="overflow-x:auto;display:flex;padding-bottom:4px;">${items}</div>
     </div>`;
   }
 }

--- a/tests/recent-changes.test.mjs
+++ b/tests/recent-changes.test.mjs
@@ -1,0 +1,148 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+import { buildRecentChanges } from '../src-tauri/sidecar/recent-changes.mjs';
+
+const NOW = 1_700_000_000_000; // fixed epoch for deterministic tests
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function alert(overrides = {}) {
+  return {
+    event: 'Thunderstorm Warning',
+    headline: 'Severe Thunderstorm Warning',
+    effective: new Date(NOW - 10 * 60 * 1000).toISOString(), // 10 min ago
+    ...overrides,
+  };
+}
+
+function feed(overrides = {}) {
+  return {
+    key: 'nws',
+    lastSuccessAt: null,
+    lastError: 'ETIMEDOUT',
+    lastAttemptAt: NOW - 5 * 60 * 1000, // 5 min ago
+    ...overrides,
+  };
+}
+
+// ── Empty / null inputs ──────────────────────────────────────────────────────
+
+test('returns empty items when both inputs are null/empty', () => {
+  const result = buildRecentChanges([], null, NOW);
+  assert.deepEqual(result, { items: [] });
+});
+
+test('returns empty items when alertCache has no alerts array', () => {
+  const result = buildRecentChanges([], { fetchedAt: new Date(NOW).toISOString() }, NOW);
+  assert.deepEqual(result, { items: [] });
+});
+
+test('returns empty items when feedSnapshots is empty and no alert cache', () => {
+  const result = buildRecentChanges([], null, NOW);
+  assert.equal(result.items.length, 0);
+});
+
+// ── Alert inclusion / exclusion ──────────────────────────────────────────────
+
+test('includes an alert within 60 min window', () => {
+  const alertCache = { alerts: [alert({ effective: new Date(NOW - 30 * 60 * 1000).toISOString() })] };
+  const result = buildRecentChanges([], alertCache, NOW);
+  assert.equal(result.items.length, 1);
+  assert.equal(result.items[0].type, 'alert');
+});
+
+test('excludes an alert older than 60 min', () => {
+  const alertCache = { alerts: [alert({ effective: new Date(NOW - 61 * 60 * 1000).toISOString() })] };
+  const result = buildRecentChanges([], alertCache, NOW);
+  assert.equal(result.items.length, 0);
+});
+
+test('excludes an alert with a future effective time', () => {
+  const alertCache = { alerts: [alert({ effective: new Date(NOW + 5 * 60 * 1000).toISOString() })] };
+  const result = buildRecentChanges([], alertCache, NOW);
+  assert.equal(result.items.length, 0);
+});
+
+test('excludes an alert with an unparseable effective date', () => {
+  const alertCache = { alerts: [alert({ effective: 'not-a-date' })] };
+  const result = buildRecentChanges([], alertCache, NOW);
+  assert.equal(result.items.length, 0);
+});
+
+test('uses headline as the alert label when present', () => {
+  const alertCache = { alerts: [alert({ headline: 'Tornado Warning for Adams County' })] };
+  const result = buildRecentChanges([], alertCache, NOW);
+  assert.equal(result.items[0].label, 'Tornado Warning for Adams County');
+});
+
+test('falls back to event field when headline is empty', () => {
+  const alertCache = { alerts: [alert({ headline: '', event: 'Flash Flood Watch' })] };
+  const result = buildRecentChanges([], alertCache, NOW);
+  assert.equal(result.items[0].label, 'Flash Flood Watch');
+});
+
+// ── Feed inclusion / exclusion ───────────────────────────────────────────────
+
+test('includes a stale feed that has never succeeded', () => {
+  const result = buildRecentChanges([feed()], null, NOW);
+  assert.equal(result.items.length, 1);
+  assert.equal(result.items[0].type, 'stale_feed');
+});
+
+test('excludes a feed whose last success is recent (<30 min)', () => {
+  const freshFeed = feed({ lastSuccessAt: NOW - 10 * 60 * 1000 });
+  const result = buildRecentChanges([freshFeed], null, NOW);
+  assert.equal(result.items.length, 0);
+});
+
+test('excludes a feed with no lastError', () => {
+  const healthyFeed = feed({ lastError: null });
+  const result = buildRecentChanges([healthyFeed], null, NOW);
+  assert.equal(result.items.length, 0);
+});
+
+test('excludes a stale feed whose lastAttemptAt is older than 60 min', () => {
+  const oldFeed = feed({ lastAttemptAt: NOW - 65 * 60 * 1000 });
+  const result = buildRecentChanges([oldFeed], null, NOW);
+  assert.equal(result.items.length, 0);
+});
+
+test('includes the feed key in the stale feed label', () => {
+  const result = buildRecentChanges([feed({ key: 'acled' })], null, NOW);
+  assert.ok(result.items[0].label.includes('acled'), 'label must contain feed key');
+});
+
+// ── Sorting ──────────────────────────────────────────────────────────────────
+
+test('sorts items by ageMs ascending (newest first)', () => {
+  const alertCache = {
+    alerts: [
+      alert({ effective: new Date(NOW - 50 * 60 * 1000).toISOString() }),
+      alert({ effective: new Date(NOW - 5 * 60 * 1000).toISOString() }),
+    ],
+  };
+  const result = buildRecentChanges([], alertCache, NOW);
+  assert.equal(result.items.length, 2);
+  assert.ok(result.items[0].ageMs < result.items[1].ageMs, 'newest item must come first');
+});
+
+test('mixes alert and stale_feed items sorted by age', () => {
+  const alertCache = { alerts: [alert({ effective: new Date(NOW - 40 * 60 * 1000).toISOString() })] };
+  const staleFeed = feed({ lastAttemptAt: NOW - 2 * 60 * 1000 });
+  const result = buildRecentChanges([staleFeed], alertCache, NOW);
+  assert.equal(result.items.length, 2);
+  assert.equal(result.items[0].type, 'stale_feed');
+  assert.equal(result.items[1].type, 'alert');
+});
+
+// ── ageMs value ───────────────────────────────────────────────────────────────
+
+test('ageMs is accurate for an alert', () => {
+  const OFFSET_MS = 15 * 60 * 1000;
+  const alertCache = { alerts: [alert({ effective: new Date(NOW - OFFSET_MS).toISOString() })] };
+  const result = buildRecentChanges([], alertCache, NOW);
+  assert.ok(
+    Math.abs(result.items[0].ageMs - OFFSET_MS) < 1000,
+    `ageMs should be ~${OFFSET_MS}ms, got ${result.items[0].ageMs}`,
+  );
+});


### PR DESCRIPTION
## Summary

Two Command Center enhancements:

### 1. Saved-places tiles (top row)
- Up to 6 colour-coded tiles sourced from `getSavedPlaces()`
- Threat level and alert count from `PersonalImpactReport` — matched by place ID or name
- Drag-to-reorder via HTML Drag and Drop API with event delegation (listeners survive panel re-renders)
- Order persisted to `localStorage['wm-command-center-tile-order']`
- `+` button navigates to the saved-places panel
- Render guard: `render()` no-ops while drag is active, resumes on `dragend`/`drop`

### 2. Live change tape (bottom)
- Scrolls last-hour alerts and stale feed errors
- Fetches `GET /api/command-center/recent-changes` every 5 min (independent of the 10 s panel refresh)
- Sidecar route is a thin wrapper over `buildRecentChanges()` pure helper in `recent-changes.mjs`
- Items sorted newest-first

### Tests
- 17 tests in `tests/recent-changes.test.mjs` — all passing
- Covers empty state, alert inclusion/exclusion by time window, headline/event fallback, stale feed filtering, mixed sorting, ageMs accuracy

### Typecheck
Zero errors on both tsconfig.json and tsconfig.api.json.

---

Cross-agent review: claude reviewed on 2026-05-11; outcome: pass