### PR TITLE
chore(release): version bump → v2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to Crystal Ball are documented here.
 
 ## [Unreleased]
 
+## [2.17.0] - 2026-05-13
+
+### Added
+
+- **Intelligence Timeline** (PR #448): chronological intelligence ledger panel rendering the deduped event stream.
+- **Operator Mode** (PR #449): dense layout variant with watch regions, mute controls, and shift handoff export.
+- **Scenario Replay** (PR #450): replay engine + five built-in disaster fixtures so the harness can prove regressions deterministically.
+- **Evidence Graph UX** (PR #451): confirming/contradicting sources surfaced separately with a per-claim confidence breakdown.
+- **Personal Relevance Layer** (PR #452): watchlist, interests, and travel-window scoring fused into a single "should I care?" filter.
+- **Alert Trace pipeline tracer** (PR #454): "why did/didn't I get warned?" 7-stage explainer for any alert id.
+- **SMS Command Interface** (PR #459): inbound `CB STATUS`, `BRIEF`, `WATCH`, `ALERT`, `SITREP` over an SMS/iMessage gateway, with tier-aware allowlist + rate limit + audit log.
+- **Self-Test Runner + mission state** (PR #460): one-button domain smoke test panel; `getMissionState(report)` maps a report to `nominal` / `reduced` / `degraded` / `critical` with top-priority life-safety override.
+- **Shortage Radar UI** (PR #461): sorted-by-risk view across the 8 commodity forecast models with per-card drivers and data gaps.
+- **Command Center polish** (PR #462): top-of-app surface tightened — top 3 things that matter, recommended actions, what-to-watch-next.
+- **Diagnostic Export enhancement** (PR #464): export bundle now ships per-domain mission state and the self-test report.
+- **⌘K Command Palette** (PR #465): keyboard-driven panel + action launcher across the full inventory.
+
+### Changed
+
+- **Release blockers cleared** (PR #455): GDACS render crash boundary fixed, sidecar route audit caught up, panel counts synced, ESLint scope, API key catalog reconciled at 68 keys.
+- **Notification all-producers tests** (PR #463): producer registry now has end-to-end coverage across all rungs.
+
 ## [2.16.0] - 2026-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Crystal Ball
 
-Real-time global intelligence platform. Desktop app and web dashboard that aggregates 50+ live data feeds into 238 interactive panels, a 3D Cesium globe with 70 geospatial layers, an explainable algorithm intelligence layer (truth scoring + evidence graph + situation clustering + compound risk + forecast calibration + watchlist relevance), domain-aware shortage / weather / insight engines, AI-powered analysis, and an MCP server that lets Claude Code query it all from the terminal.
+Real-time global intelligence platform. Desktop app and web dashboard that aggregates 50+ live data feeds into 240 interactive panels, a 3D Cesium globe with 70 geospatial layers, an explainable algorithm intelligence layer (truth scoring + evidence graph + situation clustering + compound risk + forecast calibration + watchlist relevance), domain-aware shortage / weather / insight engines, AI-powered analysis, and an MCP server that lets Claude Code query it all from the terminal.
 
 [![Version](https://img.shields.io/github/v/release/bradleybond512/crystal-ball?label=version)](https://github.com/bradleybond512/crystal-ball/releases/latest)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
@@ -15,13 +15,13 @@ Real-time global intelligence platform. Desktop app and web dashboard that aggre
 
 ## What It Does
 
-Crystal Ball pulls data from ACLED, GDACS, NWS, USGS, CISA, ThreatFox, FRED, ADS-B, AIS, CelesTrak, and dozens of other sources, then presents it across a 2D MapLibre map, a 3D Cesium globe, 238 live panels, a unified alert inbox, and a correlation engine that connects events across domains. You can ask Claude Code `/sitrep` and get a synthesized intelligence brief from all active feeds without opening the app.
+Crystal Ball pulls data from ACLED, GDACS, NWS, USGS, CISA, ThreatFox, FRED, ADS-B, AIS, CelesTrak, and dozens of other sources, then presents it across a 2D MapLibre map, a 3D Cesium globe, 240 live panels, a unified alert inbox, and a correlation engine that connects events across domains. You can ask Claude Code `/sitrep` and get a synthesized intelligence brief from all active feeds without opening the app.
 
 Four product variants share one codebase:
 
 | Variant | Panels | Focus |
 |---------|--------|-------|
-| `full` | 238 | Geopolitics, conflict, cyber, infrastructure, disasters, markets |
+| `full` | 240 | Geopolitics, conflict, cyber, infrastructure, disasters, markets |
 | `tech` | 35 | AI, startups, cloud, service health, developer ecosystems |
 | `finance` | 31 | Markets, forex, bonds, commodities, crypto, central banks |
 | `happy` | 10 | Positive news, progress, science, conservation |
@@ -336,8 +336,8 @@ All sounds are synthesized with Web Audio API -- no audio files in the repo:
 
 | Metric | Value | Source |
 |--------|-------|--------|
-| Panels (full variant) | 238 | `src/config/panels.ts` |
-| Default panel inventory | `238 full / 35 tech / 31 finance / 10 happy` | `src/config/panels.ts` |
+| Panels (full variant) | 240 | `src/config/panels.ts` |
+| Default panel inventory | `240 full / 35 tech / 31 finance / 10 happy` | `src/config/panels.ts` |
 | God's Vision map layers | 70 (26 on by default) | `src/types/index.ts` MapLayers |
 | Panel categories | 19 | `src/config/panels.ts` PANEL_CATEGORY_MAP |
 | Product variants | 4 | `src/config/variant.ts` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crystal-ball",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crystal-ball",
-      "version": "2.16.0",
+      "version": "2.17.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crystal-ball",
   "private": true,
-  "version": "2.16.0",
+  "version": "2.17.0",
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "crystalball"
-version = "2.16.0"
+version = "2.17.0"
 dependencies = [
  "getrandom 0.4.2",
  "keyring",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crystalball"
-version = "2.16.0"
+version = "2.17.0"
 description = "Crystal Ball cross-platform desktop application "
 authors = ["Bradley Bond", ""]
 edition = "2021"

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -9,7 +9,7 @@
 <dict>
   <!-- Shown as the labeled version string in Finder Get Info and Spotlight -->
   <key>CFBundleGetInfoString</key>
-  <string>Crystal Ball 2.16.0</string>
+  <string>Crystal Ball 2.17.0</string>
 
   <!-- Shown in the "More Info" section of Finder Get Info -->
   <key>NSHumanReadableCopyright</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Crystal Ball",
   "mainBinaryName": "crystalball",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "identifier": "com.bradleybond.crystalball",
   "build": {
     "beforeDevCommand": "npm run build:sidecar-sebuf && npm run dev",


### PR DESCRIPTION
Bumps Crystal Ball to **v2.17.0**.

### Version sync
- `package.json` → 2.17.0
- `package-lock.json` (both root + workspace) → 2.17.0
- `src-tauri/tauri.conf.json` → 2.17.0
- `src-tauri/Cargo.toml` → 2.17.0
- `src-tauri/Cargo.lock` → 2.17.0
- `src-tauri/Info.plist` `CFBundleGetInfoString` → `Crystal Ball 2.17.0`

`npm run version:check` passes; all six version surfaces report 2.17.0.

### CHANGELOG
Adds a `## [2.17.0] - 2026-05-13` section summarizing the 14 PRs merged since 2.16.0 (Intelligence Timeline, Operator Mode, Scenario Replay, Evidence Graph UX, Personal Relevance Layer, Alert Trace, Release blockers, SMS Command Interface, Self-Test Runner, Shortage Radar UI, Command Center polish, Notification tests, Diagnostic Export, Command Palette).

### README
Panel count synced 238 → 240 (full variant; tech/finance/happy unchanged) so `tests/panel-visibility-regression` passes.

### Validation
- `npm run version:check` ✓
- `npm run lockfile:check` ✓
- `npm run test:data` ✓ (703/703 pass)

Cross-agent review: claude reviewed on 2026-05-13; outcome: pass