### PR TITLE
feat(intelligence): evidence graph UX — confirming/contradicting sources, confidence breakdown

### DIFF
--- a/src/components/EvidenceGraphPanel.ts
+++ b/src/components/EvidenceGraphPanel.ts
@@ -8,8 +8,6 @@
  * from situation-store. 30 s auto-refresh; also re-renders on situation
  * lifecycle events.
  */
-/* eslint-disable sonarjs/no-nested-template-literals -- short row markup */
-
 import { Panel } from './Panel';
 import { getActive, getSituation } from '@/services/intelligence/situation-store';
 import { getRecent } from '@/services/intelligence/observation-store';

--- a/src/services/intelligence/evidence-graph-ux.ts
+++ b/src/services/intelligence/evidence-graph-ux.ts
@@ -215,6 +215,31 @@ interface PartitionResult {
   contradicting: { event: ObservationEvent; reason: string }[];
 }
 
+type EventVerdict =
+  | { kind: 'confirm' }
+  | { kind: 'contradict'; reason: string }
+  | { kind: 'skip' };
+
+function classifyEvent(
+  event: ObservationEvent,
+  situation: Situation,
+  situationTags: Set<string>,
+  isLinked: boolean,
+  now: number,
+): EventVerdict {
+  const eventTags = lowerSet(event.tags);
+  if (!isLinked) {
+    if (event.domain !== situation.domain) {
+      const reason = contradictionReason(eventTags, situationTags);
+      return reason ? { kind: 'contradict', reason } : { kind: 'skip' };
+    }
+    if (now - event.timestamp > TEMPORAL_LOOKBACK_MS) return { kind: 'skip' };
+    if (!eventInSituationFootprint(event, situation)) return { kind: 'skip' };
+  }
+  const reason = contradictionReason(eventTags, situationTags);
+  return reason ? { kind: 'contradict', reason } : { kind: 'confirm' };
+}
+
 function partitionEvents(
   situation: Situation,
   events: readonly ObservationEvent[],
@@ -226,24 +251,9 @@ function partitionEvents(
   const contradicting: { event: ObservationEvent; reason: string }[] = [];
 
   for (const event of events) {
-    const eventTags = lowerSet(event.tags);
-    const isLinked = obsIds.has(event.id);
-    if (!isLinked) {
-      if (event.domain !== situation.domain) {
-        const reason = contradictionReason(eventTags, situationTags);
-        if (reason) contradicting.push({ event, reason });
-        continue;
-      }
-      if (now - event.timestamp > TEMPORAL_LOOKBACK_MS) continue;
-      if (!eventInSituationFootprint(event, situation)) continue;
-    }
-
-    const reason = contradictionReason(eventTags, situationTags);
-    if (reason) {
-      contradicting.push({ event, reason });
-      continue;
-    }
-    confirming.push(event);
+    const verdict = classifyEvent(event, situation, situationTags, obsIds.has(event.id), now);
+    if (verdict.kind === 'confirm') confirming.push(event);
+    else if (verdict.kind === 'contradict') contradicting.push({ event, reason: verdict.reason });
   }
 
   return { confirming, contradicting };


### PR DESCRIPTION
## Summary

Phase 7B from `docs/CLAUDE_APP_IMPROVEMENT_GAMEPLAN_2026-05-12.md`. Adds a per-situation evidence report surface so operators can see, for any active Situation, which sources currently confirm it, which contradict it, which expected follow-on signals are still missing, and which confirming inputs have gone stale past their per-domain refresh budget. A stacked confidence-bar decomposes the situation's confidence across spatial / temporal / entity / domain dimensions so a low score is explainable.

## What ships

- **Service** — `src/services/intelligence/evidence-graph-ux.ts`. Pure, deterministic, no DOM, no fetch. Input: one `Situation` + recent `ObservationEvent[]`. Output: `EvidenceReport { confirming, contradicting, missing, stale, confidenceBreakdown, lastVerified }`.
- **Panel** — `src/components/EvidenceGraphPanel.ts` (id `evidence-graph`, category `intelligence`). Situation selector, color-bordered confirming/contradicting cards, dashed-border missing-signal rows, stale-input list, stacked 4-component confidence bar (out of 100), `last verified` timestamp, 30 s auto-refresh, re-renders on `wm:situation-created` / `wm:situation-updated`.
- **Sidecar** — `GET /api/intelligence/evidence/:situationId` mirrors the pure service against the sidecar's situation + observation mirrors.
- **Registration** — `src/config/panels.ts` (FULL panel + intelligence category) and `src/app/panel-layout.ts`.
- **Tests** — 31 unit tests covering evidence assembly, contradiction detection (tag-pair table), missing-signal expectations, per-domain stale budgets, and the four-component confidence breakdown math.

## Verification

- `npm run typecheck:all` — clean
- `npx tsx --test src/services/intelligence/__tests__/evidence-graph-ux.test.mts` — 31 pass / 0 fail
- `npm run test:situations` — 10 pass / 0 fail (no regression in adjacent sidecar mirror)
- `npx eslint` on the three new/touched files — clean

## Cross-agent review

Cross-agent review: claude reviewed on 2026-05-12; outcome: pass