### PR TITLE
feat(ux): native macOS chrome — vibrancy, transparent titlebar, traffic-light positioning

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -704,6 +704,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-biometry",
  "tauri-plugin-clipboard-manager",
+ "window-vibrancy",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["macos-private-api"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native-sync-persistent", "crypto-rust"] }
@@ -18,6 +18,9 @@ sha2 = "0.11"
 getrandom = "0.4"
 tauri-plugin-biometry = "0.2.6"
 tauri-plugin-clipboard-manager = "2"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+window-vibrancy = "0.6"
 
 [features]
 default = ["custom-protocol"]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2689,6 +2689,26 @@ fn main() {
  let cache_path = cache_file_path(&app.handle()).unwrap_or_default();
  app.manage(PersistentCache::load(&cache_path));
 
+ // Apply native macOS vibrancy (HudWindow material, 12pt rounded corners).
+ // Pairs with `transparent: true` + `macOSPrivateApi: true` in tauri.conf.json
+ // and the `app-root`/`app-titlebar` CSS in src/styles/window-chrome.css.
+ #[cfg(target_os = "macos")]
+ if let Some(window) = app.get_webview_window("main") {
+ use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial, NSVisualEffectState};
+ if let Err(err) = apply_vibrancy(
+ &window,
+ NSVisualEffectMaterial::HudWindow,
+ Some(NSVisualEffectState::FollowsWindowActiveState),
+ Some(12.0),
+ ) {
+ append_desktop_log(
+ &app.handle(),
+ "WARN",
+ &format!("apply_vibrancy failed (continuing without vibrancy): {err}"),
+ );
+ }
+ }
+
  append_desktop_log(
  &app.handle(),
  "INFO",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,6 +11,7 @@
     "devUrl": "http://localhost:3000"
   },
   "app": {
+    "macOSPrivateApi": true,
     "windows": [
       {
         "title": "Crystal Ball",
@@ -22,11 +23,12 @@
         "fullscreen": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
+        "transparent": true,
         "backgroundColor": [
-          28,
-          28,
-          30,
-          255
+          0,
+          0,
+          0,
+          0
         ]
       }
     ],

--- a/src/app/layout/html.ts
+++ b/src/app/layout/html.ts
@@ -120,7 +120,7 @@ export function buildDesktopLayout(ctx: AppContext): string {
  </div>
 
  <!-- macOS native shell -->
- <div class="mac-shell">
+ <div class="mac-shell app-root">
 
  <!-- Sidebar -->
  <aside class="mac-sidebar">
@@ -171,7 +171,7 @@ export function buildDesktopLayout(ctx: AppContext): string {
  <!-- Main content: toolbar + map/panels -->
  <main class="mac-content">
  <!-- Draggable toolbar (title bar area) — drag via JS _setupToolbarDrag() -->
- <div class="mac-content-toolbar" data-tauri-drag-region>
+ <div class="mac-content-toolbar app-titlebar" data-tauri-drag-region>
  <button class="mac-sidebar-toggle-btn" id="sidebarCollapseBtn" title="Toggle sidebar (⌘\)" aria-label="Toggle sidebar">
  <svg width="14" height="12" viewBox="0 0 14 12" fill="none" xmlns="http://www.w3.org/2000/svg">
  <rect x="0" y="0" width="4" height="12" rx="1.5" fill="currentColor" opacity="0.5"/>

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import './styles/base-layer.css';
 import './styles/happy-theme.css';
 import './styles/gods-eye-4d.css';
 import './styles/modes.css';
+import './styles/window-chrome.css';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import * as Sentry from '@sentry/browser';
 import { inject } from '@vercel/analytics';

--- a/src/styles/window-chrome.css
+++ b/src/styles/window-chrome.css
@@ -1,0 +1,46 @@
+/* Native macOS window chrome — vibrancy showthrough + traffic-light safe zone.
+ *
+ * Paired with:
+ *   - `transparent: true` + `macOSPrivateApi: true` in src-tauri/tauri.conf.json
+ *   - `apply_vibrancy(NSVisualEffectMaterial::HudWindow, …)` in src-tauri/src/main.rs
+ *
+ * Only takes effect inside Tauri (body.is-desktop-macos). Web builds remain
+ * opaque so they don't render the translucent material against a blank canvas.
+ */
+
+/* Allow NSVisualEffectView to bleed through the webview when running in Tauri. */
+body.is-desktop-macos,
+body.is-desktop-macos #app {
+  background: transparent !important;
+}
+
+/* Root translucent surface. Falls back gracefully when the OS-level
+ * vibrancy material isn't available (older macOS, web preview, etc.). */
+body.is-desktop-macos .app-root {
+  background: rgba(20, 20, 30, 0.55);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+}
+
+body.is-desktop-macos[data-theme="light"] .app-root {
+  background: rgba(242, 242, 247, 0.55);
+}
+
+/* Title-bar drag region — leaves an 80px safe zone for the macOS
+ * traffic-light buttons at the top-left. Tauri's `data-tauri-drag-region`
+ * attribute is the official drag mechanism in Tauri 2; the
+ * `-webkit-app-region: drag` rule is a belt-and-suspenders fallback for
+ * any future surface that forgets to set the attribute. */
+body.is-desktop-macos .app-titlebar {
+  -webkit-app-region: drag;
+  padding-left: 80px;
+}
+
+/* No-drag zones for interactive elements inside the titlebar. */
+body.is-desktop-macos .app-titlebar button,
+body.is-desktop-macos .app-titlebar input,
+body.is-desktop-macos .app-titlebar select,
+body.is-desktop-macos .app-titlebar a,
+body.is-desktop-macos .app-titlebar [role="button"] {
+  -webkit-app-region: no-drag;
+}


### PR DESCRIPTION
Applies window-vibrancy HudWindow material, removes the opaque window background, enables transparent titlebar overlay, and adds proper traffic-light safe zone + drag region CSS.

## What changed

- `src-tauri/Cargo.toml` — adds `window-vibrancy 0.6` under a `cfg(target_os = "macos")` target and enables the `macos-private-api` feature on the `tauri` crate (required for transparent windows on macOS).
- `src-tauri/tauri.conf.json` — sets `app.macOSPrivateApi: true`, `windows[0].transparent: true`, and zeroes the existing `backgroundColor` so the NSVisualEffectView bleeds through.
- `src-tauri/src/main.rs` — calls `apply_vibrancy(window, NSVisualEffectMaterial::HudWindow, Some(FollowsWindowActiveState), Some(12.0))` in the setup hook, behind a `#[cfg(target_os = "macos")]` gate. Logs a WARN via `append_desktop_log` and continues if vibrancy can't be applied (older macOS, sandboxed launch, etc.) — never panics.
- `src/styles/window-chrome.css` (new) — `body.is-desktop-macos`-scoped rules: transparent body/`#app`, translucent `.app-root` fallback (light + dark variants), `.app-titlebar` drag region with an 80px traffic-light safe zone, and `no-drag` exceptions for buttons/inputs/selects/links.
- `src/main.ts` — imports the new stylesheet alongside the existing style imports.
- `src/app/layout/html.ts` — adds `app-root` to the existing `.mac-shell` container and `app-titlebar` to `.mac-content-toolbar`. Other classes (`mac-content-toolbar`, `mac-shell`) are preserved so the existing `macos-native.css` rules still apply.

## Notes on the spec

The original task spec suggested `decorations: false` alongside `titleBarStyle: "Overlay"`. Those are mutually exclusive on macOS: `decorations: false` removes the entire window chrome including the traffic-light buttons, but the CSS in the same spec reserves an 80px safe zone for them. I kept `decorations` at the Tauri default (`true`) and relied on the existing `titleBarStyle: "Overlay"` + `hiddenTitle: true` to give the macOS-native "hidden title bar, content extends under, traffic lights remain at top-left" look. The safe-zone CSS is the right pairing for that mode.

## Verification

- `cargo check` — clean (after the usual `build:sidecar-{sebuf,xmpp}` + `vite build` prerequisites that `tauri::generate_context!` reads).
- `npx tsc --noEmit` — clean.
- No new test coverage — pure styling + a single gated FFI call. The existing `macos-native.css` rules remain authoritative for sidebar/toolbar look; the new stylesheet only adds the transparency + safe-zone layer.

## Cross-agent review

Cross-agent review: claude reviewed on 2026-05-13; outcome: pass