### PR TITLE
feat(intelligence): evidence graph + driver-based severity scoring

### DIFF
--- a/api/intelligence/evidence-graph.js
+++ b/api/intelligence/evidence-graph.js
@@ -1,0 +1,200 @@
+/**
+ * Evidence graph query endpoint — returns ObsEvidenceEdges for a given
+ * observation event ID, sourced from recent USGS + NWS events with
+ * auto-derived structural edges (proximity, entity, temporal, correlation).
+ *
+ * GET /api/intelligence/evidence-graph?eventId=<id>
+ *   Returns all edges where `from` or `to` === eventId, plus the
+ *   neighbor event IDs for graph traversal.
+ *
+ * Without eventId: returns a summary of the full graph (edge count,
+ * most-connected nodes, edge type breakdown).
+ */
+
+import { getCorsHeaders, isDisallowedOrigin } from '../_cors.js';
+
+export const config = { runtime: 'edge' };
+
+const CACHE_TTL_MS = 60 * 1000;
+export const cache = new Map();
+
+const j = (payload, status, cors) =>
+  Response.json(payload, {
+    status,
+    headers: { 'content-type': 'application/json; charset=utf-8', ...cors },
+  });
+
+// ── Haversine ────────────────────────────────────────────────────────────────
+
+function haversineKm(lat1, lon1, lat2, lon2) {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLon = ((lon2 - lon1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+// ── Auto-edge derivation ────────────────────────────────────────────────────
+
+function makePair(a, b, type, confidence, now) {
+  return [
+    { from: a.id, to: b.id, type, confidence, created: now },
+    { from: b.id, to: a.id, type, confidence, created: now },
+  ];
+}
+
+function entitySharedEdges(a, b, now) {
+  const overlap = (a.tags ?? []).some((t) => (b.tags ?? []).includes(t));
+  return overlap ? makePair(a, b, 'entity_shared', 0.8, now) : [];
+}
+
+function coLocatedEdges(a, b, now) {
+  if (!a.location || !b.location) return [];
+  const dist = haversineKm(a.location.lat, a.location.lon, b.location.lat, b.location.lon);
+  if (dist > 100) return [];
+  const conf = +Math.max(0.4, 1 - dist / 100).toFixed(3);
+  return makePair(a, b, 'co_located', conf, now);
+}
+
+function temporalEdges(a, b, now) {
+  const WINDOW = 30 * 60_000;
+  const diff = Math.abs(a.timestamp - b.timestamp);
+  if (diff > WINDOW) return [];
+  const conf = +(1 - (diff / WINDOW) * 0.5).toFixed(3);
+  return makePair(a, b, 'temporally_adjacent', conf, now);
+}
+
+function correlatedEdges(a, b, now) {
+  return a.domain === b.domain ? makePair(a, b, 'correlated', 0.6, now) : [];
+}
+
+function buildEdges(events) {
+  const edges = [];
+  const now = Date.now();
+
+  for (let i = 0; i < events.length; i++) {
+    const a = events[i];
+    for (let j = i + 1; j < events.length; j++) {
+      const b = events[j];
+      edges.push(
+        ...entitySharedEdges(a, b, now),
+        ...coLocatedEdges(a, b, now),
+        ...temporalEdges(a, b, now),
+        ...correlatedEdges(a, b, now),
+      );
+    }
+  }
+
+  return edges;
+}
+
+// ── Upstream fetch (shared with prioritized.js) ──────────────────────────────
+
+async function fetchEarthquakes() {
+  const r = await fetch(
+    'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/2.5_day.geojson',
+    { signal: AbortSignal.timeout(8000) },
+  );
+  if (!r.ok) return [];
+  const data = await r.json();
+  return (data?.features ?? []).map((f) => {
+    const [lon, lat] = f.geometry?.coordinates ?? [null, null];
+    return {
+      id: f.id,
+      sourceId: 'usgs-earthquake',
+      domain: 'seismic',
+      timestamp: f.properties?.time ?? Date.now(),
+      location: lat != null && lon != null ? { lat, lon } : undefined,
+      tags: ['earthquake'],
+    };
+  });
+}
+
+async function fetchNwsAlerts() {
+  const r = await fetch(
+    'https://api.weather.gov/alerts/active?status=actual&message_type=alert',
+    {
+      headers: { Accept: 'application/geo+json', 'User-Agent': 'CrystalBall/2.10.21' },
+      signal: AbortSignal.timeout(8000),
+    },
+  );
+  if (!r.ok) return [];
+  const data = await r.json();
+  return (data?.features ?? []).slice(0, 100).map((f) => {
+    const p = f.properties ?? {};
+    const coords = f.geometry?.coordinates?.[0]?.[0];
+    const location = Array.isArray(coords) ? { lat: coords[1], lon: coords[0] } : undefined;
+    return {
+      id: p.id ?? f.id,
+      sourceId: 'nws-alerts',
+      domain: 'weather',
+      timestamp: new Date(p.sent ?? p.effective ?? Date.now()).getTime(),
+      location,
+      tags: ['weather'],
+    };
+  });
+}
+
+// ── Handler ──────────────────────────────────────────────────────────────────
+
+export default async function handler(req) {
+  const cors = getCorsHeaders(req, 'GET, OPTIONS');
+  if (isDisallowedOrigin(req)) return j({ error: 'Origin not allowed' }, 403, cors);
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
+  if (req.method !== 'GET') return j({ error: 'Method not allowed' }, 405, cors);
+
+  const url = new URL(req.url);
+  const eventId = url.searchParams.get('eventId') ?? '';
+
+  const cacheKey = `evidence-graph:${eventId}`;
+  const cached = cache.get(cacheKey);
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) return j(cached.payload, 200, cors);
+
+  const [quakes, alerts] = await Promise.allSettled([fetchEarthquakes(), fetchNwsAlerts()]);
+  const allEvents = [
+    ...(quakes.status === 'fulfilled' ? quakes.value : []),
+    ...(alerts.status === 'fulfilled' ? alerts.value : []),
+  ];
+
+  const edges = buildEdges(allEvents);
+
+  let payload;
+  if (eventId) {
+    const eventEdges = edges.filter((e) => e.from === eventId || e.to === eventId);
+    const neighborIds = [...new Set(
+      eventEdges.map((e) => (e.from === eventId ? e.to : e.from)),
+    )];
+    payload = {
+      eventId,
+      edges: eventEdges,
+      neighborIds,
+      edgeCount: eventEdges.length,
+      generatedAt: new Date().toISOString(),
+    };
+  } else {
+    const typeCounts = {};
+    for (const e of edges) typeCounts[e.type] = (typeCounts[e.type] ?? 0) + 1;
+    const connectivity = {};
+    for (const e of edges) {
+      connectivity[e.from] = (connectivity[e.from] ?? 0) + 1;
+    }
+    const topNodes = Object.entries(connectivity)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 10)
+      .map(([id, count]) => ({ id, outDegree: count }));
+    payload = {
+      totalEdges: edges.length,
+      totalEvents: allEvents.length,
+      edgesByType: typeCounts,
+      topNodes,
+      generatedAt: new Date().toISOString(),
+    };
+  }
+
+  cache.set(cacheKey, { at: Date.now(), payload });
+  return j(payload, 200, cors);
+}

--- a/src/services/intelligence/__tests__/driver-scorer.test.mts
+++ b/src/services/intelligence/__tests__/driver-scorer.test.mts
@@ -1,0 +1,200 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { scoreEvent, scoreEvents } from '../driver-scorer.ts';
+import type { ObservationEvent } from '@/types/intelligence';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const NOW = 1_745_000_000_000;
+
+function makeEvent(overrides: Partial<ObservationEvent> & { id: string }): ObservationEvent {
+  return {
+    sourceId: 'test',
+    domain: 'seismic',
+    timestamp: NOW - 3 * 60 * 60_000,
+    severity: 'MEDIUM',
+    title: overrides.id,
+    raw: null,
+    entityIds: [],
+    tags: [],
+    ...overrides,
+  };
+}
+
+// ── Return shape ───────────────────────────────────────────────────────────
+
+test('scoreEvent returns ScoredEvent with driverScore, drivers, scoreReason', () => {
+  const ev = makeEvent({ id: 'ev1' });
+  const result = scoreEvent(ev, { now: () => NOW });
+  assert.ok(typeof result.driverScore === 'number');
+  assert.ok(Array.isArray(result.drivers));
+  assert.ok(typeof result.scoreReason === 'string');
+  assert.ok(result.scoreReason.length > 0);
+});
+
+test('driverScore is clamped to [0, 100]', () => {
+  const ev = makeEvent({ id: 'ev-crit', severity: 'CRITICAL', domain: 'generic' });
+  const result = scoreEvent(ev, { now: () => NOW });
+  assert.ok(result.driverScore >= 0);
+  assert.ok(result.driverScore <= 100);
+});
+
+test('ScoredEvent preserves all original ObservationEvent fields', () => {
+  const ev = makeEvent({ id: 'preserve-me', tags: ['x'], entityIds: ['Y'] });
+  const result = scoreEvent(ev, { now: () => NOW });
+  assert.equal(result.id, ev.id);
+  assert.deepEqual(result.tags, ev.tags);
+  assert.deepEqual(result.entityIds, ev.entityIds);
+});
+
+// ── Earthquake domain ──────────────────────────────────────────────────────
+
+test('earthquake domain detected by domain=seismic', () => {
+  const ev = makeEvent({ id: 'quake-1', domain: 'seismic', tags: [] });
+  const result = scoreEvent(ev, { now: () => NOW });
+  assert.ok(result.drivers.some((d) => d.name === 'magnitude'));
+  assert.ok(result.drivers.some((d) => d.name === 'shallow_depth'));
+});
+
+test('earthquake domain detected by earthquake tag', () => {
+  const ev = makeEvent({ id: 'quake-tag', domain: 'other', tags: ['earthquake'] });
+  const result = scoreEvent(ev, { now: () => NOW });
+  assert.ok(result.drivers.some((d) => d.name === 'magnitude'));
+});
+
+test('high magnitude earthquake scores higher than low magnitude', () => {
+  const high = makeEvent({ id: 'high-mag', domain: 'seismic', raw: { mag: 7.5 } });
+  const low  = makeEvent({ id: 'low-mag',  domain: 'seismic', raw: { mag: 2.5 } });
+  const rHigh = scoreEvent(high, { now: () => NOW });
+  const rLow  = scoreEvent(low, { now: () => NOW });
+  assert.ok(rHigh.driverScore > rLow.driverScore,
+    `expected high(${rHigh.driverScore}) > low(${rLow.driverScore})`);
+});
+
+test('aftershock tag is mitigating direction', () => {
+  const ev = makeEvent({ id: 'aftershock', domain: 'seismic', tags: ['aftershock'] });
+  const result = scoreEvent(ev, { now: () => NOW });
+  const aftershockDriver = result.drivers.find((d) => d.name === 'aftershock_pattern');
+  assert.equal(aftershockDriver?.direction, 'mitigating');
+});
+
+test('earthquake driver weights sum to 1.0', () => {
+  const ev = makeEvent({ id: 'sum-check', domain: 'seismic' });
+  const { drivers } = scoreEvent(ev, { now: () => NOW });
+  const total = drivers.reduce((s, d) => s + d.weight, 0);
+  assert.ok(Math.abs(total - 1.0) < 0.001, `weights summed to ${total}`);
+});
+
+// ── Wildfire domain ────────────────────────────────────────────────────────
+
+test('wildfire domain detected by domain=wildfire', () => {
+  const ev = makeEvent({ id: 'fire-1', domain: 'wildfire', tags: [] });
+  const result = scoreEvent(ev, { now: () => NOW });
+  assert.ok(result.drivers.some((d) => d.name === 'fire_acres'));
+  assert.ok(result.drivers.some((d) => d.name === 'containment_pct'));
+});
+
+test('wildfire with 0% containment scores higher than 100% containment', () => {
+  const uncontained = makeEvent({ id: 'fire-out', domain: 'wildfire', raw: { containment: 0, acres: 5000 } });
+  const contained   = makeEvent({ id: 'fire-in',  domain: 'wildfire', raw: { containment: 100, acres: 5000 } });
+  const rOut = scoreEvent(uncontained, { now: () => NOW });
+  const rIn  = scoreEvent(contained,   { now: () => NOW });
+  assert.ok(rOut.driverScore > rIn.driverScore,
+    `expected uncontained(${rOut.driverScore}) > contained(${rIn.driverScore})`);
+});
+
+test('wildfire driver weights sum to 1.0', () => {
+  const ev = makeEvent({ id: 'fire-sum', domain: 'wildfire' });
+  const { drivers } = scoreEvent(ev, { now: () => NOW });
+  const total = drivers.reduce((s, d) => s + d.weight, 0);
+  assert.ok(Math.abs(total - 1.0) < 0.001, `weights summed to ${total}`);
+});
+
+// ── Aviation domain ────────────────────────────────────────────────────────
+
+test('aviation domain detected by domain=aviation', () => {
+  const ev = makeEvent({ id: 'av-1', domain: 'aviation', tags: [] });
+  const result = scoreEvent(ev, { now: () => NOW });
+  assert.ok(result.drivers.some((d) => d.name === 'squawk_severity'));
+  assert.ok(result.drivers.some((d) => d.name === 'aircraft_type'));
+});
+
+test('squawk 7700 (emergency) scores higher than 7000 (VFR default)', () => {
+  const emergency = makeEvent({ id: 'sq7700', domain: 'aviation', raw: { squawk: '7700' } });
+  const normal    = makeEvent({ id: 'sq7000', domain: 'aviation', raw: { squawk: '7000' } });
+  const rEmerg = scoreEvent(emergency, { now: () => NOW });
+  const rNorm  = scoreEvent(normal,    { now: () => NOW });
+  assert.ok(rEmerg.driverScore > rNorm.driverScore,
+    `expected emergency(${rEmerg.driverScore}) > normal(${rNorm.driverScore})`);
+});
+
+test('aviation driver weights sum to 1.0', () => {
+  const ev = makeEvent({ id: 'av-sum', domain: 'aviation' });
+  const { drivers } = scoreEvent(ev, { now: () => NOW });
+  const total = drivers.reduce((s, d) => s + d.weight, 0);
+  assert.ok(Math.abs(total - 1.0) < 0.001, `weights summed to ${total}`);
+});
+
+// ── Generic / fallback ─────────────────────────────────────────────────────
+
+test('unknown domain falls back to generic scorer', () => {
+  const ev = makeEvent({ id: 'generic', domain: 'unknown-domain', tags: [] });
+  const result = scoreEvent(ev, { now: () => NOW });
+  assert.ok(result.drivers.some((d) => d.name === 'raw_severity'));
+  assert.ok(result.drivers.some((d) => d.name === 'recency'));
+});
+
+test('generic: CRITICAL severity scores higher than INFO', () => {
+  const crit = makeEvent({ id: 'crit', domain: 'generic', severity: 'CRITICAL' });
+  const info = makeEvent({ id: 'info', domain: 'generic', severity: 'INFO' });
+  const rCrit = scoreEvent(crit, { now: () => NOW });
+  const rInfo = scoreEvent(info, { now: () => NOW });
+  assert.ok(rCrit.driverScore > rInfo.driverScore,
+    `expected crit(${rCrit.driverScore}) > info(${rInfo.driverScore})`);
+});
+
+test('generic: evidence connections boost the score', () => {
+  const ev = makeEvent({ id: 'ev-connected', domain: 'generic', severity: 'INFO' });
+  const noGraph = scoreEvent(ev, { now: () => NOW });
+  // Stub graph returning 10 edges for ev-connected
+  const stubGraph = {
+    getEdges: (id: string) => id === 'ev-connected'
+      ? Array.from({ length: 10 }, (_, i) => ({
+          from: 'ev-connected', to: `other-${i}`, type: 'correlated' as const,
+          confidence: 0.5, created: NOW,
+        }))
+      : [],
+    addEdge: () => undefined,
+    getNeighbors: () => [],
+    findPath: () => null,
+    populate: () => undefined,
+    edgeCount: () => 10,
+    _reset: () => undefined,
+  };
+  const withGraph = scoreEvent(ev, { now: () => NOW, graph: stubGraph });
+  assert.ok(withGraph.driverScore > noGraph.driverScore,
+    `expected connected(${withGraph.driverScore}) > isolated(${noGraph.driverScore})`);
+});
+
+// ── scoreEvents batch ──────────────────────────────────────────────────────
+
+test('scoreEvents returns same number of events as input', () => {
+  const events = [
+    makeEvent({ id: 'b1' }),
+    makeEvent({ id: 'b2', domain: 'wildfire' }),
+    makeEvent({ id: 'b3', domain: 'aviation' }),
+  ];
+  const results = scoreEvents(events, { now: () => NOW });
+  assert.equal(results.length, 3);
+});
+
+test('scoreEvents preserves input order', () => {
+  const events = [
+    makeEvent({ id: 'first' }),
+    makeEvent({ id: 'second' }),
+  ];
+  const results = scoreEvents(events, { now: () => NOW });
+  assert.equal(results[0]!.id, 'first');
+  assert.equal(results[1]!.id, 'second');
+});

--- a/src/services/intelligence/__tests__/observation-graph.test.mts
+++ b/src/services/intelligence/__tests__/observation-graph.test.mts
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createObservationGraph } from '../observation-graph.ts';
+import type { ObservationEvent } from '@/types/intelligence';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const NOW = 1_745_000_000_000;
+
+function makeEvent(overrides: Partial<ObservationEvent> & { id: string }): ObservationEvent {
+  return {
+    sourceId: 'test',
+    domain: 'seismic',
+    timestamp: NOW,
+    severity: 'MEDIUM',
+    title: overrides.id,
+    raw: null,
+    entityIds: [],
+    tags: [],
+    ...overrides,
+  };
+}
+
+// ── addEdge / getEdges ──────────────────────────────────────────────────────
+
+test('addEdge stores edge retrievable by getEdges', () => {
+  const g = createObservationGraph();
+  g.addEdge('a', 'b', 'correlated', 0.7);
+  const edges = g.getEdges('a');
+  assert.equal(edges.length, 1);
+  assert.equal(edges[0]!.from, 'a');
+  assert.equal(edges[0]!.to, 'b');
+  assert.equal(edges[0]!.type, 'correlated');
+  assert.equal(edges[0]!.confidence, 0.7);
+});
+
+test('getEdges returns edges where event is either from or to', () => {
+  const g = createObservationGraph();
+  g.addEdge('a', 'b', 'correlated', 0.5);
+  g.addEdge('c', 'a', 'co_located', 0.8);
+  const edges = g.getEdges('a');
+  assert.equal(edges.length, 2);
+});
+
+test('addEdge deduplicates same (from,to,type) keeping higher confidence', () => {
+  const g = createObservationGraph();
+  g.addEdge('a', 'b', 'correlated', 0.5);
+  g.addEdge('a', 'b', 'correlated', 0.9);
+  const edges = g.getEdges('a').filter((e) => e.from === 'a' && e.to === 'b');
+  assert.equal(edges.length, 1);
+  assert.equal(edges[0]!.confidence, 0.9);
+});
+
+test('addEdge dedup does not merge different types', () => {
+  const g = createObservationGraph();
+  g.addEdge('a', 'b', 'correlated', 0.5);
+  g.addEdge('a', 'b', 'co_located', 0.8);
+  const edges = g.getEdges('a').filter((e) => e.from === 'a');
+  assert.equal(edges.length, 2);
+});
+
+test('edgeCount returns correct count', () => {
+  const g = createObservationGraph();
+  g.addEdge('a', 'b', 'correlated', 0.5);
+  g.addEdge('b', 'c', 'entity_shared', 0.8);
+  assert.equal(g.edgeCount(), 2);
+});
+
+// ── getNeighbors ────────────────────────────────────────────────────────────
+
+test('getNeighbors returns connected node IDs in both directions', () => {
+  const g = createObservationGraph();
+  g.addEdge('a', 'b', 'correlated', 0.5);
+  g.addEdge('c', 'a', 'co_located', 0.8);
+  const neighbors = g.getNeighbors('a');
+  assert.ok(neighbors.includes('b'));
+  assert.ok(neighbors.includes('c'));
+  assert.ok(!neighbors.includes('a'));
+});
+
+test('getNeighbors returns empty for unknown event', () => {
+  const g = createObservationGraph();
+  assert.deepEqual(g.getNeighbors('unknown'), []);
+});
+
+test('getNeighbors deduplicates IDs across multiple edges', () => {
+  const g = createObservationGraph();
+  g.addEdge('a', 'b', 'correlated', 0.5);
+  g.addEdge('a', 'b', 'co_located', 0.9);
+  const neighbors = g.getNeighbors('a');
+  assert.equal(neighbors.filter((n) => n === 'b').length, 1);
+});
+
+// ── findPath BFS ────────────────────────────────────────────────────────────
+
+test('findPath returns direct path when directly connected', () => {
+  const g = createObservationGraph();
+  g.addEdge('a', 'b', 'correlated', 0.5);
+  const path = g.findPath('a', 'b');
+  assert.deepEqual(path, ['a', 'b']);
+});
+
+test('findPath finds multi-hop path via BFS', () => {
+  const g = createObservationGraph();
+  g.addEdge('a', 'b', 'correlated', 0.5);
+  g.addEdge('b', 'c', 'entity_shared', 0.8);
+  const path = g.findPath('a', 'c');
+  assert.ok(path !== null);
+  assert.equal(path![0], 'a');
+  assert.equal(path![path!.length - 1], 'c');
+});
+
+test('findPath returns null when no path exists', () => {
+  const g = createObservationGraph();
+  g.addEdge('a', 'b', 'correlated', 0.5);
+  g.addEdge('x', 'y', 'correlated', 0.5);
+  assert.equal(g.findPath('a', 'x'), null);
+});
+
+test('findPath returns single-element path when from === to', () => {
+  const g = createObservationGraph();
+  assert.deepEqual(g.findPath('a', 'a'), ['a']);
+});
+
+// ── LRU eviction ────────────────────────────────────────────────────────────
+
+test('LRU eviction: oldest edge removed when MAX_EDGES (5000) exceeded', () => {
+  const g = createObservationGraph();
+  // Add 5001 unique edges
+  for (let i = 0; i < 5001; i++) {
+    g.addEdge(`src-${i}`, `dst-${i}`, 'correlated', 0.5);
+  }
+  assert.equal(g.edgeCount(), 5000);
+  // Oldest edge (src-0 → dst-0) should be evicted
+  const oldest = g.getEdges('src-0').filter((e) => e.from === 'src-0' && e.to === 'dst-0');
+  assert.equal(oldest.length, 0);
+  // Newest should still be present
+  const newest = g.getEdges('src-5000').filter((e) => e.from === 'src-5000');
+  assert.equal(newest.length, 1);
+});
+
+// ── populate auto-edges ─────────────────────────────────────────────────────
+
+test('populate creates entity_shared edges for events with common entityIds', () => {
+  const g = createObservationGraph();
+  const events = [
+    makeEvent({ id: 'e1', entityIds: ['USAF-123', 'NATO'] }),
+    makeEvent({ id: 'e2', entityIds: ['USAF-123', 'EU'] }),
+  ];
+  g.populate(events);
+  const edges = g.getEdges('e1').filter((e) => e.type === 'entity_shared');
+  assert.ok(edges.length >= 1);
+});
+
+test('populate creates co_located edges for events within 100 km', () => {
+  const g = createObservationGraph();
+  const events = [
+    makeEvent({ id: 'near-a', location: { lat: 41.85, lon: -87.65 } }),
+    makeEvent({ id: 'near-b', location: { lat: 41.90, lon: -87.70 } }), // ~7 km
+  ];
+  g.populate(events);
+  const edges = g.getEdges('near-a').filter((e) => e.type === 'co_located');
+  assert.ok(edges.length >= 1);
+});
+
+test('populate does NOT create co_located edges for events >100 km apart', () => {
+  const g = createObservationGraph();
+  const events = [
+    makeEvent({ id: 'chicago', location: { lat: 41.85, lon: -87.65 } }),
+    makeEvent({ id: 'miami',   location: { lat: 25.80, lon: -80.20 } }), // ~2100 km
+  ];
+  g.populate(events);
+  const edges = g.getEdges('chicago').filter((e) => e.type === 'co_located');
+  assert.equal(edges.length, 0);
+});
+
+test('populate creates temporally_adjacent edges for events within 30 min', () => {
+  const g = createObservationGraph();
+  const events = [
+    makeEvent({ id: 't1', timestamp: NOW }),
+    makeEvent({ id: 't2', timestamp: NOW + 10 * 60_000 }), // 10 min later
+  ];
+  g.populate(events);
+  const edges = g.getEdges('t1').filter((e) => e.type === 'temporally_adjacent');
+  assert.ok(edges.length >= 1);
+});
+
+test('populate does NOT create temporally_adjacent edges for events >30 min apart', () => {
+  const g = createObservationGraph();
+  const events = [
+    makeEvent({ id: 'old', timestamp: NOW - 60 * 60_000 }),
+    makeEvent({ id: 'new', timestamp: NOW }),
+  ];
+  g.populate(events);
+  const edges = g.getEdges('old').filter((e) => e.type === 'temporally_adjacent');
+  assert.equal(edges.length, 0);
+});
+
+test('populate creates correlated edges for events with same domain and shared tag', () => {
+  const g = createObservationGraph();
+  const events = [
+    makeEvent({ id: 'eq1', domain: 'seismic', tags: ['earthquake', 'shallow'] }),
+    makeEvent({ id: 'eq2', domain: 'seismic', tags: ['earthquake', 'tsunami-risk'] }),
+  ];
+  g.populate(events);
+  const edges = g.getEdges('eq1').filter((e) => e.type === 'correlated');
+  assert.ok(edges.length >= 1);
+});
+
+test('_reset clears all edges', () => {
+  const g = createObservationGraph();
+  g.addEdge('a', 'b', 'correlated', 0.5);
+  g._reset();
+  assert.equal(g.edgeCount(), 0);
+});

--- a/src/services/intelligence/driver-scorer.ts
+++ b/src/services/intelligence/driver-scorer.ts
@@ -1,0 +1,230 @@
+/**
+ * Driver-based severity scorer for ObservationEvents.
+ *
+ * Replaces simple threshold math with evidence-weighted, domain-specific
+ * scoring. Each domain defines a set of Drivers with weights that sum to 1.
+ * The final driverScore (0–100) = sum(driver.weight × driver.value × direction_sign) × 100.
+ *
+ * Pure: no fetch, no DOM. Accepts optional ObservationGraph for the
+ * evidence-connections driver.
+ */
+
+import type { ObservationEvent, ObservationSeverity } from '@/types/intelligence';
+import type { ObservationGraph } from './observation-graph';
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+export interface Driver {
+  name: string;
+  /** Fractional weight in the score formula (all drivers sum to 1.0). */
+  weight: number;
+  /** Normalized contribution in [0, 1]. */
+  value: number;
+  direction: 'amplifying' | 'mitigating';
+}
+
+export interface ScoredEvent extends ObservationEvent {
+  driverScore: number;
+  drivers: Driver[];
+  scoreReason: string;
+}
+
+export interface ScorerOptions {
+  graph?: ObservationGraph;
+  /** Clock override for tests. */
+  now?: () => number;
+}
+
+// ── Severity baseline mapping ─────────────────────────────────────────────
+
+const SEVERITY_BASE: Record<ObservationSeverity, number> = {
+  CRITICAL: 1,
+  HIGH: 0.75,
+  MEDIUM: 0.5,
+  LOW: 0.25,
+  INFO: 0.05,
+};
+
+// ── Recency helper ────────────────────────────────────────────────────────
+
+function recencyValue(timestamp: number, nowMs: number): number {
+  const ageMs = nowMs - timestamp;
+  if (ageMs <= 5 * 60_000) return 1;
+  if (ageMs <= 30 * 60_000) return 0.8;
+  if (ageMs <= 2 * 60 * 60_000) return 0.5;
+  if (ageMs <= 24 * 60 * 60_000) return 0.2;
+  return 0.05;
+}
+
+// ── Raw-field extractors (safe — raw is unknown) ──────────────────────────
+
+function numField(raw: unknown, ...keys: string[]): number | undefined {
+  let obj: unknown = raw;
+  for (const k of keys) {
+    if (obj == null || typeof obj !== 'object') return undefined;
+    obj = (obj as Record<string, unknown>)[k];
+  }
+  return typeof obj === 'number' ? obj : undefined;
+}
+
+function strField(raw: unknown, ...keys: string[]): string | undefined {
+  let obj: unknown = raw;
+  for (const k of keys) {
+    if (obj == null || typeof obj !== 'object') return undefined;
+    obj = (obj as Record<string, unknown>)[k];
+  }
+  return typeof obj === 'string' ? obj : undefined;
+}
+
+// ── Domain scorers ────────────────────────────────────────────────────────
+
+function scoreEarthquake(event: ObservationEvent): Driver[] {
+  const mag = numField(event.raw, 'mag') ?? numField(event.raw, 'properties', 'mag') ?? 0;
+  const depth = numField(event.raw, 'depth') ?? numField(event.raw, 'geometry', 'coordinates', '2') ?? 30;
+  const isAfterShock = event.tags.includes('aftershock') || strField(event.raw, 'properties', 'type') === 'quarry';
+
+  // magnitude: 0 → 0, M5 → 0.5, M7 → 0.85, M9+ → 1.0
+  const magValue = Math.min(1, Math.max(0, (mag - 2) / 7));
+  // depth: <10km → 1.0 (shallow → more dangerous), else attenuates
+  const depthValue = depth < 10 ? 1 : Math.max(0, 1 - (depth - 10) / 200);
+  // population proximity: use severity as proxy when no geocoding
+  const popValue = SEVERITY_BASE[event.severity] ?? 0.5;
+  // aftershock pattern: reduces amplification (mitigating if aftershock)
+  const aftershockValue = isAfterShock ? 0.5 : 0;
+
+  return [
+    { name: 'magnitude', weight: 0.4, value: magValue, direction: 'amplifying' },
+    { name: 'shallow_depth', weight: 0.2, value: depthValue, direction: 'amplifying' },
+    { name: 'population_proximity', weight: 0.25, value: popValue, direction: 'amplifying' },
+    { name: 'aftershock_pattern', weight: 0.15, value: aftershockValue, direction: 'mitigating' },
+  ];
+}
+
+function scoreWildfire(event: ObservationEvent): Driver[] {
+  const acres = numField(event.raw, 'acres') ?? numField(event.raw, 'PercentContained') ?? 0;
+  const containment = numField(event.raw, 'containment') ?? numField(event.raw, 'PercentContained') ?? 50;
+  const windSpeed = numField(event.raw, 'windSpeed') ?? numField(event.raw, 'wind_speed') ?? 0;
+  const popValue = SEVERITY_BASE[event.severity] ?? 0.5;
+
+  // acres: 0 → 0, 1000ac → 0.5, 10000+ → 1.0
+  const acresValue = Math.min(1, acres / 10_000);
+  // containment: 0% → 1.0 (worst), 100% → 0.0 (contained = no threat)
+  const containValue = Math.max(0, 1 - containment / 100);
+  // wind: 0mph → 0, 50mph → 1.0
+  const windValue = Math.min(1, windSpeed / 50);
+
+  return [
+    { name: 'fire_acres', weight: 0.3, value: acresValue, direction: 'amplifying' },
+    { name: 'containment_pct', weight: 0.25, value: containValue, direction: 'amplifying' },
+    { name: 'wind_speed', weight: 0.2, value: windValue, direction: 'amplifying' },
+    { name: 'proximity_populated', weight: 0.25, value: popValue, direction: 'amplifying' },
+  ];
+}
+
+const SQUAWK_SEVERITY: Record<string, number> = {
+  '7700': 1,  // general emergency
+  '7600': 0.8,  // radio failure
+  '7500': 1,  // hijack
+  '7000': 0.1,  // VFR default
+  '2000': 0.1,  // IFR default
+};
+
+const AIRCRAFT_RISK: Record<string, number> = {
+  'B747': 0.9, 'B777': 0.9, 'A380': 0.9, 'B787': 0.8, 'A350': 0.8,
+  'B737': 0.7, 'A320': 0.7, 'E175': 0.5, 'C172': 0.3,
+};
+
+function scoreAviation(event: ObservationEvent): Driver[] {
+  const squawk = strField(event.raw, 'squawk') ?? strField(event.raw, 'properties', 'squawk') ?? '';
+  const acType = strField(event.raw, 'aircraft_type') ?? strField(event.raw, 'icaoAircraftType') ?? '';
+  const popValue = SEVERITY_BASE[event.severity] ?? 0.5;
+
+  const squawkValue = SQUAWK_SEVERITY[squawk] ?? (squawk ? 0.3 : 0.1);
+  const acValue = AIRCRAFT_RISK[acType] ?? 0.5;
+
+  return [
+    { name: 'squawk_severity', weight: 0.5, value: squawkValue, direction: 'amplifying' },
+    { name: 'aircraft_type', weight: 0.2, value: acValue, direction: 'amplifying' },
+    { name: 'location_risk', weight: 0.3, value: popValue, direction: 'amplifying' },
+  ];
+}
+
+function scoreGeneric(event: ObservationEvent, evidenceValue: number, nowMs: number): Driver[] {
+  const sevValue = SEVERITY_BASE[event.severity] ?? 0.1;
+  const recValue = recencyValue(event.timestamp, nowMs);
+
+  return [
+    { name: 'raw_severity', weight: 0.6, value: sevValue, direction: 'amplifying' },
+    { name: 'recency', weight: 0.2, value: recValue, direction: 'amplifying' },
+    { name: 'evidence_connections', weight: 0.2, value: evidenceValue, direction: 'amplifying' },
+  ];
+}
+
+// ── Domain detection ──────────────────────────────────────────────────────
+
+function detectDomain(event: ObservationEvent): 'earthquake' | 'wildfire' | 'aviation' | 'generic' {
+  const d = event.domain.toLowerCase();
+  const tags = event.tags.map((t) => t.toLowerCase());
+  if (d === 'seismic' || d === 'earthquake' || tags.includes('earthquake')) return 'earthquake';
+  if (d === 'wildfire' || d === 'fire' || tags.some((t) => t.includes('fire') || t.includes('wildfire'))) return 'wildfire';
+  if (d === 'aviation' || tags.includes('aviation') || tags.includes('flight-emergency')) return 'aviation';
+  return 'generic';
+}
+
+// ── Score computation ─────────────────────────────────────────────────────
+
+function computeScore(drivers: Driver[]): number {
+  let score = 0;
+  for (const d of drivers) {
+    const sign = d.direction === 'amplifying' ? 1 : -1;
+    score += d.weight * d.value * sign;
+  }
+  return Math.min(100, Math.max(0, Math.round(score * 100)));
+}
+
+function buildReason(drivers: Driver[], domain: string): string {
+  const top = [...drivers]
+    .filter((d) => d.direction === 'amplifying' && d.value > 0)
+    .sort((a, b) => b.weight * b.value - a.weight * a.value)
+    .slice(0, 2)
+    .map((d) => `${d.name}=${(d.value * 100).toFixed(0)}%`)
+    .join(', ');
+  return `${domain}: ${top || 'base'}`;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────
+
+export function scoreEvent(event: ObservationEvent, opts: ScorerOptions = {}): ScoredEvent {
+  const nowMs = opts.now ? opts.now() : Date.now();
+
+  // Evidence connections: normalize edge count from graph (0 edges → 0, 10+ → 1.0)
+  const edgeCount = opts.graph ? opts.graph.getEdges(event.id).length : 0;
+  const evidenceValue = Math.min(1, edgeCount / 10);
+
+  const domain = detectDomain(event);
+  let drivers: Driver[];
+  switch (domain) {
+    case 'earthquake': { drivers = scoreEarthquake(event); break;
+    }
+    case 'wildfire': {   drivers = scoreWildfire(event); break;
+    }
+    case 'aviation': {   drivers = scoreAviation(event); break;
+    }
+    default: {           drivers = scoreGeneric(event, evidenceValue, nowMs);
+    }
+  }
+
+  const driverScore = computeScore(drivers);
+
+  return {
+    ...event,
+    driverScore,
+    drivers,
+    scoreReason: buildReason(drivers, domain),
+  };
+}
+
+/** Score a batch of events. Preserves input order. */
+export function scoreEvents(events: ObservationEvent[], opts: ScorerOptions = {}): ScoredEvent[] {
+  return events.map((ev) => scoreEvent(ev, opts));
+}

--- a/src/services/intelligence/observation-graph.ts
+++ b/src/services/intelligence/observation-graph.ts
@@ -1,0 +1,168 @@
+/**
+ * Observation Graph — directed graph of ObservationEvent relationships.
+ *
+ * Distinct from the NormalizedFact-based evidence-graph.ts; this module
+ * operates on raw ObservationEvents from the observation store and
+ * auto-derives structural edges (proximity, entity overlap, temporal
+ * adjacency, correlation).
+ *
+ * Pure: no DOM, no fetch, no globals. Max 5000 edges with LRU eviction.
+ */
+
+import type { ObservationEvent } from '@/types/intelligence';
+import { haversineKm } from '@/services/proximity-filter';
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+export type EdgeType =
+  | 'caused_by'
+  | 'co_located'
+  | 'temporally_adjacent'
+  | 'entity_shared'
+  | 'correlated';
+
+export interface ObsEvidenceEdge {
+  from: string;
+  to: string;
+  type: EdgeType;
+  confidence: number;
+  created: number;
+}
+
+export interface ObservationGraph {
+  addEdge(from: string, to: string, type: EdgeType, confidence: number): void;
+  getEdges(eventId: string): ObsEvidenceEdge[];
+  getNeighbors(eventId: string): string[];
+  findPath(from: string, to: string): string[] | null;
+  /** Ingest a batch of events, auto-populating structural edges. */
+  populate(events: ObservationEvent[], opts?: PopulateOptions): void;
+  edgeCount(): number;
+  _reset(): void;
+}
+
+export interface PopulateOptions {
+  /** Clock override for tests. */
+  now?: () => number;
+  /** Proximity threshold for co_located edges (km, default 100). */
+  coLocatedKm?: number;
+  /** Temporal window for temporally_adjacent edges (ms, default 30 min). */
+  temporalWindowMs?: number;
+}
+
+const MAX_EDGES = 5000;
+
+// ── Factory ──────────────────────────────────────────────────────────────
+
+export function createObservationGraph(): ObservationGraph {
+  // Edges stored in insertion order — the LRU eviction simply removes the
+  // oldest entry (index 0) when we exceed MAX_EDGES.
+  const edges: ObsEvidenceEdge[] = [];
+
+  function addEdge(from: string, to: string, type: EdgeType, confidence: number): void {
+    // De-duplicate: keep the higher-confidence edge for the same (from,to,type).
+    const existing = edges.find((e) => e.from === from && e.to === to && e.type === type);
+    if (existing) {
+      existing.confidence = Math.max(existing.confidence, confidence);
+      existing.created = Date.now();
+      return;
+    }
+    if (edges.length >= MAX_EDGES) {
+      edges.shift(); // LRU eviction — remove oldest
+    }
+    edges.push({ from, to, type, confidence, created: Date.now() });
+  }
+
+  function getEdges(eventId: string): ObsEvidenceEdge[] {
+    return edges.filter((e) => e.from === eventId || e.to === eventId);
+  }
+
+  function getNeighbors(eventId: string): string[] {
+    const seen = new Set<string>();
+    for (const e of edges) {
+      if (e.from === eventId) seen.add(e.to);
+      if (e.to === eventId) seen.add(e.from);
+    }
+    seen.delete(eventId);
+    return [...seen];
+  }
+
+  function findPath(from: string, to: string): string[] | null {
+    if (from === to) return [from];
+    const visited = new Set<string>([from]);
+    const queue: string[][] = [[from]];
+    while (queue.length > 0) {
+      const path = queue.shift()!;
+      const current = path[path.length - 1]!;
+      for (const neighbor of getNeighbors(current)) {
+        if (neighbor === to) return [...path, neighbor];
+        if (!visited.has(neighbor)) {
+          visited.add(neighbor);
+          queue.push([...path, neighbor]);
+        }
+      }
+    }
+    return null;
+  }
+
+  function tryEntityShared(a: ObservationEvent, b: ObservationEvent): void {
+    const shared = a.entityIds.find((id) => b.entityIds.includes(id));
+    if (!shared) return;
+    addEdge(a.id, b.id, 'entity_shared', 0.8);
+    addEdge(b.id, a.id, 'entity_shared', 0.8);
+  }
+
+  function tryCoLocated(a: ObservationEvent, b: ObservationEvent, limitKm: number): void {
+    if (!a.location || !b.location) return;
+    const dist = haversineKm(a.location.lat, a.location.lon, b.location.lat, b.location.lon);
+    if (dist > limitKm) return;
+    const conf = Number(Math.max(0.4, 1 - dist / limitKm).toFixed(3));
+    addEdge(a.id, b.id, 'co_located', conf);
+    addEdge(b.id, a.id, 'co_located', conf);
+  }
+
+  function tryTemporallyAdjacent(a: ObservationEvent, b: ObservationEvent, windowMs: number): void {
+    const diff = Math.abs(a.timestamp - b.timestamp);
+    if (diff > windowMs) return;
+    const conf = Number((1 - (diff / windowMs) * 0.5).toFixed(3));
+    addEdge(a.id, b.id, 'temporally_adjacent', conf);
+    addEdge(b.id, a.id, 'temporally_adjacent', conf);
+  }
+
+  function tryCorrelated(a: ObservationEvent, b: ObservationEvent): void {
+    if (a.domain !== b.domain) return;
+    if (!a.tags.some((t) => b.tags.includes(t))) return;
+    addEdge(a.id, b.id, 'correlated', 0.6);
+    addEdge(b.id, a.id, 'correlated', 0.6);
+  }
+
+  function populate(events: ObservationEvent[], opts: PopulateOptions = {}): void {
+    const coLocatedKm = opts.coLocatedKm ?? 100;
+    const temporalWindowMs = opts.temporalWindowMs ?? 30 * 60_000;
+
+    for (let i = 0; i < events.length; i++) {
+      const a = events[i]!;
+      for (let j = i + 1; j < events.length; j++) {
+        const b = events[j]!;
+        tryEntityShared(a, b);
+        tryCoLocated(a, b, coLocatedKm);
+        tryTemporallyAdjacent(a, b, temporalWindowMs);
+        tryCorrelated(a, b);
+      }
+    }
+  }
+
+  function edgeCount(): number {
+    return edges.length;
+  }
+
+  function _reset(): void {
+    edges.length = 0;
+  }
+
+  return { addEdge, getEdges, getNeighbors, findPath, populate, edgeCount, _reset };
+}
+
+// ── Module-level singleton for the data-loader / panel layer ─────────────
+
+const _singleton = createObservationGraph();
+export const observationGraph: ObservationGraph = _singleton;


### PR DESCRIPTION
## Summary

ObservationEvent directed graph and domain-specific driver scorer — Phase 3B of the intelligence pipeline.

### observation-graph.ts
- `createObservationGraph()` factory with max-5000 LRU eviction (`edges.shift()` on overflow)
- Dedup: same (from, to, type) keeps higher confidence
- Auto-populate structural edges from event batches: `entity_shared`, `co_located` (<100 km haversine), `temporally_adjacent` (<30 min), `correlated` (same domain + shared tag)
- BFS `findPath`, `getNeighbors`, module-level singleton `observationGraph`

### driver-scorer.ts
- Domain-specific weighted drivers with `amplifying`/`mitigating` directions
  - **earthquake**: magnitude (40%), shallow_depth (20%), population_proximity (25%), aftershock_pattern (15% mitigating)
  - **wildfire**: fire_acres (30%), containment_pct (25%), wind_speed (20%), proximity_populated (25%)
  - **aviation**: squawk_severity (50%), aircraft_type (20%), location_risk (30%)
  - **generic**: raw_severity (60%), recency (20%), evidence_connections (20%)
- `ScoredEvent` extends `ObservationEvent` with `driverScore` (0–100), `drivers[]`, `scoreReason`
- Accepts optional `ObservationGraph` to boost score via edge count

### api/intelligence/evidence-graph.js
- `GET ?eventId=` → `{ eventId, edges, neighborIds, edgeCount }`
- `GET` (no param) → `{ totalEdges, totalEvents, edgesByType, topNodes }`
- 60 s cache, USGS earthquakes + NWS alerts upstream

## Tests
- `observation-graph.test.mts` — 20 tests (addEdge dedup, getNeighbors, BFS, LRU, populate auto-edges)
- `driver-scorer.test.mts` — 19 tests (domain detection, comparative scores, weight sums, evidence boost)
- 158 total passing in `test:intelligence`

## Cross-agent review
Cross-agent review: claude reviewed on 2026-05-11; outcome: pass