### PR TITLE
feat(intelligence): Situation Store v2 — named Situations from correlated cross-domain signals

### DIFF
--- a/src/services/intelligence/situation-store-v2.ts
+++ b/src/services/intelligence/situation-store-v2.ts
@@ -1,0 +1,764 @@
+/**
+ * Situation Store v2 — named, evidence-backed Situations aggregated from
+ * raw ObservationEvents through the CorrelateEngine.
+ *
+ * Inputs (Phase 3):
+ *   - `ObservationEvent` (observation-adapters.ts) — normalized signals.
+ *   - `CorrelateEngine.correlate()` (correlate-engine.ts) — produces
+ *     `CorrelatedPair[]` with typed edges + confidences.
+ *   - `EntityRegistry` (entity-registry.ts) — resolves observation
+ *     `entityIds[]` into canonical Entity rows.
+ *
+ * Output: a stable, persistable set of `Situation` objects, each with:
+ *   - One human-readable name + summary
+ *   - Observations + typed EvidenceEdges (the evidence graph)
+ *   - Resolved entity ids
+ *   - Confidence + severity rolled up from the contributing facts
+ *   - status: 'watching' (singleton observation) → 'active' (correlated)
+ *     → 'resolved' (all observations >48h stale)
+ *
+ * Pure module — no DOM, no fetch, no globals at import time. Persists
+ * the most-recent 200 situations to `localStorage` under
+ * `wm-situation-store-v2`.
+ */
+
+import { CorrelateEngine, type CorrelatedPair, type EdgeType } from './correlate-engine';
+import { builtInCorrelationRules } from './built-in-correlation-rules';
+import { resolve as resolveEntity } from './entity-registry';
+import type { ObservationEvent } from './observation-adapters';
+
+// ── Public types ──────────────────────────────────────────────────────
+
+export type EvidenceEdgeType =
+  | 'caused_by'
+  | 'co-located'
+  | 'temporally-adjacent'
+  | 'contradicts'
+  | 'confirms';
+
+export interface EvidenceEdge {
+  type: EvidenceEdgeType;
+  sourceEventId: string;
+  targetEventId: string;
+  confidence: number;
+  /** ID of the CorrelationRule that produced this edge, when applicable. */
+  ruleId?: string;
+}
+
+export type SituationSeverity = 'low' | 'medium' | 'high' | 'critical';
+export type SituationStatus = 'active' | 'watching' | 'resolved';
+
+export interface SituationLocation {
+  lat: number;
+  lon: number;
+  radiusKm: number;
+}
+
+export interface Situation {
+  id: string;
+  name: string;
+  domain: string;
+  relatedDomains: string[];
+  severity: SituationSeverity;
+  status: SituationStatus;
+  summary: string;
+  observations: ObservationEvent[];
+  edges: EvidenceEdge[];
+  entityIds: string[];
+  /** 0..1 confidence the situation is real, weighted by edge strengths. */
+  confidence: number;
+  startedAt: Date;
+  updatedAt: Date;
+  resolvedAt?: Date;
+  location?: SituationLocation;
+  tags: string[];
+}
+
+export interface SituationFilter {
+  status?: SituationStatus;
+  domain?: string;
+  minSeverity?: SituationSeverity;
+  /** Only include situations updated at or after this epoch ms. */
+  sinceMs?: number;
+}
+
+export interface SituationStats {
+  total: number;
+  active: number;
+  watching: number;
+  resolved: number;
+  byDomain: Record<string, number>;
+}
+
+export type SituationListener = (situations: Situation[]) => void;
+
+// ── Constants + helpers ───────────────────────────────────────────────
+
+const STORAGE_KEY = 'wm-situation-store-v2';
+const MAX_SITUATIONS = 200;
+const STALE_AFTER_MS = 48 * 60 * 60 * 1000;
+const MERGE_DISTANCE_KM = 500;
+const MERGE_TIME_MS = 6 * 60 * 60 * 1000;
+
+const SEVERITY_RANK: Record<SituationSeverity, number> = {
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+};
+
+const EDGE_TYPE_MAP: Record<EdgeType, EvidenceEdgeType> = {
+  'causal-candidate': 'caused_by',
+  'co-located': 'co-located',
+  'temporally-adjacent': 'temporally-adjacent',
+  contradicts: 'contradicts',
+};
+
+const EARTH_KM = 6371;
+const DEG2RAD = Math.PI / 180;
+
+function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const dLat = (lat2 - lat1) * DEG2RAD;
+  const dLon = (lon2 - lon1) * DEG2RAD;
+  const a = Math.sin(dLat / 2) ** 2
+    + Math.cos(lat1 * DEG2RAD) * Math.cos(lat2 * DEG2RAD) * Math.sin(dLon / 2) ** 2;
+  return EARTH_KM * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function safeStorage(): Storage | null {
+  try {
+    const ls = (globalThis as { localStorage?: Storage }).localStorage;
+    return ls ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function dedupeStrings(values: readonly string[]): string[] {
+  return [...new Set(values)];
+}
+
+// ── Severity + confidence rollups ─────────────────────────────────────
+
+function severityFromObservations(observations: readonly ObservationEvent[]): SituationSeverity {
+  if (observations.length === 0) return 'low';
+  let hasCritical = false;
+  let hasHigh = false;
+  let hasMedium = false;
+  for (const o of observations) {
+    if (o.severity === 'CRITICAL') hasCritical = true;
+    else if (o.severity === 'HIGH') hasHigh = true;
+    else if (o.severity === 'MEDIUM') hasMedium = true;
+  }
+  if (hasCritical) return 'critical';
+  if (hasHigh) return 'high';
+  if (hasMedium || observations.length >= 2) return 'medium';
+  return 'low';
+}
+
+function statusFromContext(
+  observations: readonly ObservationEvent[],
+  edges: readonly EvidenceEdge[],
+  now: number,
+): SituationStatus {
+  if (observations.length === 0) return 'resolved';
+  const newest = observations.reduce((m, o) => Math.max(m, o.timestamp), 0);
+  if (now - newest > STALE_AFTER_MS) return 'resolved';
+  if (edges.length > 0 || observations.length >= 2) return 'active';
+  return 'watching';
+}
+
+function confidenceFromEdges(edges: readonly EvidenceEdge[], observationCount: number): number {
+  if (edges.length === 0) {
+    // Lone observation — anchor confidence on the existence of the signal.
+    return observationCount > 0 ? 0.5 : 0;
+  }
+  // Weighted average of edge confidences, biased upward when many
+  // independent edges agree. Capped at 0.99 — a Situation built from
+  // correlations is never "proven", only "well-supported".
+  const sum = edges.reduce((acc, e) => acc + e.confidence, 0);
+  const avg = sum / edges.length;
+  const breadthBonus = Math.min(0.2, edges.length * 0.03);
+  return Math.min(0.99, Number((avg + breadthBonus).toFixed(4)));
+}
+
+// ── Name + summary generation ─────────────────────────────────────────
+
+function regionLabel(location?: SituationLocation): string {
+  if (!location) return 'unknown region';
+  const lat = location.lat.toFixed(1);
+  const lon = location.lon.toFixed(1);
+  return `${lat}°, ${lon}°`;
+}
+
+function primaryDomain(observations: readonly ObservationEvent[]): string {
+  if (observations.length === 0) return 'unknown';
+  // Pick the most severe observation's domain; ties broken by newest.
+  const ranked = [...observations].sort((a, b) => {
+    const sevA = severityWeight(a.severity);
+    const sevB = severityWeight(b.severity);
+    if (sevB !== sevA) return sevB - sevA;
+    return b.timestamp - a.timestamp;
+  });
+  return ranked[0]!.domain;
+}
+
+function severityWeight(severity: ObservationEvent['severity']): number {
+  switch (severity) {
+    case 'CRITICAL': { return 4;
+    }
+    case 'HIGH': {     return 3;
+    }
+    case 'MEDIUM': {   return 2;
+    }
+    case 'LOW': {      return 1;
+    }
+    default: {         return 0;
+    }
+  }
+}
+
+function relatedDomainsFor(
+  primary: string,
+  observations: readonly ObservationEvent[],
+): string[] {
+  const all = dedupeStrings(observations.map((o) => o.domain));
+  return all.filter((d) => d !== primary);
+}
+
+function generateName(observations: readonly ObservationEvent[], location?: SituationLocation): string {
+  const primary = primaryDomain(observations);
+  const related = relatedDomainsFor(primary, observations);
+  const region = regionLabel(location);
+  const suffix = related.length > 0 ? ` (${[primary, ...related].join('+')})` : '';
+  return `${primary} event — ${region}${suffix}`;
+}
+
+function pluralS(count: number): string {
+  return count === 1 ? '' : 's';
+}
+
+function generateSummary(observations: readonly ObservationEvent[], edges: readonly EvidenceEdge[]): string {
+  if (observations.length === 0) return 'No observations.';
+  const ranked = [...observations].sort((a, b) => severityWeight(b.severity) - severityWeight(a.severity));
+  const lead = ranked[0]!;
+  const others = observations.length - 1;
+  const tail = others === 0
+    ? ''
+    : ` + ${others} related observation${pluralS(others)}`;
+  const evidenceFragment = edges.length === 0
+    ? ''
+    : ` linked by ${edges.length} evidence edge${pluralS(edges.length)}`;
+  return `${lead.title}${tail}${evidenceFragment}.`;
+}
+
+// ── Location aggregation ──────────────────────────────────────────────
+
+function locationFromObservations(
+  observations: readonly ObservationEvent[],
+): SituationLocation | undefined {
+  const located = observations.filter((o): o is ObservationEvent & { location: NonNullable<ObservationEvent['location']> } => !!o.location);
+  if (located.length === 0) return undefined;
+  // Centroid + max-extent radius.
+  const lat = located.reduce((acc, o) => acc + o.location.lat, 0) / located.length;
+  const lon = located.reduce((acc, o) => acc + o.location.lon, 0) / located.length;
+  const maxRadius = located.reduce((acc, o) => {
+    const d = haversineKm(lat, lon, o.location.lat, o.location.lon) + (o.location.radiusKm ?? 0);
+    return Math.max(acc, d);
+  }, 0);
+  return { lat, lon, radiusKm: Math.max(maxRadius, 1) };
+}
+
+// ── Tag + entity rollups ──────────────────────────────────────────────
+
+function aggregateTags(observations: readonly ObservationEvent[]): string[] {
+  const tags = new Set<string>();
+  for (const o of observations) {
+    for (const t of o.tags) tags.add(t);
+  }
+  return [...tags];
+}
+
+function aggregateEntityIds(observations: readonly ObservationEvent[]): string[] {
+  const ids = new Set<string>();
+  for (const o of observations) {
+    for (const id of o.entityIds) {
+      const resolved = resolveEntity(id);
+      ids.add(resolved?.id ?? id);
+    }
+  }
+  return [...ids];
+}
+
+// ── Group correlated pairs + lone observations into draft Situations ──
+
+interface DraftSituation {
+  observations: ObservationEvent[];
+  edges: EvidenceEdge[];
+}
+
+function pairToEdge(pair: CorrelatedPair): EvidenceEdge {
+  return {
+    type: EDGE_TYPE_MAP[pair.edgeType],
+    sourceEventId: pair.eventA.id,
+    targetEventId: pair.eventB.id,
+    confidence: pair.confidence,
+    ruleId: pair.ruleId,
+  };
+}
+
+/**
+ * Union-find over correlated pairs + lone observations. Two pairs are
+ * connected when they share at least one observation. Lone observations
+ * become singleton groups.
+ */
+function groupPairsByConnectivity(
+  observations: readonly ObservationEvent[],
+  pairs: readonly CorrelatedPair[],
+): DraftSituation[] {
+  const obsById = new Map<string, ObservationEvent>();
+  for (const o of observations) obsById.set(o.id, o);
+
+  const parent = new Map<string, string>();
+  const ensure = (id: string): string => {
+    if (!parent.has(id)) parent.set(id, id);
+    return id;
+  };
+  const find = (id: string): string => {
+    ensure(id);
+    let cur = parent.get(id)!;
+    while (cur !== parent.get(cur)) cur = parent.get(cur)!;
+    parent.set(id, cur);
+    return cur;
+  };
+  const union = (a: string, b: string): void => {
+    const ra = find(a);
+    const rb = find(b);
+    if (ra !== rb) parent.set(ra, rb);
+  };
+
+  for (const o of observations) ensure(o.id);
+  for (const p of pairs) {
+    ensure(p.eventA.id);
+    ensure(p.eventB.id);
+    union(p.eventA.id, p.eventB.id);
+  }
+
+  const buckets = new Map<string, DraftSituation>();
+  for (const o of observations) {
+    const root = find(o.id);
+    let bucket = buckets.get(root);
+    if (!bucket) {
+      bucket = { observations: [], edges: [] };
+      buckets.set(root, bucket);
+    }
+    bucket.observations.push(o);
+  }
+  for (const p of pairs) {
+    const root = find(p.eventA.id);
+    const bucket = buckets.get(root);
+    if (!bucket) continue;
+    // Guard against missing observations on the bucket — both events
+    // should already be there because we ensured + unioned above.
+    if (!bucket.observations.some((o) => o.id === p.eventA.id) && obsById.has(p.eventA.id)) {
+      bucket.observations.push(obsById.get(p.eventA.id)!);
+    }
+    if (!bucket.observations.some((o) => o.id === p.eventB.id) && obsById.has(p.eventB.id)) {
+      bucket.observations.push(obsById.get(p.eventB.id)!);
+    }
+    bucket.edges.push(pairToEdge(p));
+  }
+  return [...buckets.values()];
+}
+
+function meetsSeverity(severity: SituationSeverity, minimum?: SituationSeverity): boolean {
+  if (!minimum) return true;
+  return SEVERITY_RANK[severity] >= SEVERITY_RANK[minimum];
+}
+
+// ── Persistence ───────────────────────────────────────────────────────
+
+interface PersistedSituation extends Omit<Situation, 'startedAt' | 'updatedAt' | 'resolvedAt'> {
+  startedAt: number;
+  updatedAt: number;
+  resolvedAt?: number;
+}
+
+function serialize(situations: readonly Situation[]): PersistedSituation[] {
+  return situations.map((s) => ({
+    ...s,
+    observations: [...s.observations],
+    edges: [...s.edges],
+    entityIds: [...s.entityIds],
+    tags: [...s.tags],
+    relatedDomains: [...s.relatedDomains],
+    location: s.location ? { ...s.location } : undefined,
+    startedAt: s.startedAt.getTime(),
+    updatedAt: s.updatedAt.getTime(),
+    resolvedAt: s.resolvedAt?.getTime(),
+  }));
+}
+
+function asArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+function deserializeEntry(entry: unknown): Situation | undefined {
+  if (!entry || typeof entry !== 'object') return undefined;
+  const e = entry as PersistedSituation;
+  if (typeof e.id !== 'string' || typeof e.startedAt !== 'number') return undefined;
+  const updatedRaw = typeof e.updatedAt === 'number' ? e.updatedAt : e.startedAt;
+  const resolvedAt = typeof e.resolvedAt === 'number' ? new Date(e.resolvedAt) : undefined;
+  return {
+    id: e.id,
+    name: e.name ?? '',
+    domain: e.domain ?? 'unknown',
+    relatedDomains: asArray<string>(e.relatedDomains),
+    severity: (e.severity ?? 'low') as SituationSeverity,
+    status: (e.status ?? 'watching') as SituationStatus,
+    summary: e.summary ?? '',
+    observations: asArray<ObservationEvent>(e.observations),
+    edges: asArray<EvidenceEdge>(e.edges),
+    entityIds: asArray<string>(e.entityIds),
+    confidence: typeof e.confidence === 'number' ? e.confidence : 0,
+    startedAt: new Date(e.startedAt),
+    updatedAt: new Date(updatedRaw),
+    resolvedAt,
+    location: e.location ? { ...e.location } : undefined,
+    tags: asArray<string>(e.tags),
+  };
+}
+
+function deserialize(raw: unknown): Situation[] {
+  if (!Array.isArray(raw)) return [];
+  const out: Situation[] = [];
+  for (const entry of raw) {
+    const parsed = deserializeEntry(entry);
+    if (parsed) out.push(parsed);
+  }
+  return out;
+}
+
+// ── Store ─────────────────────────────────────────────────────────────
+
+export interface SituationStoreV2Options {
+  engine?: CorrelateEngine;
+  /** Override Date.now() — useful for deterministic tests. */
+  clock?: () => number;
+}
+
+export class SituationStoreV2 {
+  private situations: Situation[] = [];
+  private listeners = new Set<SituationListener>();
+  private hydrated = false;
+  private engine: CorrelateEngine;
+  private clock: () => number;
+  private idCounter = 0;
+
+  constructor(options: SituationStoreV2Options = {}) {
+    this.engine = options.engine ?? this.defaultEngine();
+    this.clock = options.clock ?? (() => Date.now());
+  }
+
+  private defaultEngine(): CorrelateEngine {
+    const engine = new CorrelateEngine();
+    for (const rule of builtInCorrelationRules) engine.registerRule(rule);
+    return engine;
+  }
+
+  private ensureHydrated(): void {
+    if (this.hydrated) return;
+    this.hydrated = true;
+    const store = safeStorage();
+    if (!store) return;
+    let raw: string | null = null;
+    try { raw = store.getItem(STORAGE_KEY); } catch { return; }
+    if (!raw) return;
+    try {
+      this.situations = deserialize(JSON.parse(raw));
+    } catch {
+      // Corrupt blob — start clean.
+    }
+  }
+
+  private persist(): void {
+    const store = safeStorage();
+    if (!store) return;
+    try {
+      store.setItem(STORAGE_KEY, JSON.stringify(serialize(this.situations)));
+    } catch {
+      // Quota or disabled — non-critical.
+    }
+  }
+
+  private nextId(now: number): string {
+    this.idCounter += 1;
+    return `sit-v2-${now.toString(36)}-${this.idCounter}`;
+  }
+
+  private notify(): void {
+    const snapshot = this.list();
+    for (const l of this.listeners) {
+      try { l(snapshot); } catch { /* listener crash isolation */ }
+    }
+  }
+
+  /** Ingest a batch of ObservationEvents. Runs CorrelateEngine to find
+   *  evidence edges, then merges results into existing open situations
+   *  or creates new ones. Auto-resolves stale situations. */
+  ingest(observations: readonly ObservationEvent[]): void {
+    this.ensureHydrated();
+    if (observations.length === 0) {
+      this.autoResolveStale();
+      this.persist();
+      this.notify();
+      return;
+    }
+    const result = this.engine.correlate(observations, new Date(this.clock()));
+    const drafts = groupPairsByConnectivity(observations, result.pairs);
+    for (const draft of drafts) this.mergeOrCreate(draft);
+    this.autoResolveStale();
+    this.enforceCapacity();
+    this.persist();
+    this.notify();
+  }
+
+  private mergeOrCreate(draft: DraftSituation): void {
+    const now = this.clock();
+    const match = this.findMergeTarget(draft);
+    if (match) {
+      this.mergeIntoExisting(match, draft, now);
+      return;
+    }
+    this.situations.push(this.buildSituation(draft, now));
+  }
+
+  private findMergeTarget(draft: DraftSituation): Situation | undefined {
+    const draftIds = new Set(draft.observations.map((o) => o.id));
+    for (const existing of this.situations) {
+      if (existing.status === 'resolved') continue;
+      // Shared observation → merge.
+      if (existing.observations.some((o) => draftIds.has(o.id))) return existing;
+      // Same place + time window → merge.
+      if (existing.location && this.isWithinMergeWindow(existing, draft)) return existing;
+    }
+    return undefined;
+  }
+
+  private isWithinMergeWindow(existing: Situation, draft: DraftSituation): boolean {
+    const draftLocation = locationFromObservations(draft.observations);
+    if (!draftLocation || !existing.location) return false;
+    const distance = haversineKm(
+      existing.location.lat, existing.location.lon,
+      draftLocation.lat, draftLocation.lon,
+    );
+    if (distance > MERGE_DISTANCE_KM) return false;
+    const draftNewest = draft.observations.reduce((m, o) => Math.max(m, o.timestamp), 0);
+    return Math.abs(existing.updatedAt.getTime() - draftNewest) <= MERGE_TIME_MS;
+  }
+
+  private buildSituation(draft: DraftSituation, now: number): Situation {
+    const observations = [...draft.observations];
+    const edges = [...draft.edges];
+    const location = locationFromObservations(observations);
+    const tags = aggregateTags(observations);
+    const entityIds = aggregateEntityIds(observations);
+    const domain = primaryDomain(observations);
+    const relatedDomains = relatedDomainsFor(domain, observations);
+    const severity = severityFromObservations(observations);
+    const status = statusFromContext(observations, edges, now);
+    const confidence = confidenceFromEdges(edges, observations.length);
+    return {
+      id: this.nextId(now),
+      name: generateName(observations, location),
+      domain,
+      relatedDomains,
+      severity,
+      status,
+      summary: generateSummary(observations, edges),
+      observations,
+      edges,
+      entityIds,
+      confidence,
+      startedAt: new Date(observations.reduce((m, o) => Math.min(m, o.timestamp), now)),
+      updatedAt: new Date(now),
+      resolvedAt: status === 'resolved' ? new Date(now) : undefined,
+      location,
+      tags,
+    };
+  }
+
+  private mergeIntoExisting(target: Situation, draft: DraftSituation, now: number): void {
+    const seenObs = new Set(target.observations.map((o) => o.id));
+    const newObs = draft.observations.filter((o) => !seenObs.has(o.id));
+    const observations = [...target.observations, ...newObs];
+
+    const seenEdge = new Set(target.edges.map((e) => edgeKey(e)));
+    const newEdges = draft.edges.filter((e) => !seenEdge.has(edgeKey(e)));
+    const edges = [...target.edges, ...newEdges];
+
+    const location = locationFromObservations(observations);
+    const severity = severityFromObservations(observations);
+    const status = statusFromContext(observations, edges, now);
+    const confidence = confidenceFromEdges(edges, observations.length);
+    const domain = primaryDomain(observations);
+
+    Object.assign(target, {
+      observations,
+      edges,
+      location,
+      severity,
+      status,
+      confidence,
+      domain,
+      relatedDomains: relatedDomainsFor(domain, observations),
+      summary: generateSummary(observations, edges),
+      name: generateName(observations, location),
+      tags: aggregateTags(observations),
+      entityIds: aggregateEntityIds(observations),
+      updatedAt: new Date(now),
+      resolvedAt: status === 'resolved' ? (target.resolvedAt ?? new Date(now)) : undefined,
+    } satisfies Partial<Situation>);
+  }
+
+  private autoResolveStale(): void {
+    const now = this.clock();
+    for (const s of this.situations) {
+      if (s.status === 'resolved') continue;
+      const newest = s.observations.reduce((m, o) => Math.max(m, o.timestamp), 0);
+      if (newest === 0) continue;
+      if (now - newest > STALE_AFTER_MS) {
+        s.status = 'resolved';
+        s.resolvedAt = new Date(now);
+        s.updatedAt = new Date(now);
+      }
+    }
+  }
+
+  private enforceCapacity(): void {
+    if (this.situations.length <= MAX_SITUATIONS) return;
+    // Drop oldest (by updatedAt) resolved first; then oldest overall.
+    this.situations.sort((a, b) => {
+      if (a.status === 'resolved' && b.status !== 'resolved') return -1;
+      if (b.status === 'resolved' && a.status !== 'resolved') return 1;
+      return a.updatedAt.getTime() - b.updatedAt.getTime();
+    });
+    this.situations.splice(0, this.situations.length - MAX_SITUATIONS);
+  }
+
+  list(): Situation[] {
+    this.ensureHydrated();
+    // Return a defensive copy so callers can't mutate internal state.
+    return this.situations.map((s) => cloneSituation(s));
+  }
+
+  getSituations(filter?: SituationFilter): Situation[] {
+    this.ensureHydrated();
+    return this.situations
+      .filter((s) => this.matchesFilter(s, filter))
+      .map((s) => cloneSituation(s));
+  }
+
+  private matchesFilter(s: Situation, filter?: SituationFilter): boolean {
+    if (!filter) return true;
+    if (filter.status && s.status !== filter.status) return false;
+    if (filter.domain && s.domain !== filter.domain) return false;
+    if (!meetsSeverity(s.severity, filter.minSeverity)) return false;
+    if (filter.sinceMs !== undefined && s.updatedAt.getTime() < filter.sinceMs) return false;
+    return true;
+  }
+
+  getSituation(id: string): Situation | undefined {
+    this.ensureHydrated();
+    const s = this.situations.find((x) => x.id === id);
+    return s ? cloneSituation(s) : undefined;
+  }
+
+  getActive(): Situation[] {
+    return this.getSituations({ status: 'active' });
+  }
+
+  subscribe(listener: SituationListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  stats(): SituationStats {
+    this.ensureHydrated();
+    const byDomain: Record<string, number> = {};
+    let active = 0;
+    let watching = 0;
+    let resolved = 0;
+    for (const s of this.situations) {
+      byDomain[s.domain] = (byDomain[s.domain] ?? 0) + 1;
+      if (s.status === 'active') active += 1;
+      else if (s.status === 'watching') watching += 1;
+      else if (s.status === 'resolved') resolved += 1;
+    }
+    return { total: this.situations.length, active, watching, resolved, byDomain };
+  }
+
+  /** Test seam — empties the store and the persisted blob. */
+  resetForTesting(): void {
+    this.situations = [];
+    this.listeners.clear();
+    this.idCounter = 0;
+    this.hydrated = true;
+    const store = safeStorage();
+    if (store) {
+      try { store.removeItem(STORAGE_KEY); } catch { /* best effort */ }
+    }
+  }
+}
+
+function edgeKey(edge: EvidenceEdge): string {
+  const [a, b] = edge.sourceEventId < edge.targetEventId
+    ? [edge.sourceEventId, edge.targetEventId]
+    : [edge.targetEventId, edge.sourceEventId];
+  return `${edge.type}|${a}|${b}|${edge.ruleId ?? ''}`;
+}
+
+function cloneSituation(s: Situation): Situation {
+  return {
+    ...s,
+    observations: s.observations.map((o) => ({ ...o, entityIds: [...o.entityIds], tags: [...o.tags] })),
+    edges: s.edges.map((e) => ({ ...e })),
+    entityIds: [...s.entityIds],
+    tags: [...s.tags],
+    relatedDomains: [...s.relatedDomains],
+    location: s.location ? { ...s.location } : undefined,
+    startedAt: new Date(s.startedAt),
+    updatedAt: new Date(s.updatedAt),
+    resolvedAt: s.resolvedAt ? new Date(s.resolvedAt) : undefined,
+  };
+}
+
+// ── Singleton ─────────────────────────────────────────────────────────
+
+let _singleton: SituationStoreV2 | null = null;
+
+export function getSituationStoreV2(): SituationStoreV2 {
+  _singleton ??= new SituationStoreV2();
+  return _singleton;
+}
+
+/** Test seam — replaces the singleton with a fresh instance. */
+export function __resetSituationStoreV2Singleton(): void {
+  _singleton = null;
+}
+
+// ── Exposed helpers for diagnostics + tests ──────────────────────────
+
+export const __internals = {
+  severityFromObservations,
+  statusFromContext,
+  generateName,
+  generateSummary,
+  groupPairsByConnectivity,
+  locationFromObservations,
+  haversineKm,
+  STALE_AFTER_MS,
+  MERGE_DISTANCE_KM,
+  MERGE_TIME_MS,
+  MAX_SITUATIONS,
+};

--- a/src/services/intelligence/situation-store.ts
+++ b/src/services/intelligence/situation-store.ts
@@ -152,3 +152,28 @@ export function __reset(): void {
   _entries = [];
   _idCounter = 0;
 }
+
+// ── Situation Store v2 re-exports ─────────────────────────────────────────
+//
+// Newer code should import directly from `./situation-store-v2`. These
+// shims let existing panels and tests keep their `./situation-store`
+// imports while the migration finishes. Nothing here overrides the
+// legacy v1 API above.
+
+export type {
+  EvidenceEdge,
+  EvidenceEdgeType,
+  Situation as SituationV2,
+  SituationFilter,
+  SituationListener,
+  SituationLocation as SituationV2Location,
+  SituationSeverity as SituationV2Severity,
+  SituationStats,
+  SituationStatus as SituationV2Status,
+  SituationStoreV2Options,
+} from './situation-store-v2';
+export {
+  SituationStoreV2,
+  getSituationStoreV2,
+  __resetSituationStoreV2Singleton,
+} from './situation-store-v2';

--- a/tests/intelligence/situation-store-v2.test.mts
+++ b/tests/intelligence/situation-store-v2.test.mts
@@ -1,0 +1,539 @@
+/**
+ * Tests for SituationStoreV2 — Phase 3 named-Situation aggregator.
+ *
+ * Service tests run against:
+ *   - a localStorage stub (codebase convention),
+ *   - an injectable CorrelateEngine (deterministic rules, no built-ins),
+ *   - an injectable clock so "now" stays stable across tests.
+ *
+ * Goal: prove the merging / severity / status / persistence behavior
+ * the panels and notification ladder depend on.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+// localStorage stub before any imports that may hydrate from it.
+const __storage = new Map<string, string>();
+(globalThis as unknown as { localStorage: Storage }).localStorage = {
+  getItem: (k: string) => __storage.get(k) ?? null,
+  setItem: (k: string, v: string) => { __storage.set(k, v); },
+  removeItem: (k: string) => { __storage.delete(k); },
+  clear: () => { __storage.clear(); },
+  get length() { return __storage.size; },
+  key: (i: number) => [...__storage.keys()][i] ?? null,
+} as Storage;
+
+import {
+  CorrelateEngine,
+  type CorrelationRule,
+} from '../../src/services/intelligence/correlate-engine.ts';
+import type { ObservationEvent, ObservationSeverity } from '../../src/services/intelligence/observation-adapters.ts';
+import {
+  SituationStoreV2,
+  __internals,
+  __resetSituationStoreV2Singleton,
+  getSituationStoreV2,
+  type Situation,
+} from '../../src/services/intelligence/situation-store-v2.ts';
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+const NOW = 1_745_000_000_000;
+
+function makeEvent(overrides: Partial<ObservationEvent> = {}): ObservationEvent {
+  return {
+    id: `ev-${Math.random().toString(36).slice(2, 8)}`,
+    sourceId: 'test',
+    domain: 'weather',
+    timestamp: NOW,
+    severity: 'MEDIUM',
+    title: 'Test event',
+    raw: null,
+    entityIds: [],
+    tags: [],
+    ...overrides,
+  };
+}
+
+/** Always-match co-located rule so we can simulate any pair as correlated. */
+const ALWAYS_RULE: CorrelationRule = {
+  id: 'always-colocated',
+  name: 'Always co-located',
+  description: 'Test rule that matches any two observations within 1h.',
+  domains: [],
+  timeWindowMs: 60 * 60 * 1000,
+  edgeType: 'co-located',
+  matchFn: () => true,
+};
+
+const CAUSAL_RULE: CorrelationRule = {
+  id: 'always-causal',
+  name: 'Always causal',
+  description: 'Test rule that promotes any pair within 1h to a causal candidate.',
+  domains: [],
+  timeWindowMs: 60 * 60 * 1000,
+  edgeType: 'causal-candidate',
+  matchFn: () => true,
+  baseConfidence: 0.9,
+};
+
+function freshStore(rule: CorrelationRule = ALWAYS_RULE, now = NOW): SituationStoreV2 {
+  __storage.clear();
+  const engine = new CorrelateEngine();
+  engine.registerRule(rule);
+  return new SituationStoreV2({ engine, clock: () => now });
+}
+
+function quietStore(now = NOW): SituationStoreV2 {
+  // No rules — observations never correlate. Useful for severity / status
+  // tests where we want predictable singletons.
+  __storage.clear();
+  const engine = new CorrelateEngine();
+  return new SituationStoreV2({ engine, clock: () => now });
+}
+
+// ── Ingest basics ─────────────────────────────────────────────────────
+
+test('ingest([]) produces no situations', () => {
+  const store = freshStore();
+  store.ingest([]);
+  assert.equal(store.list().length, 0);
+});
+
+test('single observation → 1 situation with status=watching', () => {
+  const store = quietStore();
+  store.ingest([makeEvent({ id: 'a' })]);
+  const all = store.list();
+  assert.equal(all.length, 1);
+  assert.equal(all[0]!.status, 'watching');
+  assert.equal(all[0]!.observations.length, 1);
+  assert.equal(all[0]!.edges.length, 0);
+});
+
+test('two correlated observations → 1 merged situation with edges', () => {
+  const store = freshStore();
+  store.ingest([
+    makeEvent({ id: 'a', timestamp: NOW }),
+    makeEvent({ id: 'b', timestamp: NOW + 5_000 }),
+  ]);
+  const all = store.list();
+  assert.equal(all.length, 1);
+  assert.equal(all[0]!.observations.length, 2);
+  assert.equal(all[0]!.edges.length, 1);
+  assert.equal(all[0]!.edges[0]!.type, 'co-located');
+});
+
+test('correlation rule with causal-candidate edge maps to caused_by', () => {
+  const store = freshStore(CAUSAL_RULE);
+  store.ingest([
+    makeEvent({ id: 'a', timestamp: NOW }),
+    makeEvent({ id: 'b', timestamp: NOW + 1000 }),
+  ]);
+  const sit = store.list()[0]!;
+  assert.equal(sit.edges[0]!.type, 'caused_by');
+  assert.equal(sit.edges[0]!.ruleId, 'always-causal');
+});
+
+test('two distant unrelated observations → 2 separate situations', () => {
+  const store = quietStore();
+  store.ingest([
+    makeEvent({ id: 'a', domain: 'weather', location: { lat: 40, lon: -74, radiusKm: 1 } }),
+    makeEvent({ id: 'b', domain: 'cyber', location: { lat: -33, lon: 151, radiusKm: 1 } }),
+  ]);
+  assert.equal(store.list().length, 2);
+});
+
+// ── Severity rollup ──────────────────────────────────────────────────
+
+test('severity = critical when any observation is CRITICAL', () => {
+  const store = freshStore();
+  store.ingest([
+    makeEvent({ id: 'a', severity: 'CRITICAL' }),
+    makeEvent({ id: 'b', severity: 'LOW' }),
+  ]);
+  assert.equal(store.list()[0]!.severity, 'critical');
+});
+
+test('severity = high when max observation is HIGH', () => {
+  const store = freshStore();
+  store.ingest([
+    makeEvent({ id: 'a', severity: 'HIGH' }),
+    makeEvent({ id: 'b', severity: 'INFO' }),
+  ]);
+  assert.equal(store.list()[0]!.severity, 'high');
+});
+
+test('severity = medium when only MEDIUM or several lower-severity', () => {
+  const store = quietStore();
+  store.ingest([makeEvent({ id: 'a', severity: 'MEDIUM' })]);
+  assert.equal(store.list()[0]!.severity, 'medium');
+});
+
+test('severity = low when single LOW observation', () => {
+  const store = quietStore();
+  store.ingest([makeEvent({ id: 'a', severity: 'LOW' })]);
+  assert.equal(store.list()[0]!.severity, 'low');
+});
+
+// ── Status transitions ──────────────────────────────────────────────
+
+test('status = active when at least one edge is present', () => {
+  const store = freshStore();
+  store.ingest([makeEvent({ id: 'a' }), makeEvent({ id: 'b' })]);
+  assert.equal(store.list()[0]!.status, 'active');
+});
+
+test('status = watching for lone uncorrelated observation', () => {
+  const store = quietStore();
+  store.ingest([makeEvent({ id: 'a' })]);
+  assert.equal(store.list()[0]!.status, 'watching');
+});
+
+test('stale observations (>48h old) auto-resolve on next ingest', () => {
+  const past = NOW - 50 * 60 * 60 * 1000;
+  const store = quietStore();
+  store.ingest([makeEvent({ id: 'a', timestamp: past })]);
+  // Force another ingest with no new observations to trigger the
+  // stale-sweep. autoResolveStale runs against the configured clock.
+  store.ingest([]);
+  const sit = store.list()[0]!;
+  assert.equal(sit.status, 'resolved');
+  assert.ok(sit.resolvedAt, 'expected resolvedAt to be set');
+});
+
+// ── Merging ─────────────────────────────────────────────────────────
+
+test('re-ingesting a known observation merges into the existing situation', () => {
+  const store = quietStore();
+  const a = makeEvent({ id: 'a' });
+  store.ingest([a]);
+  store.ingest([a]);
+  assert.equal(store.list().length, 1);
+  assert.equal(store.list()[0]!.observations.length, 1);
+});
+
+test('shared observation across correlated batches keeps one situation', () => {
+  // Ingest 1: a + b correlated → situation S with [a,b]. Ingest 2: a + c
+  // correlated. Pair (a,c) shares observation a with S → c joins S.
+  const store = freshStore();
+  store.ingest([
+    makeEvent({ id: 'a', timestamp: NOW }),
+    makeEvent({ id: 'b', timestamp: NOW + 1000 }),
+  ]);
+  store.ingest([
+    makeEvent({ id: 'a', timestamp: NOW }),
+    makeEvent({ id: 'c', timestamp: NOW + 2000 }),
+  ]);
+  const all = store.list();
+  assert.equal(all.length, 1);
+  assert.equal(all[0]!.observations.length, 3);
+});
+
+test('events within 500km + 6h merge across ingests by proximity', () => {
+  const store = quietStore();
+  store.ingest([makeEvent({
+    id: 'a', location: { lat: 40, lon: -74, radiusKm: 1 }, timestamp: NOW,
+  })]);
+  store.ingest([makeEvent({
+    id: 'b', location: { lat: 40.5, lon: -74.5, radiusKm: 1 }, timestamp: NOW + 60_000,
+  })]);
+  assert.equal(store.list().length, 1);
+});
+
+test('events outside 500km + 6h window stay separate', () => {
+  const store = quietStore();
+  store.ingest([makeEvent({
+    id: 'a', location: { lat: 40, lon: -74, radiusKm: 1 }, timestamp: NOW,
+  })]);
+  store.ingest([makeEvent({
+    id: 'b', location: { lat: 10, lon: -10, radiusKm: 1 }, timestamp: NOW + 60_000,
+  })]);
+  assert.equal(store.list().length, 2);
+});
+
+test('events outside 6h time window stay separate even when close in space', () => {
+  const store = quietStore();
+  store.ingest([makeEvent({
+    id: 'a', location: { lat: 40, lon: -74, radiusKm: 1 }, timestamp: NOW,
+  })]);
+  store.ingest([makeEvent({
+    id: 'b', location: { lat: 40, lon: -74, radiusKm: 1 }, timestamp: NOW + 7 * 60 * 60 * 1000,
+  })]);
+  assert.equal(store.list().length, 2);
+});
+
+test('union-find: a-b correlated + b-c correlated → single situation with a,b,c', () => {
+  const ruleAB: CorrelationRule = {
+    id: 'pair-ab', name: 'a↔b', description: 't', domains: [],
+    timeWindowMs: 60 * 60 * 1000, edgeType: 'co-located',
+    matchFn: (x, y) => (x.id === 'a' && y.id === 'b') || (x.id === 'b' && y.id === 'a'),
+  };
+  const ruleBC: CorrelationRule = {
+    id: 'pair-bc', name: 'b↔c', description: 't', domains: [],
+    timeWindowMs: 60 * 60 * 1000, edgeType: 'co-located',
+    matchFn: (x, y) => (x.id === 'b' && y.id === 'c') || (x.id === 'c' && y.id === 'b'),
+  };
+  const engine = new CorrelateEngine();
+  engine.registerRule(ruleAB);
+  engine.registerRule(ruleBC);
+  __storage.clear();
+  const store = new SituationStoreV2({ engine, clock: () => NOW });
+  store.ingest([
+    makeEvent({ id: 'a' }), makeEvent({ id: 'b' }), makeEvent({ id: 'c' }),
+  ]);
+  const all = store.list();
+  assert.equal(all.length, 1);
+  assert.equal(all[0]!.observations.length, 3);
+  assert.equal(all[0]!.edges.length, 2);
+});
+
+// ── Confidence ──────────────────────────────────────────────────────
+
+test('lone observation gets baseline 0.5 confidence', () => {
+  const store = quietStore();
+  store.ingest([makeEvent({ id: 'a' })]);
+  assert.equal(store.list()[0]!.confidence, 0.5);
+});
+
+test('correlated pair confidence is bounded by [average + bonus, 0.99]', () => {
+  const store = freshStore(CAUSAL_RULE);
+  store.ingest([makeEvent({ id: 'a', timestamp: NOW }), makeEvent({ id: 'b', timestamp: NOW + 1000 })]);
+  const c = store.list()[0]!.confidence;
+  assert.ok(c >= 0.9 && c <= 0.99, `confidence ${c} not within [0.9, 0.99]`);
+});
+
+// ── Name + summary ─────────────────────────────────────────────────
+
+test('name includes primary domain and region', () => {
+  const store = quietStore();
+  store.ingest([makeEvent({
+    id: 'a', domain: 'seismic', location: { lat: 35.5, lon: 139.5, radiusKm: 10 },
+  })]);
+  const name = store.list()[0]!.name;
+  assert.match(name, /seismic/);
+  assert.match(name, /35\.5/);
+});
+
+test('name lists multi-domain combos when related domains exist', () => {
+  const store = freshStore();
+  store.ingest([
+    makeEvent({ id: 'a', domain: 'seismic', severity: 'CRITICAL' }),
+    makeEvent({ id: 'b', domain: 'weather' }),
+  ]);
+  const name = store.list()[0]!.name;
+  assert.match(name, /\+/);
+});
+
+test('summary mentions the lead observation title and edge count', () => {
+  const store = freshStore();
+  store.ingest([
+    makeEvent({ id: 'a', title: 'M7.0 quake near Tokyo', severity: 'CRITICAL' }),
+    makeEvent({ id: 'b', title: 'Tsunami warning' }),
+  ]);
+  const summary = store.list()[0]!.summary;
+  assert.match(summary, /Tokyo/);
+  assert.match(summary, /evidence edge/);
+});
+
+// ── Filtering ──────────────────────────────────────────────────────
+
+test('getSituations filters by status', () => {
+  const store = quietStore();
+  store.ingest([makeEvent({ id: 'a' })]);
+  store.ingest([makeEvent({ id: 'b', timestamp: NOW - 100 * 60 * 60 * 1000 })]);
+  store.ingest([]);  // sweep
+  const watching = store.getSituations({ status: 'watching' });
+  const resolved = store.getSituations({ status: 'resolved' });
+  assert.equal(watching.length, 1);
+  assert.equal(resolved.length, 1);
+});
+
+test('getSituations filters by domain', () => {
+  const store = quietStore();
+  store.ingest([makeEvent({ id: 'a', domain: 'cyber' })]);
+  store.ingest([makeEvent({ id: 'b', domain: 'weather', location: { lat: 0, lon: 0 } })]);
+  const cyber = store.getSituations({ domain: 'cyber' });
+  assert.equal(cyber.length, 1);
+  assert.equal(cyber[0]!.domain, 'cyber');
+});
+
+test('getSituations filters by minSeverity', () => {
+  const store = quietStore();
+  store.ingest([makeEvent({ id: 'a', severity: 'LOW' })]);
+  store.ingest([makeEvent({ id: 'b', severity: 'HIGH', location: { lat: 50, lon: 50 } })]);
+  const highOrAbove = store.getSituations({ minSeverity: 'high' });
+  assert.equal(highOrAbove.length, 1);
+  assert.equal(highOrAbove[0]!.severity, 'high');
+});
+
+test('getSituations filters by sinceMs', () => {
+  const store = quietStore();
+  store.ingest([makeEvent({ id: 'a' })]);
+  const before = store.getSituations({ sinceMs: NOW + 10_000 });
+  const after = store.getSituations({ sinceMs: NOW - 10_000 });
+  assert.equal(before.length, 0);
+  assert.equal(after.length, 1);
+});
+
+test('getActive() is an alias for status=active', () => {
+  const store = freshStore();
+  store.ingest([makeEvent({ id: 'a' }), makeEvent({ id: 'b' })]);
+  assert.equal(store.getActive().length, 1);
+});
+
+// ── Subscribe + notification ───────────────────────────────────────
+
+test('subscribe fires the listener on every ingest', () => {
+  const store = quietStore();
+  let calls = 0;
+  store.subscribe(() => { calls += 1; });
+  store.ingest([makeEvent({ id: 'a' })]);
+  store.ingest([makeEvent({ id: 'b', location: { lat: -40, lon: 100 } })]);
+  assert.equal(calls, 2);
+});
+
+test('subscribe returns an unsubscribe function', () => {
+  const store = quietStore();
+  let calls = 0;
+  const unsubscribe = store.subscribe(() => { calls += 1; });
+  store.ingest([makeEvent({ id: 'a' })]);
+  unsubscribe();
+  store.ingest([makeEvent({ id: 'b', location: { lat: -40, lon: 100 } })]);
+  assert.equal(calls, 1);
+});
+
+test('listener crashes do not break subsequent listeners', () => {
+  const store = quietStore();
+  let secondCalled = false;
+  store.subscribe(() => { throw new Error('boom'); });
+  store.subscribe(() => { secondCalled = true; });
+  store.ingest([makeEvent({ id: 'a' })]);
+  assert.equal(secondCalled, true);
+});
+
+// ── Stats ──────────────────────────────────────────────────────────
+
+test('stats() counts total, active, watching, resolved + per-domain', () => {
+  const store = quietStore();
+  store.ingest([makeEvent({ id: 'a', domain: 'weather' })]);
+  store.ingest([makeEvent({ id: 'b', domain: 'cyber', location: { lat: 30, lon: 30 } })]);
+  const stats = store.stats();
+  assert.equal(stats.total, 2);
+  assert.equal(stats.watching, 2);
+  assert.equal(stats.active, 0);
+  assert.equal(stats.resolved, 0);
+  assert.equal(stats.byDomain.weather, 1);
+  assert.equal(stats.byDomain.cyber, 1);
+});
+
+// ── Persistence ────────────────────────────────────────────────────
+
+test('situations persist across instances via localStorage', () => {
+  __storage.clear();
+  const engine = new CorrelateEngine();
+  const a = new SituationStoreV2({ engine, clock: () => NOW });
+  a.ingest([makeEvent({ id: 'a', title: 'Persisted observation' })]);
+  // New instance with the same clock sees the persisted blob.
+  const b = new SituationStoreV2({ engine, clock: () => NOW });
+  assert.equal(b.list().length, 1);
+  assert.equal(b.list()[0]!.observations[0]!.title, 'Persisted observation');
+});
+
+test('corrupt persisted JSON is ignored without throwing', () => {
+  __storage.clear();
+  __storage.set('wm-situation-store-v2', 'not-json');
+  const store = new SituationStoreV2({ engine: new CorrelateEngine(), clock: () => NOW });
+  assert.equal(store.list().length, 0);
+});
+
+// ── Entity resolution ─────────────────────────────────────────────
+
+test('entityIds rolled up from observations are deduped on the situation', () => {
+  const store = quietStore();
+  store.ingest([
+    makeEvent({ id: 'a', entityIds: ['ship-1', 'country-jp'] }),
+  ]);
+  store.ingest([
+    makeEvent({ id: 'b', entityIds: ['ship-1', 'callsign-x'], location: { lat: 0, lon: 0 } }),
+  ]);
+  const ids = store.list().flatMap((s) => s.entityIds).sort();
+  // Two situations (no merge — distant), each has its own entity set.
+  assert.deepEqual(ids, ['callsign-x', 'country-jp', 'ship-1', 'ship-1']);
+});
+
+// ── Singleton + reset hooks ─────────────────────────────────────────
+
+test('getSituationStoreV2 returns a stable singleton', () => {
+  __resetSituationStoreV2Singleton();
+  const a = getSituationStoreV2();
+  const b = getSituationStoreV2();
+  assert.equal(a, b);
+});
+
+test('resetForTesting empties the store and the persisted blob', () => {
+  const store = quietStore();
+  store.ingest([makeEvent({ id: 'a' })]);
+  store.resetForTesting();
+  assert.equal(store.list().length, 0);
+  assert.equal(__storage.has('wm-situation-store-v2'), false);
+});
+
+// ── Internal helpers ─────────────────────────────────────────────
+
+test('groupPairsByConnectivity puts lone observations in their own buckets', () => {
+  const drafts = __internals.groupPairsByConnectivity(
+    [makeEvent({ id: 'a' }), makeEvent({ id: 'b' })],
+    [],
+  );
+  assert.equal(drafts.length, 2);
+});
+
+test('locationFromObservations returns a centroid + extent', () => {
+  const loc = __internals.locationFromObservations([
+    makeEvent({ id: 'a', location: { lat: 0, lon: 0, radiusKm: 0 } }),
+    makeEvent({ id: 'b', location: { lat: 10, lon: 10, radiusKm: 0 } }),
+  ]);
+  assert.ok(loc);
+  assert.equal(loc!.lat, 5);
+  assert.equal(loc!.lon, 5);
+  assert.ok(loc!.radiusKm > 0);
+});
+
+test('statusFromContext marks an observation older than 48h as resolved', () => {
+  const now = NOW;
+  const events = [makeEvent({ id: 'a', timestamp: now - 50 * 60 * 60 * 1000 })];
+  const status = __internals.statusFromContext(events, [], now);
+  assert.equal(status, 'resolved');
+});
+
+test('severityFromObservations promotes to medium when multiple lower-severity observations cluster', () => {
+  const events = [
+    makeEvent({ id: 'a', severity: 'LOW' as ObservationSeverity }),
+    makeEvent({ id: 'b', severity: 'LOW' as ObservationSeverity }),
+  ];
+  assert.equal(__internals.severityFromObservations(events), 'medium');
+});
+
+// ── Defensive copy ─────────────────────────────────────────────────
+
+test('list() returns defensive copies — mutating callsite does not corrupt the store', () => {
+  const store = quietStore();
+  store.ingest([makeEvent({ id: 'a' })]);
+  const first = store.list();
+  first[0]!.observations.push(makeEvent({ id: 'injected' }));
+  assert.equal(store.list()[0]!.observations.length, 1);
+});
+
+// ── Sanity: cleanup the singleton after the file finishes ───────────
+test('teardown', () => {
+  __resetSituationStoreV2Singleton();
+  __storage.clear();
+  // ensure the assertion library produced at least one expectation
+  assert.ok(true);
+
+  // Reference the imported Situation type so an unused-import warning
+  // doesn't sneak in on strict tsconfigs.
+  const _s: Situation | undefined = undefined;
+  void _s;
+});


### PR DESCRIPTION
Upgrades the Situation layer to aggregate `ObservationEvent`s through `CorrelateEngine` into named, evidence-backed `Situation` objects with typed `EvidenceEdge`s (`caused_by`, `co-located`, `temporally-adjacent`, `contradicts`, `confirms`). Wires `EntityRegistry` for entity resolution and persists to localStorage.

### What's new

- `src/services/intelligence/situation-store-v2.ts` — `SituationStoreV2` class + `getSituationStoreV2()` singleton. Ingests batches of observations, runs the correlate engine, groups pairs into draft Situations via union-find on shared observations, and merges into existing open Situations (shared observation OR primary events within 500km / 6h).
- Severity rollup: `critical` if any obs=CRITICAL; `high` if any=HIGH; `medium` for MEDIUM-only or multi-observation clusters; else `low`.
- Status ladder: `watching` (lone observation) → `active` (correlated) → `resolved` (all observations >48h stale, auto-swept on every ingest).
- Confidence: weighted average of edge confidences with a small breadth bonus, capped at 0.99.
- Persistence: localStorage `wm-situation-store-v2`, max 200 (resolved evicted first).
- `subscribe()` / `stats()` for panels + diagnostics.
- Back-compat shim in `src/services/intelligence/situation-store.ts` re-exports v2 types so panels can migrate without touching imports.

### Tests

`tests/intelligence/situation-store-v2.test.mts` — 43 deterministic tests, `npx tsx --test`:

- Ingest: empty batch, single observation → `watching`, correlated pair → merged with edges, causal-candidate rule mapped to `caused_by`, distant unrelated events stay separate.
- Severity: critical / high / medium / low rollups.
- Status: `active` on edges, `watching` on singleton, auto-resolve at >48h.
- Merging: re-ingested known observation, shared-observation chain across batches, proximity merge (500km/6h), out-of-window stays separate, union-find chain (a-b + b-c → one situation).
- Confidence: baseline 0.5 for singletons, bounded \[avg+bonus, 0.99\] for correlated.
- Name + summary: primary domain + region label, multi-domain combos, lead observation title + edge count.
- Filtering: status / domain / minSeverity / sinceMs; `getActive()` alias.
- Subscribe: fan-out, unsubscribe, listener crash isolation.
- Stats: total / status counts / by-domain.
- Persistence: round-trip across instances, corrupt blob ignored.
- Entity rollup: dedupes across observations.
- Singleton + reset hooks.
- Internal helpers: group-by-connectivity, locationFromObservations centroid, statusFromContext stale-detection, severityFromObservations multi-observation promotion.
- Defensive copy: list() return values aren't shared mutable state.

`npx tsc --noEmit` clean on both root + api tsconfigs. `tests/intelligence/correlate-engine.test.mts` (29 tests) still passes after the shim addition.

### Cross-agent review

Cross-agent review: claude reviewed on 2026-05-13; outcome: pass