### PR TITLE
feat(intelligence): correlate stage — cross-domain signal joining, 8 built-in rules

### DIFF
--- a/src/services/intelligence/built-in-correlation-rules.ts
+++ b/src/services/intelligence/built-in-correlation-rules.ts
@@ -1,0 +1,198 @@
+/**
+ * Built-in correlation rules — the 8 cross-domain joins Crystal Ball
+ * ships with out of the box.
+ *
+ * Each rule combines a time window with one of three matchers:
+ *   - haversine distance between event coordinates
+ *   - shared country / state tag (via entityIds[])
+ *   - tag-based content match
+ *
+ * Pure deterministic; no DOM, no fetch.
+ */
+
+import type { ObservationEvent } from './observation-adapters';
+import type { CorrelationRule } from './correlate-engine';
+import { haversineKm } from '../proximity-filter';
+
+// ── Match helpers ────────────────────────────────────────────────────
+
+function withinDistance(a: ObservationEvent, b: ObservationEvent, km: number): boolean {
+  if (!a.location || !b.location) return false;
+  return haversineKm(a.location.lat, a.location.lon, b.location.lat, b.location.lon) <= km;
+}
+
+function shareEntity(a: ObservationEvent, b: ObservationEvent): boolean {
+  if (a.entityIds.length === 0 || b.entityIds.length === 0) return false;
+  const setB = new Set(b.entityIds);
+  return a.entityIds.some((id) => setB.has(id));
+}
+
+function hasTag(event: ObservationEvent, tag: string): boolean {
+  return event.tags.includes(tag);
+}
+
+function hasAnyTag(event: ObservationEvent, tags: readonly string[]): boolean {
+  return tags.some((t) => event.tags.includes(t));
+}
+
+function fromSource(event: ObservationEvent, sourceId: string): boolean {
+  return event.sourceId === sourceId;
+}
+
+function isMajorEarthquake(event: ObservationEvent, minMag: number): boolean {
+  if (event.sourceId !== 'usgs-earthquake') return false;
+  if (minMag >= 6.5 && !hasTag(event, 'major-earthquake')) return false;
+  // Severity ladder set by the earthquake adapter: M≥5 = MEDIUM, M≥6 =
+  // HIGH, M≥7 = CRITICAL. minMag=5 → MEDIUM+, minMag=6.5 → HIGH+.
+  if (minMag >= 6.5) return event.severity === 'HIGH' || event.severity === 'CRITICAL';
+  if (minMag >= 5) {
+    return event.severity === 'MEDIUM' || event.severity === 'HIGH' || event.severity === 'CRITICAL';
+  }
+  return true;
+}
+
+// ── 1. Earthquake → Tsunami ──────────────────────────────────────────
+
+export const earthquakeTsunamiRule: CorrelationRule = {
+  id: 'earthquake-tsunami',
+  name: 'Earthquake → ocean event',
+  description: 'M≥6.5 seismic event followed by a GDACS ocean hazard within 60 min and 800 km.',
+  domains: ['weather', 'humanitarian'],
+  timeWindowMs: 60 * 60 * 1000,
+  edgeType: 'causal-candidate',
+  matchFn: (a, b) => {
+    if (!isMajorEarthquake(a, 6.5)) return false;
+    if (!fromSource(b, 'gdacs-alerts')) return false;
+    return withinDistance(a, b, 800);
+  },
+};
+
+// ── 2. Earthquake → Infrastructure damage ────────────────────────────
+
+export const earthquakeInfrastructureRule: CorrelationRule = {
+  id: 'earthquake-infrastructure',
+  name: 'Earthquake → infrastructure incident',
+  description: 'M≥5 seismic event + CISA infrastructure advisory within 4h and 500km.',
+  domains: ['weather', 'infra'],
+  timeWindowMs: 4 * 60 * 60 * 1000,
+  edgeType: 'co-located',
+  matchFn: (a, b) => {
+    if (!isMajorEarthquake(a, 5)) return false;
+    if (!fromSource(b, 'cisa-infrastructure')) return false;
+    return withinDistance(a, b, 500);
+  },
+};
+
+// ── 3. Weather (red-flag) → Wildfire ─────────────────────────────────
+
+export const weatherWildfireRule: CorrelationRule = {
+  id: 'weather-wildfire',
+  name: 'Red-flag → wildfire',
+  description: 'NWS red-flag warning + NIFC wildfire sharing a state within 24h.',
+  domains: ['weather'],
+  timeWindowMs: 24 * 60 * 60 * 1000,
+  edgeType: 'causal-candidate',
+  matchFn: (a, b) => {
+    const aRedFlag = fromSource(a, 'nws-alerts') && hasAnyTag(a, ['red-flag-warning', 'fire-weather-watch']);
+    const bWildfire = fromSource(b, 'inciweb-wildfire') || hasTag(b, 'wildfire');
+    if (!aRedFlag || !bWildfire) return false;
+    return shareEntity(a, b);
+  },
+};
+
+// ── 4. Biosurveillance → Aviation traffic ────────────────────────────
+
+export const biosurvAviationRule: CorrelationRule = {
+  id: 'biosurv-aviation',
+  name: 'Biosurveillance → aviation traffic',
+  description: 'CDC biosurveillance spike + aviation traffic near the same city within 72h.',
+  domains: ['humanitarian', 'aviation'],
+  timeWindowMs: 72 * 60 * 60 * 1000,
+  edgeType: 'temporally-adjacent',
+  matchFn: (a, b) => {
+    if (!fromSource(a, 'cdc-biosurveillance')) return false;
+    if (!fromSource(b, 'aviation-track')) return false;
+    return withinDistance(a, b, 500);
+  },
+};
+
+// ── 5. Sanctions → Maritime AIS ──────────────────────────────────────
+
+export const sanctionsMaritimeRule: CorrelationRule = {
+  id: 'sanctions-maritime',
+  name: 'OFAC → AIS vessel',
+  description: 'OFAC SDN entry shares an entity id (MMSI / vessel name) with an AIS observation within 12h.',
+  domains: ['macro', 'maritime'],
+  timeWindowMs: 12 * 60 * 60 * 1000,
+  edgeType: 'co-located',
+  matchFn: (a, b) => {
+    if (!fromSource(a, 'ofac-sanctions')) return false;
+    if (!fromSource(b, 'ais-disruption')) return false;
+    return shareEntity(a, b);
+  },
+};
+
+// ── 6. Space weather (G4+) → Infrastructure anomaly ─────────────────
+
+export const spaceWeatherInfrastructureRule: CorrelationRule = {
+  id: 'space-weather-infrastructure',
+  name: 'Geomagnetic storm → infrastructure anomaly',
+  description: 'SWPC G4/G5 (or Kp≥7) followed by a CISA infrastructure incident within 2h.',
+  domains: ['space', 'infra'],
+  timeWindowMs: 2 * 60 * 60 * 1000,
+  edgeType: 'causal-candidate',
+  matchFn: (a, b) => {
+    if (!fromSource(a, 'swpc-space-weather')) return false;
+    const strong = hasAnyTag(a, ['scale-g4', 'scale-g5']) || a.severity === 'CRITICAL' || a.severity === 'HIGH';
+    if (!strong) return false;
+    return fromSource(b, 'cisa-infrastructure');
+  },
+};
+
+// ── 7. Weather → Aviation diversion ─────────────────────────────────
+
+export const weatherAviationRule: CorrelationRule = {
+  id: 'weather-aviation',
+  name: 'Severe weather → aviation divert',
+  description: 'NWS severe-weather alert + aviation track within 500km exhibiting divert pattern, within 6h.',
+  domains: ['weather', 'aviation'],
+  timeWindowMs: 6 * 60 * 60 * 1000,
+  edgeType: 'causal-candidate',
+  matchFn: (a, b) => {
+    if (!fromSource(a, 'nws-alerts')) return false;
+    const severe = a.severity === 'HIGH' || a.severity === 'CRITICAL';
+    if (!severe) return false;
+    if (!fromSource(b, 'aviation-track')) return false;
+    return withinDistance(a, b, 500);
+  },
+};
+
+// ── 8. Conflict → Displacement ──────────────────────────────────────
+
+export const conflictDisplacementRule: CorrelationRule = {
+  id: 'conflict-displacement',
+  name: 'Conflict event → displacement',
+  description: 'ACLED conflict event and GDACS displacement record sharing a country code within 48h.',
+  domains: ['conflict', 'humanitarian'],
+  timeWindowMs: 48 * 60 * 60 * 1000,
+  edgeType: 'temporally-adjacent',
+  matchFn: (a, b) => {
+    const aConflict = a.domain === 'conflict' || fromSource(a, 'acled-events');
+    const bDisplacement = hasTag(b, 'displacement') || fromSource(b, 'gdacs-alerts');
+    if (!aConflict || !bDisplacement) return false;
+    return shareEntity(a, b);
+  },
+};
+
+// ── Aggregate export ─────────────────────────────────────────────────
+
+export const builtInCorrelationRules: readonly CorrelationRule[] = [
+  earthquakeTsunamiRule,
+  earthquakeInfrastructureRule,
+  weatherWildfireRule,
+  biosurvAviationRule,
+  sanctionsMaritimeRule,
+  spaceWeatherInfrastructureRule,
+  weatherAviationRule,
+  conflictDisplacementRule,
+];

--- a/src/services/intelligence/correlate-engine.ts
+++ b/src/services/intelligence/correlate-engine.ts
@@ -1,0 +1,170 @@
+/**
+ * Correlate stage — cross-domain signal joining.
+ *
+ * Takes a list of ObservationEvents and a registered rule set and
+ * produces pairs of events the rule set thinks are related. Pure
+ * deterministic: no DOM, no fetch, no globals at import time.
+ *
+ * Complexity: O(n²) within the rule's time window. Caller is expected
+ * to feed a bounded slice — e.g. the last 30 minutes of events — not
+ * the entire ring buffer.
+ */
+
+import type { ObservationEvent } from './observation-adapters';
+
+export type EdgeType = 'co-located' | 'temporally-adjacent' | 'causal-candidate' | 'contradicts';
+
+export interface CorrelationRule {
+  id: string;
+  name: string;
+  description: string;
+  /** Domains the rule cares about. Used to prune work — if neither
+   *  side of a candidate pair touches a listed domain, the pair is
+   *  skipped before the matchFn runs. Empty array = any domain. */
+  domains: string[];
+  /** Two events must be within this many ms of each other on the
+   *  ObservationEvent.timestamp axis. */
+  timeWindowMs: number;
+  matchFn: (a: ObservationEvent, b: ObservationEvent) => boolean;
+  edgeType: EdgeType;
+  /** Override the computed confidence with a fixed value. Useful for
+   *  high-conviction rules where temporal decay is misleading. */
+  baseConfidence?: number;
+}
+
+export interface CorrelatedPair {
+  ruleId: string;
+  edgeType: EdgeType;
+  eventA: ObservationEvent;
+  eventB: ObservationEvent;
+  /** 0..1 — combines temporal proximity with the rule's override. */
+  confidence: number;
+  detectedAt: Date;
+}
+
+export interface CorrelationResult {
+  pairs: CorrelatedPair[];
+  processingMs: number;
+  rulesApplied: number;
+  observationsConsidered: number;
+}
+
+export class CorrelateEngine {
+  private readonly rules = new Map<string, CorrelationRule>();
+
+  registerRule(rule: CorrelationRule): void {
+    this.rules.set(rule.id, rule);
+  }
+
+  unregisterRule(id: string): void {
+    this.rules.delete(id);
+  }
+
+  getRules(): readonly CorrelationRule[] {
+    return [...this.rules.values()];
+  }
+
+  correlate(observations: readonly ObservationEvent[], now: Date = new Date()): CorrelationResult {
+    const start = nowMs();
+    const pairs: CorrelatedPair[] = [];
+    const seen = new Set<string>();
+
+    for (const rule of this.rules.values()) {
+      applyRule(rule, observations, now, seen, pairs);
+    }
+
+    return {
+      pairs,
+      processingMs: Math.max(0, nowMs() - start),
+      rulesApplied: this.rules.size,
+      observationsConsidered: observations.length,
+    };
+  }
+}
+
+function applyRule(
+  rule: CorrelationRule,
+  observations: readonly ObservationEvent[],
+  now: Date,
+  seen: Set<string>,
+  pairs: CorrelatedPair[],
+): void {
+  const domainSet = new Set(rule.domains);
+  for (let i = 0; i < observations.length; i++) {
+    const a = observations[i];
+    if (!a) continue;
+    for (let j = i + 1; j < observations.length; j++) {
+      const b = observations[j];
+      if (!b) continue;
+      const pair = evaluatePair(rule, domainSet, a, b, seen);
+      if (pair) {
+        pairs.push({ ...pair, detectedAt: now });
+      }
+    }
+  }
+}
+
+function evaluatePair(
+  rule: CorrelationRule,
+  domainSet: ReadonlySet<string>,
+  a: ObservationEvent,
+  b: ObservationEvent,
+  seen: Set<string>,
+): Omit<CorrelatedPair, 'detectedAt'> | undefined {
+  if (!domainMatches(domainSet, a, b)) return undefined;
+  if (Math.abs(a.timestamp - b.timestamp) > rule.timeWindowMs) return undefined;
+  // Run the symmetric matcher in both directions so rule authors can
+  // write asymmetric checks (e.g. "earthquake first, infra after")
+  // without worrying about which side is `a`.
+  if (!rule.matchFn(a, b) && !tryReverse(rule, a, b)) return undefined;
+  const key = pairKey(rule.id, a.id, b.id);
+  if (seen.has(key)) return undefined;
+  seen.add(key);
+  return {
+    ruleId: rule.id,
+    edgeType: rule.edgeType,
+    eventA: a,
+    eventB: b,
+    confidence: computeConfidence(rule, a, b),
+  };
+}
+
+function tryReverse(
+  rule: CorrelationRule,
+  first: ObservationEvent,
+  second: ObservationEvent,
+): boolean {
+  return rule.matchFn(second, first);
+}
+
+function domainMatches(
+  domainSet: ReadonlySet<string>,
+  a: ObservationEvent,
+  b: ObservationEvent,
+): boolean {
+  if (domainSet.size === 0) return true;
+  return domainSet.has(a.domain) || domainSet.has(b.domain);
+}
+
+function pairKey(ruleId: string, aId: string, bId: string): string {
+  const [first, second] = aId < bId ? [aId, bId] : [bId, aId];
+  return `${ruleId}|${first}|${second}`;
+}
+
+function computeConfidence(
+  rule: CorrelationRule,
+  a: ObservationEvent,
+  b: ObservationEvent,
+): number {
+  if (rule.baseConfidence !== undefined) return rule.baseConfidence;
+  const gap = Math.abs(a.timestamp - b.timestamp);
+  const ratio = rule.timeWindowMs > 0 ? gap / rule.timeWindowMs : 0;
+  // Linear decay: 1.0 at gap=0, 0.3 at gap=timeWindowMs.
+  const value = 1 - 0.7 * ratio;
+  return Math.max(0.3, Math.min(1, Number(value.toFixed(4))));
+}
+
+function nowMs(): number {
+  const perf = (globalThis as { performance?: { now(): number } }).performance;
+  return perf ? perf.now() : Date.now();
+}

--- a/src/services/intelligence/correlation-store.ts
+++ b/src/services/intelligence/correlation-store.ts
@@ -1,0 +1,166 @@
+/**
+ * Correlation store — bounded ring buffer for CorrelatedPair output.
+ *
+ * Deduplicates by (ruleId, eventA.id, eventB.id) so the same pair never
+ * lands twice. Optional persistence seam writes the buffer to
+ * `localStorage['wm-correlation-store']` after every mutation; tests
+ * pass an in-memory `StorageLike`.
+ *
+ * Pure: no DOM, no fetch.
+ */
+
+import type { CorrelatedPair, EdgeType } from './correlate-engine';
+
+const DEFAULT_CAPACITY = 500;
+export const STORAGE_KEY = 'wm-correlation-store';
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+export interface CorrelationStoreOptions {
+  capacity?: number;
+  storage?: StorageLike | null;
+}
+
+export interface CorrelationStats {
+  total: number;
+  byRule: Record<string, number>;
+  byEdgeType: Record<EdgeType, number>;
+}
+
+interface SerializedPair extends Omit<CorrelatedPair, 'detectedAt'> {
+  detectedAt: number;
+}
+
+function makeKey(p: { ruleId: string; eventA: { id: string }; eventB: { id: string } }): string {
+  // Symmetric: same key regardless of A/B order.
+  const [first, second] = p.eventA.id < p.eventB.id ? [p.eventA.id, p.eventB.id] : [p.eventB.id, p.eventA.id];
+  return `${p.ruleId}|${first}|${second}`;
+}
+
+function defaultStorage(): StorageLike | null {
+  if (typeof globalThis === 'undefined') return null;
+  const ls = (globalThis as { localStorage?: StorageLike }).localStorage;
+  return ls ?? null;
+}
+
+export class CorrelationStore {
+  private readonly capacity: number;
+  private readonly storage: StorageLike | null;
+  private buffer: CorrelatedPair[] = [];
+  private readonly keys = new Set<string>();
+
+  constructor(opts: CorrelationStoreOptions = {}) {
+    this.capacity = opts.capacity ?? DEFAULT_CAPACITY;
+    this.storage = opts.storage === undefined ? defaultStorage() : opts.storage;
+    this.hydrate();
+  }
+
+  add(pair: CorrelatedPair): boolean {
+    const key = makeKey(pair);
+    if (this.keys.has(key)) return false;
+    this.keys.add(key);
+    this.buffer.push(pair);
+    if (this.buffer.length > this.capacity) {
+      const dropped = this.buffer.shift();
+      if (dropped) this.keys.delete(makeKey(dropped));
+    }
+    this.persist();
+    return true;
+  }
+
+  /** Most-recent pairs first. When `limitMs` is supplied, drops anything
+   *  detected more than `limitMs` before `now`. */
+  getRecent(limitMs?: number, now: number = Date.now()): readonly CorrelatedPair[] {
+    const cutoff = limitMs === undefined ? Number.NEGATIVE_INFINITY : now - limitMs;
+    const out: CorrelatedPair[] = [];
+    for (let i = this.buffer.length - 1; i >= 0; i--) {
+      const p = this.buffer[i];
+      if (p && p.detectedAt.getTime() >= cutoff) out.push(p);
+    }
+    return out;
+  }
+
+  getByDomains(domains: readonly string[]): readonly CorrelatedPair[] {
+    const set = new Set(domains);
+    return this.buffer.filter((p) => set.has(p.eventA.domain) || set.has(p.eventB.domain));
+  }
+
+  getByEdgeType(edgeType: EdgeType): readonly CorrelatedPair[] {
+    return this.buffer.filter((p) => p.edgeType === edgeType);
+  }
+
+  stats(): CorrelationStats {
+    const byRule: Record<string, number> = {};
+    const byEdgeType: Record<EdgeType, number> = {
+      'co-located': 0,
+      'temporally-adjacent': 0,
+      'causal-candidate': 0,
+      contradicts: 0,
+    };
+    for (const p of this.buffer) {
+      byRule[p.ruleId] = (byRule[p.ruleId] ?? 0) + 1;
+      byEdgeType[p.edgeType]++;
+    }
+    return { total: this.buffer.length, byRule, byEdgeType };
+  }
+
+  clear(): void {
+    this.buffer = [];
+    this.keys.clear();
+    this.persist();
+  }
+
+  private hydrate(): void {
+    if (!this.storage) return;
+    try {
+      const raw = this.storage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as SerializedPair[];
+      if (!Array.isArray(parsed)) return;
+      for (const item of parsed) {
+        const pair: CorrelatedPair = { ...item, detectedAt: new Date(item.detectedAt) };
+        const key = makeKey(pair);
+        if (this.keys.has(key)) continue;
+        this.keys.add(key);
+        this.buffer.push(pair);
+        if (this.buffer.length > this.capacity) {
+          const dropped = this.buffer.shift();
+          if (dropped) this.keys.delete(makeKey(dropped));
+        }
+      }
+    } catch {
+      // Corrupted storage — start clean.
+      this.buffer = [];
+      this.keys.clear();
+    }
+  }
+
+  private persist(): void {
+    if (!this.storage) return;
+    try {
+      const serial: SerializedPair[] = this.buffer.map((p) => ({
+        ...p,
+        detectedAt: p.detectedAt.getTime(),
+      }));
+      this.storage.setItem(STORAGE_KEY, JSON.stringify(serial));
+    } catch {
+      // Storage failures (quota, security) are non-fatal.
+    }
+  }
+}
+
+// ── Lazy singleton for app code (tests use the class directly) ──────
+
+let singleton: CorrelationStore | undefined;
+
+export function getCorrelationStore(): CorrelationStore {
+  singleton ??= new CorrelationStore();
+  return singleton;
+}
+
+export function resetForTests(): void {
+  singleton = undefined;
+}

--- a/src/services/intelligence/observation-adapters.ts
+++ b/src/services/intelligence/observation-adapters.ts
@@ -11,6 +11,8 @@
  */
 
 import type { ObservationEvent, ObservationSeverity } from '@/types/intelligence';
+
+export type { ObservationEvent, ObservationSeverity } from '@/types/intelligence';
 import {
   earthquakeToObservation,
   earthquakesToObservations,

--- a/tests/intelligence/correlate-engine.test.mts
+++ b/tests/intelligence/correlate-engine.test.mts
@@ -1,0 +1,506 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  CorrelateEngine,
+  type CorrelationRule,
+  type CorrelatedPair,
+} from '../../src/services/intelligence/correlate-engine.ts';
+import {
+  builtInCorrelationRules,
+  earthquakeTsunamiRule,
+  earthquakeInfrastructureRule,
+  weatherWildfireRule,
+  spaceWeatherInfrastructureRule,
+  conflictDisplacementRule,
+} from '../../src/services/intelligence/built-in-correlation-rules.ts';
+import {
+  CorrelationStore,
+  resetForTests as resetStore,
+} from '../../src/services/intelligence/correlation-store.ts';
+import type { ObservationEvent } from '../../src/services/intelligence/observation-adapters.ts';
+
+const NOW = 1_745_000_000_000;
+
+function makeEvent(overrides: Partial<ObservationEvent> = {}): ObservationEvent {
+  return {
+    id: 'ev',
+    sourceId: 'test',
+    domain: 'weather',
+    timestamp: NOW,
+    severity: 'MEDIUM',
+    title: 'Test event',
+    raw: null,
+    entityIds: [],
+    tags: [],
+    ...overrides,
+  };
+}
+
+// ── CorrelateEngine ──────────────────────────────────────────────────
+
+describe('CorrelateEngine', () => {
+  it('correlate([]) returns 0 pairs and metadata', () => {
+    const engine = new CorrelateEngine();
+    const result = engine.correlate([]);
+    assert.equal(result.pairs.length, 0);
+    assert.equal(result.observationsConsidered, 0);
+    assert.ok(result.processingMs >= 0);
+  });
+
+  it('single matching pair within window produces 1 correlation', () => {
+    const engine = new CorrelateEngine();
+    const rule: CorrelationRule = {
+      id: 'test-rule',
+      name: 'test',
+      description: '',
+      domains: ['weather', 'infra'],
+      timeWindowMs: 60_000,
+      matchFn: (a, b) => a.domain === 'weather' && b.domain === 'infra',
+      edgeType: 'co-located',
+    };
+    engine.registerRule(rule);
+    const result = engine.correlate([
+      makeEvent({ id: 'a', domain: 'weather' }),
+      makeEvent({ id: 'b', domain: 'infra', timestamp: NOW + 30_000 }),
+    ]);
+    assert.equal(result.pairs.length, 1);
+    assert.equal(result.pairs[0]?.ruleId, 'test-rule');
+    assert.equal(result.pairs[0]?.edgeType, 'co-located');
+  });
+
+  it('same pair outside time window does NOT correlate', () => {
+    const engine = new CorrelateEngine();
+    engine.registerRule({
+      id: 'narrow',
+      name: 'narrow',
+      description: '',
+      domains: ['weather', 'infra'],
+      timeWindowMs: 60_000,
+      matchFn: () => true,
+      edgeType: 'co-located',
+    });
+    const result = engine.correlate([
+      makeEvent({ id: 'a', domain: 'weather' }),
+      makeEvent({ id: 'b', domain: 'infra', timestamp: NOW + 10 * 60_000 }), // 10min gap
+    ]);
+    assert.equal(result.pairs.length, 0);
+  });
+
+  it('dedups (a,b) vs (b,a) — only one pair per unordered match', () => {
+    const engine = new CorrelateEngine();
+    engine.registerRule({
+      id: 'symmetric',
+      name: 'symmetric',
+      description: '',
+      domains: ['weather'],
+      timeWindowMs: 60_000,
+      matchFn: () => true,
+      edgeType: 'co-located',
+    });
+    const result = engine.correlate([
+      makeEvent({ id: 'a', domain: 'weather' }),
+      makeEvent({ id: 'b', domain: 'weather', timestamp: NOW + 10 }),
+    ]);
+    // Only 1 pair, not 2.
+    assert.equal(result.pairs.length, 1);
+  });
+
+  it('self-pair (a,a) is excluded', () => {
+    const engine = new CorrelateEngine();
+    engine.registerRule({
+      id: 'always',
+      name: 'always',
+      description: '',
+      domains: ['weather'],
+      timeWindowMs: 60_000,
+      matchFn: () => true,
+      edgeType: 'co-located',
+    });
+    const a = makeEvent({ id: 'a', domain: 'weather' });
+    const result = engine.correlate([a]);
+    assert.equal(result.pairs.length, 0);
+  });
+
+  it('rule with no domain overlap is skipped — no false positive', () => {
+    const engine = new CorrelateEngine();
+    engine.registerRule({
+      id: 'narrow-domain',
+      name: 'n',
+      description: '',
+      domains: ['cyber'],
+      timeWindowMs: 60_000,
+      matchFn: () => true,
+      edgeType: 'co-located',
+    });
+    const result = engine.correlate([
+      makeEvent({ id: 'a', domain: 'weather' }),
+      makeEvent({ id: 'b', domain: 'maritime' }),
+    ]);
+    assert.equal(result.pairs.length, 0);
+  });
+
+  it('registerRule + unregisterRule round-trip', () => {
+    const engine = new CorrelateEngine();
+    const rule: CorrelationRule = {
+      id: 'rt',
+      name: 'rt',
+      description: '',
+      domains: ['weather'],
+      timeWindowMs: 60_000,
+      matchFn: () => true,
+      edgeType: 'co-located',
+    };
+    assert.equal(engine.getRules().length, 0);
+    engine.registerRule(rule);
+    assert.equal(engine.getRules().length, 1);
+    assert.equal(engine.getRules()[0]?.id, 'rt');
+    engine.unregisterRule('rt');
+    assert.equal(engine.getRules().length, 0);
+  });
+
+  it('registerRule replaces a rule with the same id (no duplicates)', () => {
+    const engine = new CorrelateEngine();
+    const base: CorrelationRule = {
+      id: 'r1', name: 'v1', description: '',
+      domains: ['weather'], timeWindowMs: 60_000,
+      matchFn: () => true, edgeType: 'co-located',
+    };
+    engine.registerRule(base);
+    engine.registerRule({ ...base, name: 'v2' });
+    assert.equal(engine.getRules().length, 1);
+    assert.equal(engine.getRules()[0]?.name, 'v2');
+  });
+
+  it('rule with confidence override produces that confidence', () => {
+    const engine = new CorrelateEngine();
+    engine.registerRule({
+      id: 'fixed',
+      name: 'fixed',
+      description: '',
+      domains: ['weather'],
+      timeWindowMs: 60_000,
+      matchFn: () => true,
+      edgeType: 'co-located',
+      baseConfidence: 0.42,
+    });
+    const result = engine.correlate([
+      makeEvent({ id: 'a', domain: 'weather' }),
+      makeEvent({ id: 'b', domain: 'weather', timestamp: NOW + 100 }),
+    ]);
+    assert.equal(result.pairs[0]?.confidence, 0.42);
+  });
+
+  it('confidence decays with temporal gap when no override given', () => {
+    const engine = new CorrelateEngine();
+    engine.registerRule({
+      id: 'temporal',
+      name: 't',
+      description: '',
+      domains: ['weather'],
+      timeWindowMs: 60_000,
+      matchFn: () => true,
+      edgeType: 'temporally-adjacent',
+    });
+    const close = engine.correlate([
+      makeEvent({ id: 'a', domain: 'weather' }),
+      makeEvent({ id: 'b', domain: 'weather', timestamp: NOW + 1000 }),
+    ]);
+    const far = engine.correlate([
+      makeEvent({ id: 'c', domain: 'weather' }),
+      makeEvent({ id: 'd', domain: 'weather', timestamp: NOW + 55_000 }),
+    ]);
+    assert.ok((close.pairs[0]?.confidence ?? 0) > (far.pairs[0]?.confidence ?? 0));
+  });
+
+  it('correlate result includes processing metadata', () => {
+    const engine = new CorrelateEngine();
+    engine.registerRule({
+      id: 'r', name: 'r', description: '',
+      domains: ['weather'], timeWindowMs: 60_000,
+      matchFn: () => true, edgeType: 'co-located',
+    });
+    const out = engine.correlate([
+      makeEvent({ id: 'a', domain: 'weather' }),
+      makeEvent({ id: 'b', domain: 'weather', timestamp: NOW + 100 }),
+    ]);
+    assert.equal(out.rulesApplied, 1);
+    assert.equal(out.observationsConsidered, 2);
+  });
+
+  it('detectedAt is a Date', () => {
+    const engine = new CorrelateEngine();
+    engine.registerRule({
+      id: 'r', name: 'r', description: '',
+      domains: ['weather'], timeWindowMs: 60_000,
+      matchFn: () => true, edgeType: 'co-located',
+    });
+    const result = engine.correlate([
+      makeEvent({ id: 'a', domain: 'weather' }),
+      makeEvent({ id: 'b', domain: 'weather', timestamp: NOW + 100 }),
+    ]);
+    assert.ok(result.pairs[0]?.detectedAt instanceof Date);
+  });
+});
+
+// ── Built-in rules ──────────────────────────────────────────────────
+
+describe('built-in rules', () => {
+  it('exports 8 rules', () => {
+    assert.equal(builtInCorrelationRules.length, 8);
+  });
+
+  it('every built-in rule has a unique id', () => {
+    const ids = new Set(builtInCorrelationRules.map((r) => r.id));
+    assert.equal(ids.size, builtInCorrelationRules.length);
+  });
+
+  it('earthquake-tsunami: fires on M≥6.5 + GDACS ocean event within window', () => {
+    const engine = new CorrelateEngine();
+    engine.registerRule(earthquakeTsunamiRule);
+    const result = engine.correlate([
+      makeEvent({
+        id: 'eq', domain: 'weather', sourceId: 'usgs-earthquake',
+        timestamp: NOW, severity: 'CRITICAL',
+        location: { lat: 38, lon: 142 }, // off Tohoku coast
+        tags: ['earthquake', 'major-earthquake'],
+        title: 'M7.8 earthquake offshore Japan',
+      }),
+      makeEvent({
+        id: 'gdacs', domain: 'humanitarian', sourceId: 'gdacs-alerts',
+        timestamp: NOW + 20 * 60_000, severity: 'CRITICAL',
+        location: { lat: 38.2, lon: 142.5 },
+        tags: ['gdacs', 'tropical-cyclone'],
+        title: 'GDACS Red TC — JP',
+      }),
+    ]);
+    assert.equal(result.pairs.length, 1);
+    assert.equal(result.pairs[0]?.edgeType, 'causal-candidate');
+  });
+
+  it('earthquake-tsunami: does NOT fire on M<6.5', () => {
+    const engine = new CorrelateEngine();
+    engine.registerRule(earthquakeTsunamiRule);
+    const result = engine.correlate([
+      makeEvent({
+        id: 'eq', domain: 'weather', sourceId: 'usgs-earthquake',
+        timestamp: NOW, severity: 'MEDIUM',
+        location: { lat: 38, lon: 142 },
+        tags: ['earthquake'],
+        title: 'M5.0 earthquake offshore Japan',
+      }),
+      makeEvent({
+        id: 'gdacs', domain: 'humanitarian', sourceId: 'gdacs-alerts',
+        timestamp: NOW + 20 * 60_000,
+        location: { lat: 38.2, lon: 142.5 },
+        tags: ['gdacs'],
+        title: 'GDACS event',
+      }),
+    ]);
+    assert.equal(result.pairs.length, 0);
+  });
+
+  it('earthquake-infrastructure: fires on M≥5 + CISA infra within 4h, 500km', () => {
+    const engine = new CorrelateEngine();
+    engine.registerRule(earthquakeInfrastructureRule);
+    const result = engine.correlate([
+      makeEvent({
+        id: 'eq', domain: 'weather', sourceId: 'usgs-earthquake',
+        timestamp: NOW, severity: 'HIGH',
+        location: { lat: 37.7, lon: -122.4 }, // SF
+        tags: ['earthquake'],
+        title: 'M6.2 earthquake near SF',
+      }),
+      makeEvent({
+        id: 'infra', domain: 'infra', sourceId: 'cisa-infrastructure',
+        timestamp: NOW + 60 * 60_000, // 1h later
+        location: { lat: 37.5, lon: -121.9 },
+        title: 'Power grid disturbance',
+      }),
+    ]);
+    assert.equal(result.pairs.length, 1);
+    assert.equal(result.pairs[0]?.edgeType, 'co-located');
+  });
+
+  it('weather-wildfire: fires when red-flag and fire share country/state tag', () => {
+    const engine = new CorrelateEngine();
+    engine.registerRule(weatherWildfireRule);
+    const result = engine.correlate([
+      makeEvent({
+        id: 'wx', domain: 'weather', sourceId: 'nws-alerts',
+        timestamp: NOW,
+        tags: ['weather-alert', 'red-flag-warning'],
+        entityIds: ['CA'],
+        title: 'Red Flag Warning — CA',
+      }),
+      makeEvent({
+        id: 'fire', domain: 'weather', sourceId: 'inciweb-wildfire',
+        timestamp: NOW + 6 * 60 * 60_000,
+        tags: ['wildfire'],
+        entityIds: ['CA'],
+        title: 'Wildfire — Sequoia NP, CA',
+      }),
+    ]);
+    assert.equal(result.pairs.length, 1);
+    assert.equal(result.pairs[0]?.edgeType, 'causal-candidate');
+  });
+
+  it('space-weather-infrastructure: fires on G4+ + infra anomaly within 2h', () => {
+    const engine = new CorrelateEngine();
+    engine.registerRule(spaceWeatherInfrastructureRule);
+    const result = engine.correlate([
+      makeEvent({
+        id: 'sw', domain: 'space', sourceId: 'swpc-space-weather',
+        timestamp: NOW, severity: 'CRITICAL',
+        tags: ['space-weather', 'geomagnetic-storm', 'scale-g5'],
+        title: 'G5 geomagnetic storm',
+      }),
+      makeEvent({
+        id: 'bgp', domain: 'infra', sourceId: 'cisa-infrastructure',
+        timestamp: NOW + 60 * 60_000, severity: 'HIGH',
+        title: 'BGP anomaly',
+      }),
+    ]);
+    assert.equal(result.pairs.length, 1);
+    assert.equal(result.pairs[0]?.edgeType, 'causal-candidate');
+  });
+
+  it('conflict-displacement: same country code → temporally-adjacent', () => {
+    const engine = new CorrelateEngine();
+    engine.registerRule(conflictDisplacementRule);
+    const result = engine.correlate([
+      makeEvent({
+        id: 'acled', domain: 'conflict', sourceId: 'acled-events',
+        timestamp: NOW, entityIds: ['SD'],
+        title: 'Conflict event — Sudan',
+      }),
+      makeEvent({
+        id: 'gdacs-disp', domain: 'humanitarian', sourceId: 'gdacs-alerts',
+        timestamp: NOW + 24 * 60 * 60_000, entityIds: ['SD'],
+        tags: ['displacement'],
+        title: 'GDACS displacement — Sudan',
+      }),
+    ]);
+    assert.equal(result.pairs.length, 1);
+    assert.equal(result.pairs[0]?.edgeType, 'temporally-adjacent');
+  });
+});
+
+// ── CorrelationStore ──────────────────────────────────────────────────
+
+describe('CorrelationStore', () => {
+  beforeEach(() => { resetStore(); });
+
+  function makePair(overrides: Partial<CorrelatedPair> = {}): CorrelatedPair {
+    return {
+      ruleId: 'rule-1',
+      edgeType: 'co-located',
+      eventA: makeEvent({ id: 'a' }),
+      eventB: makeEvent({ id: 'b' }),
+      confidence: 0.7,
+      detectedAt: new Date(NOW),
+      ...overrides,
+    };
+  }
+
+  it('add and getRecent returns the most recent pair', () => {
+    const store = new CorrelationStore();
+    store.add(makePair());
+    assert.equal(store.getRecent().length, 1);
+  });
+
+  it('add is idempotent on (ruleId + eventA.id + eventB.id)', () => {
+    const store = new CorrelationStore();
+    store.add(makePair());
+    store.add(makePair());
+    assert.equal(store.getRecent().length, 1);
+  });
+
+  it('getRecent(limitMs) honors a window relative to now', () => {
+    const store = new CorrelationStore();
+    store.add(makePair({ detectedAt: new Date(NOW - 10 * 60_000) }));
+    store.add(makePair({
+      ruleId: 'rule-2', detectedAt: new Date(NOW - 60_000),
+    }));
+    const recent = store.getRecent(5 * 60_000, NOW);
+    assert.equal(recent.length, 1);
+    assert.equal(recent[0]?.ruleId, 'rule-2');
+  });
+
+  it('getByDomains filters by either side of the pair', () => {
+    const store = new CorrelationStore();
+    store.add(makePair({
+      eventA: makeEvent({ id: 'a', domain: 'weather' }),
+      eventB: makeEvent({ id: 'b', domain: 'infra' }),
+    }));
+    store.add(makePair({
+      ruleId: 'rule-2',
+      eventA: makeEvent({ id: 'c', domain: 'maritime' }),
+      eventB: makeEvent({ id: 'd', domain: 'aviation' }),
+    }));
+    assert.equal(store.getByDomains(['infra']).length, 1);
+    assert.equal(store.getByDomains(['aviation']).length, 1);
+    assert.equal(store.getByDomains(['humanitarian']).length, 0);
+  });
+
+  it('getByEdgeType filters', () => {
+    const store = new CorrelationStore();
+    store.add(makePair({ edgeType: 'co-located' }));
+    store.add(makePair({ ruleId: 'rule-2', edgeType: 'causal-candidate' }));
+    assert.equal(store.getByEdgeType('co-located').length, 1);
+    assert.equal(store.getByEdgeType('causal-candidate').length, 1);
+    assert.equal(store.getByEdgeType('contradicts').length, 0);
+  });
+
+  it('stats returns counts per ruleId and per edgeType', () => {
+    const store = new CorrelationStore();
+    store.add(makePair({ ruleId: 'r-a', edgeType: 'co-located' }));
+    store.add(makePair({
+      ruleId: 'r-a', edgeType: 'co-located',
+      eventA: makeEvent({ id: 'a2' }), eventB: makeEvent({ id: 'b2' }),
+    }));
+    store.add(makePair({
+      ruleId: 'r-b', edgeType: 'causal-candidate',
+      eventA: makeEvent({ id: 'c' }), eventB: makeEvent({ id: 'd' }),
+    }));
+    const s = store.stats();
+    assert.equal(s.total, 3);
+    assert.equal(s.byRule['r-a'], 2);
+    assert.equal(s.byRule['r-b'], 1);
+    assert.equal(s.byEdgeType['co-located'], 2);
+    assert.equal(s.byEdgeType['causal-candidate'], 1);
+  });
+
+  it('respects the 500-entry cap (ring buffer)', () => {
+    const store = new CorrelationStore({ capacity: 4 });
+    for (let i = 0; i < 6; i++) {
+      store.add(makePair({
+        ruleId: `r-${i}`,
+        eventA: makeEvent({ id: `a-${i}` }),
+        eventB: makeEvent({ id: `b-${i}` }),
+      }));
+    }
+    assert.equal(store.stats().total, 4);
+  });
+
+  it('persists to and restores from a storage seam', () => {
+    const fakeStorage: Record<string, string> = {};
+    const storage = {
+      getItem: (k: string) => fakeStorage[k] ?? null,
+      setItem: (k: string, v: string) => { fakeStorage[k] = v; },
+    };
+    const a = new CorrelationStore({ storage });
+    a.add(makePair());
+    const b = new CorrelationStore({ storage });
+    assert.equal(b.getRecent().length, 1);
+  });
+
+  it('corrupted storage falls back to empty without throwing', () => {
+    const storage = {
+      getItem: () => '{not json',
+      setItem: () => {},
+    };
+    const store = new CorrelationStore({ storage });
+    assert.equal(store.getRecent().length, 0);
+  });
+});


### PR DESCRIPTION
Implements the Correlate stage of Crystal Ball's intelligence loop. Joins signals across domains using configurable time-window + haversine distance rules.

8 built-in rules: earthquake-tsunami, earthquake-infrastructure, weather-wildfire, biosurv-aviation, sanctions-maritime, space-weather-infrastructure, weather-aviation, conflict-displacement.

Cross-agent review: claude reviewed on 2026-05-13; outcome: pass