### PR TITLE
feat(intelligence): cross-domain correlation engine v2 — causal chains + confidence scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Crystal Ball are documented here.
 
 ## [Unreleased]
 
+## [2.15.0] - 2026-05-12
+
+### Added
+
+- **Cross-domain correlation engine v2** (`src/services/intelligence/correlator-v2.ts`): Causal chain detection across 7 domain-transition rules (seismic cascade, wildfire cascade, hurricane cascade, cyber cascade, conflict cascade, maritime-economic, aviation-conflict). Configurable time windows per transition pair (15 min for seismic → tsunami, 6 hr for weather → supply chain, 24 hr for conflict → displacement). Confidence scoring blends spatial overlap, temporal proximity, and entity match; degrades 0.1 per domain hop with a 0.3 floor. Event-level de-duplication merges overlapping chains by keeping the stronger one. Exports `CorrelatorV2`, `startV2Cycle()`, `stopV2Cycle()`, `getActiveChains()`, `getCorrelationsForEvent()`.
+- **Correlation Map panel** (`correlation-map`, category: `intelligence`): Shows active correlation chains as a sortable list with chain-type badge, confidence bar, event count, and domain icons. Click to expand individual events in a chain. 30 s auto-refresh from sidecar.
+- **Sidecar endpoints**: `POST/GET /api/intelligence/correlations/chains` — renderer pushes v2 chain snapshots; `GET /api/intelligence/correlations/event/:id` — chains containing a specific event.
+- **34 unit tests** (`src/services/intelligence/__tests__/correlator-v2.test.mts`): chain detection, confidence math, time-window boundaries, de-duplication, cross-domain pairs, module-level singleton, and backward-compat `toCorrelations()`.
+
 ## [2.14.0] - 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Crystal Ball
 
-Real-time global intelligence platform. Desktop app and web dashboard that aggregates 50+ live data feeds into 212 interactive panels, a 3D Cesium globe with 70 geospatial layers, an explainable algorithm intelligence layer (truth scoring + evidence graph + situation clustering + compound risk + forecast calibration + watchlist relevance), domain-aware shortage / weather / insight engines, AI-powered analysis, and an MCP server that lets Claude Code query it all from the terminal.
+Real-time global intelligence platform. Desktop app and web dashboard that aggregates 50+ live data feeds into 229 interactive panels, a 3D Cesium globe with 70 geospatial layers, an explainable algorithm intelligence layer (truth scoring + evidence graph + situation clustering + compound risk + forecast calibration + watchlist relevance), domain-aware shortage / weather / insight engines, AI-powered analysis, and an MCP server that lets Claude Code query it all from the terminal.
 
 [![Version](https://img.shields.io/github/v/release/bradleybond512/crystal-ball?label=version)](https://github.com/bradleybond512/crystal-ball/releases/latest)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
@@ -15,13 +15,13 @@ Real-time global intelligence platform. Desktop app and web dashboard that aggre
 
 ## What It Does
 
-Crystal Ball pulls data from ACLED, GDACS, NWS, USGS, CISA, ThreatFox, FRED, ADS-B, AIS, CelesTrak, and dozens of other sources, then presents it across a 2D MapLibre map, a 3D Cesium globe, 212 live panels, a unified alert inbox, and a correlation engine that connects events across domains. You can ask Claude Code `/sitrep` and get a synthesized intelligence brief from all active feeds without opening the app.
+Crystal Ball pulls data from ACLED, GDACS, NWS, USGS, CISA, ThreatFox, FRED, ADS-B, AIS, CelesTrak, and dozens of other sources, then presents it across a 2D MapLibre map, a 3D Cesium globe, 229 live panels, a unified alert inbox, and a correlation engine that connects events across domains. You can ask Claude Code `/sitrep` and get a synthesized intelligence brief from all active feeds without opening the app.
 
 Four product variants share one codebase:
 
 | Variant | Panels | Focus |
 |---------|--------|-------|
-| `full` | 212 | Geopolitics, conflict, cyber, infrastructure, disasters, markets |
+| `full` | 229 | Geopolitics, conflict, cyber, infrastructure, disasters, markets |
 | `tech` | 35 | AI, startups, cloud, service health, developer ecosystems |
 | `finance` | 31 | Markets, forex, bonds, commodities, crypto, central banks |
 | `happy` | 10 | Positive news, progress, science, conservation |
@@ -336,8 +336,8 @@ All sounds are synthesized with Web Audio API -- no audio files in the repo:
 
 | Metric | Value | Source |
 |--------|-------|--------|
-| Panels (full variant) | 212 | `src/config/panels.ts` |
-| Default panel inventory | `212 full / 35 tech / 31 finance / 10 happy` | `src/config/panels.ts` |
+| Panels (full variant) | 229 | `src/config/panels.ts` |
+| Default panel inventory | `229 full / 35 tech / 31 finance / 10 happy` | `src/config/panels.ts` |
 | God's Vision map layers | 70 (26 on by default) | `src/types/index.ts` MapLayers |
 | Panel categories | 19 | `src/config/panels.ts` PANEL_CATEGORY_MAP |
 | Product variants | 4 | `src/config/variant.ts` |

--- a/docs/CSP_AUDIT.md
+++ b/docs/CSP_AUDIT.md
@@ -1,0 +1,123 @@
+# Content-Security-Policy audit
+
+This file is the standing audit record for Crystal Ball's CSP. It documents
+every concession to a stricter policy, why it exists, and what would have to
+change before it can be removed.
+
+## TL;DR
+
+- `unsafe-eval` on `script-src` — **REQUIRED** by Cesium 1.140.0; removal blocked.
+- `wasm-unsafe-eval` on `script-src` — **REQUIRED** by Cesium WASM workers (KTX2 transcoder, etc.).
+- `unsafe-inline` on `style-src` — **PRESENT**; lower-risk; documented TODO for nonce migration.
+- `unsafe-inline` on `script-src` — **ABSENT**. The one inline bootstrap script in `index.html` is
+  pinned by hash (`'sha256-CEQjAz+RfGVMlmAv8C9h16vbduoug7nuW41coE/SDtM='`).
+
+## Where the CSP is set
+
+There are two enforcement points:
+
+1. **Desktop (Tauri webview):** `src-tauri/tauri.conf.json` → `security.csp`.
+   Tauri injects this as the `Content-Security-Policy` HTTP header for the
+   built webview. This is the binding policy at runtime in the macOS app.
+
+2. **Web / dev preview:** `index.html` `<meta http-equiv="Content-Security-Policy">`.
+   Applied when the bundle is served by Vite or hosted on `crystalball.app`.
+   Slightly more permissive on `connect-src` and `frame-src` because dev
+   tooling and YouTube embeds need additional hosts. Inline-script use is
+   pinned by SHA-256 hash, not `'unsafe-inline'`.
+
+## Why `unsafe-eval` cannot be removed today
+
+Cesium 1.140.0 — currently the only 3D-globe engine we ship — uses runtime
+dynamic-code evaluation in at least three documented call paths:
+
+1. **Shader compilation pipeline.** Cesium synthesises GLSL fragments from
+   user-provided properties (entity descriptions, materials, label fonts)
+   and compiles them via dynamic function constructors inside
+   `cesium/Build/Cesium/Cesium.js`. Replacing this would require Cesium to
+   ship strict-CSP shader builds. The current upstream (1.140.0) does not.
+2. **Bundled protobuf dispatch.** The vendored `protobuf.js` lite runtime
+   uses dynamic function construction for fast tag-dispatch.
+3. **KTX2 / Draco worker compilation.** Asynchronous worker payloads in
+   `cesium/Build/Cesium/Workers/transcodeKTX2.js` instantiate Emscripten
+   modules via runtime function factories. This call site is partially
+   covered by `wasm-unsafe-eval` but the surrounding glue still requires
+   full `unsafe-eval` until Cesium ships an opt-in strict-CSP build.
+
+Stripping `unsafe-eval` today produces a black map view, broken labels, and
+broken KTX2 texture decoding. The previous CLAUDE.md note ("Required by
+Cesium (God's Eye 3D globe) for shader compilation. Do not remove without
+first replacing Cesium with a non-eval globe library.") still holds.
+
+### What would let us remove `unsafe-eval`
+
+- Cesium ships an official strict-CSP build (tracked upstream as a long-
+  standing open issue). When that lands, swap the bundle path and drop the
+  directive.
+- OR: replace Cesium with a globe engine that does not need runtime eval
+  (e.g. MapLibre + a terrain extension). Out of scope for security work; a
+  product decision.
+
+Until one of those happens, the directive stays. The `wasm-unsafe-eval`
+directive is the narrower, more modern variant; it must stay alongside
+`unsafe-eval` for Cesium's WASM workers regardless.
+
+## Why `unsafe-inline` on `style-src` is still present
+
+A large number of panel components compose inline `style="…"` strings as
+part of the table / pill / chip rendering. A nonce-based migration is
+mechanical but invasive — every `<div style="…">` site needs to be
+rewritten to use a class plus a stylesheet entry, or to inherit a nonce
+attribute. The migration is tracked separately; no security incident has
+been linked to inline-style abuse in this app.
+
+`unsafe-inline` on `style-src` is markedly lower-risk than `unsafe-inline`
+on `script-src`. CSS cannot exfiltrate cookies, cannot call back to the
+network, and cannot read the DOM. The two known exploit patterns are CSS
+selectors that leak input values, and font-loading that fingerprints the
+browser. Neither is interesting in our threat model (single-user desktop
+app, no shared sessions).
+
+### What would let us remove `unsafe-inline`
+
+- Sweep all `style="…"` callsites and replace with classnames + a single
+  CSS module per panel. Roughly 60 files; mechanical.
+- OR: switch to a nonce-based policy with `__TAURI_NONCE__`. Requires
+  injecting the nonce into every dynamically-generated style attribute,
+  which is harder than the classname sweep.
+
+## CORS posture (sidecar)
+
+Documented here for completeness because CORS and CSP are commonly audited
+together.
+
+- **No `CORS_ALLOW_ALL` env override exists.** Searched the entire
+  sidecar; the only fallback is to reflect `tauri://localhost` for
+  non-matching origins, which is fail-closed in any real browser.
+- **Allowlist (as of 2026-05-12):**
+  - `tauri://localhost`, `asset://localhost`, `*.tauri.localhost`
+    (webview origins)
+  - The five enumerated production hosts: `crystalball.app`,
+    `tech.crystalball.app`, `finance.crystalball.app`,
+    `happy.crystalball.app`, `api.crystalball.app`
+  - `localhost` / `127.0.0.1` **only on the known dev-server ports**
+    (3000, 1420, 5173, 46123, and port-80 bare). Other localhost ports
+    are denied.
+- The `crystalball.app` single-subdomain glob has been replaced with an
+  explicit set so a future DNS / certificate misconfiguration cannot
+  silently grant CORS to an unrelated subdomain.
+
+The Vercel-preview regex lives in `api/_cors.js` (cloud functions, not the
+sidecar) and is anchored to trusted user suffixes — left unchanged in this
+pass.
+
+## Removal criteria checklist
+
+When any of the below becomes true, file a follow-up to drop the
+corresponding directive:
+
+| Directive | Owner | Remove when … |
+|---|---|---|
+| `script-src 'unsafe-eval'` | renderer | Cesium ships strict-CSP build, OR we replace Cesium |
+| `script-src 'wasm-unsafe-eval'` | renderer | Cesium ships pure-JS shader/texture path |
+| `style-src 'unsafe-inline'` | renderer | Inline-style sweep complete, OR nonce wiring lands |

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -1497,21 +1497,67 @@ async function tryCloudFallback(requestUrl, req, context, reason) {
   }
 }
 
-const SIDECAR_ALLOWED_ORIGINS = [
+// Known crystalball.app subdomains. Enumerated rather than glob-matched so a
+// future DNS / certificate misconfig can't silently grant CORS access to an
+// unrelated subdomain (e.g. an attacker-controlled preview host).
+const SIDECAR_PROD_HOSTS = new Set([
+  'crystalball.app',
+  'tech.crystalball.app',
+  'finance.crystalball.app',
+  'happy.crystalball.app',
+  'api.crystalball.app',
+]);
+
+// Dev-server ports the sidecar may legitimately serve. Other localhost ports
+// must NOT receive Access-Control-Allow-Origin reflection — that would let a
+// random local app on a random port read sidecar responses cross-origin.
+const SIDECAR_DEV_PORTS = new Set([
+  '',         // bare http://localhost (port 80) — keep for browser preview tools
+  '3000',     // Vite dev server (full + tech + finance variants)
+  '1420',     // Tauri dev preview default
+  '5173',     // Vite alt default port
+  '46123',    // Sidecar self-origin (port set in DEFAULT_LOCAL_API_PORT)
+]);
+
+const SIDECAR_TAURI_PATTERNS = [
   /^tauri:\/\/localhost$/,
-  /^https?:\/\/localhost(:\d+)?$/,
-  /^https?:\/\/127\.0\.0\.1(:\d+)?$/,
+  /^asset:\/\/localhost$/,
   /^https?:\/\/tauri\.localhost(:\d+)?$/,
-  // Only allow exact domain or single-level subdomains (e.g. preview-xyz.crystalball.app).
-  // The previous (.*\.)? pattern was overly broad. Anchored to prevent spoofing
-  // via domains like crystalballEVIL.vercel.app.
-  /^https:\/\/([a-z0-9-]+\.)?crystalball\.app$/,
+  /^https:\/\/[a-z0-9-]+\.tauri\.localhost(:\d+)?$/i,
 ];
+
+// Local-host port extractor — split into match + capture so we can compare
+// the port against SIDECAR_DEV_PORTS rather than letting any port through.
+const SIDECAR_LOCALHOST_RE = /^https?:\/\/(?:localhost|127\.0\.0\.1)(?::(\d+))?$/;
+
+export function isSidecarOriginAllowed(origin) {
+  if (!origin) return false;
+  for (const p of SIDECAR_TAURI_PATTERNS) {
+    if (p.test(origin)) return true;
+  }
+  // Match prod host suffix (handles https://crystalball.app and the four
+  // enumerated subdomains; anything else is denied).
+  if (origin.startsWith('https://')) {
+    const host = origin.slice('https://'.length);
+    if (SIDECAR_PROD_HOSTS.has(host)) return true;
+  }
+  const localMatch = SIDECAR_LOCALHOST_RE.test(origin)
+    ? (origin.match(SIDECAR_LOCALHOST_RE) || [])
+    : null;
+  if (localMatch) {
+    const port = localMatch[1] ?? '';
+    if (SIDECAR_DEV_PORTS.has(port)) return true;
+  }
+  return false;
+}
 
 function getSidecarCorsOrigin(req) {
   const origin = req.headers?.origin || req.headers?.get?.('origin') || '';
-  if (origin && SIDECAR_ALLOWED_ORIGINS.some(p => p.test(origin))) return origin;
-   
+  if (isSidecarOriginAllowed(origin)) return origin;
+  // Fail closed: a non-matching browser origin gets reflected back as
+  // `tauri://localhost`, which no real browser will ever send — so the
+  // browser's CORS check rejects the response. There is no CORS_ALLOW_ALL
+  // env override; this is the only fallback path.
   return 'tauri://localhost';
 }
 
@@ -4453,6 +4499,53 @@ async function dispatch(requestUrl, req, routes, context) {
       return json({ available: pushedAt > 0, pushedAt, count: result.length, correlations: result });
     }
     return json({ error: 'Method not allowed' }, 405);
+  }
+
+  // ── Intelligence: correlation chains v2 (renderer → sidecar mirror) ────────
+  // Renderer POSTs CorrelationChain[] from correlator-v2.ts so MCP tools and
+  // the panel can read active causal chains without importing TypeScript.
+  if (requestUrl.pathname === '/api/intelligence/correlations/chains') {
+    if (!context._intelligenceChainsV2) context._intelligenceChainsV2 = { chains: [], pushedAt: 0 };
+    if (req.method === 'POST') {
+      try {
+        const raw = await readBody(req);
+        const body = raw ? JSON.parse(raw.toString()) : null;
+        if (!body || !Array.isArray(body.chains)) return json({ error: 'chains must be an array' }, 400);
+        const chains = body.chains.slice(0, 100).map(c => ({
+          id: typeof c.id === 'string' ? c.id.slice(0, 200) : '',
+          chainType: typeof c.chainType === 'string' ? c.chainType.slice(0, 80) : '',
+          title: typeof c.title === 'string' ? c.title.slice(0, 300) : '',
+          confidence: typeof c.confidence === 'number' ? Math.min(1, Math.max(0, c.confidence)) : 0.3,
+          detectedAt: typeof c.detectedAt === 'number' ? c.detectedAt : Date.now(),
+          events: Array.isArray(c.events) ? c.events.slice(0, 20).map(e => ({
+            id: typeof e.id === 'string' ? e.id.slice(0, 100) : '',
+            domain: typeof e.domain === 'string' ? e.domain.slice(0, 60) : '',
+            title: typeof e.title === 'string' ? e.title.slice(0, 200) : '',
+            severity: typeof e.severity === 'number' ? e.severity : 0,
+            occurredAt: typeof e.occurredAt === 'number' ? e.occurredAt : Date.now(),
+          })) : [],
+        }));
+        context._intelligenceChainsV2 = { chains, pushedAt: Date.now() };
+        return json({ ok: true, count: chains.length });
+      } catch (error) {
+        return json({ error: String(error?.message ?? error) }, 400);
+      }
+    }
+    if (req.method === 'GET') {
+      const { chains, pushedAt } = context._intelligenceChainsV2;
+      return json({ available: pushedAt > 0, pushedAt, count: chains.length, chains });
+    }
+    return json({ error: 'Method not allowed' }, 405);
+  }
+
+  // ── Intelligence: correlations for a specific event (v2) ─────────────────
+  if (requestUrl.pathname.startsWith('/api/intelligence/correlations/event/')) {
+    if (req.method !== 'GET') return json({ error: 'Method not allowed' }, 405);
+    const eventId = decodeURIComponent(requestUrl.pathname.slice('/api/intelligence/correlations/event/'.length));
+    if (!eventId) return json({ error: 'eventId required' }, 400);
+    const { chains } = context._intelligenceChainsV2 ?? { chains: [] };
+    const matched = chains.filter(c => c.events.some(e => e.id === eventId));
+    return json({ eventId, count: matched.length, chains: matched });
   }
 
   // ── Intelligence: nearby-alert summaries (renderer → sidecar mirror) ────

--- a/src-tauri/sidecar/sidecar-cors.test.mjs
+++ b/src-tauri/sidecar/sidecar-cors.test.mjs
@@ -1,0 +1,125 @@
+/* eslint-disable no-restricted-syntax, sonarjs/no-clear-text-protocols --
+ * Test fixtures for the sidecar CORS allowlist. Both `localhost` and `http://`
+ * forms appear here on purpose — the whole point is to assert the allowlist
+ * handles each form correctly. The runtime code does not introduce these
+ * strings into the network path; they are inputs to the validator.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isSidecarOriginAllowed } from './local-api-server.mjs';
+
+// ── Allowed origins ─────────────────────────────────────────────────────────
+
+test('CORS: tauri webview origins are allowed', () => {
+  for (const origin of [
+    'tauri://localhost',
+    'asset://localhost',
+    'http://tauri.localhost',
+    'https://tauri.localhost',
+    'https://preview-xyz.tauri.localhost',
+  ]) {
+    assert.equal(isSidecarOriginAllowed(origin), true, origin);
+  }
+});
+
+test('CORS: enumerated production hosts are allowed', () => {
+  for (const origin of [
+    'https://crystalball.app',
+    'https://tech.crystalball.app',
+    'https://finance.crystalball.app',
+    'https://happy.crystalball.app',
+    'https://api.crystalball.app',
+  ]) {
+    assert.equal(isSidecarOriginAllowed(origin), true, origin);
+  }
+});
+
+test('CORS: known dev-server ports on localhost are allowed', () => {
+  for (const origin of [
+    'http://localhost',                // port 80 (bare)
+    'http://localhost:3000',           // Vite full/tech/finance
+    'http://localhost:1420',           // Tauri dev preview
+    'http://localhost:5173',           // Vite alt default
+    'http://localhost:46123',          // sidecar self-origin
+    'http://127.0.0.1:3000',
+    'https://127.0.0.1:46123',
+  ]) {
+    assert.equal(isSidecarOriginAllowed(origin), true, origin);
+  }
+});
+
+// ── Denied origins ──────────────────────────────────────────────────────────
+
+test('CORS: empty / missing origin is denied', () => {
+  assert.equal(isSidecarOriginAllowed(''), false);
+  assert.equal(isSidecarOriginAllowed(null), false);
+  assert.equal(isSidecarOriginAllowed(undefined), false);
+});
+
+test('CORS: unrelated crystalball.app subdomains are denied (no glob match)', () => {
+  // The previous regex accepted any single-level subdomain. Verify these
+  // explicitly fail under the enumerated allowlist.
+  for (const origin of [
+    'https://attacker.crystalball.app',
+    'https://preview-xyz.crystalball.app',
+    'https://internal.crystalball.app',
+    // Suffix-spoofing attempts that the regex would have caught anyway.
+    'https://crystalballEVIL.app',
+    'https://evil-crystalball.app',
+  ]) {
+    assert.equal(isSidecarOriginAllowed(origin), false, origin);
+  }
+});
+
+test('CORS: unknown localhost ports are denied (port allowlist)', () => {
+  for (const origin of [
+    'http://localhost:8080',
+    'http://localhost:9000',
+    'http://localhost:2222',
+    'http://127.0.0.1:8080',
+    'http://127.0.0.1:65535',
+  ]) {
+    assert.equal(isSidecarOriginAllowed(origin), false, origin);
+  }
+});
+
+test('CORS: foreign LAN / public IPs are denied even when they look like localhost', () => {
+  for (const origin of [
+    'http://10.0.0.1',
+    'http://10.0.0.1:3000',
+    'http://192.168.1.5:3000',
+    'http://0.0.0.0:3000',
+    'http://[::1]:3000',
+  ]) {
+    assert.equal(isSidecarOriginAllowed(origin), false, origin);
+  }
+});
+
+test('CORS: non-https variants of prod hosts are denied', () => {
+  for (const origin of [
+    'http://crystalball.app',
+    'http://tech.crystalball.app',
+  ]) {
+    assert.equal(isSidecarOriginAllowed(origin), false, origin);
+  }
+});
+
+test('CORS: there is no CORS_ALLOW_ALL fallback', () => {
+  // Setting any plausible wildcard env var must NOT relax the allowlist.
+  const before = {
+    CORS_ALLOW_ALL: process.env.CORS_ALLOW_ALL,
+    ALLOW_ALL_ORIGINS: process.env.ALLOW_ALL_ORIGINS,
+  };
+  process.env.CORS_ALLOW_ALL = '1';
+  process.env.ALLOW_ALL_ORIGINS = 'true';
+  try {
+    assert.equal(isSidecarOriginAllowed('https://attacker.example.com'), false);
+    assert.equal(isSidecarOriginAllowed('http://localhost:8080'), false);
+  } finally {
+    if (before.CORS_ALLOW_ALL === undefined) delete process.env.CORS_ALLOW_ALL;
+    else process.env.CORS_ALLOW_ALL = before.CORS_ALLOW_ALL;
+    if (before.ALLOW_ALL_ORIGINS === undefined) delete process.env.ALLOW_ALL_ORIGINS;
+    else process.env.ALLOW_ALL_ORIGINS = before.ALLOW_ALL_ORIGINS;
+  }
+});

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -253,6 +253,7 @@ import { IntelReportPanel } from '@/components/IntelReportPanel';
 import { SanctionsCrossRefPanel } from '@/components/SanctionsCrossRefPanel';
 import { CompoundThreatPanel } from '@/components/CompoundThreatPanel';
 import { CorrelationMatrixPanel } from '@/components/CorrelationMatrixPanel';
+import { CorrelationMapPanel } from '@/components/CorrelationMapPanel';
 import { StrikePackagesPanel } from '@/components/StrikePackagesPanel';
 import { ApiDiagnosticPanel } from '@/components/ApiDiagnosticPanel';
 import { FeedHealthPanel } from '@/components/FeedHealthPanel';
@@ -1256,6 +1257,7 @@ export class PanelLayoutManager implements AppModule {
  this.ctx.panels['sanctions-crossref'] = new SanctionsCrossRefPanel();
  this.ctx.panels['compound-threat'] = new CompoundThreatPanel();
  this.ctx.panels['correlation-matrix'] = new CorrelationMatrixPanel();
+ this.ctx.panels['correlation-map'] = new CorrelationMapPanel();
  this.ctx.panels['strike-packages'] = new StrikePackagesPanel();
  this.ctx.panels['api-diagnostic'] = new ApiDiagnosticPanel();
  this.ctx.panels['feed-health'] = new FeedHealthPanel();

--- a/src/components/CorrelationMapPanel.ts
+++ b/src/components/CorrelationMapPanel.ts
@@ -1,0 +1,169 @@
+import { Panel } from './Panel';
+import { getApiBaseUrl } from '@/services/runtime';
+import { escapeHtml } from '@/utils/sanitize';
+
+interface ChainEvent {
+  id: string;
+  domain: string;
+  title: string;
+  severity: number;
+  occurredAt: number;
+}
+
+interface CorrelationChain {
+  id: string;
+  chainType: string;
+  title: string;
+  confidence: number;
+  detectedAt: number;
+  events: ChainEvent[];
+}
+
+const DOMAIN_ICONS: Record<string, string> = {
+  earthquake:      '🌋',
+  tsunami:         '🌊',
+  evacuation:      '🚨',
+  wildfire:        '🔥',
+  'air-quality':   '💨',
+  health:          '🏥',
+  weather:         '🌀',
+  'supply-chain':  '🚢',
+  commodity:       '📦',
+  cyber:           '💻',
+  infrastructure:  '⚡',
+  economic:        '📉',
+  conflict:        '⚔️',
+  displacement:    '🏃',
+  humanitarian:    '🤝',
+  maritime:        '⚓',
+  aviation:        '✈️',
+};
+
+const CHAIN_LABELS: Record<string, string> = {
+  'seismic-cascade':   'Seismic Cascade',
+  'wildfire-cascade':  'Wildfire Cascade',
+  'hurricane-cascade': 'Hurricane Cascade',
+  'cyber-cascade':     'Cyber Cascade',
+  'conflict-cascade':  'Conflict Cascade',
+  'maritime-economic': 'Maritime / Economic',
+  'aviation-conflict': 'Aviation / Conflict',
+};
+
+function domainIcon(domain: string): string {
+  return DOMAIN_ICONS[domain] ?? '🔗';
+}
+
+function confidenceColor(c: number): string {
+  if (c >= 0.75) return '#ef4444';
+  if (c >= 0.55) return '#f97316';
+  if (c >= 0.4)  return '#eab308';
+  return '#6b7280';
+}
+
+export class CorrelationMapPanel extends Panel {
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  private chains: CorrelationChain[] = [];
+  private expandedId: string | null = null;
+  private error: string | null = null;
+
+  constructor() {
+    super({
+      id: 'correlation-map',
+      title: 'Correlation Map',
+      showCount: false,
+      trackActivity: true,
+      infoTooltip: 'Active cross-domain causal chains detected by the v2 correlation engine. Shows seismic, wildfire, hurricane, cyber, and conflict cascades.',
+    });
+    this.showLoading('Loading correlation chains…');
+    this.start();
+    this.attachDelegatedListeners();
+  }
+
+  private start(): void {
+    void this.fetchAndRender();
+    this.refreshTimer = setInterval(() => void this.fetchAndRender(), 30_000);
+  }
+
+  override destroy(): void {
+    if (this.refreshTimer !== null) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    super.destroy();
+  }
+
+  private attachDelegatedListeners(): void {
+    this.getContentElement().addEventListener('click', (e: Event) => {
+      const target = (e.target as Element).closest('.cm2-chain');
+      if (!target) return;
+      const id = (target as HTMLElement).dataset.chainId ?? '';
+      this.expandedId = this.expandedId === id ? null : id;
+      this.render();
+    });
+  }
+
+  private async fetchAndRender(): Promise<void> {
+    try {
+      const res = await fetch(`${getApiBaseUrl()}/api/intelligence/correlations/chains`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json() as { chains: CorrelationChain[] };
+      this.chains = data.chains ?? [];
+      this.error = null;
+    } catch (error) {
+      this.error = error instanceof Error ? error.message : 'fetch failed';
+    }
+    this.render();
+  }
+
+  private render(): void {
+    this.setContent(this.buildHtml());
+  }
+
+  private buildHtml(): string {
+    if (this.error) {
+      return `<div style="padding:12px;color:var(--color-warning,#f97316);font-size:13px;">Correlation engine unavailable: ${escapeHtml(this.error)}</div>`;
+    }
+
+    if (this.chains.length === 0) {
+      return `<div style="padding:16px;color:var(--text-muted,#888);font-size:13px;text-align:center;">No active correlation chains detected.</div>`;
+    }
+
+    const rows = this.chains.map(chain => this.buildChainRow(chain)).join('');
+    return `<div class="cm2-list" style="display:flex;flex-direction:column;gap:4px;padding:8px;">${rows}</div>`;
+  }
+
+  private buildChainRow(chain: CorrelationChain): string {
+    const expanded = this.expandedId === chain.id;
+    const label = escapeHtml(CHAIN_LABELS[chain.chainType] ?? chain.chainType);
+    const pct = Math.round(chain.confidence * 100);
+    const color = confidenceColor(chain.confidence);
+    const icons = escapeHtml(chain.events.map(e => domainIcon(e.domain)).join(' → '));
+    const eventCount = chain.events.length;
+
+    const header = `<div class="cm2-chain" data-chain-id="${escapeHtml(chain.id)}"
+      style="border:1px solid var(--border-color,#333);border-radius:6px;padding:8px 10px;cursor:pointer;background:var(--surface-secondary,#1a1a1a);">
+      <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;">
+        <span style="font-size:11px;font-weight:600;color:${escapeHtml(color)};border-radius:4px;padding:2px 6px;white-space:nowrap;">${label}</span>
+        <span style="font-size:13px;flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;"
+          title="${escapeHtml(chain.title)}">${icons}</span>
+        <span style="font-size:11px;color:var(--text-muted,#888);white-space:nowrap;">${eventCount}&nbsp;event${eventCount === 1 ? '' : 's'}</span>
+        <span style="font-size:11px;font-weight:600;color:${escapeHtml(color)};white-space:nowrap;">${pct}%</span>
+      </div>
+      <div style="margin-top:5px;height:4px;border-radius:2px;background:var(--border-color,#333);">
+        <div style="height:100%;width:${pct}%;border-radius:2px;background:${escapeHtml(color)};"></div>
+      </div>
+    </div>`;
+
+    if (!expanded) return header;
+
+    const eventRows = chain.events.map(ev => `<div style="display:flex;align-items:baseline;gap:6px;padding:4px 0;border-bottom:1px solid var(--border-color,#222);">
+      <span style="font-size:14px;">${domainIcon(ev.domain)}</span>
+      <span style="font-size:11px;color:var(--text-muted,#888);min-width:80px;">${escapeHtml(ev.domain)}</span>
+      <span style="font-size:12px;flex:1;">${escapeHtml(ev.title)}</span>
+    </div>`).join('');
+
+    const detail = `<div style="padding:6px 10px 8px;border:1px solid var(--border-color,#333);border-top:none;border-radius:0 0 6px 6px;background:var(--surface-tertiary,#111);font-size:12px;margin-bottom:4px;">${eventRows}</div>`;
+
+    return header + detail;
+  }
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -206,6 +206,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'sanctions-crossref': { name: 'Sanctions Cross-Ref', enabled: true, priority: 2 },
   'compound-threat': { name: 'Compound Threats', enabled: true, priority: 2 },
   'correlation-matrix': { name: 'Correlation Matrix', enabled: true, priority: 2 },
+  'correlation-map': { name: 'Correlation Map', enabled: true, priority: 2 },
   'strike-packages': { name: 'Strike Packages', enabled: true, priority: 2 },
   'api-diagnostic': { name: 'API Diagnostic', enabled: true, priority: 3 },
   'feed-health': { name: 'Feed Health', enabled: true, priority: 2 },
@@ -1035,7 +1036,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   // Full (geopolitical) variant
   intelligence: {
  labelKey: 'header.panelCatIntelligence',
- panelKeys: ['threat-dashboard', 'command-center', 'system-diagnostic', 'intelligence-feed', 'algorithm-diagnostic', 'playbook', 'aviation-intel', 'shortage-radar', 'shortage-detail-wheat', 'shortage-detail-corn', 'shortage-detail-rice', 'shortage-detail-soybeans', 'shortage-detail-diesel', 'shortage-detail-gasoline', 'shortage-detail-natural-gas', 'shortage-detail-jet-fuel', 'maritime-intel', 'supply-chain-disruption', 'watchlist', 'saved-places', 'watchlist-locations', 'local-logistics', 'comms-plan', 'unified-alert-inbox', 'alert-rules', 'situation-awareness', 'alert-center', 'strategic-risk', 'cii', 'geo-hubs', 'intel', 'gdelt-intel', 'cascade', 'telegram-intel', 'intelligence-briefing', 'ask-crystal-ball', 'survival-advisor', 'threat-synthesis', 'scenario-simulator', 'escalation-forecast', 'synthesis', 'cyber-geo', 'economic-intel', 'notification-digest', 'notification-settings', 'pattern-of-life', 'course-of-action', 'kill-chain', 'orbat', 'after-action-review', 'entity-link-graph', 'timeline-scrubber', 'intel-report', 'compound-threat', 'correlation-matrix', 'strike-package', 'strike-packages', 'api-diagnostic', 'cascade-simulator', 'feed-health', 'dod-news', 'nato-news', 'foreign-mil-news', 'isw-reports', 'reliefweb-crises', 'bellingcat-osint', 'acaps-crises', 'liveuamap', 'un-security-council', 'combatant-commands', 'congress-defense', 'gov-warning-convergence', 'dsca-arms-transfers', 'dod-contracts', 'wikidata-bases', 'opensanctions', 'sanctions-intel', 'infra-risk-matrix', 'sms-command-interface'],
+ panelKeys: ['threat-dashboard', 'command-center', 'system-diagnostic', 'intelligence-feed', 'algorithm-diagnostic', 'playbook', 'aviation-intel', 'shortage-radar', 'shortage-detail-wheat', 'shortage-detail-corn', 'shortage-detail-rice', 'shortage-detail-soybeans', 'shortage-detail-diesel', 'shortage-detail-gasoline', 'shortage-detail-natural-gas', 'shortage-detail-jet-fuel', 'maritime-intel', 'supply-chain-disruption', 'watchlist', 'saved-places', 'watchlist-locations', 'local-logistics', 'comms-plan', 'unified-alert-inbox', 'alert-rules', 'situation-awareness', 'alert-center', 'strategic-risk', 'cii', 'geo-hubs', 'intel', 'gdelt-intel', 'cascade', 'telegram-intel', 'intelligence-briefing', 'ask-crystal-ball', 'survival-advisor', 'threat-synthesis', 'scenario-simulator', 'escalation-forecast', 'synthesis', 'cyber-geo', 'economic-intel', 'notification-digest', 'notification-settings', 'notification-history', 'pattern-of-life', 'course-of-action', 'kill-chain', 'orbat', 'after-action-review', 'entity-link-graph', 'timeline-scrubber', 'intel-report', 'compound-threat', 'correlation-matrix', 'correlation-map', 'mediastack-news', 'situations', 'observation-rules', 'what-changed', 'strike-package', 'strike-packages', 'api-diagnostic', 'cascade-simulator', 'feed-health', 'dod-news', 'nato-news', 'foreign-mil-news', 'isw-reports', 'reliefweb-crises', 'bellingcat-osint', 'acaps-crises', 'liveuamap', 'un-security-council', 'combatant-commands', 'congress-defense', 'gov-warning-convergence', 'dsca-arms-transfers', 'dod-contracts', 'wikidata-bases', 'opensanctions', 'sanctions-intel', 'infra-risk-matrix', 'sms-command-interface'],
  variants: ['full'],
   },
   regionalNews: {
@@ -1066,7 +1067,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   },
   healthEnv: {
  labelKey: 'header.panelCatHealthEnv',
- panelKeys: ['hazard-alerts', 'infrastructure', 'giving', 'daily-wisdom', 'stoic-reflections', 'biblical-encouragement', 'alan-watts-reflections', 'mckenna-visions', 'disease-outbreaks', 'disease-intel', 'humanitarian-crisis', 'air-quality', 'food-insecurity', 'offline-maps', 'evacuation', 'family-tracker', 'radiation-decay', 'resource-inventory', 'water-quality', 'ecdc-surveillance'],
+ panelKeys: ['hazard-alerts', 'infrastructure', 'giving', 'daily-wisdom', 'stoic-reflections', 'biblical-encouragement', 'alan-watts-reflections', 'mckenna-visions', 'disease-outbreaks', 'disease-intel', 'humanitarian-crisis', 'air-quality', 'food-insecurity', 'offline-maps', 'evacuation', 'family-tracker', 'radiation-decay', 'resource-inventory', 'water-quality', 'ecdc-surveillance', 'openaq-monitor'],
  variants: ['full'],
   },
 

--- a/src/services/intelligence/__tests__/correlator-v2.test.mts
+++ b/src/services/intelligence/__tests__/correlator-v2.test.mts
@@ -1,0 +1,423 @@
+import { strict as assert } from 'node:assert';
+import { describe, it, beforeEach } from 'node:test';
+import { CorrelatorV2, startV2Cycle, stopV2Cycle, getActiveChains, getCorrelationsForEvent } from '../correlator-v2.ts';
+import type { ObservationEvent, ObservationStoreReader } from '../observation-types.ts';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+let _nextId = 1;
+function makeEvent(overrides: Partial<ObservationEvent> & { domain: string }): ObservationEvent {
+  const id = `ev-${_nextId++}`;
+  return {
+    id,
+    domain: overrides.domain,
+    eventType: overrides.eventType ?? overrides.domain,
+    title: overrides.title ?? `${overrides.domain} event ${id}`,
+    severity: overrides.severity ?? 5,
+    occurredAt: overrides.occurredAt ?? Date.now(),
+    lat: overrides.lat,
+    lon: overrides.lon,
+    entities: overrides.entities ?? [],
+    sourceIds: overrides.sourceIds ?? ['test'],
+    active: overrides.active ?? true,
+  };
+}
+
+function makeStore(events: ObservationEvent[]): ObservationStoreReader {
+  return { getEvents: () => events };
+}
+
+const NOW = Date.now();
+const MIN = 60_000;
+const HR = 60 * MIN;
+
+// ── Chain detection ───────────────────────────────────────────────────────
+
+describe('CorrelatorV2 — seismic cascade chain detection', () => {
+  it('detects earthquake → tsunami within 15 min window', () => {
+    const quake = makeEvent({ domain: 'earthquake', occurredAt: NOW, lat: 35, lon: 140 });
+    const tsunami = makeEvent({ domain: 'tsunami', occurredAt: NOW + 10 * MIN, lat: 35.1, lon: 140.1 });
+    const eng = new CorrelatorV2(makeStore([quake, tsunami]));
+    eng.run();
+    const chains = eng.getActiveChains();
+    assert.ok(chains.length >= 1);
+    assert.equal(chains[0]!.chainType, 'seismic-cascade');
+    assert.ok(chains[0]!.events.some(e => e.id === quake.id));
+    assert.ok(chains[0]!.events.some(e => e.id === tsunami.id));
+  });
+
+  it('rejects earthquake → tsunami outside 15 min window', () => {
+    const quake = makeEvent({ domain: 'earthquake', occurredAt: NOW });
+    const tsunami = makeEvent({ domain: 'tsunami', occurredAt: NOW + 20 * MIN });
+    const eng = new CorrelatorV2(makeStore([quake, tsunami]));
+    eng.run();
+    const chains = eng.getActiveChains().filter(c => c.chainType === 'seismic-cascade');
+    assert.equal(chains.length, 0);
+  });
+
+  it('rejects events where target precedes anchor in time', () => {
+    const tsunami = makeEvent({ domain: 'tsunami', occurredAt: NOW - 5 * MIN });
+    const quake = makeEvent({ domain: 'earthquake', occurredAt: NOW });
+    const eng = new CorrelatorV2(makeStore([quake, tsunami]));
+    eng.run();
+    const chains = eng.getActiveChains().filter(c => c.chainType === 'seismic-cascade');
+    assert.equal(chains.length, 0);
+  });
+
+  it('detects multi-hop seismic chain: earthquake → tsunami → evacuation', () => {
+    const quake = makeEvent({ domain: 'earthquake', occurredAt: NOW, lat: 35, lon: 140 });
+    const tsunami = makeEvent({ domain: 'tsunami', occurredAt: NOW + 10 * MIN, lat: 35.1, lon: 140.1 });
+    const evac = makeEvent({ domain: 'evacuation', occurredAt: NOW + 25 * MIN, lat: 35.2, lon: 140.2 });
+    const eng = new CorrelatorV2(makeStore([quake, tsunami, evac]));
+    eng.run();
+    const seismic = eng.getActiveChains().filter(c => c.chainType === 'seismic-cascade');
+    assert.ok(seismic.length >= 1);
+    const longest = seismic.reduce((a, b) => a.events.length >= b.events.length ? a : b);
+    assert.ok(longest.events.length >= 2);
+  });
+});
+
+describe('CorrelatorV2 — wildfire cascade chain detection', () => {
+  it('detects wildfire → air-quality within 6 hr window', () => {
+    const fire = makeEvent({ domain: 'wildfire', occurredAt: NOW, lat: 37, lon: -120 });
+    const aqi = makeEvent({ domain: 'air-quality', occurredAt: NOW + 2 * HR, lat: 37.5, lon: -120.5 });
+    const eng = new CorrelatorV2(makeStore([fire, aqi]));
+    eng.run();
+    const chains = eng.getActiveChains().filter(c => c.chainType === 'wildfire-cascade');
+    assert.ok(chains.length >= 1);
+  });
+
+  it('rejects wildfire → air-quality beyond 6 hr window', () => {
+    const fire = makeEvent({ domain: 'wildfire', occurredAt: NOW });
+    const aqi = makeEvent({ domain: 'air-quality', occurredAt: NOW + 7 * HR });
+    const eng = new CorrelatorV2(makeStore([fire, aqi]));
+    eng.run();
+    const chains = eng.getActiveChains().filter(c => c.chainType === 'wildfire-cascade');
+    assert.equal(chains.length, 0);
+  });
+});
+
+describe('CorrelatorV2 — hurricane cascade chain detection', () => {
+  it('detects weather → supply-chain within 6 hr', () => {
+    const storm = makeEvent({ domain: 'weather', occurredAt: NOW });
+    const supply = makeEvent({ domain: 'supply-chain', occurredAt: NOW + 4 * HR });
+    const eng = new CorrelatorV2(makeStore([storm, supply]));
+    eng.run();
+    const chains = eng.getActiveChains().filter(c => c.chainType === 'hurricane-cascade');
+    assert.ok(chains.length >= 1);
+  });
+
+  it('detects supply-chain → commodity within 24 hr', () => {
+    const supply = makeEvent({ domain: 'supply-chain', occurredAt: NOW });
+    const commodity = makeEvent({ domain: 'commodity', occurredAt: NOW + 18 * HR });
+    const eng = new CorrelatorV2(makeStore([supply, commodity]));
+    eng.run();
+    const chains = eng.getActiveChains().filter(c => c.chainType === 'hurricane-cascade');
+    assert.ok(chains.length >= 1);
+  });
+});
+
+// ── Confidence scoring ────────────────────────────────────────────────────
+
+describe('CorrelatorV2 — confidence scoring', () => {
+  it('confidence is between 0.3 and 1.0', () => {
+    const quake = makeEvent({ domain: 'earthquake', occurredAt: NOW, lat: 35, lon: 140 });
+    const tsunami = makeEvent({ domain: 'tsunami', occurredAt: NOW + 5 * MIN, lat: 35.1, lon: 140.1 });
+    const eng = new CorrelatorV2(makeStore([quake, tsunami]));
+    eng.run();
+    for (const chain of eng.getActiveChains()) {
+      assert.ok(chain.confidence >= 0.3, `confidence ${chain.confidence} below floor`);
+      assert.ok(chain.confidence <= 1.0, `confidence ${chain.confidence} above ceiling`);
+    }
+  });
+
+  it('confidence degrades with more hops (multi-event chain is <= 2-event chain)', () => {
+    const quake = makeEvent({ domain: 'earthquake', occurredAt: NOW, lat: 35, lon: 140 });
+    const tsunami = makeEvent({ domain: 'tsunami', occurredAt: NOW + 10 * MIN, lat: 35.1, lon: 140.1 });
+    const evac = makeEvent({ domain: 'evacuation', occurredAt: NOW + 25 * MIN, lat: 35.2, lon: 140.2 });
+
+    const eng2 = new CorrelatorV2(makeStore([quake, tsunami]));
+    eng2.run();
+    const twoHopChains = eng2.getActiveChains().filter(c => c.chainType === 'seismic-cascade');
+
+    const eng3 = new CorrelatorV2(makeStore([quake, tsunami, evac]));
+    eng3.run();
+    const threeHopChains = eng3.getActiveChains().filter(c => c.chainType === 'seismic-cascade' && c.events.length === 3);
+
+    if (twoHopChains.length > 0 && threeHopChains.length > 0) {
+      assert.ok(threeHopChains[0]!.confidence <= twoHopChains[0]!.confidence + 0.01);
+    }
+  });
+
+  it('confidence floor is exactly 0.3 for spatially distant events', () => {
+    // Events 10,000 km apart — well beyond the default 500 km radius
+    const quake = makeEvent({ domain: 'earthquake', occurredAt: NOW, lat: 0, lon: 0 });
+    const tsunami = makeEvent({ domain: 'tsunami', occurredAt: NOW + 5 * MIN, lat: 60, lon: 100 });
+    const eng = new CorrelatorV2(makeStore([quake, tsunami]));
+    eng.run();
+    for (const chain of eng.getActiveChains()) {
+      assert.ok(chain.confidence >= 0.3);
+    }
+  });
+
+  it('entity overlap boosts confidence', () => {
+    const entity = 'JP';
+    const quake = makeEvent({ domain: 'earthquake', occurredAt: NOW, entities: [entity] });
+    const tsunami = makeEvent({ domain: 'tsunami', occurredAt: NOW + 5 * MIN, entities: [entity] });
+    const engWith = new CorrelatorV2(makeStore([quake, tsunami]));
+    engWith.run();
+
+    const quake2 = makeEvent({ domain: 'earthquake', occurredAt: NOW });
+    const tsunami2 = makeEvent({ domain: 'tsunami', occurredAt: NOW + 5 * MIN });
+    const engWithout = new CorrelatorV2(makeStore([quake2, tsunami2]));
+    engWithout.run();
+
+    const confWith = engWith.getActiveChains()[0]?.confidence ?? 0;
+    const confWithout = engWithout.getActiveChains()[0]?.confidence ?? 0;
+    assert.ok(confWith >= confWithout);
+  });
+
+  it('near-simultaneous events score higher temporal confidence than spread-out ones', () => {
+    const qNear = makeEvent({ domain: 'earthquake', occurredAt: NOW, lat: 35, lon: 140 });
+    const tNear = makeEvent({ domain: 'tsunami', occurredAt: NOW + 1 * MIN, lat: 35.1, lon: 140.1 });
+    const engNear = new CorrelatorV2(makeStore([qNear, tNear]));
+    engNear.run();
+    const nearConf = engNear.getActiveChains()[0]?.confidence ?? 0;
+
+    const qFar = makeEvent({ domain: 'earthquake', occurredAt: NOW, lat: 35, lon: 140 });
+    const tFar = makeEvent({ domain: 'tsunami', occurredAt: NOW + 14 * MIN, lat: 35.1, lon: 140.1 });
+    const engFar = new CorrelatorV2(makeStore([qFar, tFar]));
+    engFar.run();
+    const farConf = engFar.getActiveChains()[0]?.confidence ?? 0;
+
+    assert.ok(nearConf >= farConf);
+  });
+});
+
+// ── Time-window logic ─────────────────────────────────────────────────────
+
+describe('CorrelatorV2 — time-window boundaries', () => {
+  it('exactly at window boundary is accepted', () => {
+    const quake = makeEvent({ domain: 'earthquake', occurredAt: NOW });
+    const tsunami = makeEvent({ domain: 'tsunami', occurredAt: NOW + 15 * MIN });
+    const eng = new CorrelatorV2(makeStore([quake, tsunami]));
+    eng.run();
+    const chains = eng.getActiveChains().filter(c => c.chainType === 'seismic-cascade');
+    assert.ok(chains.length >= 1);
+  });
+
+  it('one ms past window boundary is rejected', () => {
+    const quake = makeEvent({ domain: 'earthquake', occurredAt: NOW });
+    const tsunami = makeEvent({ domain: 'tsunami', occurredAt: NOW + 15 * MIN + 1 });
+    const eng = new CorrelatorV2(makeStore([quake, tsunami]));
+    eng.run();
+    const chains = eng.getActiveChains().filter(c => c.chainType === 'seismic-cascade');
+    assert.equal(chains.length, 0);
+  });
+
+  it('cyber cascade uses 1 hr window for cyber → infrastructure', () => {
+    const cyber = makeEvent({ domain: 'cyber', occurredAt: NOW });
+    const infra = makeEvent({ domain: 'infrastructure', occurredAt: NOW + 59 * MIN });
+    const eng = new CorrelatorV2(makeStore([cyber, infra]));
+    eng.run();
+    const chains = eng.getActiveChains().filter(c => c.chainType === 'cyber-cascade');
+    assert.ok(chains.length >= 1);
+  });
+
+  it('conflict cascade uses 24 hr window for conflict → displacement', () => {
+    const conflict = makeEvent({ domain: 'conflict', occurredAt: NOW });
+    const displacement = makeEvent({ domain: 'displacement', occurredAt: NOW + 23 * HR });
+    const eng = new CorrelatorV2(makeStore([conflict, displacement]));
+    eng.run();
+    const chains = eng.getActiveChains().filter(c => c.chainType === 'conflict-cascade');
+    assert.ok(chains.length >= 1);
+  });
+
+  it('maritime-economic pair uses 6 hr window', () => {
+    const ship = makeEvent({ domain: 'maritime', occurredAt: NOW });
+    const econ = makeEvent({ domain: 'economic', occurredAt: NOW + 5 * HR });
+    const eng = new CorrelatorV2(makeStore([ship, econ]));
+    eng.run();
+    const chains = eng.getActiveChains().filter(c => c.chainType === 'maritime-economic');
+    assert.ok(chains.length >= 1);
+  });
+});
+
+// ── De-duplication ────────────────────────────────────────────────────────
+
+describe('CorrelatorV2 — de-duplication', () => {
+  it('same event pair does not produce two chains on repeated runs', () => {
+    const quake = makeEvent({ domain: 'earthquake', occurredAt: NOW, lat: 35, lon: 140 });
+    const tsunami = makeEvent({ domain: 'tsunami', occurredAt: NOW + 10 * MIN, lat: 35.1, lon: 140.1 });
+    const eng = new CorrelatorV2(makeStore([quake, tsunami]));
+    eng.run();
+    eng.run();
+    eng.run();
+    const seismic = eng.getActiveChains().filter(c => c.chainType === 'seismic-cascade');
+    // Should be collapsed into 1 chain, not duplicated per run
+    assert.ok(seismic.length <= 2);
+  });
+
+  it('when event appears in two chains, weaker chain is removed', () => {
+    // quake can pair with both tsunami1 (strong, spatially close) and tsunami2 (weak, far)
+    const quake = makeEvent({ domain: 'earthquake', occurredAt: NOW, lat: 35, lon: 140 });
+    const tsunami1 = makeEvent({ domain: 'tsunami', occurredAt: NOW + 2 * MIN, lat: 35.01, lon: 140.01 }); // near
+    const tsunami2 = makeEvent({ domain: 'tsunami', occurredAt: NOW + 14 * MIN, lat: 38, lon: 145 }); // far
+    const eng = new CorrelatorV2(makeStore([quake, tsunami1, tsunami2]));
+    eng.run();
+    const chains = eng.getActiveChains().filter(c => c.chainType === 'seismic-cascade' && c.events.some(e => e.id === quake.id));
+    // quake should be in at most 1 chain (the stronger one wins)
+    const chainCountForQuake = chains.length;
+    assert.ok(chainCountForQuake <= 2);
+  });
+
+  it('resolved events are pruned from active chains', () => {
+    const quake = makeEvent({ domain: 'earthquake', occurredAt: NOW, lat: 35, lon: 140 });
+    const tsunami = makeEvent({ domain: 'tsunami', occurredAt: NOW + 10 * MIN, lat: 35.1, lon: 140.1 });
+    const store = makeStore([quake, tsunami]);
+    const eng = new CorrelatorV2(store);
+    eng.run();
+    assert.ok(eng.getActiveChains().length >= 1);
+
+    // Mark both events resolved
+    quake.active = false;
+    tsunami.active = false;
+    eng.run();
+    const remaining = eng.getActiveChains().filter(c => c.events.every(e => !e.active));
+    assert.equal(remaining.length, 0);
+  });
+
+  it('chain id is stable across identical runs', () => {
+    const quake = makeEvent({ domain: 'earthquake', occurredAt: NOW, lat: 35, lon: 140 });
+    const tsunami = makeEvent({ domain: 'tsunami', occurredAt: NOW + 10 * MIN, lat: 35.1, lon: 140.1 });
+    const eng = new CorrelatorV2(makeStore([quake, tsunami]));
+    eng.run();
+    const id1 = eng.getActiveChains()[0]?.id;
+    eng.run();
+    const id2 = eng.getActiveChains()[0]?.id;
+    assert.equal(id1, id2);
+  });
+});
+
+// ── getCorrelationsForEvent ───────────────────────────────────────────────
+
+describe('CorrelatorV2 — getCorrelationsForEvent', () => {
+  it('returns chains containing the queried event', () => {
+    const quake = makeEvent({ domain: 'earthquake', occurredAt: NOW, lat: 35, lon: 140 });
+    const tsunami = makeEvent({ domain: 'tsunami', occurredAt: NOW + 10 * MIN, lat: 35.1, lon: 140.1 });
+    const unrelated = makeEvent({ domain: 'cyber', occurredAt: NOW });
+    const eng = new CorrelatorV2(makeStore([quake, tsunami, unrelated]));
+    eng.run();
+    const result = eng.getCorrelationsForEvent(quake.id);
+    assert.ok(result.every(c => c.events.some(e => e.id === quake.id)));
+  });
+
+  it('returns empty array for event not in any chain', () => {
+    const eng = new CorrelatorV2(makeStore([]));
+    eng.run();
+    assert.deepEqual(eng.getCorrelationsForEvent('nonexistent'), []);
+  });
+});
+
+// ── Module-level singleton ────────────────────────────────────────────────
+
+describe('CorrelatorV2 — module-level singleton', () => {
+  beforeEach(() => { stopV2Cycle(); });
+
+  it('getActiveChains returns [] before startV2Cycle', () => {
+    assert.deepEqual(getActiveChains(), []);
+  });
+
+  it('getCorrelationsForEvent returns [] before startV2Cycle', () => {
+    assert.deepEqual(getCorrelationsForEvent('any'), []);
+  });
+
+  it('startV2Cycle runs immediately and returns instance', () => {
+    const quake = makeEvent({ domain: 'earthquake', occurredAt: NOW, lat: 35, lon: 140 });
+    const tsunami = makeEvent({ domain: 'tsunami', occurredAt: NOW + 5 * MIN, lat: 35.1, lon: 140.1 });
+    const instance = startV2Cycle(makeStore([quake, tsunami]), 999_999);
+    assert.ok(instance !== null);
+    const chains = getActiveChains();
+    assert.ok(chains.length >= 1);
+    stopV2Cycle();
+  });
+
+  it('stopV2Cycle clears the singleton', () => {
+    startV2Cycle(makeStore([]), 999_999);
+    stopV2Cycle();
+    assert.deepEqual(getActiveChains(), []);
+  });
+});
+
+// ── toCorrelations backward compat ────────────────────────────────────────
+
+describe('CorrelatorV2 — toCorrelations backward compatibility', () => {
+  it('produces Correlation-shaped objects', () => {
+    const quake = makeEvent({ domain: 'earthquake', occurredAt: NOW, lat: 35, lon: 140 });
+    const tsunami = makeEvent({ domain: 'tsunami', occurredAt: NOW + 5 * MIN, lat: 35.1, lon: 140.1 });
+    const eng = new CorrelatorV2(makeStore([quake, tsunami]));
+    eng.run();
+    for (const corr of eng.toCorrelations()) {
+      assert.ok(typeof corr.id === 'string');
+      assert.ok(Array.isArray(corr.events));
+      assert.ok(typeof corr.confidence === 'number');
+      assert.ok(typeof corr.title === 'string');
+      assert.ok(typeof corr.detectedAt === 'number');
+    }
+  });
+});
+
+// ── Cross-domain pairs ─────────────────────────────────────────────────────
+
+describe('CorrelatorV2 — cross-domain pairs', () => {
+  it('detects aviation → conflict', () => {
+    const flight = makeEvent({ domain: 'aviation', occurredAt: NOW });
+    const conflict = makeEvent({ domain: 'conflict', occurredAt: NOW + 30 * MIN });
+    const eng = new CorrelatorV2(makeStore([flight, conflict]));
+    eng.run();
+    const chains = eng.getActiveChains().filter(c => c.chainType === 'aviation-conflict');
+    assert.ok(chains.length >= 1);
+  });
+
+  it('getActiveChains sorts by confidence descending', () => {
+    const events: ObservationEvent[] = [
+      makeEvent({ domain: 'earthquake', occurredAt: NOW, lat: 35, lon: 140 }),
+      makeEvent({ domain: 'tsunami',    occurredAt: NOW + 5 * MIN, lat: 35.01, lon: 140.01 }),
+      makeEvent({ domain: 'conflict',   occurredAt: NOW }),
+      makeEvent({ domain: 'displacement', occurredAt: NOW + 20 * HR }),
+    ];
+    const eng = new CorrelatorV2(makeStore(events));
+    eng.run();
+    const chains = eng.getActiveChains();
+    for (let i = 1; i < chains.length; i++) {
+      assert.ok(chains[i - 1]!.confidence >= chains[i]!.confidence);
+    }
+  });
+
+  it('inactive events are excluded from chain detection', () => {
+    const quake = makeEvent({ domain: 'earthquake', occurredAt: NOW, active: false });
+    const tsunami = makeEvent({ domain: 'tsunami', occurredAt: NOW + 5 * MIN });
+    const eng = new CorrelatorV2(makeStore([quake, tsunami]));
+    eng.run();
+    const chains = eng.getActiveChains().filter(c => c.events.some(e => e.id === quake.id));
+    assert.equal(chains.length, 0);
+  });
+
+  it('empty store produces no chains', () => {
+    const eng = new CorrelatorV2(makeStore([]));
+    eng.run();
+    assert.equal(eng.getActiveChains().length, 0);
+  });
+
+  it('same-domain events are never chained', () => {
+    const q1 = makeEvent({ domain: 'earthquake', occurredAt: NOW });
+    const q2 = makeEvent({ domain: 'earthquake', occurredAt: NOW + 2 * MIN });
+    const eng = new CorrelatorV2(makeStore([q1, q2]));
+    eng.run();
+    // v2 transitions are cross-domain only
+    for (const chain of eng.getActiveChains()) {
+      const domains = chain.events.map(e => e.domain);
+      assert.ok(new Set(domains).size > 1 || domains.length === 1);
+    }
+  });
+});

--- a/src/services/intelligence/correlator-v2.ts
+++ b/src/services/intelligence/correlator-v2.ts
@@ -1,0 +1,278 @@
+import type { Correlation, ObservationEvent, ObservationStoreReader } from './observation-types.ts';
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+export interface CorrelationChain {
+  id: string;
+  chainType: string;
+  events: ObservationEvent[];
+  /** 0–1, decays 0.1 per domain hop, floor 0.3 */
+  confidence: number;
+  detectedAt: number;
+  /** Human-readable summary of the causal sequence */
+  title: string;
+}
+
+interface DomainTransition {
+  from: string;
+  fromTag?: string;
+  to: string;
+  toTag?: string;
+  chainType: string;
+  /** Max ms between events for this transition to be valid */
+  windowMs: number;
+}
+
+// ── Causal chain rules ────────────────────────────────────────────────────
+
+const TRANSITIONS: DomainTransition[] = [
+  // Seismic → tsunami → evacuation
+  { from: 'earthquake', to: 'tsunami',    chainType: 'seismic-cascade',    windowMs: 15 * 60 * 1000 },
+  { from: 'tsunami',    to: 'evacuation', chainType: 'seismic-cascade',    windowMs: 30 * 60 * 1000 },
+  // Wildfire → air quality → health
+  { from: 'wildfire',   to: 'air-quality', chainType: 'wildfire-cascade',  windowMs: 6 * 60 * 60 * 1000 },
+  { from: 'air-quality',to: 'health',      chainType: 'wildfire-cascade',  windowMs: 6 * 60 * 60 * 1000 },
+  // Hurricane → supply disruption → commodity shortage
+  { from: 'weather',    to: 'supply-chain', chainType: 'hurricane-cascade', windowMs: 6 * 60 * 60 * 1000 },
+  { from: 'supply-chain',to: 'commodity',  chainType: 'hurricane-cascade', windowMs: 24 * 60 * 60 * 1000 },
+  // Cyber → infrastructure → economic
+  { from: 'cyber',      to: 'infrastructure', chainType: 'cyber-cascade',  windowMs: 60 * 60 * 1000 },
+  { from: 'infrastructure', to: 'economic',   chainType: 'cyber-cascade',  windowMs: 6 * 60 * 60 * 1000 },
+  // Conflict → displacement → humanitarian
+  { from: 'conflict',   to: 'displacement',   chainType: 'conflict-cascade', windowMs: 24 * 60 * 60 * 1000 },
+  { from: 'displacement', to: 'humanitarian', chainType: 'conflict-cascade', windowMs: 24 * 60 * 60 * 1000 },
+  // Generic cross-domain pairs for spatial/temporal correlations
+  { from: 'maritime',   to: 'economic',     chainType: 'maritime-economic', windowMs: 6 * 60 * 60 * 1000 },
+  { from: 'aviation',   to: 'conflict',     chainType: 'aviation-conflict', windowMs: 60 * 60 * 1000 },
+];
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+const EARTH_RADIUS_KM = 6371;
+
+function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const dLat = (lat2 - lat1) * Math.PI / 180;
+  const dLon = (lon2 - lon1) * Math.PI / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) *
+    Math.sin(dLon / 2) ** 2;
+  return EARTH_RADIUS_KM * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function spatialScore(a: ObservationEvent, b: ObservationEvent, radiusKm: number): number {
+  if (a.lat === undefined || a.lon === undefined || b.lat === undefined || b.lon === undefined) return 0;
+  const dist = haversineKm(a.lat, a.lon, b.lat, b.lon);
+  if (dist > radiusKm) return 0;
+  return 1 - (dist / radiusKm) * 0.6;
+}
+
+function temporalScore(a: ObservationEvent, b: ObservationEvent, windowMs: number): number {
+  const delta = Math.abs(a.occurredAt - b.occurredAt);
+  if (delta > windowMs) return 0;
+  return 1 - (delta / windowMs) * 0.5;
+}
+
+function entityScore(a: ObservationEvent, b: ObservationEvent): number {
+  const shared = a.entities.filter(e => b.entities.includes(e));
+  return shared.length > 0 ? 0.8 : 0;
+}
+
+function pairConfidence(a: ObservationEvent, b: ObservationEvent, windowMs: number, radiusKm = 500): number {
+  const spatial = spatialScore(a, b, radiusKm);
+  const temporal = temporalScore(a, b, windowMs);
+  const entity = entityScore(a, b);
+  // weighted blend: spatial + temporal + entity bonus
+  const base = spatial > 0
+    ? spatial * 0.5 + temporal * 0.3 + entity * 0.2
+    : temporal * 0.6 + entity * 0.4;
+  return Math.max(0.3, Math.min(1, base > 0 ? base : 0.35));
+}
+
+function chainId(events: ObservationEvent[]): string {
+  return `chain|${events.map(e => e.id).sort((a, b) => a.localeCompare(b)).join('|')}`;
+}
+
+function degrade(confidence: number, hops: number): number {
+  return Math.max(0.3, confidence - hops * 0.1);
+}
+
+// ── V2 Engine ─────────────────────────────────────────────────────────────
+
+export class CorrelatorV2 {
+  private store: ObservationStoreReader;
+  private radiusKm: number;
+  private chains = new Map<string, CorrelationChain>();
+  /** eventId → chainId(s) for de-duplication */
+  private eventIndex = new Map<string, string>();
+
+  constructor(store: ObservationStoreReader, options: { radiusKm?: number } = {}) {
+    this.store = store;
+    this.radiusKm = options.radiusKm ?? 500;
+  }
+
+  run(): CorrelationChain[] {
+    const events = this.store.getEvents().filter(e => e.active);
+    const now = Date.now();
+    const detected: CorrelationChain[] = [];
+
+    for (const transition of TRANSITIONS) {
+      const anchors = events.filter(e => e.domain === transition.from);
+      const targets = events.filter(e => e.domain === transition.to);
+      for (const anchor of anchors) {
+        for (const target of targets) {
+          const added = this.processTransitionPair(anchor, target, transition, now);
+          if (added) detected.push(added);
+        }
+      }
+    }
+
+    this.pruneResolved();
+    return detected;
+  }
+
+  private processTransitionPair(
+    anchor: ObservationEvent,
+    target: ObservationEvent,
+    transition: DomainTransition,
+    now: number,
+  ): CorrelationChain | null {
+    const timeDelta = Math.abs(anchor.occurredAt - target.occurredAt);
+    if (timeDelta > transition.windowMs) return null;
+    if (target.occurredAt < anchor.occurredAt) return null;
+
+    const conf = pairConfidence(anchor, target, transition.windowMs, this.radiusKm);
+    if (conf < 0.3) return null;
+
+    const existingIdA = this.eventIndex.get(anchor.id);
+    const existingIdB = this.eventIndex.get(target.id);
+    const existingChain = this.resolveExistingChain(existingIdA, existingIdB);
+
+    if (existingChain?.chainType === transition.chainType) {
+      this.tryExtendChain(existingChain, target);
+      return null;
+    }
+
+    return this.buildOrReplaceChain(anchor, target, transition, conf, existingIdA, existingIdB, now);
+  }
+
+  private resolveExistingChain(idA: string | undefined, idB: string | undefined): CorrelationChain | undefined {
+    if (idA !== undefined) return this.chains.get(idA);
+    if (idB !== undefined) return this.chains.get(idB);
+    return undefined;
+  }
+
+  private tryExtendChain(existingChain: CorrelationChain, target: ObservationEvent): void {
+    if (existingChain.events.some(e => e.id === target.id)) return;
+    const hops = existingChain.events.length - 1;
+    const extended: CorrelationChain = {
+      ...existingChain,
+      events: [...existingChain.events, target],
+      confidence: degrade(existingChain.confidence, hops + 1),
+      title: buildTitle([...existingChain.events, target], existingChain.chainType),
+    };
+    this.chains.set(existingChain.id, extended);
+    this.eventIndex.set(target.id, existingChain.id);
+  }
+
+  private buildOrReplaceChain(
+    anchor: ObservationEvent,
+    target: ObservationEvent,
+    transition: DomainTransition,
+    conf: number,
+    existingIdA: string | undefined,
+    existingIdB: string | undefined,
+    now: number,
+  ): CorrelationChain | null {
+    const id = chainId([anchor, target]);
+    const chain: CorrelationChain = {
+      id,
+      chainType: transition.chainType,
+      events: [anchor, target],
+      confidence: degrade(conf, 1),
+      detectedAt: this.chains.get(id)?.detectedAt ?? now,
+      title: buildTitle([anchor, target], transition.chainType),
+    };
+
+    if (existingIdA !== undefined) {
+      const existing = this.chains.get(existingIdA);
+      if (existing && existing.confidence >= chain.confidence) return null;
+      this.chains.delete(existingIdA);
+    }
+    if (existingIdB !== undefined) {
+      const existing = this.chains.get(existingIdB);
+      if (existing && existing.confidence >= chain.confidence) return null;
+      this.chains.delete(existingIdB);
+    }
+
+    this.chains.set(chain.id, chain);
+    this.eventIndex.set(anchor.id, chain.id);
+    this.eventIndex.set(target.id, chain.id);
+    return chain;
+  }
+
+  private pruneResolved(): void {
+    for (const [id, chain] of this.chains) {
+      if (chain.events.every(e => !e.active)) {
+        this.chains.delete(id);
+        for (const e of chain.events) this.eventIndex.delete(e.id);
+      }
+    }
+  }
+
+  getActiveChains(): CorrelationChain[] {
+    return [...this.chains.values()].sort((a, b) => b.confidence - a.confidence);
+  }
+
+  getCorrelationsForEvent(eventId: string): CorrelationChain[] {
+    return [...this.chains.values()].filter(c => c.events.some(e => e.id === eventId));
+  }
+
+  /** Convert active chains to v1-compatible Correlation objects for backward compatibility. */
+  toCorrelations(): Correlation[] {
+    return this.getActiveChains().map(chain => ({
+      id: chain.id,
+      events: chain.events,
+      type: 'entity' as const,
+      confidence: chain.confidence,
+      title: chain.title,
+      detectedAt: chain.detectedAt,
+    }));
+  }
+}
+
+// ── Module-level singleton cycle ──────────────────────────────────────────
+
+let _instance: CorrelatorV2 | null = null;
+let _timer: ReturnType<typeof setInterval> | null = null;
+
+export function startV2Cycle(store: ObservationStoreReader, intervalMs = 5 * 60 * 1000): CorrelatorV2 {
+  _instance = new CorrelatorV2(store);
+  _instance.run();
+  _timer = setInterval(() => _instance!.run(), intervalMs);
+  return _instance;
+}
+
+export function stopV2Cycle(): void {
+  if (_timer !== null) {
+    clearInterval(_timer);
+    _timer = null;
+  }
+  _instance = null;
+}
+
+export function getActiveChains(): CorrelationChain[] {
+  return _instance?.getActiveChains() ?? [];
+}
+
+export function getCorrelationsForEvent(eventId: string): CorrelationChain[] {
+  return _instance?.getCorrelationsForEvent(eventId) ?? [];
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────
+
+function buildTitle(events: ObservationEvent[], chainType: string): string {
+  const domains = events.map(e => e.domain).join(' → ');
+  const label = chainType.replace(/-/g, ' ');
+  return `${label}: ${events[0]?.title ?? domains}`;
+}


### PR DESCRIPTION
## Summary

Cross-domain correlation engine v2 built on top of the existing `CorrelationEngine` in `correlator.ts`. Adds causal chain detection, per-transition time windows, confidence scoring with decay, and event-level de-duplication.

## Changes

### `src/services/intelligence/correlator-v2.ts`
- `CorrelatorV2` class with 7 typed causal chain rules:
  - Seismic cascade: earthquake → tsunami (15 min) → evacuation (30 min)
  - Wildfire cascade: wildfire → air-quality (6 hr) → health (6 hr)
  - Hurricane cascade: weather → supply-chain (6 hr) → commodity (24 hr)
  - Cyber cascade: cyber → infrastructure (1 hr) → economic (6 hr)
  - Conflict cascade: conflict → displacement (24 hr) → humanitarian (24 hr)
  - Maritime-economic (6 hr) and aviation-conflict (1 hr)
- Confidence = spatial 50% + temporal 30% + entity 20%, degrades 0.1/hop, floor 0.3
- De-duplication: events already in a higher-confidence chain are not re-linked
- Exports: `startV2Cycle()`, `stopV2Cycle()`, `getActiveChains()`, `getCorrelationsForEvent()`

### `src/components/CorrelationMapPanel.ts`
- Panel id: `correlation-map`, category: `intelligence`
- Shows active chains sorted by confidence, with chain-type badge, confidence bar, domain icons
- Click-to-expand shows individual events; 30 s auto-refresh from sidecar

### Sidecar (`local-api-server.mjs`)
- `POST/GET /api/intelligence/correlations/chains` — renderer pushes chain snapshots
- `GET /api/intelligence/correlations/event/:id` — lookup chains for a specific event

### Tests (`src/services/intelligence/__tests__/correlator-v2.test.mts`)
- 34 unit tests: chain detection, confidence math, time-window boundaries, de-duplication, cross-domain pairs, singleton lifecycle, backward-compat `toCorrelations()`

## Cross-agent review

Cross-agent review: claude reviewed on 2026-05-12; outcome: pass