### PR TITLE
feat(intelligence): shortage radar UI — commodity overview panel + alert wiring

### DIFF
--- a/src-tauri/sidecar/__tests__/shortage-overview.test.mjs
+++ b/src-tauri/sidecar/__tests__/shortage-overview.test.mjs
@@ -1,0 +1,163 @@
+/**
+ * Sidecar tests for:
+ *   POST /api/shortage/state    — renderer pushes summary entries
+ *   GET  /api/shortage/overview — UI-ready sorted rows (commodity name,
+ *                                  riskScore, riskLevel, topDriver, trend)
+ *   GET  /api/shortage/:commodity — full detail still resolves and is not
+ *                                    captured by the new overview route
+ */
+import { strict as assert } from 'node:assert';
+import { request as httpRequest } from 'node:http';
+import test from 'node:test';
+
+process.env.LOCAL_API_TOKEN ??= 'test-token-shortage-overview';
+
+import { createLocalApiServer } from '../local-api-server.mjs';
+
+async function startSidecar() {
+  const app = await createLocalApiServer({
+    port: 0,
+    apiDir: undefined,
+    remoteBase: 'http://127.0.0.1:1',
+    logger: { log() {}, warn() {}, error() {} },
+  });
+  const { port } = await app.start();
+  return { base: `http://127.0.0.1:${port}`, async close() { await app.close(); } };
+}
+
+function httpJson(method, url, body) {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url);
+    const headers = { authorization: `Bearer ${process.env.LOCAL_API_TOKEN}` };
+    if (body !== undefined) headers['Content-Type'] = 'application/json';
+    const req = httpRequest({
+      hostname: u.hostname, port: u.port, method,
+      path: u.pathname + u.search, headers,
+    }, (res) => {
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => {
+        const text = Buffer.concat(chunks).toString('utf8');
+        try { resolve({ status: res.statusCode, body: text ? JSON.parse(text) : null }); }
+        catch (error) { reject(error); }
+      });
+    });
+    req.on('error', reject);
+    if (body !== undefined) req.write(JSON.stringify(body));
+    req.end();
+  });
+}
+
+function makeEntry(commodity, riskScore, riskLevel, drivers = ['driver-1'], trend = 'stable') {
+  return {
+    commodity,
+    riskScore,
+    riskLevel,
+    primaryDrivers: drivers,
+    timeToImpact: '30d',
+    trend,
+    forecast: { drivers: [], dataGaps: [], confidence: 'medium' },
+  };
+}
+
+test('GET /api/shortage/overview returns [] when renderer has not pushed state yet', async () => {
+  const sc = await startSidecar();
+  try {
+    const res = await httpJson('GET', `${sc.base}/api/shortage/overview`);
+    assert.equal(res.status, 200);
+    assert.deepEqual(res.body, []);
+  } finally { await sc.close(); }
+});
+
+test('GET /api/shortage/overview returns rows sorted by riskScore desc after POST', async () => {
+  const sc = await startSidecar();
+  try {
+    const post = await httpJson('POST', `${sc.base}/api/shortage/state`, {
+      entries: [
+        makeEntry('wheat', 25, 'LOW'),
+        makeEntry('corn', 92, 'CRITICAL', ['drought']),
+        makeEntry('diesel', 75, 'CRITICAL', ['hormuz']),
+      ],
+      updatedAt: Date.now(),
+      ttlMs: 60 * 60 * 1000,
+    });
+    assert.equal(post.status, 200);
+    const res = await httpJson('GET', `${sc.base}/api/shortage/overview`);
+    assert.equal(res.status, 200);
+    assert.ok(Array.isArray(res.body));
+    assert.equal(res.body.length, 3);
+    assert.deepEqual(res.body.map((r) => r.commodity), ['corn', 'diesel', 'wheat']);
+  } finally { await sc.close(); }
+});
+
+test('GET /api/shortage/overview rows have name/riskScore/riskLevel/topDriver/trend shape', async () => {
+  const sc = await startSidecar();
+  try {
+    await httpJson('POST', `${sc.base}/api/shortage/state`, {
+      entries: [makeEntry('corn', 92, 'CRITICAL', ['drought'], 'deteriorating')],
+      updatedAt: Date.now(),
+      ttlMs: 60 * 60 * 1000,
+    });
+    const res = await httpJson('GET', `${sc.base}/api/shortage/overview`);
+    assert.equal(res.body[0].commodity, 'corn');
+    assert.equal(res.body[0].riskScore, 92);
+    assert.equal(res.body[0].riskLevel, 'CRITICAL');
+    assert.equal(res.body[0].topDriver, 'drought');
+    assert.equal(res.body[0].trend, 'deteriorating');
+  } finally { await sc.close(); }
+});
+
+test('GET /api/shortage/overview uses "—" when primaryDrivers is empty', async () => {
+  const sc = await startSidecar();
+  try {
+    await httpJson('POST', `${sc.base}/api/shortage/state`, {
+      entries: [makeEntry('wheat', 50, 'HIGH', [])],
+      updatedAt: Date.now(),
+      ttlMs: 60 * 60 * 1000,
+    });
+    const res = await httpJson('GET', `${sc.base}/api/shortage/overview`);
+    assert.equal(res.body[0].topDriver, '—');
+  } finally { await sc.close(); }
+});
+
+test('GET /api/shortage/overview returns [] when state is past its TTL', async () => {
+  const sc = await startSidecar();
+  try {
+    await httpJson('POST', `${sc.base}/api/shortage/state`, {
+      entries: [makeEntry('corn', 92, 'CRITICAL', ['drought'])],
+      updatedAt: Date.now() - 60_000, // pushed 60s ago
+      ttlMs: 1000,                   // but TTL is 1s — so it's stale
+    });
+    const res = await httpJson('GET', `${sc.base}/api/shortage/overview`);
+    assert.deepEqual(res.body, []);
+  } finally { await sc.close(); }
+});
+
+test('GET /api/shortage/:commodity still returns detail (overview did not capture it)', async () => {
+  const sc = await startSidecar();
+  try {
+    await httpJson('POST', `${sc.base}/api/shortage/state`, {
+      entries: [makeEntry('corn', 92, 'CRITICAL', ['drought'])],
+      updatedAt: Date.now(),
+      ttlMs: 60 * 60 * 1000,
+    });
+    const res = await httpJson('GET', `${sc.base}/api/shortage/corn`);
+    assert.equal(res.status, 200);
+    assert.equal(res.body.commodity, 'corn');
+    assert.equal(res.body.riskLevel, 'CRITICAL');
+    assert.equal(res.body.available, true);
+  } finally { await sc.close(); }
+});
+
+test('GET /api/shortage/overview rounds non-integer scores', async () => {
+  const sc = await startSidecar();
+  try {
+    await httpJson('POST', `${sc.base}/api/shortage/state`, {
+      entries: [makeEntry('corn', 73.7, 'CRITICAL', ['drought'])],
+      updatedAt: Date.now(),
+      ttlMs: 60 * 60 * 1000,
+    });
+    const res = await httpJson('GET', `${sc.base}/api/shortage/overview`);
+    assert.equal(res.body[0].riskScore, 74);
+  } finally { await sc.close(); }
+});

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -4667,10 +4667,33 @@ async function dispatch(requestUrl, req, routes, context) {
     return json(summary);
   }
 
+  // GET /api/shortage/overview — narrow per-commodity rows sorted by riskScore
+  // desc. Shape matches what external tools (MCP, dashboards) want: one row
+  // per commodity with name, riskScore, riskLevel, topDriver, trend.
+  // Returns an empty array if the renderer hasn't pushed state yet or the
+  // state is past its TTL.
+  if (requestUrl.pathname === '/api/shortage/overview' && req.method === 'GET') {
+    const s = context._shortageState;
+    if (!s) return json([]);
+    const ageMs = Date.now() - s.updatedAt;
+    if (ageMs > s.ttlMs) return json([]);
+    const rows = s.entries
+      .map((e) => ({
+        commodity: e.commodity,
+        riskScore: typeof e.riskScore === 'number' ? Math.round(e.riskScore) : 0,
+        riskLevel: e.riskLevel ?? 'LOW',
+        topDriver: (e.primaryDrivers && e.primaryDrivers[0]) || '—',
+        trend: e.trend ?? 'stable',
+      }))
+      .sort((a, b) => b.riskScore - a.riskScore || a.commodity.localeCompare(b.commodity));
+    return json(rows);
+  }
+
   // GET /api/shortage/:commodity — returns full forecast for one commodity.
   if (requestUrl.pathname.startsWith('/api/shortage/') &&
       requestUrl.pathname !== '/api/shortage/state' &&
       requestUrl.pathname !== '/api/shortage/summary' &&
+      requestUrl.pathname !== '/api/shortage/overview' &&
       req.method === 'GET') {
     const commodity = requestUrl.pathname.slice('/api/shortage/'.length).split('/')[0];
     if (!commodity) return json({ error: 'commodity required' }, 400);

--- a/src/components/NotificationSettingsPanel.ts
+++ b/src/components/NotificationSettingsPanel.ts
@@ -1,4 +1,4 @@
-/* eslint-disable sonarjs/no-nested-template-literals */
+ 
 import { Panel } from './Panel';
 import {
   getSettings,
@@ -19,6 +19,7 @@ const DOMAIN_LABELS: Record<NotificationDomain, string> = {
   geopolitical: 'Geopolitical',
   weather: 'Weather (NWS)',
   cyber: 'Cyber / HIBP',
+  supply: 'Supply / Shortages',
 };
 
 const ALL_DOMAINS: NotificationDomain[] = [
@@ -32,6 +33,7 @@ const ALL_DOMAINS: NotificationDomain[] = [
   'geopolitical',
   'weather',
   'cyber',
+  'supply',
 ];
 
 export class NotificationSettingsPanel extends Panel {

--- a/src/components/ShortageRadarPanel.ts
+++ b/src/components/ShortageRadarPanel.ts
@@ -1,38 +1,47 @@
-/* eslint-disable sonarjs/no-nested-template-literals */
+ 
 /**
- * Shortage Radar Panel — 2×4 overview grid for 8 commodity shortage models.
+ * Shortage Radar Panel — overview table for 8 commodity shortage models.
  *
  * Commodities: wheat · corn · rice · soybeans · diesel · gasoline ·
  *              natural-gas · jet-fuel
  *
- * Each card shows risk level badge, score, top driver, and trend arrow.
- * Clicking a card dispatches `wm:shortage-drill-down` so ShortageDetailPanel
- * can open. CRITICAL transitions are routed to the notification ladder.
- * After each render the computed state is pushed to the sidecar so
- * /api/shortage/summary is populated for external tools.
+ * Layout: a sorted table (highest risk first). Each row shows name, risk
+ * score, risk-level badge, top driver, and a trend arrow. Clicking a row
+ * (or pressing Enter on it) toggles an inline drill-down panel with the
+ * full driver list, data gaps, time-to-impact, and confidence band.
+ *
+ * Refresh: every 5 minutes. Alerts: any commodity that *crosses* the HIGH
+ * threshold (score > 70) or the CRITICAL threshold (> 85) on a refresh
+ * gets emitted as a UnifiedAlert, gated through `shouldNotify('supply', ...)`
+ * so users can mute the domain or raise the floor in notification settings.
  */
 
 import { Panel } from './Panel';
 import {
   computeShortageFullSet,
-  ALL_FULLSET_COMMODITIES,
+  computeShortageDetail,
   type ShortageSummaryEntry,
   type FullSetCommodity,
   type RiskLevel,
-  type Trend,
 } from '@/services/shortage/shortage-fullset';
+import {
+  buildOverviewRows,
+  countByRiskLevel,
+  type OverviewRow,
+} from '@/services/shortage/shortage-overview-helpers';
+import {
+  emitShortageAlerts,
+  severityFromScore,
+} from '@/services/shortage/shortage-alert-emitter';
 import type { ShortageInputBag } from '@/services/shortage/shortage-types';
-import { getPlaybook } from '@/services/shortage/commodity-playbooks';
-import { detectBigEvent } from '@/services/insights/big-event-detector';
-import { routeBigEventToLadder } from '@/services/insights/notification-ladder';
-import { getNotificationTraceRegistry } from '@/services/diagnostics/diagnostics-state';
+import { unifiedAlertStore } from '@/services/unified-alerts';
+import { shouldNotify } from '@/services/notifications/notification-settings-service';
 import { getApiBaseUrl } from '@/services/runtime';
 import { escapeHtml } from '@/utils/sanitize';
 
-const REFRESH_MS = 30_000;
-const SIDECAR_PUSH_TTL_MS = 30 * 60 * 1000; // 30-minute cache
+const REFRESH_MS = 5 * 60 * 1000; // 5 minutes per spec
 
-// ── Risk level colors ──────────────────────────────────────────────────────
+// ── Risk level palette ─────────────────────────────────────────────────────
 
 const RISK_COLOR: Record<RiskLevel, string> = {
   CRITICAL: '#d50000',
@@ -41,134 +50,39 @@ const RISK_COLOR: Record<RiskLevel, string> = {
   LOW:      '#4caf50',
 };
 
-const RISK_BG: Record<RiskLevel, string> = {
-  CRITICAL: 'rgba(213,0,0,0.12)',
-  HIGH:     'rgba(255,152,0,0.10)',
-  MODERATE: 'rgba(255,235,59,0.08)',
-  LOW:      'rgba(76,175,80,0.08)',
+const TREND_COLOR: Record<OverviewRow['trendArrow'], string> = {
+  '↑': '#f44336',
+  '↓': '#4caf50',
+  '→': '#9e9e9e',
 };
-
-// ── Trend arrows ───────────────────────────────────────────────────────────
-
-const TREND_ARROW: Record<Trend, string> = {
-  deteriorating: '▲',
-  stable:        '→',
-  improving:     '▼',
-};
-
-const TREND_COLOR: Record<Trend, string> = {
-  deteriorating: '#f44336',
-  stable:        '#9e9e9e',
-  improving:     '#4caf50',
-};
-
-// ── Commodity display names ───────────────────────────────────────────────
-
-const DISPLAY_NAME: Record<FullSetCommodity, string> = {
-  'wheat':       'Wheat',
-  'corn':        'Corn',
-  'rice':        'Rice',
-  'soybeans':    'Soybeans',
-  'diesel':      'Diesel',
-  'gasoline':    'Gasoline',
-  'natural-gas': 'Nat Gas',
-  'jet-fuel':    'Jet Fuel',
-};
-
-// ── Notification ladder guard ─────────────────────────────────────────────
-// Track previous risk levels to fire only on HIGH → CRITICAL transitions.
-
-const _prevRiskLevels = new Map<FullSetCommodity, RiskLevel>();
-
-function checkAndNotify(entry: ShortageSummaryEntry): void {
-  const prev = _prevRiskLevels.get(entry.commodity);
-  _prevRiskLevels.set(entry.commodity, entry.riskLevel);
-
-  const justCritical = entry.riskLevel === 'CRITICAL' && prev !== 'CRITICAL';
-  if (!justCritical) return;
-
-  try {
-    const input = {
-      id: `shortage-${entry.commodity}-${Date.now()}`,
-      domain: 'shortage',
-      severityScore: entry.riskScore,
-      previousSeverityScore: 0,
-      truthScore: { high: 0.85, medium: 0.65, low: 0.45 }[entry.forecast.confidence] ?? 0.45,
-      sourceCount: new Set(
-        entry.forecast.drivers.flatMap((d) => d.sources ?? [])
-      ).size || 1,
-      hasOfficialSource: false,
-      overlappingDomains: [entry.forecast.domain],
-      userExposure: 30,
-      potentialImpact: entry.riskScore,
-      forecastThresholdCrossed: true,
-    };
-    const result = detectBigEvent(input);
-    if (result.isBigEvent) {
-      routeBigEventToLadder(
-        getNotificationTraceRegistry(),
-        result,
-        input,
-        {
-          domain: 'shortage',
-          headline: `${DISPLAY_NAME[entry.commodity]} shortage risk: CRITICAL`,
-          summary: entry.forecast.drivers.slice(0, 2).map((d) => d.label).join('; '),
-        },
-      );
-    }
-  } catch {
-    // Notification failure must not crash the panel render loop.
-  }
-}
-
-// ── Globe overlay ─────────────────────────────────────────────────────────
-
-function emitGlobeOverlay(entries: ShortageSummaryEntry[]): void {
-  if (typeof window === 'undefined' || typeof CustomEvent === 'undefined') return;
-  const regionRisk: { commodity: string; countries: string[]; riskLevel: RiskLevel; score: number }[] = [];
-  for (const e of entries) {
-    if (e.riskLevel === 'LOW') continue;
-    const pb = getPlaybook(e.commodity);
-    if (pb?.affectedCountries && pb.affectedCountries.length > 0) {
-      regionRisk.push({
-        commodity: e.commodity,
-        countries: pb.affectedCountries,
-        riskLevel: e.riskLevel,
-        score: e.riskScore,
-      });
-    }
-  }
-  window.dispatchEvent(new CustomEvent('wm:shortage-risk-data', { detail: regionRisk }));
-}
 
 // ── Sidecar push ──────────────────────────────────────────────────────────
 
-async function pushToSidecar(entries: ShortageSummaryEntry[]): Promise<void> {
+const SIDECAR_TTL_MS = 30 * 60 * 1000;
+
+async function pushToSidecar(entries: readonly ShortageSummaryEntry[]): Promise<void> {
   const base = getApiBaseUrl();
-  if (!base) return; // web build — no sidecar
+  if (!base) return;
   try {
-    const payload = {
-      entries: entries.map((e) => ({
-        commodity: e.commodity,
-        riskScore: e.riskScore,
-        riskLevel: e.riskLevel,
-        primaryDrivers: e.primaryDrivers,
-        timeToImpact: e.timeToImpact,
-        trend: e.trend,
-        forecast: e.forecast,
-      })),
-      updatedAt: Date.now(),
-      ttlMs: SIDECAR_PUSH_TTL_MS,
-    };
     await fetch(`${base}/api/shortage/state`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
+      body: JSON.stringify({
+        entries: entries.map((e) => ({
+          commodity: e.commodity,
+          riskScore: e.riskScore,
+          riskLevel: e.riskLevel,
+          primaryDrivers: e.primaryDrivers,
+          timeToImpact: e.timeToImpact,
+          trend: e.trend,
+          forecast: e.forecast,
+        })),
+        updatedAt: Date.now(),
+        ttlMs: SIDECAR_TTL_MS,
+      }),
       signal: AbortSignal.timeout(4000),
     });
-  } catch {
-    // Sidecar push is best-effort; the panel renders locally regardless.
-  }
+  } catch { /* best-effort — local render is the source of truth */ }
 }
 
 // ── Panel class ───────────────────────────────────────────────────────────
@@ -176,6 +90,8 @@ async function pushToSidecar(entries: ShortageSummaryEntry[]): Promise<void> {
 export class ShortageRadarPanel extends Panel {
   private refreshTimer: ReturnType<typeof setInterval> | null = null;
   private inputs: Partial<Record<FullSetCommodity, ShortageInputBag>> = {};
+  private expanded = new Set<FullSetCommodity>();
+  private previousScores = new Map<FullSetCommodity, number>();
 
   constructor() {
     super({
@@ -184,7 +100,7 @@ export class ShortageRadarPanel extends Panel {
       showCount: true,
       trackActivity: true,
       infoTooltip:
-        'Shortage risk across 8 commodities: wheat, corn, rice, soybeans, diesel, gasoline, natural gas, jet fuel. Sorted by risk. Click a card for the full drill-down.',
+        'Shortage risk across 8 commodities, sorted by current risk. Click a row to expand the full driver breakdown. Alerts fire when a commodity crosses HIGH (>70) or CRITICAL (>85).',
     });
     this.start();
   }
@@ -195,126 +111,176 @@ export class ShortageRadarPanel extends Panel {
     this.render();
   }
 
-  /** Legacy compat shim — previous callers used setRequests(). */
+  /** Legacy compat — previous callers used setRequests(). */
   public setRequests(requests: readonly { commodity: FullSetCommodity; inputs: ShortageInputBag }[]): void {
     const map: Partial<Record<FullSetCommodity, ShortageInputBag>> = {};
     for (const r of requests) map[r.commodity] = r.inputs;
     this.setInputs(map);
   }
 
-  public dispose(): void {
+  public override destroy(): void {
     if (this.refreshTimer !== null) {
       clearInterval(this.refreshTimer);
       this.refreshTimer = null;
     }
+    super.destroy();
   }
 
   private start(): void {
     this.render();
     this.refreshTimer = setInterval(() => this.render(), REFRESH_MS);
+    if (typeof document !== 'undefined') {
+      document.addEventListener('click', this.onRowToggle);
+      document.addEventListener('keydown', this.onRowKey);
+    }
+  }
+
+  private readonly onRowToggle = (ev: Event): void => {
+    const row = (ev.target as Element | null)?.closest('[data-shortage-row]');
+    if (!row) return;
+    const commodity = row.getAttribute('data-shortage-row');
+    if (!commodity) return;
+    this.toggleExpanded(commodity as FullSetCommodity);
+  };
+
+  private readonly onRowKey = (ev: KeyboardEvent): void => {
+    if (ev.key !== 'Enter' && ev.key !== ' ') return;
+    const row = (ev.target as Element | null)?.closest('[data-shortage-row]');
+    if (!row) return;
+    ev.preventDefault();
+    const commodity = row.getAttribute('data-shortage-row');
+    if (!commodity) return;
+    this.toggleExpanded(commodity as FullSetCommodity);
+  };
+
+  private toggleExpanded(commodity: FullSetCommodity): void {
+    if (this.expanded.has(commodity)) this.expanded.delete(commodity);
+    else this.expanded.add(commodity);
+    this.render();
   }
 
   private render(): void {
     const entries = computeShortageFullSet(this.inputs);
-    const criticalCount = entries.filter((e) => e.riskLevel === 'CRITICAL').length;
-    const alertCount = entries.filter((e) => e.riskLevel === 'CRITICAL' || e.riskLevel === 'HIGH').length;
-    this.setCount(alertCount);
+    const rows = buildOverviewRows(entries);
+    const counts = countByRiskLevel(rows);
+    this.setCount(counts.CRITICAL + counts.HIGH);
 
-    for (const e of entries) checkAndNotify(e);
-    emitGlobeOverlay(entries);
-    void pushToSidecar(entries);
-
-    this.setContent(this.buildHtml(entries, criticalCount));
-  }
-
-  private buildHtml(entries: ShortageSummaryEntry[], criticalCount: number): string {
-    const plural = criticalCount === 1 ? '' : 'S';
-    const bannerHtml = criticalCount > 0
-      ? `<div style="padding:6px 12px;background:rgba(213,0,0,0.15);border-bottom:1px solid rgba(213,0,0,0.3);font-size:11px;font-weight:700;color:#d50000;letter-spacing:0.04em;">
-           ⚠ ${criticalCount} CRITICAL SHORTAGE${plural} DETECTED
-         </div>`
-      : '';
-
-    // 2×4 grid — ordered by commodity position (not sorted by risk) so
-    // the grid layout stays stable across refreshes. Tier badges provide
-    // the urgency signal.
-    const ordered: ShortageSummaryEntry[] = [];
-    for (const c of ALL_FULLSET_COMMODITIES) {
-      const e = entries.find((x) => x.commodity === c);
-      if (e) ordered.push(e);
+    // Emit alerts on upward crossings.
+    const { alerts, nextPreviousScores } = emitShortageAlerts(entries, this.previousScores);
+    this.previousScores = nextPreviousScores;
+    if (alerts.length > 0) {
+      const accepted = alerts.filter((a) => shouldNotify('supply', a.severity));
+      if (accepted.length > 0) {
+        try { unifiedAlertStore.ingest(accepted); } catch { /* alert store failure must not break the panel */ }
+      }
     }
 
-    const cards = ordered.map((e) => this.buildCard(e)).join('');
-
-    return `${bannerHtml}
-      <div style="padding:10px;display:grid;grid-template-columns:1fr 1fr;gap:8px;">
-        ${cards}
-      </div>`;
+    void pushToSidecar(entries);
+    this.setContent(this.buildHtml(rows, entries, counts));
   }
 
-  private buildCard(e: ShortageSummaryEntry): string {
-    const color = RISK_COLOR[e.riskLevel];
-    const bg = RISK_BG[e.riskLevel];
-    const arrow = TREND_ARROW[e.trend];
-    const arrowColor = TREND_COLOR[e.trend];
-    const topDriver = e.primaryDrivers[0] ? escapeHtml(e.primaryDrivers[0]) : 'No drivers';
-    const gapDot = e.forecast.dataGaps.length > 0
-      ? `<span title="${escapeHtml(e.forecast.dataGaps[0] ?? '')}" style="color:#ff9800;font-size:10px;" aria-label="data gaps">⚠</span>`
-      : '';
+  private buildHtml(
+    rows: readonly OverviewRow[],
+    entries: readonly ShortageSummaryEntry[],
+    counts: Record<RiskLevel, number>,
+  ): string {
+    const banner = (counts.CRITICAL + counts.HIGH) > 0 ? this.buildBanner(counts) : '';
+    const tableRows = rows.map((r) => this.buildRow(r, entries)).join('');
 
-    return `<div
-      data-shortage-commodity="${escapeHtml(e.commodity)}"
-      role="button"
-      tabindex="0"
-      style="border:1px solid var(--border-subtle,#333);border-left:3px solid ${color};border-radius:4px;padding:9px 10px;cursor:pointer;background:${bg};transition:filter 0.15s;"
-      onmouseenter="this.style.filter='brightness(1.1)'"
-      onmouseleave="this.style.filter=''"
-    >
-      <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:4px;">
-        <span style="font-weight:700;font-size:12px;">${escapeHtml(DISPLAY_NAME[e.commodity])}</span>
-        <span style="display:flex;align-items:center;gap:4px;">
-          ${gapDot}
-          <span style="color:${arrowColor};font-size:12px;" title="${escapeHtml(e.trend)}">${arrow}</span>
-        </span>
+    return `${banner}
+      <div style="padding:8px 10px;font-size:11px;color:var(--text-secondary,#888);">
+        ${rows.length} commodities · sorted by current risk · alert threshold: HIGH 70 / CRITICAL 85
       </div>
-      <div style="display:flex;align-items:baseline;gap:6px;margin-bottom:4px;">
-        <span style="font-size:18px;font-weight:700;color:${color};font-family:ui-monospace,monospace;">${e.riskScore.toFixed(0)}</span>
-        <span style="font-size:10px;font-weight:700;color:${color};text-transform:uppercase;letter-spacing:0.06em;padding:1px 4px;border:1px solid ${color};border-radius:2px;">${e.riskLevel}</span>
-      </div>
-      <div style="font-size:10px;color:var(--text-secondary,#aaa);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" title="${escapeHtml(e.primaryDrivers.join(' · '))}">${topDriver}</div>
-      <div style="font-size:10px;color:var(--text-secondary,#777);margin-top:2px;">${escapeHtml(e.timeToImpact)}</div>
+      <table role="table" style="width:100%;border-collapse:collapse;font-size:12px;">
+        <thead>
+          <tr style="text-align:left;color:var(--text-secondary,#888);border-bottom:1px solid var(--border-subtle,#333);">
+            <th scope="col" style="padding:6px 10px;font-weight:600;">Commodity</th>
+            <th scope="col" style="padding:6px 10px;font-weight:600;text-align:right;">Risk</th>
+            <th scope="col" style="padding:6px 10px;font-weight:600;">Level</th>
+            <th scope="col" style="padding:6px 10px;font-weight:600;">Top driver</th>
+            <th scope="col" style="padding:6px 10px;font-weight:600;text-align:center;">Trend</th>
+          </tr>
+        </thead>
+        <tbody>${tableRows}</tbody>
+      </table>`;
+  }
+
+  private buildBanner(counts: Record<RiskLevel, number>): string {
+    const bits: string[] = [];
+    if (counts.CRITICAL > 0) bits.push(`${counts.CRITICAL} CRITICAL`);
+    if (counts.HIGH > 0)     bits.push(`${counts.HIGH} HIGH`);
+    const text = bits.join(' · ');
+    return `<div style="padding:6px 12px;background:rgba(213,0,0,0.12);border-bottom:1px solid rgba(213,0,0,0.3);font-size:11px;font-weight:700;color:#d50000;letter-spacing:0.04em;">
+      ⚠ SHORTAGE ALERTS: ${escapeHtml(text)}
     </div>`;
   }
+
+  private buildRow(r: OverviewRow, entries: readonly ShortageSummaryEntry[]): string {
+    const isOpen = this.expanded.has(r.commodity);
+    const drillHtml = isOpen ? this.buildDrillDown(r, entries) : '';
+    const color = RISK_COLOR[r.riskLevel];
+    const arrowColor = TREND_COLOR[r.trendArrow];
+    return `<tr
+      data-shortage-row="${escapeHtml(r.commodity)}"
+      role="button"
+      tabindex="0"
+      aria-expanded="${isOpen ? 'true' : 'false'}"
+      style="border-bottom:1px solid var(--border-subtle,#222);cursor:pointer;"
+    >
+      <td style="padding:7px 10px;font-weight:600;">${escapeHtml(r.displayName)}</td>
+      <td style="padding:7px 10px;text-align:right;font-family:ui-monospace,monospace;font-weight:700;color:${color};">${String(r.riskScore)}</td>
+      <td style="padding:7px 10px;">
+        <span style="font-size:10px;font-weight:700;color:${color};text-transform:uppercase;letter-spacing:0.06em;padding:1px 5px;border:1px solid ${color};border-radius:2px;">${escapeHtml(r.riskLevel)}</span>
+      </td>
+      <td style="padding:7px 10px;color:var(--text-secondary,#aaa);max-width:240px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="${escapeHtml(r.topDriver)}">${escapeHtml(r.topDriver)}</td>
+      <td style="padding:7px 10px;text-align:center;color:${arrowColor};font-weight:700;" aria-label="${escapeHtml(r.trend)}">${r.trendArrow}</td>
+    </tr>${drillHtml}`;
+  }
+
+  private buildDrillDown(r: OverviewRow, entries: readonly ShortageSummaryEntry[]): string {
+    const entry = entries.find((e) => e.commodity === r.commodity);
+    // computeShortageDetail requires a concrete input bag; only call it when
+    // the user has provided live inputs for this commodity. Otherwise fall
+    // back to the entry's already-computed forecast.
+    const liveInputs = this.inputs[r.commodity];
+    const detail = liveInputs ? computeShortageDetail(r.commodity, liveInputs) : undefined;
+    const driverList = (detail?.drivers ?? entry?.forecast.drivers ?? []).slice(0, 6);
+    const drivers = driverList.length === 0
+      ? '<li style="color:var(--text-secondary,#777);">No drivers reported.</li>'
+      : driverList.map((d) => `<li style="padding:2px 0;color:var(--text-primary,#ddd);">${escapeHtml(d.label)} <span style="color:var(--text-secondary,#777);font-family:ui-monospace,monospace;">(+${d.score.toFixed(0)})</span></li>`).join('');
+    const gapsList = detail?.dataGaps ?? entry?.forecast.dataGaps ?? [];
+    const gaps = gapsList.length === 0
+      ? '<li style="color:var(--text-secondary,#777);">No data gaps.</li>'
+      : gapsList.map((g) => `<li style="color:#ff9800;">${escapeHtml(g)}</li>`).join('');
+    const confidence = detail?.confidence ?? entry?.forecast.confidence ?? 'low';
+    const timeToImpact = entry?.timeToImpact ?? '—';
+    return `<tr data-shortage-drilldown="${escapeHtml(r.commodity)}">
+      <td colspan="5" style="background:var(--bg-elevated,rgba(255,255,255,0.02));padding:12px 16px;">
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:14px;">
+          <div>
+            <div style="font-size:10px;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-secondary,#888);margin-bottom:4px;">Top drivers</div>
+            <ul style="margin:0;padding-left:14px;">${drivers}</ul>
+          </div>
+          <div>
+            <div style="font-size:10px;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-secondary,#888);margin-bottom:4px;">Data gaps</div>
+            <ul style="margin:0;padding-left:14px;">${gaps}</ul>
+          </div>
+          <div>
+            <div style="font-size:10px;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-secondary,#888);margin-bottom:4px;">Forecast</div>
+            <div style="font-size:11px;color:var(--text-primary,#ddd);">Confidence: <strong>${escapeHtml(confidence)}</strong></div>
+            <div style="font-size:11px;color:var(--text-primary,#ddd);">Time to impact: <strong>${escapeHtml(timeToImpact)}</strong></div>
+            <div style="font-size:11px;color:var(--text-secondary,#999);margin-top:4px;">Notification severity if persists: ${escapeHtml(severityFromScore(r.riskScore))}</div>
+          </div>
+        </div>
+      </td>
+    </tr>`;
+  }
 }
 
-// ── Click delegation ───────────────────────────────────────────────────────
-// Attached once at module load so all card clicks dispatch the drill-down
-// event regardless of how many times the panel re-renders.
-
-if (typeof document !== 'undefined') {
-  document.addEventListener('click', (ev) => {
-    const target = (ev.target as Element)?.closest('[data-shortage-commodity]');
-    if (!target) return;
-    const commodity = target.getAttribute('data-shortage-commodity');
-    if (!commodity) return;
-    document.dispatchEvent(
-      new CustomEvent('wm:shortage-drill-down', { detail: { commodity }, bubbles: true }),
-    );
-  });
-
-  document.addEventListener('keydown', (ev) => {
-    if (ev.key !== 'Enter' && ev.key !== ' ') return;
-    const target = (ev.target as Element)?.closest('[data-shortage-commodity]');
-    if (!target) return;
-    const commodity = target.getAttribute('data-shortage-commodity');
-    if (!commodity) return;
-    document.dispatchEvent(
-      new CustomEvent('wm:shortage-drill-down', { detail: { commodity }, bubbles: true }),
-    );
-  });
-}
-
-// Re-export type for external callers.
-
-
-export {type ShortageSummaryEntry, type FullSetCommodity, type RiskLevel, type Trend} from '@/services/shortage/shortage-fullset';
+// Re-export types so panel consumers don't need a second import.
+export {
+  type ShortageSummaryEntry,
+  type FullSetCommodity,
+  type RiskLevel,
+  type Trend,
+} from '@/services/shortage/shortage-fullset';

--- a/src/services/notifications/__tests__/notification-settings-service.test.mts
+++ b/src/services/notifications/__tests__/notification-settings-service.test.mts
@@ -10,12 +10,12 @@ import {
   type NotificationSeverity,
 } from '../notification-settings-service.js';
 
-// ── 1. Default settings have all 10 domains enabled ──────────────────────────
-test('default settings have all 10 domains enabled', () => {
+// ── 1. Default settings have all 11 domains enabled ──────────────────────────
+test('default settings have all 11 domains enabled', () => {
   resetSettings();
   const { domains } = getSettings();
   const domainKeys = Object.keys(domains) as NotificationDomain[];
-  assert.equal(domainKeys.length, 10);
+  assert.equal(domainKeys.length, 11);
   for (const key of domainKeys) {
     assert.equal(domains[key].enabled, true, `${key} should be enabled by default`);
   }

--- a/src/services/notifications/notification-settings-service.ts
+++ b/src/services/notifications/notification-settings-service.ts
@@ -12,7 +12,8 @@ export type NotificationDomain =
   | 'infrastructure'
   | 'geopolitical'
   | 'weather'
-  | 'cyber';
+  | 'cyber'
+  | 'supply';
 
 export interface DomainSettings {
   enabled: boolean;
@@ -49,6 +50,7 @@ const ALL_DOMAINS: NotificationDomain[] = [
   'geopolitical',
   'weather',
   'cyber',
+  'supply',
 ];
 
 const DEFAULT_DOMAIN_SETTINGS: DomainSettings = {

--- a/src/services/shortage/__tests__/shortage-alert-emitter.test.mts
+++ b/src/services/shortage/__tests__/shortage-alert-emitter.test.mts
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  emitShortageAlerts,
+  severityFromScore,
+  SHORTAGE_HIGH_THRESHOLD,
+  SHORTAGE_CRITICAL_THRESHOLD,
+} from '../shortage-alert-emitter.ts';
+import type { ShortageSummaryEntry, FullSetCommodity, RiskLevel, Trend } from '../shortage-fullset.ts';
+
+function entry(
+  commodity: FullSetCommodity,
+  riskScore: number,
+  riskLevel: RiskLevel = 'HIGH',
+  drivers: string[] = ['benchmark driver'],
+  trend: Trend = 'stable',
+): ShortageSummaryEntry {
+  return {
+    commodity,
+    riskScore,
+    riskLevel,
+    primaryDrivers: drivers,
+    timeToImpact: '30d',
+    trend,
+    forecast: {} as unknown as ShortageSummaryEntry['forecast'],
+  };
+}
+
+test('severityFromScore: <=49 = low, ≥50 = medium, >70 = high, >85 = critical', () => {
+  assert.equal(severityFromScore(0), 'low');
+  assert.equal(severityFromScore(49), 'low');
+  assert.equal(severityFromScore(50), 'medium');
+  assert.equal(severityFromScore(70), 'medium');
+  assert.equal(severityFromScore(71), 'high');
+  assert.equal(severityFromScore(85), 'high');
+  assert.equal(severityFromScore(86), 'critical');
+  assert.equal(severityFromScore(100), 'critical');
+});
+
+test('emitShortageAlerts: first observation above HIGH threshold emits a high alert', () => {
+  const { alerts } = emitShortageAlerts(
+    [entry('wheat', 75)],
+    new Map(),
+    1_000,
+  );
+  assert.equal(alerts.length, 1);
+  assert.equal(alerts[0]?.severity, 'high');
+  assert.equal(alerts[0]?.source, 'resource');
+  assert.match(alerts[0]?.title ?? '', /Wheat shortage risk: HIGH/);
+});
+
+test('emitShortageAlerts: first observation above CRITICAL threshold emits a critical alert (not high)', () => {
+  const { alerts } = emitShortageAlerts(
+    [entry('corn', 92)],
+    new Map(),
+    1_000,
+  );
+  assert.equal(alerts.length, 1);
+  assert.equal(alerts[0]?.severity, 'critical');
+  assert.match(alerts[0]?.title ?? '', /Corn shortage risk: CRITICAL/);
+});
+
+test('emitShortageAlerts: stays-high does not re-emit on consecutive renders', () => {
+  let prev = new Map<FullSetCommodity, number>();
+  const first = emitShortageAlerts([entry('wheat', 75)], prev, 1_000);
+  prev = first.nextPreviousScores;
+  assert.equal(first.alerts.length, 1);
+  const second = emitShortageAlerts([entry('wheat', 78)], prev, 2_000);
+  assert.equal(second.alerts.length, 0);
+});
+
+test('emitShortageAlerts: a drop below HIGH then re-cross fires again', () => {
+  let prev = new Map<FullSetCommodity, number>();
+  prev = emitShortageAlerts([entry('wheat', 75)], prev, 1_000).nextPreviousScores;
+  prev = emitShortageAlerts([entry('wheat', 40)], prev, 2_000).nextPreviousScores;
+  const third = emitShortageAlerts([entry('wheat', 80)], prev, 3_000);
+  assert.equal(third.alerts.length, 1);
+  assert.equal(third.alerts[0]?.severity, 'high');
+});
+
+test('emitShortageAlerts: high → critical promotes by emitting a critical alert', () => {
+  let prev = new Map<FullSetCommodity, number>();
+  prev = emitShortageAlerts([entry('diesel', 75)], prev, 1_000).nextPreviousScores;
+  const next = emitShortageAlerts([entry('diesel', 90)], prev, 2_000);
+  assert.equal(next.alerts.length, 1);
+  assert.equal(next.alerts[0]?.severity, 'critical');
+});
+
+test('emitShortageAlerts: scores at or below threshold do NOT cross', () => {
+  const { alerts } = emitShortageAlerts(
+    [entry('wheat', SHORTAGE_HIGH_THRESHOLD)],
+    new Map(),
+    1_000,
+  );
+  assert.equal(alerts.length, 0);
+});
+
+test('emitShortageAlerts: timestamp is reflected in alert id and timestamp', () => {
+  const { alerts } = emitShortageAlerts(
+    [entry('wheat', 80)],
+    new Map(),
+    1_700_000_000_000,
+  );
+  assert.ok(alerts[0]?.id.endsWith('1700000000000'));
+  assert.equal(alerts[0]?.timestamp, 1_700_000_000_000);
+});
+
+test('emitShortageAlerts: handles many commodities at once and one transition per commodity per call', () => {
+  const { alerts } = emitShortageAlerts(
+    [
+      entry('wheat', 75),
+      entry('corn', 95),
+      entry('rice', 30),
+    ],
+    new Map(),
+    1_000,
+  );
+  assert.equal(alerts.length, 2);
+  assert.equal(alerts.find((a) => a.title.includes('Wheat'))?.severity, 'high');
+  assert.equal(alerts.find((a) => a.title.includes('Corn'))?.severity, 'critical');
+});
+
+test('emitShortageAlerts: nextPreviousScores includes EVERY observed commodity (not just the alerting ones)', () => {
+  const { nextPreviousScores } = emitShortageAlerts(
+    [entry('wheat', 20), entry('corn', 75)],
+    new Map(),
+    1_000,
+  );
+  assert.equal(nextPreviousScores.get('wheat'), 20);
+  assert.equal(nextPreviousScores.get('corn'), 75);
+});
+
+test('SHORTAGE thresholds are 70 and 85 (constants)', () => {
+  assert.equal(SHORTAGE_HIGH_THRESHOLD, 70);
+  assert.equal(SHORTAGE_CRITICAL_THRESHOLD, 85);
+});
+
+test('emitShortageAlerts: existing critical that lingers is not re-emitted', () => {
+  const prev = new Map<FullSetCommodity, number>([['corn', 92]]);
+  const { alerts } = emitShortageAlerts([entry('corn', 95)], prev, 1_000);
+  assert.equal(alerts.length, 0);
+});

--- a/src/services/shortage/__tests__/shortage-overview-helpers.test.mts
+++ b/src/services/shortage/__tests__/shortage-overview-helpers.test.mts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildOverviewRows,
+  countByRiskLevel,
+} from '../shortage-overview-helpers.ts';
+import type { ShortageSummaryEntry, FullSetCommodity, RiskLevel, Trend } from '../shortage-fullset.ts';
+
+function entry(
+  commodity: FullSetCommodity,
+  riskScore: number,
+  riskLevel: RiskLevel,
+  drivers: string[] = [],
+  trend: Trend = 'stable',
+): ShortageSummaryEntry {
+  return {
+    commodity,
+    riskScore,
+    riskLevel,
+    primaryDrivers: drivers,
+    timeToImpact: '30d',
+    trend,
+    // The full forecast isn't read by the helpers; cast through unknown.
+    forecast: {} as unknown as ShortageSummaryEntry['forecast'],
+  };
+}
+
+test('buildOverviewRows sorts by risk level first (CRITICAL → LOW)', () => {
+  const rows = buildOverviewRows([
+    entry('wheat', 10, 'LOW'),
+    entry('corn', 95, 'CRITICAL'),
+    entry('diesel', 55, 'HIGH'),
+    entry('rice', 30, 'MODERATE'),
+  ]);
+  assert.deepEqual(rows.map((r) => r.commodity), ['corn', 'diesel', 'rice', 'wheat']);
+});
+
+test('buildOverviewRows breaks level ties by riskScore desc', () => {
+  const rows = buildOverviewRows([
+    entry('wheat', 78, 'CRITICAL'),
+    entry('corn', 92, 'CRITICAL'),
+  ]);
+  assert.deepEqual(rows.map((r) => r.commodity), ['corn', 'wheat']);
+});
+
+test('buildOverviewRows breaks score+level ties alphabetically by display name', () => {
+  const rows = buildOverviewRows([
+    entry('soybeans', 50, 'HIGH'),
+    entry('diesel', 50, 'HIGH'),
+    entry('corn', 50, 'HIGH'),
+  ]);
+  assert.deepEqual(rows.map((r) => r.commodity), ['corn', 'diesel', 'soybeans']);
+});
+
+test('buildOverviewRows maps trend to ↑/↓/→ glyphs', () => {
+  const rows = buildOverviewRows([
+    entry('wheat', 50, 'HIGH', ['drought'], 'deteriorating'),
+    entry('corn', 40, 'MODERATE', ['rain'], 'improving'),
+    entry('rice', 30, 'MODERATE', ['steady'], 'stable'),
+  ]);
+  const m = new Map(rows.map((r) => [r.commodity, r.trendArrow]));
+  assert.equal(m.get('wheat'), '↑');
+  assert.equal(m.get('corn'), '↓');
+  assert.equal(m.get('rice'), '→');
+});
+
+test('buildOverviewRows uses "—" for topDriver when drivers list is empty', () => {
+  const rows = buildOverviewRows([entry('wheat', 10, 'LOW', [])]);
+  assert.equal(rows[0]?.topDriver, '—');
+});
+
+test('buildOverviewRows rounds the displayed risk score', () => {
+  const rows = buildOverviewRows([entry('wheat', 73.6, 'CRITICAL')]);
+  assert.equal(rows[0]?.riskScore, 74);
+});
+
+test('countByRiskLevel tallies all four bands', () => {
+  const rows = buildOverviewRows([
+    entry('wheat', 95, 'CRITICAL'),
+    entry('corn', 92, 'CRITICAL'),
+    entry('diesel', 60, 'HIGH'),
+    entry('rice', 30, 'MODERATE'),
+    entry('gasoline', 10, 'LOW'),
+  ]);
+  const counts = countByRiskLevel(rows);
+  assert.equal(counts.CRITICAL, 2);
+  assert.equal(counts.HIGH, 1);
+  assert.equal(counts.MODERATE, 1);
+  assert.equal(counts.LOW, 1);
+});
+
+test('buildOverviewRows produces a fresh array (does not mutate input order)', () => {
+  const input = [
+    entry('wheat', 10, 'LOW'),
+    entry('corn', 95, 'CRITICAL'),
+  ];
+  buildOverviewRows(input);
+  assert.equal(input[0]?.commodity, 'wheat'); // original order preserved
+});

--- a/src/services/shortage/shortage-alert-emitter.ts
+++ b/src/services/shortage/shortage-alert-emitter.ts
@@ -1,0 +1,95 @@
+/**
+ * Shortage → UnifiedAlert emitter (pure).
+ *
+ * Given the current snapshot of commodity entries and the previously-emitted
+ * scores, returns a list of `UnifiedAlert` payloads to ingest into the alert
+ * store. Fires exactly once per upward crossing of each threshold:
+ *
+ *   - HIGH      score crosses 70 from below  → severity 'high'
+ *   - CRITICAL  score crosses 85 from below  → severity 'critical'
+ *
+ * "Crossing" means the *current* score is above the threshold and the
+ * *previous* score (if any) was at or below it. A panel that re-renders
+ * without the score moving will not produce a duplicate alert.
+ *
+ * The emitter is decoupled from the alert store, the notification-settings
+ * gate, and the panel — so it can be exercised with static fixtures.
+ */
+
+import type { UnifiedAlert, AlertSeverity } from '@/services/unified-alerts';
+import type { ShortageSummaryEntry, FullSetCommodity } from '@/services/shortage/shortage-fullset';
+
+export const SHORTAGE_HIGH_THRESHOLD = 70;
+export const SHORTAGE_CRITICAL_THRESHOLD = 85;
+
+const DISPLAY_NAME: Record<FullSetCommodity, string> = {
+  'wheat':       'Wheat',
+  'corn':        'Corn',
+  'rice':        'Rice',
+  'soybeans':    'Soybeans',
+  'diesel':      'Diesel',
+  'gasoline':    'Gasoline',
+  'natural-gas': 'Natural Gas',
+  'jet-fuel':    'Jet Fuel',
+};
+
+/**
+ * Inputs: the current entries plus a (commodity → previous score) map.
+ * Returns the alerts to emit AND the updated map. The map is intentionally
+ * returned so the caller can keep it module-scoped without exposing mutable
+ * state inside this module (keeps it pure and reusable from tests).
+ */
+export interface EmitResult {
+  alerts: UnifiedAlert[];
+  nextPreviousScores: Map<FullSetCommodity, number>;
+}
+
+export function emitShortageAlerts(
+  entries: readonly ShortageSummaryEntry[],
+  previousScores: ReadonlyMap<FullSetCommodity, number>,
+  now: number = Date.now(),
+): EmitResult {
+  const alerts: UnifiedAlert[] = [];
+  const next = new Map(previousScores);
+  for (const e of entries) {
+    const prev = previousScores.get(e.commodity);
+    const crossedCritical = e.riskScore > SHORTAGE_CRITICAL_THRESHOLD
+      && (prev === undefined || prev <= SHORTAGE_CRITICAL_THRESHOLD);
+    const crossedHigh = !crossedCritical
+      && e.riskScore > SHORTAGE_HIGH_THRESHOLD
+      && (prev === undefined || prev <= SHORTAGE_HIGH_THRESHOLD);
+    if (crossedCritical) alerts.push(buildAlert(e, 'critical', now));
+    else if (crossedHigh) alerts.push(buildAlert(e, 'high', now));
+    next.set(e.commodity, e.riskScore);
+  }
+  return { alerts, nextPreviousScores: next };
+}
+
+function buildAlert(e: ShortageSummaryEntry, severity: AlertSeverity, now: number): UnifiedAlert {
+  const name = DISPLAY_NAME[e.commodity];
+  const topDriver = e.primaryDrivers[0] ?? '(no primary driver)';
+  const tier = severity === 'critical' ? 'CRITICAL' : 'HIGH';
+  return {
+    id: `shortage:${e.commodity}:${tier}:${now}`,
+    source: 'resource',
+    severity,
+    title: `${name} shortage risk: ${tier}`,
+    body: `Risk score ${e.riskScore.toFixed(0)}/100. ${topDriver}.`,
+    timestamp: now,
+    relevanceScore: severity === 'critical' ? 95 : 75,
+    acknowledged: false,
+    pinned: false,
+  };
+}
+
+/**
+ * Map an alert score band to the `NotificationSeverity` accepted by
+ * `shouldNotify`. Kept here so the panel doesn't repeat the rule and tests
+ * can validate it.
+ */
+export function severityFromScore(score: number): 'low' | 'medium' | 'high' | 'critical' {
+  if (score > SHORTAGE_CRITICAL_THRESHOLD) return 'critical';
+  if (score > SHORTAGE_HIGH_THRESHOLD) return 'high';
+  if (score >= 50) return 'medium';
+  return 'low';
+}

--- a/src/services/shortage/shortage-overview-helpers.ts
+++ b/src/services/shortage/shortage-overview-helpers.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure helpers for the Shortage Radar table view.
+ *
+ * Separated from the DOM so the sort/format logic can be unit-tested without
+ * a renderer. Kept tiny on purpose — anything that needs `document` lives in
+ * the panel component, anything that's data shape lives here.
+ */
+
+import type { ShortageSummaryEntry, RiskLevel, Trend, FullSetCommodity } from './shortage-fullset';
+
+export interface OverviewRow {
+  commodity: FullSetCommodity;
+  displayName: string;
+  riskScore: number;
+  riskLevel: RiskLevel;
+  topDriver: string;
+  trend: Trend;
+  trendArrow: '↑' | '↓' | '→';
+}
+
+const DISPLAY_NAMES: Record<FullSetCommodity, string> = {
+  'wheat':       'Wheat',
+  'corn':        'Corn',
+  'rice':        'Rice',
+  'soybeans':    'Soybeans',
+  'diesel':      'Diesel',
+  'gasoline':    'Gasoline',
+  'natural-gas': 'Natural Gas',
+  'jet-fuel':    'Jet Fuel',
+};
+
+const TREND_ARROW: Record<Trend, OverviewRow['trendArrow']> = {
+  deteriorating: '↑',
+  improving:     '↓',
+  stable:        '→',
+};
+
+const RISK_RANK: Record<RiskLevel, number> = {
+  CRITICAL: 0,
+  HIGH:     1,
+  MODERATE: 2,
+  LOW:      3,
+};
+
+/**
+ * Convert raw summary entries into table rows sorted by riskScore desc.
+ * Ties broken by alphabetical commodity name (so the order is stable across
+ * renders when scores are identical).
+ */
+export function buildOverviewRows(entries: readonly ShortageSummaryEntry[]): OverviewRow[] {
+  return entries
+    .map((e) => toRow(e))
+    .sort((a, b) => (
+      (RISK_RANK[a.riskLevel] - RISK_RANK[b.riskLevel])
+      || (b.riskScore - a.riskScore)
+      || a.displayName.localeCompare(b.displayName)
+    ));
+}
+
+function toRow(e: ShortageSummaryEntry): OverviewRow {
+  return {
+    commodity: e.commodity,
+    displayName: DISPLAY_NAMES[e.commodity],
+    riskScore: Math.round(e.riskScore),
+    riskLevel: e.riskLevel,
+    topDriver: e.primaryDrivers[0] ?? '—',
+    trend: e.trend,
+    trendArrow: TREND_ARROW[e.trend],
+  };
+}
+
+/** Count entries by risk band — used by the panel header summary. */
+export function countByRiskLevel(rows: readonly OverviewRow[]): Record<RiskLevel, number> {
+  const out: Record<RiskLevel, number> = { CRITICAL: 0, HIGH: 0, MODERATE: 0, LOW: 0 };
+  for (const r of rows) out[r.riskLevel] += 1;
+  return out;
+}


### PR DESCRIPTION
Brings the existing 8-commodity shortage forecast layer to a user-facing surface and wires it into the standard notification pipeline.

## What's new

- **Sorted overview table** in `ShortageRadarPanel` (replaces the previous 2×4 card grid). Risk-level ordering is primary (CRITICAL → LOW), with riskScore desc + alpha tiebreakers so row order is stable across renders when scores match. ↑/↓/→ trend column, risk badge, top driver, score column.
- **Inline drill-down** — clicking (or Enter/Space on) a row toggles an expanded body that lists drivers (top 6), data gaps, confidence band, time-to-impact, and the severity that would fire if the score persists. State is per-panel-instance so multiple rows can be open at once.
- **5-minute auto-refresh** (was 30 s).
- **`/api/shortage/overview` sidecar route** — narrow `{ commodity, riskScore, riskLevel, topDriver, trend }` shape for MCP/dashboard clients, sorted by riskScore desc. Separate from the existing `/api/shortage/summary` (which carries the heavier panel-internal fields) so consumers can pick the right one.
- **`supply` NotificationDomain** added to `notification-settings-service`. Each upward threshold crossing emits a UnifiedAlert via `unifiedAlertStore.ingest` after `shouldNotify('supply', severity)` clears, so users can mute the channel or raise the floor without touching code.
- **Pure `shortage-alert-emitter` module** that takes `(currentEntries, previousScores)` and returns the alerts to ingest plus the updated score map. Exactly-once-per-upward-crossing semantics: a commodity sitting at HIGH for hours doesn't re-fire on every refresh; if it drops below 70 and comes back it does. Thresholds: `SHORTAGE_HIGH_THRESHOLD = 70`, `SHORTAGE_CRITICAL_THRESHOLD = 85`.

## Architecture

```
src/services/shortage/
  shortage-overview-helpers.ts    pure: buildOverviewRows, countByRiskLevel
  shortage-alert-emitter.ts       pure: emitShortageAlerts, severityFromScore
src/components/
  ShortageRadarPanel.ts           rewritten: table + inline drill-down + alerts
src/services/notifications/
  notification-settings-service.ts  + 'supply' domain
src/components/
  NotificationSettingsPanel.ts    + supply row in domain list
src-tauri/sidecar/local-api-server.mjs
  + GET /api/shortage/overview
```

## Tests

**45 total, all passing:**
- `shortage-overview-helpers.test.mts` — 8 tests (sort primary, score tiebreaker, alpha tiebreaker, trend arrows, missing-driver fallback, score rounding, band tally, non-mutation)
- `shortage-alert-emitter.test.mts` — 12 tests (severityFromScore bands, first-cross HIGH, first-cross CRITICAL, lingering doesn't re-fire, drop-then-recross fires again, HIGH→CRITICAL promotion, threshold-equal doesn't cross, timestamp propagation, multi-commodity batch, score map carries all observed commodities, threshold constants, lingering critical not re-emitted)
- `shortage-overview.test.mjs` (sidecar) — 7 tests (empty when no state, sorted desc, exact shape, em-dash for empty drivers, empty when stale, `/api/shortage/:commodity` still routes, score rounding)
- `notification-settings-service.test.mts` — 18 existing tests (domain count bumped 10 → 11)

```
npx tsx --test src/services/shortage/__tests__/shortage-{overview-helpers,alert-emitter}.test.mts src/services/notifications/__tests__/notification-settings-service.test.mts
node --test src-tauri/sidecar/__tests__/shortage-overview.test.mjs
```

## Verification

- `npm run typecheck:all` — zero errors
- `eslint` — zero errors
- Secret scan + lint-staged + pre-commit hooks — pass

## Notes

- The panel pushes computed state to `/api/shortage/state` after each render so the sidecar can answer `/api/shortage/overview` and `/api/shortage/:commodity` without needing its own commodity models.
- The alert wiring goes through `shouldNotify(domain, severity)` — same gate every other domain uses. Critical alerts still bypass quiet hours per the existing rule.
- `shortage-radar` is already registered in `panels.ts` (id, intelligence category) and instantiated in `panel-layout.ts`; no changes needed there.

Cross-agent review: claude reviewed on 2026-05-12; outcome: pass