### PR TITLE
feat(diagnostics): diagnostic export — algorithm trace, mission state, panel health, self-test results

### DIFF
--- a/src/components/SystemDiagnosticPanel.ts
+++ b/src/components/SystemDiagnosticPanel.ts
@@ -186,7 +186,7 @@ export class SystemDiagnosticPanel extends Panel {
         <span class="syd-mission-badge" title="Feed-staleness mission state" style="font-size:9px;padding:2px 5px;background:${msBadgeColor};color:#fff;border-radius:3px;text-transform:uppercase;letter-spacing:0.05em;">${escapeHtml(ms)}</span>
       </div>
       <div style="display:flex;gap:6px;align-items:center;">
-        <button class="syd-export" style="font-size:11px;padding:3px 8px;background:transparent;color:var(--text-secondary,#aaa);border:1px solid var(--border-subtle,#333);border-radius:3px;cursor:pointer;">Export JSON</button>
+        <button class="syd-export" title="Download the full diagnostic bundle (panel health, situations, correlations, algorithm trace, self-test, mission state) as JSON" style="font-size:11px;padding:3px 8px;background:transparent;color:var(--text-secondary,#aaa);border:1px solid var(--border-subtle,#333);border-radius:3px;cursor:pointer;">Export Full Bundle</button>
         <button class="syd-refresh" style="font-size:11px;padding:3px 8px;background:transparent;color:var(--text-secondary,#aaa);border:1px solid var(--border-subtle,#333);border-radius:3px;cursor:pointer;">Refresh</button>
       </div>
     </div>`;

--- a/src/services/diagnostics/__tests__/export-bundle-enhancements.test.mts
+++ b/src/services/diagnostics/__tests__/export-bundle-enhancements.test.mts
@@ -1,0 +1,355 @@
+/**
+ * Tests for the Phase 2 diagnostic-export enhancements:
+ *   - panelHealthSummary    — rendered/degraded/errored counts + entries
+ *   - situations            — active situation inventory with confidence
+ *   - correlations          — active correlation chains
+ *   - algorithmTrace        — per-situation algorithm provenance
+ *   - markdown rendering    — human-readable sections for the above
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildExportBundle,
+  exportBundleToJson,
+  exportBundleToMarkdown,
+  type AlgorithmTraceEntry,
+  type CorrelationSummary,
+  type PanelHealthSummary,
+  type SituationSummary,
+} from '../export-bundle.ts';
+import { createDiagnosticEventBus } from '../diagnostic-events.ts';
+import { createNotificationTraceRegistry } from '../notification-trace.ts';
+import type {
+  NotificationTraceSummary,
+  SystemHealthReport,
+} from '../system-health-types.ts';
+
+const NOW = 1_745_000_000_000;
+
+function emptyNotifSummary(): NotificationTraceSummary {
+  return {
+    generatedAt: NOW,
+    candidates: 0,
+    dispatched: 0,
+    suppressedByReason: {},
+    unsafeSuppressions: [],
+  };
+}
+
+function makeSystemHealth(): SystemHealthReport {
+  return {
+    generatedAt: NOW,
+    status: 'healthy',
+    summary: 'All features healthy.',
+    features: [],
+    panels: [],
+    sources: [],
+    providers: [],
+    notifications: emptyNotifSummary(),
+    sidecar: { status: 'healthy', authenticated: true, reason: 'OK' },
+    recommendations: [],
+  };
+}
+
+function baseInput() {
+  return {
+    now: () => NOW,
+    app: { variant: 'full', version: '2.16.0', runtime: 'desktop' as const },
+    systemHealth: makeSystemHealth(),
+    notifications: { registry: createNotificationTraceRegistry() },
+    events: createDiagnosticEventBus(),
+  };
+}
+
+// ── Panel health summary ───────────────────────────────────────────────
+
+test('panelHealthSummary surfaces rendered/degraded/errored counts', () => {
+  const panelHealthSummary: PanelHealthSummary = {
+    total: 5,
+    rendered: 3,
+    degraded: 1,
+    errored: 1,
+    entries: [
+      { panelId: 'map', label: 'Global Map', status: 'healthy', lastRenderAt: NOW - 10_000 },
+      { panelId: 'alerts', label: 'Alerts', status: 'degraded', lastRenderAt: NOW - 600_000, reason: 'stale' },
+      { panelId: 'gov', label: 'Gov', status: 'failing', lastErrorAt: NOW - 1_000, reason: 'fetch failed' },
+    ],
+  };
+  const bundle = buildExportBundle({ ...baseInput(), panelHealthSummary });
+  assert.ok(bundle.panelHealthSummary);
+  assert.equal(bundle.panelHealthSummary?.total, 5);
+  assert.equal(bundle.panelHealthSummary?.rendered, 3);
+  assert.equal(bundle.panelHealthSummary?.degraded, 1);
+  assert.equal(bundle.panelHealthSummary?.errored, 1);
+  assert.equal(bundle.panelHealthSummary?.entries.length, 3);
+});
+
+test('panelHealthSummary is omitted when not supplied', () => {
+  const bundle = buildExportBundle(baseInput());
+  assert.equal(bundle.panelHealthSummary, undefined);
+});
+
+test('panelHealthSummary entries redact free-text reason fields', () => {
+  const panelHealthSummary: PanelHealthSummary = {
+    total: 1,
+    rendered: 0,
+    degraded: 0,
+    errored: 1,
+    entries: [{
+      panelId: 'gov',
+      status: 'failing',
+      reason: 'fetch user@example.com password=hunter2 failed',
+    }],
+  };
+  const bundle = buildExportBundle({ ...baseInput(), panelHealthSummary });
+  const entry = bundle.panelHealthSummary?.entries[0];
+  assert.ok(entry);
+  assert.ok(!entry.reason?.includes('user@example.com'), `email leaked: ${entry.reason}`);
+  assert.ok(!entry.reason?.includes('hunter2'), `password leaked: ${entry.reason}`);
+});
+
+// ── Situations inventory ───────────────────────────────────────────────
+
+test('situations inventory carries id, name, status, severity, confidence', () => {
+  const situations: SituationSummary[] = [{
+    id: 'sit-1',
+    name: 'Hurricane Milton',
+    status: 'active',
+    severity: 'critical',
+    domain: 'weather',
+    startedAt: NOW - 3_600_000,
+    updatedAt: NOW - 60_000,
+    observationIds: ['ev-1', 'ev-2'],
+    correlationIds: ['corr-1'],
+    confidence: 0.82,
+    tags: ['hurricane'],
+  }];
+  const bundle = buildExportBundle({ ...baseInput(), situations });
+  assert.equal(bundle.situations?.length, 1);
+  const s = bundle.situations?.[0];
+  assert.equal(s?.id, 'sit-1');
+  assert.equal(s?.severity, 'critical');
+  assert.equal(s?.confidence, 0.82);
+  assert.deepEqual(s?.observationIds, ['ev-1', 'ev-2']);
+});
+
+test('situations is omitted when not supplied', () => {
+  const bundle = buildExportBundle(baseInput());
+  assert.equal(bundle.situations, undefined);
+});
+
+test('situations summary field is redacted for embedded PII', () => {
+  const situations: SituationSummary[] = [{
+    id: 'sit-1',
+    name: 'Test',
+    status: 'active',
+    severity: 'high',
+    domain: 'weather',
+    startedAt: NOW,
+    updatedAt: NOW,
+    observationIds: [],
+    correlationIds: [],
+    confidence: 0.5,
+    tags: [],
+    summary: 'Reach out to user@example.com',
+  }];
+  const bundle = buildExportBundle({ ...baseInput(), situations });
+  assert.ok(!bundle.situations?.[0]?.summary?.includes('user@example.com'));
+});
+
+// ── Correlations inventory ─────────────────────────────────────────────
+
+test('correlations inventory carries chainType, title, confidence, eventIds', () => {
+  const correlations: CorrelationSummary[] = [{
+    id: 'corr-1',
+    chainType: 'seismic-cascade',
+    title: 'M6.0 → tsunami alert',
+    confidence: 0.7,
+    detectedAt: NOW - 120_000,
+    eventIds: ['ev-1', 'ev-2', 'ev-3'],
+  }];
+  const bundle = buildExportBundle({ ...baseInput(), correlations });
+  assert.equal(bundle.correlations?.length, 1);
+  const c = bundle.correlations?.[0];
+  assert.equal(c?.chainType, 'seismic-cascade');
+  assert.equal(c?.confidence, 0.7);
+  assert.equal(c?.eventIds.length, 3);
+});
+
+test('correlations is omitted when not supplied', () => {
+  const bundle = buildExportBundle(baseInput());
+  assert.equal(bundle.correlations, undefined);
+});
+
+// ── Algorithm trace ────────────────────────────────────────────────────
+
+test('algorithmTrace links a situation to the algorithm + evidence chain', () => {
+  const algorithmTrace: AlgorithmTraceEntry[] = [{
+    situationId: 'sit-1',
+    algorithmId: 'situation-clustering',
+    confidence: 0.82,
+    evidenceChain: [
+      { kind: 'observation', id: 'ev-1', summary: 'M6.0 earthquake offshore' },
+      { kind: 'observation', id: 'ev-2', summary: 'Tsunami advisory' },
+      { kind: 'correlation', id: 'corr-1', summary: 'seismic-cascade chain' },
+    ],
+  }];
+  const bundle = buildExportBundle({ ...baseInput(), algorithmTrace });
+  assert.equal(bundle.algorithmTrace?.length, 1);
+  const t = bundle.algorithmTrace?.[0];
+  assert.equal(t?.situationId, 'sit-1');
+  assert.equal(t?.algorithmId, 'situation-clustering');
+  assert.equal(t?.evidenceChain.length, 3);
+  assert.equal(t?.evidenceChain[0]?.kind, 'observation');
+  assert.equal(t?.evidenceChain[2]?.kind, 'correlation');
+});
+
+test('algorithmTrace evidence summaries are redacted for PII', () => {
+  const algorithmTrace: AlgorithmTraceEntry[] = [{
+    situationId: 'sit-1',
+    algorithmId: 'situation-clustering',
+    confidence: 0.5,
+    evidenceChain: [
+      { kind: 'observation', id: 'ev-1', summary: 'Contact attacker@malicious.com' },
+    ],
+  }];
+  const bundle = buildExportBundle({ ...baseInput(), algorithmTrace });
+  const summary = bundle.algorithmTrace?.[0]?.evidenceChain[0]?.summary;
+  assert.ok(!summary?.includes('attacker@malicious.com'), `email leaked: ${summary}`);
+});
+
+test('algorithmTrace is omitted when not supplied', () => {
+  const bundle = buildExportBundle(baseInput());
+  assert.equal(bundle.algorithmTrace, undefined);
+});
+
+// ── JSON round-trip ────────────────────────────────────────────────────
+
+test('exportBundleToJson preserves all new sections', () => {
+  const situations: SituationSummary[] = [{
+    id: 'sit-1',
+    name: 'X',
+    status: 'active',
+    severity: 'high',
+    domain: 'weather',
+    startedAt: NOW,
+    updatedAt: NOW,
+    observationIds: [],
+    correlationIds: [],
+    confidence: 0.5,
+    tags: [],
+  }];
+  const correlations: CorrelationSummary[] = [{
+    id: 'corr-1', chainType: 'x', title: 't', confidence: 0.5, detectedAt: NOW, eventIds: [],
+  }];
+  const algorithmTrace: AlgorithmTraceEntry[] = [{
+    situationId: 'sit-1', algorithmId: 'x', confidence: 0.5, evidenceChain: [],
+  }];
+  const panelHealthSummary: PanelHealthSummary = {
+    total: 1, rendered: 1, degraded: 0, errored: 0,
+    entries: [{ panelId: 'map', status: 'healthy' }],
+  };
+  const bundle = buildExportBundle({
+    ...baseInput(),
+    situations,
+    correlations,
+    algorithmTrace,
+    panelHealthSummary,
+  });
+  const round = JSON.parse(exportBundleToJson(bundle));
+  assert.equal(round.situations?.length, 1);
+  assert.equal(round.correlations?.length, 1);
+  assert.equal(round.algorithmTrace?.length, 1);
+  assert.equal(round.panelHealthSummary?.entries.length, 1);
+});
+
+// ── Markdown rendering ─────────────────────────────────────────────────
+
+test('exportBundleToMarkdown includes a Situations section when present', () => {
+  const situations: SituationSummary[] = [{
+    id: 'sit-hurricane', name: 'Hurricane Milton', status: 'active',
+    severity: 'critical', domain: 'weather', startedAt: NOW, updatedAt: NOW,
+    observationIds: ['ev-1'], correlationIds: [], confidence: 0.82, tags: [],
+  }];
+  const md = exportBundleToMarkdown(buildExportBundle({ ...baseInput(), situations }));
+  assert.match(md, /Active situations/i);
+  assert.match(md, /Hurricane Milton/);
+  assert.match(md, /critical/);
+});
+
+test('exportBundleToMarkdown includes a Panel health section when present', () => {
+  const panelHealthSummary: PanelHealthSummary = {
+    total: 2, rendered: 1, degraded: 1, errored: 0,
+    entries: [
+      { panelId: 'map', label: 'Map', status: 'healthy' },
+      { panelId: 'alerts', label: 'Alerts', status: 'degraded', reason: 'stale' },
+    ],
+  };
+  const md = exportBundleToMarkdown(buildExportBundle({ ...baseInput(), panelHealthSummary }));
+  assert.match(md, /Panel health/i);
+  assert.match(md, /1 degraded/);
+});
+
+test('exportBundleToMarkdown omits new sections when sources are absent', () => {
+  const md = exportBundleToMarkdown(buildExportBundle(baseInput()));
+  assert.ok(!/Active situations/i.test(md), 'should not render Situations heading');
+  assert.ok(!/Correlation chains/i.test(md), 'should not render Correlations heading');
+  assert.ok(!/Algorithm trace/i.test(md), 'should not render Algorithm trace heading');
+});
+
+test('exportBundleToMarkdown includes Algorithm trace + Correlations when present', () => {
+  const correlations: CorrelationSummary[] = [{
+    id: 'corr-1', chainType: 'seismic-cascade', title: 'M6 → tsunami',
+    confidence: 0.7, detectedAt: NOW, eventIds: ['e1', 'e2'],
+  }];
+  const algorithmTrace: AlgorithmTraceEntry[] = [{
+    situationId: 'sit-1', algorithmId: 'situation-clustering',
+    confidence: 0.82, evidenceChain: [
+      { kind: 'observation', id: 'e1', summary: 'quake' },
+    ],
+  }];
+  const md = exportBundleToMarkdown(buildExportBundle({
+    ...baseInput(), correlations, algorithmTrace,
+  }));
+  assert.match(md, /Correlation chains/i);
+  assert.match(md, /seismic-cascade/);
+  assert.match(md, /Algorithm trace/i);
+  assert.match(md, /situation-clustering/);
+});
+
+// ── Bounded growth ────────────────────────────────────────────────────
+
+test('truncations record is added when more than the cap of situations are passed', () => {
+  const many: SituationSummary[] = Array.from({ length: 60 }, (_, i) => ({
+    id: `s-${i}`, name: `S${i}`, status: 'active' as const,
+    severity: 'low' as const, domain: 'weather',
+    startedAt: NOW, updatedAt: NOW,
+    observationIds: [], correlationIds: [], confidence: 0.1, tags: [],
+  }));
+  const bundle = buildExportBundle({
+    ...baseInput(),
+    situations: many,
+    caps: { maxSituations: 25 },
+  });
+  assert.equal(bundle.situations?.length, 25);
+  const note = bundle.truncations.find((t) => t.field === 'situations');
+  assert.ok(note, 'expected truncation note for situations');
+  assert.equal(note?.originalCount, 60);
+  assert.equal(note?.keptCount, 25);
+});
+
+test('default cap on algorithmTrace prevents unbounded growth', () => {
+  const many: AlgorithmTraceEntry[] = Array.from({ length: 200 }, (_, i) => ({
+    situationId: `s-${i}`,
+    algorithmId: 'x',
+    confidence: 0.1,
+    evidenceChain: [],
+  }));
+  const bundle = buildExportBundle({ ...baseInput(), algorithmTrace: many });
+  // Default cap is 100
+  assert.ok(bundle.algorithmTrace!.length <= 100, `expected ≤100, got ${bundle.algorithmTrace?.length}`);
+  const note = bundle.truncations.find((t) => t.field === 'algorithmTrace');
+  assert.ok(note, 'expected truncation note for algorithmTrace');
+});

--- a/src/services/diagnostics/export-bundle.ts
+++ b/src/services/diagnostics/export-bundle.ts
@@ -129,6 +129,78 @@ export interface SystemInfo {
   memoryUsedBytes?: number;
 }
 
+// ── Phase 2 enhancements: situation / correlation / panel-health / trace ──
+
+/** Compact PanelHealth row shipped in the export. Mirrors the registry
+ *  shape but keeps only fields that survive redaction + paste-cap. */
+export interface PanelHealthEntry {
+  panelId: string;
+  label?: string;
+  status: string;
+  lastRenderAt?: number;
+  lastErrorAt?: number;
+  reason?: string;
+}
+
+/** Panel health rollup — counts plus a capped list of entries.
+ *  Lets a triager answer "which panels are actually rendering?" in one
+ *  glance without joining the full SystemHealthReport panel list. */
+export interface PanelHealthSummary {
+  total: number;
+  rendered: number;
+  degraded: number;
+  errored: number;
+  entries: readonly PanelHealthEntry[];
+}
+
+/** Active situation snapshot — id, name, severity, confidence + the
+ *  IDs of the evidence the situation was built from. Cross-references
+ *  with `correlations` and `recentEvents` so a triager can reconstruct
+ *  the cascade without joining other tables. */
+export interface SituationSummary {
+  id: string;
+  name: string;
+  status: string;
+  severity: string;
+  domain: string;
+  startedAt: number;
+  updatedAt: number;
+  observationIds: readonly string[];
+  correlationIds: readonly string[];
+  confidence: number;
+  tags: readonly string[];
+  summary?: string;
+}
+
+/** Correlation chain summary from correlator-v2. Confidence + chainType
+ *  let a triager see "is the engine actually finding cross-domain
+ *  links?" at a glance. */
+export interface CorrelationSummary {
+  id: string;
+  chainType: string;
+  title: string;
+  confidence: number;
+  detectedAt: number;
+  eventIds: readonly string[];
+}
+
+/** Per-situation algorithm trace — answers "which algorithm produced
+ *  this and on what evidence?". Confidence is the algorithm's reported
+ *  confidence; evidenceChain is the ordered list of observations and
+ *  correlations the algorithm consumed. */
+export interface AlgorithmTraceEvidence {
+  kind: 'observation' | 'correlation';
+  id: string;
+  summary?: string;
+}
+
+export interface AlgorithmTraceEntry {
+  situationId: string;
+  algorithmId: string;
+  confidence: number;
+  evidenceChain: readonly AlgorithmTraceEvidence[];
+}
+
 // ── Public API ──────────────────────────────────────────────────────────
 
 export interface ExportBundleAppMeta {
@@ -192,6 +264,14 @@ export interface DiagnosticsExportBundle {
   missionMapping?: MissionMappingSummary;
   /** System runtime info: version, uptime, memory. */
   systemInfo?: SystemInfo;
+  /** Phase 2: panel rendered/degraded/errored rollup + capped entries. */
+  panelHealthSummary?: PanelHealthSummary;
+  /** Phase 2: active situations with evidence cross-references. */
+  situations?: readonly SituationSummary[];
+  /** Phase 2: active correlation chains from correlator-v2. */
+  correlations?: readonly CorrelationSummary[];
+  /** Phase 2: per-situation algorithm trace + evidence chain. */
+  algorithmTrace?: readonly AlgorithmTraceEntry[];
   /** Anything truncated for size, recorded so the consumer knows what
    *  was dropped. */
   truncations: ExportTruncationNote[];
@@ -234,12 +314,20 @@ export interface BuildExportBundleInput {
   algorithmParameters?: readonly AlgorithmParameterSummary[];
   missionMapping?: MissionMappingSummary;
   systemInfo?: SystemInfo;
+  panelHealthSummary?: PanelHealthSummary;
+  situations?: readonly SituationSummary[];
+  correlations?: readonly CorrelationSummary[];
+  algorithmTrace?: readonly AlgorithmTraceEntry[];
   /** Caps; see DEFAULTS below. */
   caps?: Partial<{
     maxNotificationTraces: number;
     maxRecentEvents: number;
     maxBundleBytes: number;
     maxQualityDebt: number;
+    maxSituations: number;
+    maxCorrelations: number;
+    maxAlgorithmTrace: number;
+    maxPanelHealthEntries: number;
   }>;
 }
 
@@ -247,6 +335,10 @@ const DEFAULT_MAX_NOTIFICATION_TRACES = 50;
 const DEFAULT_MAX_RECENT_EVENTS = 200;
 const DEFAULT_MAX_BUNDLE_BYTES = 256 * 1024; // 256 KB
 const DEFAULT_MAX_QUALITY_DEBT = 25;
+const DEFAULT_MAX_SITUATIONS = 50;
+const DEFAULT_MAX_CORRELATIONS = 50;
+const DEFAULT_MAX_ALGORITHM_TRACE = 100;
+const DEFAULT_MAX_PANEL_HEALTH_ENTRIES = 100;
 
 export function buildExportBundle(input: BuildExportBundleInput): DiagnosticsExportBundle {
   const now = input.now ?? (() => Date.now());
@@ -256,6 +348,10 @@ export function buildExportBundle(input: BuildExportBundleInput): DiagnosticsExp
     maxRecentEvents: input.caps?.maxRecentEvents ?? DEFAULT_MAX_RECENT_EVENTS,
     maxBundleBytes: input.caps?.maxBundleBytes ?? DEFAULT_MAX_BUNDLE_BYTES,
     maxQualityDebt: input.caps?.maxQualityDebt ?? DEFAULT_MAX_QUALITY_DEBT,
+    maxSituations: input.caps?.maxSituations ?? DEFAULT_MAX_SITUATIONS,
+    maxCorrelations: input.caps?.maxCorrelations ?? DEFAULT_MAX_CORRELATIONS,
+    maxAlgorithmTrace: input.caps?.maxAlgorithmTrace ?? DEFAULT_MAX_ALGORITHM_TRACE,
+    maxPanelHealthEntries: input.caps?.maxPanelHealthEntries ?? DEFAULT_MAX_PANEL_HEALTH_ENTRIES,
   };
 
   const { summary: notificationSummary, entries: notificationTracesRaw, totalCount } =
@@ -310,6 +406,33 @@ export function buildExportBundle(input: BuildExportBundleInput): DiagnosticsExp
     }
   }
 
+  const panelHealthSummary = redactPanelHealthSummary(
+    input.panelHealthSummary,
+    caps.maxPanelHealthEntries,
+    truncations,
+  );
+  const situations = capAndRedact(
+    input.situations,
+    caps.maxSituations,
+    'situations',
+    truncations,
+    redactSituation,
+  );
+  const correlations = capAndRedact(
+    input.correlations,
+    caps.maxCorrelations,
+    'correlations',
+    truncations,
+    redactCorrelation,
+  );
+  const algorithmTrace = capAndRedact(
+    input.algorithmTrace,
+    caps.maxAlgorithmTrace,
+    'algorithmTrace',
+    truncations,
+    redactAlgorithmTrace,
+  );
+
   const bundle: DiagnosticsExportBundle = {
     schemaVersion: 2,
     generatedAt: now(),
@@ -342,10 +465,94 @@ export function buildExportBundle(input: BuildExportBundleInput): DiagnosticsExp
         }
       : undefined,
     systemInfo: input.systemInfo ? { ...input.systemInfo } : undefined,
+    panelHealthSummary,
+    situations,
+    correlations,
+    algorithmTrace,
     truncations,
   };
 
   return enforceByteCap(bundle, caps.maxBundleBytes);
+}
+
+function capAndRedact<T>(
+  source: readonly T[] | undefined,
+  cap: number,
+  field: string,
+  truncations: ExportTruncationNote[],
+  redactor: (item: T) => T,
+): readonly T[] | undefined {
+  if (source === undefined) return undefined;
+  const kept = source.length > cap ? source.slice(0, cap) : source;
+  if (source.length > cap) {
+    truncations.push({
+      field,
+      originalCount: source.length,
+      keptCount: kept.length,
+      reason: 'paste-friendly cap',
+    });
+  }
+  return kept.map((item) => redactor(item));
+}
+
+function redactPanelHealthSummary(
+  summary: PanelHealthSummary | undefined,
+  cap: number,
+  truncations: ExportTruncationNote[],
+): PanelHealthSummary | undefined {
+  if (summary === undefined) return undefined;
+  const entries = summary.entries.length > cap ? summary.entries.slice(0, cap) : summary.entries;
+  if (summary.entries.length > cap) {
+    truncations.push({
+      field: 'panelHealthSummary.entries',
+      originalCount: summary.entries.length,
+      keptCount: entries.length,
+      reason: 'paste-friendly cap',
+    });
+  }
+  return {
+    total: summary.total,
+    rendered: summary.rendered,
+    degraded: summary.degraded,
+    errored: summary.errored,
+    entries: entries.map((e) => ({
+      panelId: e.panelId,
+      label: e.label,
+      status: e.status,
+      lastRenderAt: e.lastRenderAt,
+      lastErrorAt: e.lastErrorAt,
+      reason: e.reason ? redactString(e.reason) : e.reason,
+    })),
+  };
+}
+
+function redactSituation(s: SituationSummary): SituationSummary {
+  return {
+    ...s,
+    observationIds: [...s.observationIds],
+    correlationIds: [...s.correlationIds],
+    tags: [...s.tags],
+    summary: s.summary ? redactString(s.summary) : s.summary,
+  };
+}
+
+function redactCorrelation(c: CorrelationSummary): CorrelationSummary {
+  return {
+    ...c,
+    title: redactString(c.title),
+    eventIds: [...c.eventIds],
+  };
+}
+
+function redactAlgorithmTrace(t: AlgorithmTraceEntry): AlgorithmTraceEntry {
+  return {
+    ...t,
+    evidenceChain: t.evidenceChain.map((e) => ({
+      kind: e.kind,
+      id: e.id,
+      summary: e.summary ? redactString(e.summary) : e.summary,
+    })),
+  };
 }
 
 /** Structural-clone redactor for strategic-self-improvement export
@@ -368,7 +575,52 @@ export function exportBundleToJson(bundle: DiagnosticsExportBundle): string {
  *  pasting into a GitHub issue. */
 export function exportBundleToMarkdown(bundle: DiagnosticsExportBundle): string {
   const json = exportBundleToJson(bundle);
-  return `### Crystal Ball diagnostics bundle\n\nGenerated: ${new Date(bundle.generatedAt).toISOString()}  \nApp: ${bundle.app.variant} v${bundle.app.version} (${bundle.app.runtime})\n\n\`\`\`json\n${json}\n\`\`\`\n`;
+  const sections: string[] = [
+    `### Crystal Ball diagnostics bundle`,
+    ``,
+    `Generated: ${new Date(bundle.generatedAt).toISOString()}  `,
+    `App: ${bundle.app.variant} v${bundle.app.version} (${bundle.app.runtime})`,
+  ];
+
+  if (bundle.panelHealthSummary) {
+    const p = bundle.panelHealthSummary;
+    sections.push(
+      ``,
+      `#### Panel health`,
+      ``,
+      `${p.total} total · ${p.rendered} rendered · ${p.degraded} degraded · ${p.errored} errored`,
+    );
+  }
+
+  if (bundle.situations && bundle.situations.length > 0) {
+    sections.push(``, `#### Active situations`, ``);
+    for (const s of bundle.situations) {
+      sections.push(
+        `- **${s.name}** (\`${s.id}\`) — ${s.severity} · ${s.domain} · confidence ${s.confidence.toFixed(2)}`,
+      );
+    }
+  }
+
+  if (bundle.correlations && bundle.correlations.length > 0) {
+    sections.push(``, `#### Correlation chains`, ``);
+    for (const c of bundle.correlations) {
+      sections.push(
+        `- \`${c.chainType}\` — ${c.title} (confidence ${c.confidence.toFixed(2)}, ${c.eventIds.length} events)`,
+      );
+    }
+  }
+
+  if (bundle.algorithmTrace && bundle.algorithmTrace.length > 0) {
+    sections.push(``, `#### Algorithm trace`, ``);
+    for (const t of bundle.algorithmTrace) {
+      sections.push(
+        `- \`${t.algorithmId}\` → situation \`${t.situationId}\` (confidence ${t.confidence.toFixed(2)}, ${t.evidenceChain.length} evidence)`,
+      );
+    }
+  }
+
+  sections.push(``, `\`\`\`json`, json, `\`\`\``, ``);
+  return sections.join('\n');
 }
 
 // ── Resolution helpers ─────────────────────────────────────────────────

--- a/src/services/diagnostics/frontend-export-composer.ts
+++ b/src/services/diagnostics/frontend-export-composer.ts
@@ -20,17 +20,24 @@ import {
   buildExportBundle,
   exportBundleToMarkdown,
   type AlgorithmCalibrationSummary,
+  type AlgorithmTraceEntry,
+  type CorrelationSummary,
   type DiagnosticsExportBundle,
   type ExportBundleAppMeta,
   type ExportBundleEnvHints,
   type FeedHealthEntry,
+  type PanelHealthSummary,
+  type SituationSummary,
   type SystemInfo,
 } from './export-bundle';
 import { getLiveDiagnosticsSnapshot } from './live-diagnostics-snapshot';
 import {
   getFeatureHealthRegistry,
   getNotificationTraceRegistry,
+  getPanelHealthRegistry,
 } from './diagnostics-state';
+import { getAll as getAllSituations } from '@/services/intelligence/situation-store';
+import { getActiveChains } from '@/services/intelligence/correlator-v2';
 import { summarizeScenarioCoverage } from '@/services/scenarios/scenario-library';
 import { getActiveQualityDebt } from '@/services/quality/quality-debt-state';
 import { getMissionStateDetail } from './mission-state-service';
@@ -133,6 +140,75 @@ export function composeFrontendDiagnosticsExport(
     };
   });
 
+  const panelHealthSummary = safe((): PanelHealthSummary => {
+    const all = getPanelHealthRegistry().all();
+    let rendered = 0;
+    let degraded = 0;
+    let errored = 0;
+    for (const p of all) {
+      if (p.status === 'healthy') rendered++;
+      else if (p.status === 'degraded' || p.status === 'stale') degraded++;
+      else if (p.status === 'failing' || p.status === 'blind' || p.status === 'unsafe') errored++;
+    }
+    return {
+      total: all.length,
+      rendered,
+      degraded,
+      errored,
+      entries: all.map((p) => ({
+        panelId: p.panelId,
+        label: p.label,
+        status: p.status,
+        lastRenderAt: p.lastRenderAt,
+        lastErrorAt: p.lastErrorAt,
+        reason: p.lastError,
+      })),
+    };
+  });
+
+  const situations = safe((): SituationSummary[] =>
+    getAllSituations()
+      .filter((s) => s.status !== 'resolved')
+      .map((s) => ({
+        id: s.id,
+        name: s.name,
+        status: s.status,
+        severity: s.severity,
+        domain: s.domain,
+        startedAt: s.startedAt,
+        updatedAt: s.updatedAt,
+        observationIds: s.observationIds,
+        correlationIds: s.correlationIds,
+        confidence: s.confidence,
+        tags: s.tags,
+        summary: s.summary,
+      })),
+  );
+
+  const correlations = safe((): CorrelationSummary[] =>
+    getActiveChains().map((c) => ({
+      id: c.id,
+      chainType: c.chainType,
+      title: c.title,
+      confidence: c.confidence,
+      detectedAt: c.detectedAt,
+      eventIds: c.events.map((e) => e.id),
+    })),
+  );
+
+  const algorithmTrace = safe((): AlgorithmTraceEntry[] => {
+    if (!situations) return [];
+    return situations.map((s) => ({
+      situationId: s.id,
+      algorithmId: 'situation-clustering',
+      confidence: s.confidence,
+      evidenceChain: [
+        ...s.observationIds.map((id) => ({ kind: 'observation' as const, id })),
+        ...s.correlationIds.map((id) => ({ kind: 'correlation' as const, id })),
+      ],
+    }));
+  });
+
   const bundle = buildExportBundle({
     now,
     app: input.app,
@@ -148,6 +224,10 @@ export function composeFrontendDiagnosticsExport(
     feedHealth,
     algorithmState,
     systemInfo,
+    panelHealthSummary,
+    situations,
+    correlations,
+    algorithmTrace,
   });
 
   let markdown = exportBundleToMarkdown(bundle);


### PR DESCRIPTION
## Phase 2 — Diagnostic Export Enhancement

Adds four new optional sections to the schema-v2 diagnostic bundle so the \"paste this into a GitHub issue\" output can answer the questions a triager actually has.

| Section | Source | Answers |
| --- | --- | --- |
| `panelHealthSummary` | `getPanelHealthRegistry().all()` | which panels actually rendered? |
| `situations` | `situation-store.getAll()` | what's the app worried about right now? |
| `correlations` | `correlator-v2.getActiveChains()` | is the cross-domain engine actually finding links? |
| `algorithmTrace` | derived join over situations | which algorithm produced this and on what evidence? |

Mission state, feed health, algorithm calibration, self-test results, and notification history are already in the bundle from earlier work — this PR closes the remaining Phase 2 gaps.

## Design

- All four new fields are **optional** on `BuildExportBundleInput` and `DiagnosticsExportBundle` — buildExportBundle's contract is additive, no breakage for existing callers.
- New strings (reason / title / summary / evidenceChain.summary) run through the existing `redactString` pipeline so the bundle's PII / secret-leak guarantees hold.
- Each section has its own paste-friendly cap (50 situations, 50 correlations, 100 algorithm-trace entries, 100 panel-health entries) that emits a `truncations` note when exceeded.
- The frontend composer (`frontend-export-composer.ts`) wraps each new source in `safe(...)` so a thrown registry doesn't kill the whole export.

## UI

- `SystemDiagnosticPanel` button relabelled from \"Export JSON\" to \"Export Full Bundle\" with a tooltip enumerating the now-included sections.

## Tests

18 new unit tests in [src/services/diagnostics/__tests__/export-bundle-enhancements.test.mts](src/services/diagnostics/__tests__/export-bundle-enhancements.test.mts) cover:

- Section presence with all fields preserved (panel-health, situations, correlations, algorithm-trace)
- Section absence when input is undefined
- PII redaction inside `reason` / `summary` / `evidenceChain.summary` (email + `password=` substrings)
- JSON round-trip
- Markdown rendering — section headings appear when data present, disappear when absent
- Per-section truncation caps emit notes

Existing diagnostics tests (18 in export-bundle, 7 in frontend-export-composer) all still pass → 43/43 in the combined run.

## Verification

- `npm run typecheck:all` — clean
- `npx eslint <changed files>` — clean
- `npx tsx --test src/services/diagnostics/__tests__/export-bundle*.test.mts frontend-export-composer.test.mts` — 43/43

## Cross-agent review

Cross-agent review: claude reviewed on 2026-05-13; outcome: pass