### PR TITLE
feat(intelligence): observation adapters — normalize all feeds to ObservationEvent schema

### DIFF
--- a/src/services/intelligence/__tests__/observation-adapters.test.mts
+++ b/src/services/intelligence/__tests__/observation-adapters.test.mts
@@ -1,0 +1,352 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  AdapterRegistry,
+  createDefaultRegistry,
+  GenericAdapter,
+  type ObservationAdapter,
+  EarthquakeAdapter,
+  WeatherAdapter,
+  AviationAdapter,
+  MaritimeAdapter,
+  WildfireAdapter,
+  SpaceWeatherAdapter,
+  BiosurveillanceAdapter,
+  SanctionsAdapter,
+  InfrastructureAdapter,
+  GdacsAdapter,
+} from '../observation-adapters.ts';
+import type { ObservationEvent } from '@/types/intelligence';
+
+// ── AdapterRegistry semantics ────────────────────────────────────────────
+
+test('AdapterRegistry registers and retrieves adapters by domain', () => {
+  const reg = new AdapterRegistry();
+  const adapter: ObservationAdapter<{ x: number }> = {
+    sourceId: 'test',
+    domain: 'weather',
+    adaptOne: (raw) => ({
+      id: `t-${raw.x}`,
+      sourceId: 'test',
+      domain: 'weather',
+      timestamp: 0,
+      severity: 'INFO',
+      title: `x=${raw.x}`,
+      raw,
+      entityIds: [],
+      tags: [],
+    }),
+    adaptMany: (raws) => raws.map((r) => adapter.adaptOne(r)),
+  };
+  reg.register(adapter);
+  const result = reg.adapt('test', { x: 1 });
+  assert.equal(result?.id, 't-1');
+});
+
+test('AdapterRegistry.adaptAll dispatches an array through its sourceId adapter', () => {
+  const reg = createDefaultRegistry();
+  const fakeQuakes = [
+    { id: 'q1', occurredAt: 1000, magnitude: 6.2, place: 'Tokyo', depthKm: 30,
+      location: { latitude: 35.68, longitude: 139.69 } },
+  ];
+  const out = reg.adaptAll('usgs-earthquake', fakeQuakes);
+  assert.equal(out.length, 1);
+  assert.equal(out[0]?.domain, 'weather');
+  assert.equal(out[0]?.severity, 'HIGH');
+});
+
+test('AdapterRegistry.adapt returns undefined for an unknown sourceId', () => {
+  const reg = new AdapterRegistry();
+  assert.equal(reg.adapt('nope', {}), undefined);
+});
+
+test('createDefaultRegistry has all 10 built-in adapters wired', () => {
+  const reg = createDefaultRegistry();
+  for (const id of [
+    'usgs-earthquake',
+    'nws-alerts',
+    'aviation-track',
+    'ais-disruption',
+    'inciweb-wildfire',
+    'swpc-space-weather',
+    'cdc-biosurveillance',
+    'ofac-sanctions',
+    'cisa-infrastructure',
+    'gdacs-alerts',
+  ]) {
+    assert.ok(reg.has(id), `expected ${id} adapter registered`);
+  }
+});
+
+// ── EarthquakeAdapter ────────────────────────────────────────────────────
+
+test('EarthquakeAdapter produces a CRITICAL ObservationEvent for M7+ quake', () => {
+  const obs = EarthquakeAdapter.adaptOne({
+    id: 'eq-1', occurredAt: 1000, magnitude: 7.3, place: 'Tokyo',
+    depthKm: 20, location: { latitude: 35.68, longitude: 139.69 },
+  });
+  assert.equal(obs.severity, 'CRITICAL');
+  assert.equal(obs.domain, 'weather');
+  assert.equal(obs.location?.lat, 35.68);
+  assert.ok(obs.tags.includes('earthquake'));
+  assert.ok(obs.tags.includes('major-earthquake'));
+});
+
+test('EarthquakeAdapter falls back to INFO severity for M<4 quakes', () => {
+  const obs = EarthquakeAdapter.adaptOne({
+    id: 'eq-2', occurredAt: 1000, magnitude: 3.5, place: 'Suburb',
+    depthKm: 10, location: { latitude: 0, longitude: 0 },
+  });
+  assert.equal(obs.severity, 'INFO');
+});
+
+// ── WeatherAdapter ────────────────────────────────────────────────────
+
+test('WeatherAdapter maps NWS Severe severity to HIGH/CRITICAL', () => {
+  const obs = WeatherAdapter.adaptOne({
+    id: 'nws-1',
+    event: 'Severe Thunderstorm Warning',
+    severity: 'Severe',
+    onset: 1000,
+    expires: 4000,
+    area: 'La Porte, IN',
+    geometry: { coordinates: [-86.7, 41.6] },
+  });
+  assert.equal(obs.domain, 'weather');
+  assert.equal(obs.severity, 'HIGH');
+  assert.match(obs.title, /Severe Thunderstorm/);
+  assert.equal(obs.location?.lat, 41.6);
+});
+
+test('WeatherAdapter Extreme severity maps to CRITICAL', () => {
+  const obs = WeatherAdapter.adaptOne({
+    id: 'nws-2', event: 'Tornado Warning', severity: 'Extreme',
+    onset: 1000, expires: 2000, area: 'Boone County',
+  });
+  assert.equal(obs.severity, 'CRITICAL');
+  assert.ok(obs.tags.includes('tornado-warning'));
+});
+
+// ── AviationAdapter ────────────────────────────────────────────────────
+
+test('AviationAdapter handles OpenSky state-vector with squawk 7700 → CRITICAL', () => {
+  const obs = AviationAdapter.adaptOne({
+    icao24: 'abc123', callsign: 'UAL900',
+    latitude: 41.85, longitude: -87.65,
+    altitude: 11_000, squawk: '7700', timestamp: 1000,
+  });
+  assert.equal(obs.domain, 'aviation');
+  assert.equal(obs.severity, 'CRITICAL');
+  assert.ok(obs.tags.includes('emergency-squawk'));
+  assert.ok(obs.entityIds.includes('UAL900'));
+});
+
+test('AviationAdapter normal squawk = INFO', () => {
+  const obs = AviationAdapter.adaptOne({
+    icao24: 'def456', callsign: 'DAL10',
+    latitude: 0, longitude: 0,
+    altitude: 10_000, squawk: '1234', timestamp: 1000,
+  });
+  assert.equal(obs.severity, 'INFO');
+});
+
+// ── MaritimeAdapter ────────────────────────────────────────────────────
+
+test('MaritimeAdapter maps AIS vessel to maritime observation', () => {
+  const obs = MaritimeAdapter.adaptOne({
+    mmsi: '477123456', vesselName: 'Test Carrier',
+    lat: 25.0, lon: -80.0, speedKn: 12, destination: 'Miami',
+    timestamp: 1000,
+  });
+  assert.equal(obs.domain, 'maritime');
+  assert.equal(obs.entityIds[0], '477123456');
+  assert.match(obs.title, /Test Carrier/);
+});
+
+test('MaritimeAdapter vessel with 0kn speed gets adrift tag', () => {
+  const obs = MaritimeAdapter.adaptOne({
+    mmsi: '477', vesselName: 'X', lat: 0, lon: 0, speedKn: 0,
+    destination: '', timestamp: 1000,
+  });
+  assert.ok(obs.tags.includes('vessel-stopped'));
+});
+
+// ── WildfireAdapter ────────────────────────────────────────────────────
+
+test('WildfireAdapter exposes the existing wildfire-adapter behavior through the registry', () => {
+  const obs = WildfireAdapter.adaptOne({
+    id: 'wf-1', name: 'Test', state: 'CA',
+    severity: 'high', incidentType: 'Wildfire',
+    acresBurned: 1000, percentContained: 20,
+    discoveryDate: new Date(1000),
+    updatedAt: new Date(1000),
+    lat: 40, lon: -120,
+    evacuationOrders: 1, evacuationWarnings: 0,
+  });
+  assert.ok(obs);
+  assert.equal(obs!.domain, 'weather');
+  assert.equal(obs!.severity, 'HIGH');
+});
+
+// ── SpaceWeatherAdapter ────────────────────────────────────────────────
+
+test('SpaceWeatherAdapter maps G5 geomagnetic storm to CRITICAL', () => {
+  const obs = SpaceWeatherAdapter.adaptOne({
+    id: 'sw-1', eventType: 'geomagnetic-storm',
+    scale: 'G5', onset: 1000, regions: ['polar'],
+  });
+  assert.equal(obs.domain, 'space');
+  assert.equal(obs.severity, 'CRITICAL');
+  assert.ok(obs.tags.includes('geomagnetic-storm'));
+});
+
+test('SpaceWeatherAdapter low-scale event = LOW', () => {
+  const obs = SpaceWeatherAdapter.adaptOne({
+    id: 'sw-2', eventType: 'solar-radiation-storm',
+    scale: 'S1', onset: 1000, regions: [],
+  });
+  assert.equal(obs.severity, 'LOW');
+});
+
+// ── BiosurveillanceAdapter ────────────────────────────────────────────
+
+test('BiosurveillanceAdapter scales severity by case count', () => {
+  const big = BiosurveillanceAdapter.adaptOne({
+    id: 'bio-1', disease: 'Avian Influenza H5N1',
+    location: 'Vietnam', caseCount: 1500, timestamp: 1000,
+  });
+  assert.equal(big.severity, 'CRITICAL');
+  const small = BiosurveillanceAdapter.adaptOne({
+    id: 'bio-2', disease: 'Norovirus',
+    location: 'Cruise ship', caseCount: 5, timestamp: 1000,
+  });
+  assert.equal(small.severity, 'LOW');
+});
+
+test('BiosurveillanceAdapter sets domain to humanitarian', () => {
+  const obs = BiosurveillanceAdapter.adaptOne({
+    id: 'bio-3', disease: 'X', location: 'Y', caseCount: 100, timestamp: 1000,
+  });
+  assert.equal(obs.domain, 'humanitarian');
+});
+
+// ── SanctionsAdapter ───────────────────────────────────────────────────
+
+test('SanctionsAdapter normalizes OFAC entry', () => {
+  const obs = SanctionsAdapter.adaptOne({
+    sdnId: 'SDN-12345', entityType: 'Individual',
+    name: 'John Doe', reason: 'Iran-related', timestamp: 1000,
+  });
+  assert.equal(obs.domain, 'macro');
+  assert.equal(obs.severity, 'MEDIUM');
+  assert.equal(obs.entityIds[0], 'SDN-12345');
+});
+
+// ── InfrastructureAdapter ───────────────────────────────────────────────
+
+test('InfrastructureAdapter maps CISA advisory to infra observation', () => {
+  const obs = InfrastructureAdapter.adaptOne({
+    id: 'cisa-1', affectedSystem: 'Industrial Control System',
+    impactType: 'remote-code-execution', severity: 'critical', timestamp: 1000,
+  });
+  assert.equal(obs.domain, 'infra');
+  assert.equal(obs.severity, 'CRITICAL');
+});
+
+// ── GdacsAdapter ───────────────────────────────────────────────────────
+
+test('GdacsAdapter maps Red alert level to CRITICAL', () => {
+  const obs = GdacsAdapter.adaptOne({
+    id: 'gdacs-1', eventType: 'TC', alertLevel: 'Red',
+    country: 'PH', lat: 14.6, lon: 120.98, onset: 1000,
+  });
+  assert.equal(obs.severity, 'CRITICAL');
+  assert.equal(obs.entityIds[0], 'PH');
+  assert.ok(obs.tags.includes('tropical-cyclone'));
+});
+
+test('GdacsAdapter maps Green alert level to LOW', () => {
+  const obs = GdacsAdapter.adaptOne({
+    id: 'gdacs-2', eventType: 'EQ', alertLevel: 'Green',
+    country: 'CL', lat: -33, lon: -70, onset: 1000,
+  });
+  assert.equal(obs.severity, 'LOW');
+});
+
+// ── GenericAdapter ─────────────────────────────────────────────────────
+
+test('GenericAdapter maps any object with title + lat/lon + severity', () => {
+  const adapter = new GenericAdapter({
+    sourceId: 'custom-feed',
+    domain: 'cyber',
+  });
+  const obs = adapter.adaptOne({
+    id: 'x-1', title: 'Custom event', lat: 41, lon: -86,
+    severity: 'HIGH', timestamp: 1000,
+  });
+  assert.equal(obs.domain, 'cyber');
+  assert.equal(obs.sourceId, 'custom-feed');
+  assert.equal(obs.title, 'Custom event');
+  assert.equal(obs.severity, 'HIGH');
+});
+
+test('GenericAdapter defaults severity to INFO when missing', () => {
+  const adapter = new GenericAdapter({ sourceId: 'x', domain: 'other' });
+  const obs = adapter.adaptOne({ id: 'x', title: 't', timestamp: 1000 });
+  assert.equal(obs.severity, 'INFO');
+});
+
+// ── ingestRaw wiring ───────────────────────────────────────────────────
+
+test('observation-store.ingestRaw adapts and stores raw provider payloads', async () => {
+  const { ingestRaw, getRecent, _clearStoreForTests } = await import('../observation-store.ts');
+  _clearStoreForTests();
+  const adapted = ingestRaw('usgs-earthquake', [{
+    id: 'eq-store-1', occurredAt: 1234, magnitude: 6.0, place: 'Test',
+    depthKm: 10, location: { latitude: 0, longitude: 0 },
+  }]);
+  assert.equal(adapted.length, 1);
+  const stored = getRecent(5);
+  assert.ok(stored.some((e) => e.id === 'usgs-eq-eq-store-1'));
+  _clearStoreForTests();
+});
+
+test('observation-store.ingestRaw silently drops unknown sourceIds', async () => {
+  const { ingestRaw, _clearStoreForTests, storeSize } = await import('../observation-store.ts');
+  _clearStoreForTests();
+  const adapted = ingestRaw('unknown-source', [{ x: 1 }]);
+  assert.deepEqual(adapted, []);
+  assert.equal(storeSize(), 0);
+});
+
+// ── Output invariants ──────────────────────────────────────────────────
+
+test('every built-in adapter produces a JSON-serializable ObservationEvent', () => {
+  const samples: { id: string; raw: unknown; adapter: ObservationAdapter<never> }[] = [
+    { id: 'usgs-earthquake', adapter: EarthquakeAdapter as ObservationAdapter<never>,
+      raw: { id: 'q', occurredAt: 1, magnitude: 5, place: 'p', depthKm: 1,
+        location: { latitude: 0, longitude: 0 } } },
+    { id: 'nws-alerts', adapter: WeatherAdapter as ObservationAdapter<never>,
+      raw: { id: 'n', event: 'Test', severity: 'Moderate', onset: 0, expires: 0, area: 'a' } },
+    { id: 'aviation-track', adapter: AviationAdapter as ObservationAdapter<never>,
+      raw: { icao24: 'x', callsign: 'y', latitude: 0, longitude: 0, altitude: 0, squawk: '1234', timestamp: 0 } },
+    { id: 'ais-disruption', adapter: MaritimeAdapter as ObservationAdapter<never>,
+      raw: { mmsi: '1', vesselName: 'v', lat: 0, lon: 0, speedKn: 1, destination: '', timestamp: 0 } },
+    { id: 'inciweb-wildfire', adapter: WildfireAdapter as ObservationAdapter<never>,
+      raw: { id: 'w', name: 'x', state: 's', severity: 'low', incidentType: 'Wildfire',
+        acresBurned: 1, percentContained: 1, discoveryDate: new Date(0), updatedAt: new Date(0),
+        lat: 0, lon: 0, evacuationOrders: 0, evacuationWarnings: 0 } },
+  ];
+  for (const s of samples) {
+    const obs = s.adapter.adaptOne(s.raw as never);
+    if (!obs) continue;
+    // JSON round-trip must succeed
+    const json = JSON.stringify({ ...obs, raw: '<redacted>' });
+    const parsed = JSON.parse(json) as ObservationEvent;
+    assert.equal(typeof parsed.id, 'string');
+    assert.equal(typeof parsed.title, 'string');
+    assert.ok(Array.isArray(parsed.tags));
+    assert.ok(Array.isArray(parsed.entityIds));
+  }
+});

--- a/src/services/intelligence/__tests__/observation-normalizer.test.mts
+++ b/src/services/intelligence/__tests__/observation-normalizer.test.mts
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  normalize,
+  computeContinent,
+  computeCountryCode,
+  type NormalizedObservation,
+} from '../observation-normalizer.ts';
+import type { ObservationEvent } from '@/types/intelligence';
+import type { SavedPlace } from '@/services/saved-places';
+
+const NOW = 1_745_000_000_000;
+
+function makeObs(overrides: Partial<ObservationEvent> = {}): ObservationEvent {
+  return {
+    id: 'ev-1',
+    sourceId: 'test',
+    domain: 'weather',
+    timestamp: NOW - 60_000,
+    severity: 'MEDIUM',
+    title: 'Test',
+    raw: null,
+    entityIds: [],
+    tags: [],
+    ...overrides,
+  };
+}
+
+function makePlace(name: string, lat: number, lon: number): SavedPlace {
+  return {
+    id: `p-${name}`, name, lat, lon, radiusKm: 100, tags: [], priority: 1,
+    notes: '', offlinePinned: false, primary: false, source: 'manual' as SavedPlace['source'],
+    sortIndex: 0, createdAt: 0, updatedAt: 0,
+  };
+}
+
+// ── continent classification ─────────────────────────────────────────────
+
+test('computeContinent: La Porte (US Midwest) → North America', () => {
+  assert.equal(computeContinent(41.6, -86.7), 'NA');
+});
+
+test('computeContinent: Tokyo → Asia', () => {
+  assert.equal(computeContinent(35.68, 139.69), 'AS');
+});
+
+test('computeContinent: Paris → Europe', () => {
+  assert.equal(computeContinent(48.85, 2.35), 'EU');
+});
+
+test('computeContinent: Sydney → Oceania', () => {
+  assert.equal(computeContinent(-33.87, 151.21), 'OC');
+});
+
+test('computeContinent: São Paulo → South America', () => {
+  assert.equal(computeContinent(-23.55, -46.63), 'SA');
+});
+
+test('computeContinent: Cape Town → Africa', () => {
+  assert.equal(computeContinent(-33.92, 18.42), 'AF');
+});
+
+test('computeContinent: South Pole → Antarctica', () => {
+  assert.equal(computeContinent(-85, 0), 'AN');
+});
+
+// ── country code (light heuristic) ─────────────────────────────────────
+
+test('computeCountryCode: continental US bounds → US', () => {
+  assert.equal(computeCountryCode(41.6, -86.7), 'US');
+});
+
+test('computeCountryCode: out-of-bounds returns undefined', () => {
+  assert.equal(computeCountryCode(0, 0), undefined); // open ocean
+});
+
+// ── normalize() main path ──────────────────────────────────────────────
+
+test('normalize: fills continent + countryCode when missing', () => {
+  const obs = makeObs({ location: { lat: 41.6, lon: -86.7 } });
+  const out = normalize(obs);
+  assert.equal(out.continent, 'NA');
+  assert.equal(out.countryCode, 'US');
+});
+
+test('normalize: preserves provided countryCode (no overwrite)', () => {
+  const obs = makeObs({ location: { lat: 41.6, lon: -86.7 } });
+  const out = normalize(obs, { countryCode: 'CA' });
+  assert.equal(out.countryCode, 'CA');
+});
+
+test('normalize: continent and country undefined when no location', () => {
+  const obs = makeObs({});
+  const out = normalize(obs);
+  assert.equal(out.continent, undefined);
+  assert.equal(out.countryCode, undefined);
+});
+
+// ── proximity to saved places ──────────────────────────────────────────
+
+test('normalize: proximityToSavedPlaces computes one distance per place', () => {
+  const obs = makeObs({ location: { lat: 41.6, lon: -86.7 } });
+  const out = normalize(obs, {
+    savedPlaces: [
+      makePlace('home', 41.6, -86.7),
+      makePlace('work', 41.85, -87.65),
+    ],
+  });
+  assert.equal(out.proximityToSavedPlaces?.length, 2);
+  assert.equal(out.proximityToSavedPlaces?.[0]?.placeName, 'home');
+  assert.ok((out.proximityToSavedPlaces?.[0]?.distanceKm ?? 9999) < 1);
+  assert.ok((out.proximityToSavedPlaces?.[1]?.distanceKm ?? 0) > 50);
+});
+
+test('normalize: proximityToSavedPlaces sorted by distance ascending', () => {
+  const obs = makeObs({ location: { lat: 41.6, lon: -86.7 } });
+  const out = normalize(obs, {
+    savedPlaces: [
+      makePlace('chicago', 41.85, -87.65),
+      makePlace('home', 41.6, -86.7),
+    ],
+  });
+  assert.equal(out.proximityToSavedPlaces?.[0]?.placeName, 'home');
+  assert.equal(out.proximityToSavedPlaces?.[1]?.placeName, 'chicago');
+});
+
+test('normalize: proximityToSavedPlaces omitted when no places supplied', () => {
+  const obs = makeObs({ location: { lat: 0, lon: 0 } });
+  const out = normalize(obs);
+  assert.equal(out.proximityToSavedPlaces, undefined);
+});
+
+test('normalize: proximityToSavedPlaces empty array → undefined', () => {
+  const obs = makeObs({ location: { lat: 0, lon: 0 } });
+  const out = normalize(obs, { savedPlaces: [] });
+  assert.equal(out.proximityToSavedPlaces, undefined);
+});
+
+// ── relevance score ────────────────────────────────────────────────────
+
+test('normalize: relevanceScore is between 0 and 100', () => {
+  const obs = makeObs({ severity: 'CRITICAL', location: { lat: 41.6, lon: -86.7 } });
+  const out = normalize(obs, { savedPlaces: [makePlace('home', 41.6, -86.7)], nowMs: NOW });
+  assert.ok(out.relevanceScore !== undefined);
+  assert.ok((out.relevanceScore ?? 0) >= 0 && (out.relevanceScore ?? 0) <= 100);
+});
+
+test('normalize: CRITICAL severity + near home → higher relevance than INFO far away', () => {
+  const close = normalize(makeObs({
+    severity: 'CRITICAL', timestamp: NOW, location: { lat: 41.6, lon: -86.7 },
+  }), { savedPlaces: [makePlace('home', 41.6, -86.7)], nowMs: NOW });
+  const far = normalize(makeObs({
+    severity: 'INFO', timestamp: NOW - 86_400_000, location: { lat: 25.8, lon: -80.2 },
+  }), { savedPlaces: [makePlace('home', 41.6, -86.7)], nowMs: NOW });
+  assert.ok((close.relevanceScore ?? 0) > (far.relevanceScore ?? 0));
+});
+
+// ── NormalizedObservation shape stability ──────────────────────────────
+
+test('NormalizedObservation extends ObservationEvent without breaking the base shape', () => {
+  const obs = makeObs();
+  const out: NormalizedObservation = normalize(obs);
+  // Every base field is preserved
+  assert.equal(out.id, obs.id);
+  assert.equal(out.title, obs.title);
+  assert.equal(out.domain, obs.domain);
+  assert.equal(out.severity, obs.severity);
+});

--- a/src/services/intelligence/observation-adapters.ts
+++ b/src/services/intelligence/observation-adapters.ts
@@ -1,0 +1,471 @@
+/**
+ * Observation Adapter registry — Phase 3 of the intelligence loop.
+ *
+ * Every feed in the app eventually produces ObservationEvents. Historically
+ * each provider had a hand-written `<thing>ToObservation()` function and
+ * callers wired them up by hand. This module gives those adapters a
+ * uniform shape, registers them by `sourceId`, and ships a fallback
+ * `GenericAdapter` for sources that don't yet have one.
+ *
+ * Pure deterministic. No DOM, no fetch, no I/O. Inputs are plain objects.
+ */
+
+import type { ObservationEvent, ObservationSeverity } from '@/types/intelligence';
+import {
+  earthquakeToObservation,
+  earthquakesToObservations,
+} from './adapters/earthquake-adapter';
+import {
+  wildfireToObservation,
+  wildifiresToObservations,
+} from './adapters/wildfire-adapter';
+
+// ── Adapter interface ─────────────────────────────────────────────────────
+
+export interface ObservationAdapter<TRaw> {
+  /** Stable id used to dispatch — matches ObservationEvent.sourceId. */
+  sourceId: string;
+  domain: string;
+  /** Returns undefined when the raw record can't be normalized
+   *  (e.g. wildfire with missing coordinates). */
+  adaptOne(raw: TRaw): ObservationEvent | undefined;
+  adaptMany(raws: readonly TRaw[]): ObservationEvent[];
+}
+
+export class AdapterRegistry {
+  private readonly bySourceId = new Map<string, ObservationAdapter<unknown>>();
+
+  register<T>(adapter: ObservationAdapter<T>): void {
+    this.bySourceId.set(adapter.sourceId, adapter as ObservationAdapter<unknown>);
+  }
+
+  has(sourceId: string): boolean {
+    return this.bySourceId.has(sourceId);
+  }
+
+  adapt(sourceId: string, raw: unknown): ObservationEvent | undefined {
+    return this.bySourceId.get(sourceId)?.adaptOne(raw);
+  }
+
+  adaptAll(sourceId: string, raws: readonly unknown[]): ObservationEvent[] {
+    const adapter = this.bySourceId.get(sourceId);
+    return adapter ? adapter.adaptMany(raws) : [];
+  }
+}
+
+// ── Built-in adapter: USGS earthquakes ────────────────────────────────────
+
+interface EarthquakeRaw {
+  id: string;
+  occurredAt: number;
+  magnitude: number;
+  place: string;
+  depthKm: number;
+  location?: { latitude: number; longitude: number };
+}
+
+export const EarthquakeAdapter: ObservationAdapter<EarthquakeRaw> = {
+  sourceId: 'usgs-earthquake',
+  domain: 'weather',
+  adaptOne: (raw) => earthquakeToObservation(raw as never),
+  adaptMany: (raws) => earthquakesToObservations(raws as never[]),
+};
+
+// ── Built-in adapter: NWS weather alerts ─────────────────────────────────
+
+interface NwsAlertRaw {
+  id: string;
+  event: string;
+  severity: 'Minor' | 'Moderate' | 'Severe' | 'Extreme' | 'Unknown';
+  onset: number;
+  expires: number;
+  area: string;
+  geometry?: { coordinates?: readonly [number, number] };
+}
+
+const NWS_SEVERITY: Record<NwsAlertRaw['severity'], ObservationSeverity> = {
+  Extreme: 'CRITICAL',
+  Severe: 'HIGH',
+  Moderate: 'MEDIUM',
+  Minor: 'LOW',
+  Unknown: 'INFO',
+};
+
+export const WeatherAdapter: ObservationAdapter<NwsAlertRaw> = {
+  sourceId: 'nws-alerts',
+  domain: 'weather',
+  adaptOne: (raw) => {
+    const coords = raw.geometry?.coordinates;
+    const location = coords ? { lat: coords[1], lon: coords[0] } : undefined;
+    const tags = ['weather-alert', raw.event.toLowerCase().replace(/\s+/g, '-')];
+    return {
+      id: `nws-${raw.id}`,
+      sourceId: 'nws-alerts',
+      domain: 'weather',
+      timestamp: raw.onset,
+      location,
+      severity: NWS_SEVERITY[raw.severity],
+      title: `${raw.event} — ${raw.area}`,
+      raw,
+      entityIds: [],
+      tags,
+    };
+  },
+  adaptMany(raws) {
+    return raws.map((r) => this.adaptOne(r)).filter((x): x is ObservationEvent => Boolean(x));
+  },
+};
+
+// ── Built-in adapter: aviation (OpenSky / FlightAware) ───────────────────
+
+interface AviationRaw {
+  icao24: string;
+  callsign?: string | null;
+  latitude: number;
+  longitude: number;
+  altitude: number;
+  /** Squawk code; 7500/7600/7700 are emergency. */
+  squawk?: string | null;
+  timestamp: number;
+}
+
+const EMERGENCY_SQUAWKS = new Set(['7500', '7600', '7700']);
+
+export const AviationAdapter: ObservationAdapter<AviationRaw> = {
+  sourceId: 'aviation-track',
+  domain: 'aviation',
+  adaptOne: (raw) => {
+    const emergency = raw.squawk ? EMERGENCY_SQUAWKS.has(raw.squawk) : false;
+    const tags = ['aviation'];
+    if (emergency) tags.push('emergency-squawk', `squawk-${raw.squawk}`);
+    return {
+      id: `aviation-${raw.icao24}-${raw.timestamp}`,
+      sourceId: 'aviation-track',
+      domain: 'aviation',
+      timestamp: raw.timestamp,
+      location: { lat: raw.latitude, lon: raw.longitude },
+      severity: emergency ? 'CRITICAL' : 'INFO',
+      title: emergency
+        ? `Emergency squawk ${raw.squawk} — ${raw.callsign ?? raw.icao24}`
+        : `Aviation track ${raw.callsign ?? raw.icao24}`,
+      raw,
+      entityIds: raw.callsign ? [raw.callsign, raw.icao24] : [raw.icao24],
+      tags,
+    };
+  },
+  adaptMany(raws) {
+    return raws.map((r) => this.adaptOne(r)).filter((x): x is ObservationEvent => Boolean(x));
+  },
+};
+
+// ── Built-in adapter: maritime AIS ────────────────────────────────────────
+
+interface MaritimeRaw {
+  mmsi: string;
+  vesselName: string;
+  lat: number;
+  lon: number;
+  speedKn: number;
+  destination: string;
+  timestamp: number;
+}
+
+export const MaritimeAdapter: ObservationAdapter<MaritimeRaw> = {
+  sourceId: 'ais-disruption',
+  domain: 'maritime',
+  adaptOne: (raw) => {
+    const stopped = raw.speedKn === 0;
+    const tags = ['ais', 'maritime'];
+    if (stopped) tags.push('vessel-stopped');
+    const destSuffix = raw.destination ? ` → ${raw.destination}` : '';
+    return {
+      id: `ais-${raw.mmsi}-${raw.timestamp}`,
+      sourceId: 'ais-disruption',
+      domain: 'maritime',
+      timestamp: raw.timestamp,
+      location: { lat: raw.lat, lon: raw.lon },
+      severity: stopped ? 'MEDIUM' : 'INFO',
+      title: `${raw.vesselName} (${raw.mmsi})${destSuffix}`,
+      raw,
+      entityIds: [raw.mmsi],
+      tags,
+    };
+  },
+  adaptMany(raws) {
+    return raws.map((r) => this.adaptOne(r)).filter((x): x is ObservationEvent => Boolean(x));
+  },
+};
+
+// ── Built-in adapter: wildfire (InciWeb) ──────────────────────────────────
+
+export const WildfireAdapter: ObservationAdapter<Parameters<typeof wildfireToObservation>[0]> = {
+  sourceId: 'inciweb-wildfire',
+  domain: 'weather',
+  adaptOne: (raw) => wildfireToObservation(raw) ?? undefined,
+  adaptMany: (raws) => wildifiresToObservations(raws as never[]),
+};
+
+// ── Built-in adapter: space weather (SWPC) ────────────────────────────────
+
+interface SpaceWeatherRaw {
+  id: string;
+  eventType: 'geomagnetic-storm' | 'solar-flare' | 'solar-radiation-storm' | 'radio-blackout';
+  /** G/S/R scale: G1..G5, S1..S5, R1..R5. */
+  scale: string;
+  onset: number;
+  regions: readonly string[];
+}
+
+function spaceWeatherSeverity(scale: string): ObservationSeverity {
+  const digit = Number(scale.replace(/^[A-Z]/, ''));
+  if (digit >= 5) return 'CRITICAL';
+  if (digit >= 4) return 'HIGH';
+  if (digit >= 3) return 'MEDIUM';
+  if (digit >= 1) return 'LOW';
+  return 'INFO';
+}
+
+export const SpaceWeatherAdapter: ObservationAdapter<SpaceWeatherRaw> = {
+  sourceId: 'swpc-space-weather',
+  domain: 'space',
+  adaptOne: (raw) => ({
+    id: `swpc-${raw.id}`,
+    sourceId: 'swpc-space-weather',
+    domain: 'space',
+    timestamp: raw.onset,
+    severity: spaceWeatherSeverity(raw.scale),
+    title: `${raw.eventType.replace(/-/g, ' ')} ${raw.scale}`,
+    raw,
+    entityIds: [...raw.regions],
+    tags: ['space-weather', raw.eventType, `scale-${raw.scale.toLowerCase()}`],
+  }),
+  adaptMany(raws) {
+    return raws.map((r) => this.adaptOne(r)).filter((x): x is ObservationEvent => Boolean(x));
+  },
+};
+
+// ── Built-in adapter: biosurveillance (CDC / WHO) ─────────────────────────
+
+interface BiosurveillanceRaw {
+  id: string;
+  disease: string;
+  location: string;
+  caseCount: number;
+  timestamp: number;
+  lat?: number;
+  lon?: number;
+}
+
+function biosurveillanceSeverity(cases: number): ObservationSeverity {
+  if (cases >= 1000) return 'CRITICAL';
+  if (cases >= 250) return 'HIGH';
+  if (cases >= 50) return 'MEDIUM';
+  return 'LOW';
+}
+
+export const BiosurveillanceAdapter: ObservationAdapter<BiosurveillanceRaw> = {
+  sourceId: 'cdc-biosurveillance',
+  domain: 'humanitarian',
+  adaptOne: (raw) => ({
+    id: `bio-${raw.id}`,
+    sourceId: 'cdc-biosurveillance',
+    domain: 'humanitarian',
+    timestamp: raw.timestamp,
+    location: raw.lat != null && raw.lon != null ? { lat: raw.lat, lon: raw.lon } : undefined,
+    severity: biosurveillanceSeverity(raw.caseCount),
+    title: `${raw.disease} — ${raw.location} (${raw.caseCount} cases)`,
+    raw,
+    entityIds: [],
+    tags: ['biosurveillance', 'outbreak', raw.disease.toLowerCase().replace(/\s+/g, '-')],
+  }),
+  adaptMany(raws) {
+    return raws.map((r) => this.adaptOne(r)).filter((x): x is ObservationEvent => Boolean(x));
+  },
+};
+
+// ── Built-in adapter: sanctions (OFAC) ───────────────────────────────────
+
+interface SanctionsRaw {
+  sdnId: string;
+  entityType: 'Individual' | 'Entity' | 'Vessel' | 'Aircraft';
+  name: string;
+  reason: string;
+  timestamp: number;
+}
+
+export const SanctionsAdapter: ObservationAdapter<SanctionsRaw> = {
+  sourceId: 'ofac-sanctions',
+  domain: 'macro',
+  adaptOne: (raw) => ({
+    id: `ofac-${raw.sdnId}`,
+    sourceId: 'ofac-sanctions',
+    domain: 'macro',
+    timestamp: raw.timestamp,
+    severity: 'MEDIUM',
+    title: `OFAC: ${raw.entityType} ${raw.name} — ${raw.reason}`,
+    raw,
+    entityIds: [raw.sdnId],
+    tags: ['sanctions', 'ofac', raw.entityType.toLowerCase()],
+  }),
+  adaptMany(raws) {
+    return raws.map((r) => this.adaptOne(r)).filter((x): x is ObservationEvent => Boolean(x));
+  },
+};
+
+// ── Built-in adapter: infrastructure (CISA / BGP) ────────────────────────
+
+interface InfrastructureRaw {
+  id: string;
+  affectedSystem: string;
+  impactType: string;
+  severity: 'low' | 'medium' | 'high' | 'critical';
+  timestamp: number;
+  lat?: number;
+  lon?: number;
+}
+
+const INFRA_SEVERITY: Record<InfrastructureRaw['severity'], ObservationSeverity> = {
+  critical: 'CRITICAL',
+  high: 'HIGH',
+  medium: 'MEDIUM',
+  low: 'LOW',
+};
+
+export const InfrastructureAdapter: ObservationAdapter<InfrastructureRaw> = {
+  sourceId: 'cisa-infrastructure',
+  domain: 'infra',
+  adaptOne: (raw) => ({
+    id: `cisa-${raw.id}`,
+    sourceId: 'cisa-infrastructure',
+    domain: 'infra',
+    timestamp: raw.timestamp,
+    location: raw.lat != null && raw.lon != null ? { lat: raw.lat, lon: raw.lon } : undefined,
+    severity: INFRA_SEVERITY[raw.severity],
+    title: `${raw.affectedSystem} — ${raw.impactType}`,
+    raw,
+    entityIds: [],
+    tags: ['infrastructure', 'cisa', raw.impactType],
+  }),
+  adaptMany(raws) {
+    return raws.map((r) => this.adaptOne(r)).filter((x): x is ObservationEvent => Boolean(x));
+  },
+};
+
+// ── Built-in adapter: GDACS multi-hazard alerts ──────────────────────────
+
+interface GdacsRaw {
+  id: string;
+  /** TC = Tropical Cyclone, EQ = Earthquake, FL = Flood, VO = Volcano, WF = Wildfire, DR = Drought. */
+  eventType: 'TC' | 'EQ' | 'FL' | 'VO' | 'WF' | 'DR';
+  alertLevel: 'Red' | 'Orange' | 'Green';
+  country: string;
+  lat: number;
+  lon: number;
+  onset: number;
+}
+
+const GDACS_SEVERITY: Record<GdacsRaw['alertLevel'], ObservationSeverity> = {
+  Red: 'CRITICAL',
+  Orange: 'HIGH',
+  Green: 'LOW',
+};
+
+const GDACS_TAG: Record<GdacsRaw['eventType'], string> = {
+  TC: 'tropical-cyclone',
+  EQ: 'earthquake',
+  FL: 'flood',
+  VO: 'volcano',
+  WF: 'wildfire',
+  DR: 'drought',
+};
+
+export const GdacsAdapter: ObservationAdapter<GdacsRaw> = {
+  sourceId: 'gdacs-alerts',
+  domain: 'humanitarian',
+  adaptOne: (raw) => ({
+    id: `gdacs-${raw.id}`,
+    sourceId: 'gdacs-alerts',
+    domain: 'humanitarian',
+    timestamp: raw.onset,
+    location: { lat: raw.lat, lon: raw.lon },
+    severity: GDACS_SEVERITY[raw.alertLevel],
+    title: `GDACS ${raw.alertLevel} ${raw.eventType} — ${raw.country}`,
+    raw,
+    entityIds: [raw.country],
+    tags: ['gdacs', GDACS_TAG[raw.eventType], `alert-${raw.alertLevel.toLowerCase()}`],
+  }),
+  adaptMany(raws) {
+    return raws.map((r) => this.adaptOne(r)).filter((x): x is ObservationEvent => Boolean(x));
+  },
+};
+
+// ── Generic fallback adapter ─────────────────────────────────────────────
+
+interface GenericInput {
+  id: string;
+  title: string;
+  timestamp: number;
+  severity?: ObservationSeverity;
+  lat?: number;
+  lon?: number;
+  tags?: readonly string[];
+  entityIds?: readonly string[];
+}
+
+export interface GenericAdapterOptions {
+  sourceId: string;
+  domain: string;
+}
+
+export class GenericAdapter implements ObservationAdapter<GenericInput> {
+  public readonly sourceId: string;
+  public readonly domain: string;
+
+  constructor(opts: GenericAdapterOptions) {
+    this.sourceId = opts.sourceId;
+    this.domain = opts.domain;
+  }
+
+  adaptOne(raw: GenericInput): ObservationEvent {
+    return {
+      id: `${this.sourceId}-${raw.id}`,
+      sourceId: this.sourceId,
+      domain: this.domain,
+      timestamp: raw.timestamp,
+      location: raw.lat != null && raw.lon != null ? { lat: raw.lat, lon: raw.lon } : undefined,
+      severity: raw.severity ?? 'INFO',
+      title: raw.title,
+      raw,
+      entityIds: raw.entityIds ? [...raw.entityIds] : [],
+      tags: raw.tags ? [...raw.tags] : [],
+    };
+  }
+
+  adaptMany(raws: readonly GenericInput[]): ObservationEvent[] {
+    return raws.map((r) => this.adaptOne(r));
+  }
+}
+
+// ── Default registry ─────────────────────────────────────────────────────
+
+export function createDefaultRegistry(): AdapterRegistry {
+  const reg = new AdapterRegistry();
+  reg.register(EarthquakeAdapter);
+  reg.register(WeatherAdapter);
+  reg.register(AviationAdapter);
+  reg.register(MaritimeAdapter);
+  reg.register(WildfireAdapter);
+  reg.register(SpaceWeatherAdapter);
+  reg.register(BiosurveillanceAdapter);
+  reg.register(SanctionsAdapter);
+  reg.register(InfrastructureAdapter);
+  reg.register(GdacsAdapter);
+  return reg;
+}
+
+let defaultRegistry: AdapterRegistry | undefined;
+
+export function getDefaultRegistry(): AdapterRegistry {
+  defaultRegistry ??= createDefaultRegistry();
+  return defaultRegistry;
+}

--- a/src/services/intelligence/observation-normalizer.ts
+++ b/src/services/intelligence/observation-normalizer.ts
@@ -1,0 +1,97 @@
+/**
+ * Observation normalizer — post-adapter enrichment.
+ *
+ * Adapters produce ObservationEvents with the minimum required fields.
+ * The normalizer fills in computed fields the rest of the intelligence
+ * loop expects to be present: continent, country, distances to saved
+ * places, and an initial relevance score.
+ *
+ * Pure: no DOM, no fetch, no globals. Callers pass saved places + clock.
+ */
+
+import type { ObservationEvent } from '@/types/intelligence';
+import type { SavedPlace } from '@/services/saved-places';
+import { haversineKm } from '@/services/proximity-filter';
+import { prioritize } from './prioritizer';
+
+export type Continent = 'NA' | 'SA' | 'EU' | 'AF' | 'AS' | 'OC' | 'AN';
+
+export interface ProximityHit {
+  placeId: string;
+  placeName: string;
+  distanceKm: number;
+}
+
+export interface NormalizedObservation extends ObservationEvent {
+  /** Two-letter continent code derived from location. */
+  continent?: Continent;
+  /** ISO-2 country code; may be undefined when coordinates fall outside
+   *  the lightweight bounding boxes we ship in this module. */
+  countryCode?: string;
+  /** Distance from the event to each saved place, sorted by distance
+   *  ascending. Undefined when no places were supplied. */
+  proximityToSavedPlaces?: readonly ProximityHit[];
+  /** Initial relevance score (0..100) before personal-relevance scoring
+   *  is layered on. Driven by `prioritizer.ts`. */
+  relevanceScore?: number;
+}
+
+export interface NormalizeOptions {
+  savedPlaces?: readonly SavedPlace[];
+  /** Override the country code if the caller already resolved it from a
+   *  more authoritative source (geocoder, provider tag, etc.). */
+  countryCode?: string;
+  nowMs?: number;
+}
+
+// ── Continent classification (coarse bounding boxes) ─────────────────────
+
+export function computeContinent(lat: number, lon: number): Continent | undefined {
+  if (lat <= -60) return 'AN';
+  if (lat >= 7 && lat <= 83 && lon >= -170 && lon <= -50) return 'NA';
+  if (lat < 13 && lat >= -57 && lon >= -82 && lon <= -34) return 'SA';
+  if (lat >= 35 && lat <= 72 && lon >= -25 && lon <= 50) return 'EU';
+  if (lat >= -35 && lat <= 38 && lon >= -20 && lon <= 52) return 'AF';
+  if (lat >= -12 && lat <= 78 && lon >= 25 && lon <= 180) return 'AS';
+  if (lat >= -50 && lat <= 0 && lon >= 110 && lon <= 180) return 'OC';
+  return undefined;
+}
+
+// ── Country code (light heuristic — continental US only) ─────────────────
+
+export function computeCountryCode(lat: number, lon: number): string | undefined {
+  // Continental US — the only country with a precise enough bounding box
+  // here. Open ocean and other countries fall through to undefined and
+  // should be resolved by a real geocoder upstream when present.
+  if (lat >= 24 && lat <= 49 && lon >= -125 && lon <= -66) return 'US';
+  return undefined;
+}
+
+function proximityToSavedPlaces(
+  obs: ObservationEvent,
+  places: readonly SavedPlace[] | undefined,
+): readonly ProximityHit[] | undefined {
+  if (!places || places.length === 0 || !obs.location) return undefined;
+  const { lat, lon } = obs.location;
+  return places
+    .map((p) => ({ placeId: p.id, placeName: p.name, distanceKm: haversineKm(lat, lon, p.lat, p.lon) }))
+    .sort((a, b) => a.distanceKm - b.distanceKm);
+}
+
+export function normalize(obs: ObservationEvent, opts: NormalizeOptions = {}): NormalizedObservation {
+  const continent = obs.location ? computeContinent(obs.location.lat, obs.location.lon) : undefined;
+  const countryCode = opts.countryCode
+    ?? (obs.location ? computeCountryCode(obs.location.lat, obs.location.lon) : undefined);
+  const proximity = proximityToSavedPlaces(obs, opts.savedPlaces);
+
+  const prioritized = prioritize([obs], opts.savedPlaces ? [...opts.savedPlaces] : [], {}, opts.nowMs ?? Date.now());
+  const relevanceScore = prioritized[0]?.relevanceScore;
+
+  return {
+    ...obs,
+    continent,
+    countryCode,
+    proximityToSavedPlaces: proximity,
+    relevanceScore,
+  };
+}

--- a/src/services/intelligence/observation-store.ts
+++ b/src/services/intelligence/observation-store.ts
@@ -9,6 +9,7 @@
  */
 
 import type { ObservationEvent } from '@/types/intelligence';
+import { getDefaultRegistry } from './observation-adapters';
 
 const CAPACITY = 1000;
 
@@ -67,6 +68,16 @@ function matchesQuery(evt: ObservationEvent, q: ObservationQuery): boolean {
   if (q.until != null && evt.timestamp > q.until) return false;
   if (q.tag && !evt.tags.includes(q.tag)) return false;
   return true;
+}
+
+/** Ingest raw provider payloads by dispatching through the adapter
+ *  registry, then storing the resulting ObservationEvents. Unknown
+ *  sourceIds drop silently so a misbehaving caller can't pollute the
+ *  ring buffer with garbage records. */
+export function ingestRaw(sourceId: string, raws: readonly unknown[]): ObservationEvent[] {
+  const adapted = getDefaultRegistry().adaptAll(sourceId, raws);
+  if (adapted.length > 0) ingest(adapted);
+  return adapted;
 }
 
 /** Return matching events, newest first. */


### PR DESCRIPTION
## Phase 3 — Observation Adapters

Every feed in the app eventually produces \`ObservationEvent\`s, but historically each provider had a hand-written \`<thing>ToObservation()\` function and callers wired them up by hand. This PR gives those adapters a uniform shape, dispatches them by \`sourceId\`, and ships a \`GenericAdapter\` fallback for sources without a built-in.

## What ships

### \`src/services/intelligence/observation-adapters.ts\`

| Adapter | sourceId | domain | Notable rule |
| --- | --- | --- | --- |
| EarthquakeAdapter | \`usgs-earthquake\` | weather | wraps existing \`earthquakeToObservation\` |
| WeatherAdapter | \`nws-alerts\` | weather | Extreme → CRITICAL, Severe → HIGH ladder |
| AviationAdapter | \`aviation-track\` | aviation | squawk 7500/7600/7700 → CRITICAL |
| MaritimeAdapter | \`ais-disruption\` | maritime | speedKn=0 → \`vessel-stopped\` tag + MEDIUM |
| WildfireAdapter | \`inciweb-wildfire\` | weather | wraps existing wildfire-adapter |
| SpaceWeatherAdapter | \`swpc-space-weather\` | space | G/S/R scale digit → severity |
| BiosurveillanceAdapter | \`cdc-biosurveillance\` | humanitarian | case count → severity (1000+/250/50) |
| SanctionsAdapter | \`ofac-sanctions\` | macro | SDN ID becomes the entity id |
| InfrastructureAdapter | \`cisa-infrastructure\` | infra | CISA severity passthrough |
| GdacsAdapter | \`gdacs-alerts\` | humanitarian | Red/Orange/Green + 6 event types |
| GenericAdapter | (caller-supplied) | (any) | fallback for ad-hoc feeds |

\`AdapterRegistry\` exposes \`register / has / adapt / adaptAll\`. \`createDefaultRegistry()\` wires all 10 built-ins. \`getDefaultRegistry()\` returns a lazy singleton.

### \`src/services/intelligence/observation-normalizer.ts\`

- \`computeContinent(lat, lon)\` — 7-region bounding-box classifier (NA/SA/EU/AF/AS/OC/AN)
- \`computeCountryCode(lat, lon)\` — continental US bounding box; other countries return undefined (intentional — should be resolved by a real geocoder upstream)
- \`normalize(obs, { savedPlaces?, countryCode?, nowMs? })\` — fills \`continent\`, \`countryCode\`, \`proximityToSavedPlaces\` (sorted ascending), and an initial \`relevanceScore\` via \`prioritize()\`

### \`observation-store.ingestRaw(sourceId, raws[])\`

Dispatches raw provider payloads through the registry, then ingests the resulting \`ObservationEvent\`s. Unknown sourceIds drop silently so a misbehaving caller can't pollute the ring buffer.

## Tests — 45 new

[src/services/intelligence/__tests__/observation-adapters.test.mts](src/services/intelligence/__tests__/observation-adapters.test.mts) — 27 tests:
- Registry dispatch + the 10 built-ins
- Severity ladders for earthquakes (M7+ CRITICAL, <M4 INFO), weather (Extreme/Severe), aviation (emergency squawks), maritime (stopped vessel), space weather (G5 → CRITICAL), biosurveillance (case-count scaling), GDACS (Red/Orange/Green)
- GenericAdapter happy path + severity default
- JSON serializability invariant across all built-ins
- \`ingestRaw\` integration with the store + unknown-source drop

[src/services/intelligence/__tests__/observation-normalizer.test.mts](src/services/intelligence/__tests__/observation-normalizer.test.mts) — 18 tests:
- Continent classification across all 7 continents
- Country-code heuristic (continental US match + open-ocean miss)
- Proximity hit sort order + missing places fallback
- Relevance composition (CRITICAL+close beats INFO+far)
- NormalizedObservation shape preserves base ObservationEvent fields

Combined with existing prioritizer suite: **65/65 tests pass**.

## Verification

- \`npm run typecheck:all\` — clean
- \`npx eslint <changed files>\` — clean

## Cross-agent review

Cross-agent review: claude reviewed on 2026-05-13; outcome: pass