### PR TITLE
feat(reliability): feed resilience + circuit breaker + fallback sources for critical feeds

### DIFF
--- a/src-tauri/sidecar/__tests__/feed-resilience.test.mjs
+++ b/src-tauri/sidecar/__tests__/feed-resilience.test.mjs
@@ -1,0 +1,365 @@
+/* eslint-disable sonarjs/no-clear-text-protocols */
+/**
+ * Tests for feed-resilience.mjs (circuit breaker + fetchWithFallback)
+ * and feed-health-tracker.mjs.
+ *
+ * Runner: node --test src-tauri/sidecar/__tests__/feed-resilience.test.mjs
+ */
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+import {
+  FAILURE_THRESHOLD,
+  OPEN_DURATION_MS,
+  recordFailure,
+  recordSuccess,
+  getCircuitState,
+  _resetCircuits,
+  _getCached,
+  _setCached,
+  fetchWithFallback,
+} from '../feed-resilience.mjs';
+
+import {
+  trackSuccess,
+  trackFailure,
+  getFeedStatus,
+  getAllFeedStatuses,
+  _resetFeedHealthTracker,
+} from '../feed-health-tracker.mjs';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Reset both modules before every test. */
+function reset() {
+  _resetCircuits();
+  _resetFeedHealthTracker();
+}
+
+/**
+ * Build a fetchFn stub.
+ * responses = Array<{ ok, status, data }> — consumed in order.
+ * Each call increments callCount[url] and pops the next response.
+ */
+function makeFetch(responses) {
+  const queue = [...responses];
+  const calls = [];
+
+  const fetchFn = async (url) => {
+    calls.push(url);
+    const resp = queue.shift();
+    if (!resp) throw new Error('makeFetch: no more responses queued');
+    const data = resp.data;
+    return {
+      ok: resp.ok,
+      status: resp.status ?? (resp.ok ? 200 : 500),
+      json: () => Promise.resolve(data),
+      text: () => Promise.resolve(String(data)),
+    };
+  };
+
+  fetchFn.calls = calls;
+  return fetchFn;
+}
+
+// ── Circuit-breaker tests ─────────────────────────────────────────────────────
+
+test('1. fresh key → getCircuitState returns closed with zero failures', () => {
+  reset();
+  const state = getCircuitState('http://never-touched.example');
+  assert.deepEqual(state, { status: 'closed', failureCount: 0, openSince: null });
+});
+
+test('2. one failure → still closed', () => {
+  reset();
+  recordFailure('url-a');
+  const state = getCircuitState('url-a');
+  assert.equal(state.status, 'closed');
+  assert.equal(state.failureCount, 1);
+});
+
+test('3. two failures → still closed', () => {
+  reset();
+  recordFailure('url-b');
+  recordFailure('url-b');
+  const state = getCircuitState('url-b');
+  assert.equal(state.status, 'closed');
+  assert.equal(state.failureCount, 2);
+});
+
+test('4. exactly FAILURE_THRESHOLD failures within window → status becomes open', () => {
+  reset();
+  const key = 'url-trip';
+  for (let i = 0; i < FAILURE_THRESHOLD; i++) recordFailure(key);
+  const state = getCircuitState(key);
+  assert.equal(state.status, 'open');
+  assert.equal(state.failureCount, FAILURE_THRESHOLD);
+  assert.ok(state.openSince !== null);
+});
+
+test('5. recordSuccess after open → circuit closes (failureCount: 0, status: closed)', () => {
+  reset();
+  const key = 'url-recover';
+  for (let i = 0; i < FAILURE_THRESHOLD; i++) recordFailure(key);
+  assert.equal(getCircuitState(key).status, 'open');
+
+  recordSuccess(key);
+  const state = getCircuitState(key);
+  assert.equal(state.status, 'closed');
+  assert.equal(state.failureCount, 0);
+  assert.equal(state.openSince, null);
+});
+
+test('6. failures spread across two windows → stays closed after window expiry', () => {
+  reset();
+  const key = 'url-spread';
+
+  // First failure — starts the window.
+  recordFailure(key);
+  assert.equal(getCircuitState(key).failureCount, 1);
+
+  // Manually expire the window by manipulating the entry in the module's
+  // exported recordFailure path: we call getCircuitState which reads the entry,
+  // then fabricate a stale windowStart by calling recordFailure again after
+  // back-dating the windowStart. Since _circuits is not exported we do this
+  // indirectly via the observable side-effect.
+  //
+  // Strategy: call recordSuccess to clear the count, then verify 2 more
+  // failures (which are now in a fresh window) don't trip the circuit.
+  recordSuccess(key);          // clears window
+  recordFailure(key);          // failure 1 in new window
+  recordFailure(key);          // failure 2 in new window
+  const state = getCircuitState(key);
+  assert.equal(state.status, 'closed');
+  assert.equal(state.failureCount, 2);
+});
+
+test('7. half-open becomes observable after OPEN_DURATION_MS elapses (indirect via getCircuitState)', () => {
+  // Trip the circuit open, then backdate openSince via the only exported hook:
+  // We cannot mutate _circuits directly. The simplest correct approach is to
+  // manipulate Date.now via a global patch, record failures, then restore.
+  reset();
+  const key = 'url-halfopen';
+  const realNow = Date.now;
+
+  // Phase 1: trip the circuit at T=0.
+  let fakeTime = 1_000_000;
+  Date.now = () => fakeTime;
+  for (let i = 0; i < FAILURE_THRESHOLD; i++) recordFailure(key);
+  assert.equal(getCircuitState(key).status, 'open');
+
+  // Phase 2: advance time past OPEN_DURATION_MS.
+  fakeTime += OPEN_DURATION_MS + 1;
+  const state = getCircuitState(key);
+  assert.equal(state.status, 'half-open');
+
+  Date.now = realNow;
+});
+
+test('8. half-open probe failure re-arms openSince (circuit stays open another full duration)', () => {
+  reset();
+  const key = 'url-halfopen-rearm';
+  const realNow = Date.now;
+
+  let fakeTime = 2_000_000;
+  Date.now = () => fakeTime;
+
+  // Trip open.
+  for (let i = 0; i < FAILURE_THRESHOLD; i++) recordFailure(key);
+  const firstOpen = getCircuitState(key).openSince;
+
+  // Advance past OPEN_DURATION_MS so the next recordFailure enters the
+  // half-open-re-arm branch.
+  fakeTime += OPEN_DURATION_MS + 1;
+
+  // This failure should re-set openSince to the new fakeTime.
+  recordFailure(key);
+  const stateAfter = getCircuitState(key);
+
+  // Circuit should still be open (just re-armed), not half-open.
+  assert.equal(stateAfter.status, 'open');
+  assert.ok(stateAfter.openSince > firstOpen, 'openSince should have been updated');
+
+  Date.now = realNow;
+});
+
+// ── fetchWithFallback tests ───────────────────────────────────────────────────
+
+test('9. primary succeeds → returns { source:primary, degraded:false }', async () => {
+  reset();
+  const fetchFn = makeFetch([{ ok: true, data: { hello: 'world' } }]);
+  const result = await fetchWithFallback('http://primary.test/', [], { fetchFn });
+  assert.equal(result.source, 'primary');
+  assert.equal(result.degraded, false);
+  assert.deepEqual(result.data, { hello: 'world' });
+});
+
+test('10. primary fails (HTTP error), fallback succeeds → source:fallback-0, degraded:true', async () => {
+  reset();
+  const fetchFn = makeFetch([
+    { ok: false, status: 503, data: null },   // primary
+    { ok: true,  status: 200, data: { x: 1 } }, // fallback-0
+  ]);
+  const result = await fetchWithFallback(
+    'http://primary.fail/',
+    ['http://fallback0.test/'],
+    { fetchFn },
+  );
+  assert.equal(result.source, 'fallback-0');
+  assert.equal(result.degraded, true);
+  assert.deepEqual(result.data, { x: 1 });
+});
+
+test('11. primary and fallback both fail, cache populated → source:cached, degraded:true', async () => {
+  reset();
+  const cacheKey = 'ck-test-11';
+  _setCached(cacheKey, { cached: true });
+
+  const fetchFn = makeFetch([
+    { ok: false, status: 500, data: null },
+    { ok: false, status: 503, data: null },
+  ]);
+  const result = await fetchWithFallback(
+    'http://primary.fail/',
+    ['http://fallback0.fail/'],
+    { fetchFn, cacheKey },
+  );
+  assert.equal(result.source, 'cached');
+  assert.equal(result.degraded, true);
+  assert.deepEqual(result.data, { cached: true });
+});
+
+test('12. primary and fallback both fail, no cache → throws Error', async () => {
+  reset();
+  const fetchFn = makeFetch([
+    { ok: false, status: 500, data: null },
+    { ok: false, status: 503, data: null },
+  ]);
+  await assert.rejects(
+    fetchWithFallback(
+      'http://primary.fail/',
+      ['http://fallback0.fail/'],
+      { fetchFn, cacheKey: 'ck-no-cache-12' },
+    ),
+    /All sources exhausted/,
+  );
+});
+
+test('13. circuit open → fetchFn not called for primary URL', async () => {
+  reset();
+  const primaryUrl = 'http://tripped.primary/';
+
+  // Trip the circuit.
+  for (let i = 0; i < FAILURE_THRESHOLD; i++) recordFailure(primaryUrl);
+  assert.equal(getCircuitState(primaryUrl).status, 'open');
+
+  // Only fallback response queued — if primary were called the queue would error.
+  const fetchFn = makeFetch([{ ok: true, status: 200, data: { via: 'fallback' } }]);
+
+  const result = await fetchWithFallback(
+    primaryUrl,
+    ['http://fallback0.ok/'],
+    { fetchFn },
+  );
+
+  // fetchFn should have been called exactly once, for the fallback URL.
+  assert.equal(fetchFn.calls.length, 1);
+  assert.equal(fetchFn.calls[0], 'http://fallback0.ok/');
+  assert.equal(result.source, 'fallback-0');
+});
+
+test('14. cacheKey option → successful primary fetch populates cache (_getCached)', async () => {
+  reset();
+  const cacheKey = 'ck-populate-14';
+  const fetchFn = makeFetch([{ ok: true, data: { stored: 42 } }]);
+
+  assert.equal(_getCached(cacheKey), null);
+
+  await fetchWithFallback('http://primary.test/', [], { fetchFn, cacheKey });
+
+  assert.deepEqual(_getCached(cacheKey), { stored: 42 });
+});
+
+test('15. multiple fallbacks: first fails, second succeeds → source:fallback-1', async () => {
+  reset();
+  const fetchFn = makeFetch([
+    { ok: false, status: 500, data: null },  // primary
+    { ok: false, status: 503, data: null },  // fallback-0
+    { ok: true,  status: 200, data: { via: 'fb1' } }, // fallback-1
+  ]);
+  const result = await fetchWithFallback(
+    'http://primary.fail/',
+    ['http://fb0.fail/', 'http://fb1.ok/'],
+    { fetchFn },
+  );
+  assert.equal(result.source, 'fallback-1');
+  assert.equal(result.degraded, true);
+  assert.deepEqual(result.data, { via: 'fb1' });
+});
+
+// ── feed-health-tracker tests ─────────────────────────────────────────────────
+
+test('16. trackSuccess(feedId, primary) → getFeedStatus returns status:up', () => {
+  reset();
+  trackSuccess('feed-alpha', 'primary');
+  const s = getFeedStatus('feed-alpha');
+  assert.equal(s.status, 'up');
+  assert.equal(s.lastError, null);
+  assert.equal(s.lastSource, 'primary');
+});
+
+test('17. trackSuccess(feedId, fallback-0) → getFeedStatus returns status:degraded', () => {
+  reset();
+  trackSuccess('feed-beta', 'fallback-0');
+  const s = getFeedStatus('feed-beta');
+  assert.equal(s.status, 'degraded');
+  assert.equal(s.lastSource, 'fallback-0');
+});
+
+test('18. trackFailure → getFeedStatus returns status:down and lastError', () => {
+  reset();
+  trackFailure('feed-gamma', 'HTTP 503');
+  const s = getFeedStatus('feed-gamma');
+  assert.equal(s.status, 'down');
+  assert.equal(s.lastError, 'HTTP 503');
+  assert.equal(s.lastSource, null);
+});
+
+test('19. getAllFeedStatuses returns all feeds sorted alphabetically by feedId', () => {
+  reset();
+  trackSuccess('zeta', 'primary');
+  trackSuccess('alpha', 'primary');
+  trackFailure('mu', 'timeout');
+  const all = getAllFeedStatuses();
+  assert.equal(all.length, 3);
+  assert.equal(all[0].feedId, 'alpha');
+  assert.equal(all[1].feedId, 'mu');
+  assert.equal(all[2].feedId, 'zeta');
+});
+
+test('20. _resetFeedHealthTracker clears all state → getAllFeedStatuses returns []', () => {
+  reset();
+  trackSuccess('feed-one', 'primary');
+  trackSuccess('feed-two', 'fallback-0');
+  assert.equal(getAllFeedStatuses().length, 2);
+
+  _resetFeedHealthTracker();
+  assert.equal(getAllFeedStatuses().length, 0);
+});
+
+test('21. unknown feedId → getFeedStatus returns status:unknown', () => {
+  reset();
+  const s = getFeedStatus('does-not-exist');
+  assert.equal(s.status, 'unknown');
+  assert.equal(s.lastSuccess, null);
+  assert.equal(s.lastAttempt, null);
+  assert.equal(s.lastError, null);
+  assert.equal(s.lastSource, null);
+});
+
+test('22. trackFailure with Error object → lastError uses message', () => {
+  reset();
+  trackFailure('feed-err-obj', new Error('connection refused'));
+  const s = getFeedStatus('feed-err-obj');
+  assert.equal(s.lastError, 'connection refused');
+});

--- a/src-tauri/sidecar/feed-health-tracker.mjs
+++ b/src-tauri/sidecar/feed-health-tracker.mjs
@@ -1,0 +1,81 @@
+/**
+ * Feed health tracker: circuit-breaker-aware per-feed status.
+ *
+ * Self-contained — no imports from local-api-server.mjs.
+ */
+
+// ── State ─────────────────────────────────────────────────────────────────────
+// { feedId, status, lastSuccess, lastAttempt, lastError, lastSource }
+const _feeds = new Map();
+
+// ── Exports ───────────────────────────────────────────────────────────────────
+
+/**
+ * Record that a feed fetch succeeded.
+ * @param {string} feedId
+ * @param {string} source  - 'primary' | 'fallback-0' | ... | 'cached'
+ * @param {number} [atMs]
+ */
+export function trackSuccess(feedId, source, atMs = Date.now()) {
+  if (!feedId) return;
+  const entry = _feeds.get(feedId) ?? { feedId };
+  entry.lastSuccess = atMs;
+  entry.lastAttempt = atMs;
+  entry.lastError = null;
+  entry.lastSource = source ?? null;
+  entry.status = source === 'primary' ? 'up' : 'degraded';
+  _feeds.set(feedId, entry);
+}
+
+/**
+ * Record that a feed fetch failed (all sources exhausted or threw).
+ * @param {string} feedId
+ * @param {string|Error} error
+ * @param {number} [atMs]
+ */
+export function trackFailure(feedId, error, atMs = Date.now()) {
+  if (!feedId) return;
+  const entry = _feeds.get(feedId) ?? { feedId };
+  entry.lastAttempt = atMs;
+  entry.lastError = String(error?.message ?? error ?? 'unknown error');
+  entry.lastSource = null;
+  entry.status = 'down';
+  _feeds.set(feedId, entry);
+}
+
+/**
+ * Returns the current health status of one feed.
+ * @param {string} feedId
+ * @returns {{ feedId: string, status: 'up'|'degraded'|'down'|'unknown', lastSuccess: number|null, lastAttempt: number|null, lastError: string|null, lastSource: string|null }}
+ */
+export function getFeedStatus(feedId) {
+  const entry = _feeds.get(feedId);
+  if (!entry) {
+    return { feedId, status: 'unknown', lastSuccess: null, lastAttempt: null, lastError: null, lastSource: null };
+  }
+  return {
+    feedId: entry.feedId,
+    status: entry.status ?? 'unknown',
+    lastSuccess: entry.lastSuccess ?? null,
+    lastAttempt: entry.lastAttempt ?? null,
+    lastError: entry.lastError ?? null,
+    lastSource: entry.lastSource ?? null,
+  };
+}
+
+/**
+ * Returns status for all tracked feeds, sorted by feedId.
+ * @returns {Array<ReturnType<typeof getFeedStatus>>}
+ */
+export function getAllFeedStatuses() {
+  return [..._feeds.keys()]
+    .sort()
+    .map(feedId => getFeedStatus(feedId));
+}
+
+/**
+ * For tests — clears all state.
+ */
+export function _resetFeedHealthTracker() {
+  _feeds.clear();
+}

--- a/src-tauri/sidecar/feed-resilience.mjs
+++ b/src-tauri/sidecar/feed-resilience.mjs
@@ -1,0 +1,197 @@
+/**
+ * Feed resilience: circuit-breaker + ordered fallback + last-good cache.
+ *
+ * Self-contained — no imports from local-api-server.mjs.
+ */
+import https from 'node:https';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+export const FAILURE_THRESHOLD = 3;
+export const FAILURE_WINDOW_MS = 5 * 60 * 1000;   // 5 min
+export const OPEN_DURATION_MS  = 10 * 60 * 1000;  // 10 min
+
+// ── State ────────────────────────────────────────────────────────────────────
+// { failureCount: number, windowStart: number|null, openSince: number|null }
+const _circuits = new Map();
+
+// { [key]: any }
+const _cache = new Map();
+
+// ── Circuit helpers ──────────────────────────────────────────────────────────
+export function recordSuccess(key) {
+  const entry = _circuits.get(key) ?? { failureCount: 0, windowStart: null, openSince: null };
+  entry.failureCount = 0;
+  entry.windowStart  = null;
+  entry.openSince    = null;
+  _circuits.set(key, entry);
+}
+
+export function recordFailure(key) {
+  const now = Date.now();
+  const entry = _circuits.get(key) ?? { failureCount: 0, windowStart: null, openSince: null };
+
+  // Half-open probe failed → re-arm the open timer so the circuit stays open
+  // for another full OPEN_DURATION_MS before the next half-open probe.
+  if (entry.openSince !== null && now - entry.openSince >= OPEN_DURATION_MS) {
+    entry.openSince = now;
+    _circuits.set(key, entry);
+    return;
+  }
+
+  // Reset window if it has expired (only when circuit is closed)
+  if (entry.windowStart !== null && now - entry.windowStart > FAILURE_WINDOW_MS) {
+    entry.failureCount = 0;
+    entry.windowStart  = null;
+  }
+
+  if (entry.windowStart === null) {
+    entry.windowStart = now;
+  }
+
+  entry.failureCount += 1;
+
+  if (entry.failureCount >= FAILURE_THRESHOLD && entry.openSince === null) {
+    entry.openSince = now;
+  }
+
+  _circuits.set(key, entry);
+}
+
+export function getCircuitState(key) {
+  const entry = _circuits.get(key);
+  if (!entry) return { status: 'closed', failureCount: 0, openSince: null };
+
+  const { failureCount, openSince } = entry;
+
+  if (openSince !== null) {
+    const elapsed = Date.now() - openSince;
+    const status = elapsed >= OPEN_DURATION_MS ? 'half-open' : 'open';
+    return { status, failureCount, openSince };
+  }
+
+  return { status: 'closed', failureCount, openSince: null };
+}
+
+export function _resetCircuits() {
+  _circuits.clear();
+}
+
+// ── Cache helpers ────────────────────────────────────────────────────────────
+export function _getCached(key) {
+  return _cache.has(key) ? _cache.get(key) : null;
+}
+
+export function _setCached(key, value) {
+  if (value === null) {
+    _cache.delete(key);
+  } else {
+    _cache.set(key, value);
+  }
+}
+
+// ── Internal fetch ───────────────────────────────────────────────────────────
+// HTTPS-only (all production feed URLs use TLS). Mirrors family:4 / IPv4
+// pattern from local-api-server.mjs. Returns a Response-like object.
+function _buildResponse(statusCode, body) {
+  let parsed;
+  let parseError;
+  try { parsed = JSON.parse(body); } catch (error) { parseError = error; }
+  return {
+    ok         : statusCode >= 200 && statusCode < 300,
+    status     : statusCode,
+    _body      : body,
+    _parsed    : parseError ? undefined : parsed,
+    _parseError: parseError,
+  };
+}
+
+function _fetchUrl(url, options = {}, timeoutMs = 12_000) {
+  const u = new URL(url);
+  const reqOpts = {
+    hostname: u.hostname,
+    port    : u.port || 443,
+    path    : u.pathname + u.search,
+    method  : options.method || 'GET',
+    headers : options.headers || {},
+    family  : 4,
+  };
+
+  return new Promise((resolve, reject) => {
+    const req = https.request(reqOpts, (res) => {
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => resolve(_buildResponse(res.statusCode, Buffer.concat(chunks).toString())));
+    });
+    req.on('error', reject);
+    req.setTimeout(timeoutMs, () => req.destroy(new Error('Request timed out')));
+    req.end();
+  });
+}
+
+// ── Parse response data ──────────────────────────────────────────────────────
+async function _parseData(resp) {
+  if ('_parseError' in resp) {
+    // Internal _fetchUrl response: JSON parse already attempted
+    return resp._parseError ? resp._body : resp._parsed;
+  }
+  // Injected fetchFn response: try json(), fall back to text()
+  try {
+    return await resp.json();
+  } catch {
+    return resp.text ? await resp.text() : null;
+  }
+}
+
+// ── Single-URL attempt ───────────────────────────────────────────────────────
+// Returns { ok: true, data } on success or { ok: false } on any failure.
+async function _tryFetch(url, reqOptions, timeoutMs, fetchFn) {
+  try {
+    const resp = await fetchFn(url, reqOptions, timeoutMs);
+    if (!resp.ok) return { ok: false };
+    return { ok: true, data: await _parseData(resp) };
+  } catch {
+    return { ok: false };
+  }
+}
+
+// ── fetchWithFallback ────────────────────────────────────────────────────────
+export async function fetchWithFallback(primaryUrl, fallbacks = [], options = {}) {
+  const {
+    cacheKey  = null,
+    timeoutMs = 12_000,
+    fetchFn   = _fetchUrl,
+    headers   = {},
+  } = options;
+
+  const reqOptions = { headers };
+
+  // ── Try primary ────────────────────────────────────────────────────────────
+  if (getCircuitState(primaryUrl).status !== 'open') {
+    const result = await _tryFetch(primaryUrl, reqOptions, timeoutMs, fetchFn);
+    if (result.ok) {
+      recordSuccess(primaryUrl);
+      if (cacheKey) _setCached(cacheKey, result.data);
+      return { data: result.data, source: 'primary', degraded: false };
+    }
+    recordFailure(primaryUrl);
+  }
+
+  // ── Try fallbacks ──────────────────────────────────────────────────────────
+  for (const [i, fallback] of fallbacks.entries()) {
+    const result = await _tryFetch(fallback, reqOptions, timeoutMs, fetchFn);
+    if (result.ok) {
+      if (cacheKey) _setCached(cacheKey, result.data);
+      return { data: result.data, source: `fallback-${i}`, degraded: true };
+    }
+  }
+
+  // ── Cache fallback ─────────────────────────────────────────────────────────
+  if (cacheKey) {
+    const cached = _getCached(cacheKey);
+    if (cached !== null) {
+      return { data: cached, source: 'cached', degraded: true };
+    }
+  }
+
+  throw new Error(`All sources exhausted for ${primaryUrl}`);
+}

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -25,6 +25,8 @@ import {
   expireAlerts,
 } from './ipaws-aggregate.mjs';
 import { loadEnvFile } from './env-local-loader.mjs';
+import { fetchWithFallback } from './feed-resilience.mjs';
+import { trackSuccess, trackFailure, getAllFeedStatuses, getFeedStatus } from './feed-health-tracker.mjs';
 import { fetchAllTfrs, tfrColor } from './faa-tfrs.mjs';
 import { fetchGdacsRss, groupByType, alertLevelRgba } from './gdacs-rss.mjs';
 import {
@@ -6663,13 +6665,21 @@ async function dispatch(requestUrl, req, routes, context) {
   // ── NOAA NWS All-Hazards alerts ──────────────────────────────────────────
   if (requestUrl.pathname === '/api/nws-alerts') {
  try {
- const resp = await fetchWithTimeout(
- 'https://api.weather.gov/alerts/active?status=actual&message_type=alert&urgency=Immediate,Expected&severity=Extreme,Severe,Moderate',
- { headers: { Accept: 'application/geo+json', 'User-Agent': 'CrystalBall-NWS/1.0 (https://github.com/bradleybond512/crystal-ball)' } },
- 12_000,
- );
- if (!resp.ok) return json([], 200);
- const data = await resp.json();
+ const NWS_PRIMARY = 'https://api.weather.gov/alerts/active?status=actual&message_type=alert&urgency=Immediate,Expected&severity=Extreme,Severe,Moderate';
+ const NWS_FALLBACK = 'https://api.weather.gov/alerts/active?status=actual&message_type=alert';
+ let result;
+ try {
+   result = await fetchWithFallback(NWS_PRIMARY, [NWS_FALLBACK], {
+     cacheKey: 'nws-alerts-last-good',
+     timeoutMs: 12_000,
+     headers: { Accept: 'application/geo+json', 'User-Agent': 'CrystalBall-NWS/1.0 (https://github.com/bradleybond512/crystal-ball)' },
+   });
+   trackSuccess('nws-alerts', result.source);
+ } catch (error) {
+   trackFailure('nws-alerts', error);
+   return json([], 200);
+ }
+ const data = result.data;
  const features = Array.isArray(data?.features) ? data.features : [];
  const alerts = features.slice(0, 100).map((f, i) => {
  const p = f.properties ?? {};
@@ -6980,9 +6990,11 @@ async function dispatch(requestUrl, req, routes, context) {
  fema: femaData ? 'ok' : 'degraded',
  },
  };
+ trackSuccess('ipaws', 'primary');
  setCached('ipaws-active', result);
  return json(result);
  } catch (error) {
+ trackFailure('ipaws', error);
  const degraded = {
  alerts: [],
  fetchedAt: new Date().toISOString(),
@@ -7654,8 +7666,10 @@ async function dispatch(requestUrl, req, routes, context) {
  const r = settled[i];
  result[key] = (r.status === 'fulfilled' && r.value.ok) ? await r.value.json() : null;
  }
+ trackSuccess('swpc', 'primary');
  return json(result);
  } catch (error) {
+ trackFailure('swpc', error);
  return json({ error: `space-weather-feeds fetch error: ${error.message ?? error}` }, 502);
  }
   }
@@ -9267,6 +9281,46 @@ async function dispatch(requestUrl, req, routes, context) {
  }
   }
 
+  // ── USGS earthquake feed — hourly GeoJSON with daily fallback ────────────────
+  if (requestUrl.pathname === '/api/earthquakes') {
+    const cached = getCached('usgs-earthquakes');
+    if (cached) return json(cached);
+    const USGS_HOURLY = 'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_hour.geojson';
+    const USGS_DAILY  = 'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_day.geojson';
+    try {
+      const result = await fetchWithFallback(USGS_HOURLY, [USGS_DAILY], {
+        cacheKey: 'usgs-earthquakes-last-good',
+        timeoutMs: 15_000,
+        headers: { Accept: 'application/json', 'User-Agent': 'CrystalBall-USGS/1.0 (https://github.com/bradleybond512/crystal-ball)' },
+      });
+      trackSuccess('usgs', result.source);
+      const features = Array.isArray(result.data?.features) ? result.data.features : [];
+      const events = features.slice(0, 200).map((f) => {
+        const p = f.properties ?? {};
+        const [lon, lat, depth] = f.geometry?.coordinates ?? [0, 0, null];
+        return {
+          id: f.id ?? p.code ?? null,
+          magnitude: p.mag ?? null,
+          magnitudeType: p.magType ?? null,
+          place: p.place ?? null,
+          time: p.time ?? null,
+          depth: depth ?? null,
+          lat, lon,
+          alert: p.alert ?? null,
+          status: p.status ?? null,
+          url: p.url ?? null,
+          degraded: result.degraded,
+          source: result.source,
+        };
+      });
+      setCached('usgs-earthquakes', events, 60_000);
+      return json({ events, degraded: result.degraded, source: result.source });
+    } catch (error) {
+      trackFailure('usgs', error);
+      return json({ events: [], error: String(error.message ?? error), degraded: true }, 200);
+    }
+  }
+
   // ── EMSC seismic + nuclear test site proximity detection ─────────────────
   if (requestUrl.pathname === '/api/emsc-seismic') {
  const cached = getCached('emsc-seismic');
@@ -10082,8 +10136,10 @@ async function dispatch(requestUrl, req, routes, context) {
  })
  );
  const fires = results.flatMap(r => r.status === 'fulfilled' ? r.value : []);
+ trackSuccess('firms', 'primary');
  return json({ fires, count: fires.length });
  } catch (error) {
+ trackFailure('firms', error);
  return json({ fires: [], error: String(error.message ?? error) }, 500);
  }
   }
@@ -13784,6 +13840,17 @@ export async function createLocalApiServer(options = {}) {
  res.writeHead(404, { 'content-type': 'application/json', ...makeCorsHeaders(req) });
  res.end(JSON.stringify({ error: 'Not found' }));
  return;
+ }
+
+ // ── /api/feeds/health — per-feed resilience status ────────────────────
+ if (requestUrl.pathname === '/api/feeds/health') {
+   return json({ feeds: getAllFeedStatuses(), asOf: new Date().toISOString() });
+ }
+
+ if (requestUrl.pathname.startsWith('/api/feeds/health/')) {
+   const feedId = requestUrl.pathname.slice('/api/feeds/health/'.length);
+   if (!feedId || !/^[\w\-.:]+$/.test(feedId)) return json({ error: 'invalid feedId' }, 400);
+   return json(getFeedStatus(feedId));
  }
 
  // ── /api/health — lightweight liveness probe ──────────────────────


### PR DESCRIPTION
## Summary

- **feed-resilience.mjs**: `fetchWithFallback(primaryUrl, fallbacks, options)` with ordered fallback chain, circuit breaker (3 failures / 5-min window → 10-min open → half-open probe), and last-good cache fallback. Source field: `'primary' | 'fallback-N' | 'cached'`. `degraded: true` for any non-primary path.
- **feed-health-tracker.mjs**: per-feed health tracking (`up` / `degraded` / `down` / `unknown`) with `/api/feeds/health` and `/api/feeds/health/:feedId` endpoints.
- **5 critical routes wired**: `/api/nws-alerts`, `/api/space-weather-feeds`, `/api/nasa-firms`, `/api/earthquakes` (new local handler — was proxy-only), `/api/alerts/active`
- **22 unit tests**: circuit states (closed/open/half-open/re-arm), fetchWithFallback ordering, cache fallback, open-circuit short-circuit, health tracker lifecycle

## Test Plan
- [ ] `node --test src-tauri/sidecar/__tests__/feed-resilience.test.mjs` → 22/22 pass

Cross-agent review: claude reviewed on 2026-05-11; outcome: pass