### PR TITLE
feat(intelligence): evidence graph — typed edge traversal, BFS/DFS, shortest path, confidence propagation

### DIFF
--- a/src/services/intelligence/evidence-graph-bridge.ts
+++ b/src/services/intelligence/evidence-graph-bridge.ts
@@ -1,0 +1,286 @@
+/**
+ * Bridge between EvidenceGraphV2 and the existing `evidence-graph-ux`
+ * report shape consumed by the Evidence Graph panel.
+ *
+ * The v2 Situation carries observations + typed evidence edges directly
+ * on the object. This bridge takes a single Situation, indexes it into
+ * a fresh `EvidenceGraphV2`, and returns the `EvidenceAssembly` rollup
+ * shape the UI / briefing layer expects.
+ *
+ * The "EvidenceAssembly" type defined here mirrors the legacy
+ * `EvidenceReport` from `evidence-graph-ux.ts` for new v2 callers.
+ * The legacy report is still produced from v1 Situations by that
+ * module — this bridge is the v2 path.
+ */
+
+import type { ObservationEvent } from './observation-adapters';
+import {
+  EvidenceGraphV2,
+  type EdgeTypeCounts,
+  type GraphStats,
+} from './evidence-graph-v2';
+import type {
+  EvidenceEdge,
+  EvidenceEdgeType,
+  Situation,
+} from './situation-store-v2';
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+export interface EvidenceSourceRow {
+  sourceId: string;
+  domain: string;
+  title: string;
+  timestamp: number;
+  confidence: number;
+}
+
+export interface ContradictingRow {
+  sourceId: string;
+  domain: string;
+  title: string;
+  timestamp: number;
+  reason: string;
+}
+
+export interface MissingSignal {
+  domain: string;
+  expectedSignal: string;
+}
+
+export interface StaleInput {
+  sourceId: string;
+  domain: string;
+  title: string;
+  ageMs: number;
+}
+
+/** Normalized per-edge-type confidence weights, scaled to [0, 1]. */
+export type ConfidenceBreakdown = Record<EvidenceEdgeType, number>;
+
+export interface EvidenceAssembly {
+  situationId: string;
+  confirming: EvidenceSourceRow[];
+  contradicting: ContradictingRow[];
+  missing: MissingSignal[];
+  stale: StaleInput[];
+  confidenceBreakdown: ConfidenceBreakdown;
+  lastVerified: number;
+  /** Snapshot of the underlying graph stats — useful for diagnostics. */
+  graphStats: GraphStats;
+}
+
+export interface AssembleOptions {
+  /** Override the clock — defaults to `Date.now()`. Tests inject this. */
+  now?: number;
+  /** Minimum edge confidence treated as "strong / confirming". */
+  minConfirmingConfidence?: number;
+}
+
+// ── Domain refresh budgets + expected follow-on signals ──────────────
+
+const DEFAULT_REFRESH_BUDGET_MS = 30 * 60 * 1000;
+const DEFAULT_STRONG_CONFIDENCE = 0.6;
+
+const REFRESH_BUDGET_MS: Record<string, number> = {
+  weather: 10 * 60 * 1000,
+  earthquake: 5 * 60 * 1000,
+  seismic: 5 * 60 * 1000,
+  cyber: 30 * 60 * 1000,
+  maritime: 15 * 60 * 1000,
+  aviation: 15 * 60 * 1000,
+  conflict: 60 * 60 * 1000,
+  wildfire: 15 * 60 * 1000,
+  space: 30 * 60 * 1000,
+  health: 60 * 60 * 1000,
+  economic: 60 * 60 * 1000,
+};
+
+const EXPECTED_SIGNALS: Record<string, readonly { sourceId: string; label: string }[]> = {
+  earthquake: [
+    { sourceId: 'usgs-shakemap', label: 'USGS ShakeMap report' },
+    { sourceId: 'noaa-tsunami', label: 'NOAA tsunami advisory' },
+  ],
+  seismic: [
+    { sourceId: 'usgs-shakemap', label: 'USGS ShakeMap report' },
+    { sourceId: 'noaa-tsunami', label: 'NOAA tsunami advisory' },
+  ],
+  weather: [
+    { sourceId: 'nws-alert', label: 'NWS polygon alert' },
+    { sourceId: 'nws-radar', label: 'NEXRAD radar update' },
+  ],
+  cyber: [
+    { sourceId: 'cisa-kev', label: 'CISA KEV / advisory' },
+    { sourceId: 'cert', label: 'CERT bulletin' },
+  ],
+};
+
+// ── Bridge ────────────────────────────────────────────────────────────
+
+export function assembleSituationEvidence(
+  situation: Situation,
+  options: AssembleOptions = {},
+): EvidenceAssembly {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(situation);
+  const now = options.now ?? Date.now();
+  const minStrong = options.minConfirmingConfidence ?? DEFAULT_STRONG_CONFIDENCE;
+
+  const strong = graph.getStrongEdges(minStrong)
+    .filter((e) => e.type === 'confirms' || e.type === 'co-located');
+  const contradictions = graph.getContradictions();
+  const observationsById = indexObservations(situation.observations);
+
+  const confirming = buildConfirmingRows(strong, observationsById);
+  const contradicting = buildContradictingRows(contradictions, observationsById);
+
+  const missing = detectMissing(situation, observationsById);
+  const stale = detectStale(situation, now);
+
+  const stats = graph.stats();
+  const confidenceBreakdown = normalizeBreakdown(stats.byEdgeType);
+  const lastVerified = computeLastVerified(situation, confirming);
+
+  return {
+    situationId: situation.id,
+    confirming,
+    contradicting,
+    missing,
+    stale,
+    confidenceBreakdown,
+    lastVerified,
+    graphStats: stats,
+  };
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function indexObservations(observations: readonly ObservationEvent[]): Map<string, ObservationEvent> {
+  const out = new Map<string, ObservationEvent>();
+  for (const o of observations) out.set(o.id, o);
+  return out;
+}
+
+function buildConfirmingRows(
+  edges: readonly EvidenceEdge[],
+  observations: ReadonlyMap<string, ObservationEvent>,
+): EvidenceSourceRow[] {
+  const seen = new Set<string>();
+  const rows: EvidenceSourceRow[] = [];
+  for (const edge of edges) {
+    pushIfNew(observations, edge.sourceEventId, edge.confidence, seen, rows);
+    pushIfNew(observations, edge.targetEventId, edge.confidence, seen, rows);
+  }
+  return rows;
+}
+
+function pushIfNew(
+  observations: ReadonlyMap<string, ObservationEvent>,
+  observationId: string,
+  confidence: number,
+  seen: Set<string>,
+  rows: EvidenceSourceRow[],
+): void {
+  if (seen.has(observationId)) return;
+  const obs = observations.get(observationId);
+  if (!obs) return;
+  seen.add(observationId);
+  rows.push({
+    sourceId: obs.sourceId,
+    domain: obs.domain,
+    title: obs.title,
+    timestamp: obs.timestamp,
+    confidence,
+  });
+}
+
+function buildContradictingRows(
+  edges: readonly EvidenceEdge[],
+  observations: ReadonlyMap<string, ObservationEvent>,
+): ContradictingRow[] {
+  const rows: ContradictingRow[] = [];
+  for (const edge of edges) {
+    const target = observations.get(edge.targetEventId);
+    if (!target) continue;
+    rows.push({
+      sourceId: target.sourceId,
+      domain: target.domain,
+      title: target.title,
+      timestamp: target.timestamp,
+      reason: edge.ruleId
+        ? `Contradicting evidence flagged by rule ${edge.ruleId} (confidence ${edge.confidence.toFixed(2)})`
+        : `Contradicting evidence (confidence ${edge.confidence.toFixed(2)})`,
+    });
+  }
+  return rows;
+}
+
+function detectMissing(
+  situation: Situation,
+  observations: ReadonlyMap<string, ObservationEvent>,
+): MissingSignal[] {
+  const expected = EXPECTED_SIGNALS[situation.domain];
+  if (!expected || expected.length === 0) return [];
+  const seenSources = new Set<string>();
+  const seenTagFragments = new Set<string>();
+  for (const obs of observations.values()) {
+    seenSources.add(obs.sourceId);
+    for (const tag of obs.tags) seenTagFragments.add(tag.toLowerCase());
+  }
+  const out: MissingSignal[] = [];
+  for (const sig of expected) {
+    if (seenSources.has(sig.sourceId)) continue;
+    if (seenTagFragments.has(sig.sourceId.toLowerCase())) continue;
+    out.push({ domain: situation.domain, expectedSignal: sig.label });
+  }
+  return out;
+}
+
+function detectStale(situation: Situation, now: number): StaleInput[] {
+  const out: StaleInput[] = [];
+  for (const obs of situation.observations) {
+    const budget = REFRESH_BUDGET_MS[obs.domain] ?? DEFAULT_REFRESH_BUDGET_MS;
+    const ageMs = now - obs.timestamp;
+    if (ageMs <= budget) continue;
+    out.push({
+      sourceId: obs.sourceId,
+      domain: obs.domain,
+      title: obs.title,
+      ageMs,
+    });
+  }
+  return out;
+}
+
+function normalizeBreakdown(counts: EdgeTypeCounts): ConfidenceBreakdown {
+  let total = 0;
+  for (const v of Object.values(counts)) total += v;
+  if (total === 0) {
+    return {
+      caused_by: 0,
+      'co-located': 0,
+      'temporally-adjacent': 0,
+      contradicts: 0,
+      confirms: 0,
+    };
+  }
+  return {
+    caused_by: Number((counts.caused_by / total).toFixed(4)),
+    'co-located': Number((counts['co-located'] / total).toFixed(4)),
+    'temporally-adjacent': Number((counts['temporally-adjacent'] / total).toFixed(4)),
+    contradicts: Number((counts.contradicts / total).toFixed(4)),
+    confirms: Number((counts.confirms / total).toFixed(4)),
+  };
+}
+
+function computeLastVerified(
+  situation: Situation,
+  confirming: readonly EvidenceSourceRow[],
+): number {
+  let max = 0;
+  for (const r of confirming) max = Math.max(max, r.timestamp);
+  if (max === 0) {
+    for (const o of situation.observations) max = Math.max(max, o.timestamp);
+  }
+  return max;
+}

--- a/src/services/intelligence/evidence-graph-v2.ts
+++ b/src/services/intelligence/evidence-graph-v2.ts
@@ -1,0 +1,502 @@
+/**
+ * Evidence Graph v2 — typed-edge graph traversal over SituationStoreV2.
+ *
+ * Sits on top of `Situation.observations` + `Situation.edges` from
+ * `situation-store-v2.ts` and exposes the queries the panels + briefings
+ * actually want:
+ *
+ *   - getNode / getNeighbors — single-hop indexing
+ *   - bfs / dfs — full traversal with depth caps
+ *   - shortestPath — Dijkstra weighted by (1 - edge.confidence)
+ *   - propagateConfidence — BFS that multiplies confidences along paths
+ *   - getStrongEdges / getContradictions — bucket queries
+ *   - stats — graph-level rollup for diagnostics surfaces
+ *
+ * Pure module: no DOM, no fetch, no globals at import time. The
+ * singleton getter (`getEvidenceGraph()`) lazily instantiates a single
+ * graph for the renderer to share; tests construct their own.
+ *
+ * Naming: this file is `evidence-graph-v2.ts` rather than overwriting
+ * the existing `evidence-graph.ts` (PR #422, NormalizedFact-based truth
+ * scoring) because the two layers have incompatible node/edge shapes
+ * and several downstream services still depend on the v1 graph.
+ */
+
+import type { ObservationEvent } from './observation-adapters';
+import type { EvidenceEdge, EvidenceEdgeType, Situation } from './situation-store-v2';
+
+// ── Public types ──────────────────────────────────────────────────────
+
+export interface GraphNode {
+  id: string;
+  observation: ObservationEvent;
+  situationIds: string[];
+  incomingEdges: EvidenceEdge[];
+  outgoingEdges: EvidenceEdge[];
+  /** Mean confidence across every edge touching the node. 0 when isolated. */
+  aggregateConfidence: number;
+}
+
+export interface GraphPath {
+  nodes: GraphNode[];
+  edges: EvidenceEdge[];
+  /** Product of edge confidences along the path. */
+  totalConfidence: number;
+  /** Edge type that appears most often along the path. Ties broken by
+   *  insertion order — first dominant wins. */
+  dominantEdgeType: EvidenceEdgeType;
+}
+
+export type EdgeTypeCounts = Record<EvidenceEdgeType, number>;
+
+export interface GraphStats {
+  nodeCount: number;
+  edgeCount: number;
+  byEdgeType: EdgeTypeCounts;
+  averageConfidence: number;
+  mostConnectedNodeId: string | null;
+  isolatedNodeCount: number;
+}
+
+// ── Constants ─────────────────────────────────────────────────────────
+
+const DEFAULT_STRONG_CONFIDENCE = 0.7;
+const DEFAULT_MAX_DEPTH = 16;
+
+const EDGE_TYPES: readonly EvidenceEdgeType[] = [
+  'caused_by',
+  'co-located',
+  'temporally-adjacent',
+  'contradicts',
+  'confirms',
+];
+
+function emptyEdgeCounts(): EdgeTypeCounts {
+  return {
+    caused_by: 0,
+    'co-located': 0,
+    'temporally-adjacent': 0,
+    contradicts: 0,
+    confirms: 0,
+  };
+}
+
+// ── Graph ─────────────────────────────────────────────────────────────
+
+interface MutableNode {
+  id: string;
+  observation: ObservationEvent;
+  situationIds: Set<string>;
+  incomingEdges: EvidenceEdge[];
+  outgoingEdges: EvidenceEdge[];
+}
+
+export class EvidenceGraphV2 {
+  private readonly nodes = new Map<string, MutableNode>();
+  /** Edge dedupe key — same source/target/type/ruleId collapses. */
+  private readonly seenEdges = new Set<string>();
+
+  // ── Build ───────────────────────────────────────────────────────────
+
+  /** Index one Situation's observations + edges. Idempotent on re-add. */
+  buildFromSituation(situation: Situation): void {
+    for (const observation of situation.observations) {
+      this.upsertNode(observation, situation.id);
+    }
+    for (const edge of situation.edges) {
+      this.addEdge(edge);
+    }
+  }
+
+  buildFromSituations(situations: readonly Situation[]): void {
+    for (const s of situations) this.buildFromSituation(s);
+  }
+
+  private upsertNode(observation: ObservationEvent, situationId: string): MutableNode {
+    let node = this.nodes.get(observation.id);
+    if (!node) {
+      node = {
+        id: observation.id,
+        observation,
+        situationIds: new Set([situationId]),
+        incomingEdges: [],
+        outgoingEdges: [],
+      };
+      this.nodes.set(observation.id, node);
+      return node;
+    }
+    node.situationIds.add(situationId);
+    return node;
+  }
+
+  private addEdge(edge: EvidenceEdge): void {
+    const key = edgeKey(edge);
+    if (this.seenEdges.has(key)) return;
+    this.seenEdges.add(key);
+    const source = this.nodes.get(edge.sourceEventId);
+    const target = this.nodes.get(edge.targetEventId);
+    if (source) source.outgoingEdges.push(edge);
+    if (target) target.incomingEdges.push(edge);
+  }
+
+  // ── Single-hop queries ─────────────────────────────────────────────
+
+  getNode(observationId: string): GraphNode | undefined {
+    const node = this.nodes.get(observationId);
+    return node ? toGraphNode(node) : undefined;
+  }
+
+  /** All nodes reachable in one hop from `observationId`, in either
+   *  direction. Optional edgeTypes filter narrows by type. */
+  getNeighbors(observationId: string, edgeTypes?: readonly EvidenceEdgeType[]): GraphNode[] {
+    const node = this.nodes.get(observationId);
+    if (!node) return [];
+    const typeFilter = edgeTypes && edgeTypes.length > 0 ? new Set(edgeTypes) : null;
+    const seen = new Set<string>();
+    const out: GraphNode[] = [];
+    const consider = (edge: EvidenceEdge, otherId: string): void => {
+      if (typeFilter && !typeFilter.has(edge.type)) return;
+      if (otherId === observationId || seen.has(otherId)) return;
+      const other = this.nodes.get(otherId);
+      if (!other) return;
+      seen.add(otherId);
+      out.push(toGraphNode(other));
+    };
+    for (const edge of node.outgoingEdges) consider(edge, edge.targetEventId);
+    for (const edge of node.incomingEdges) consider(edge, edge.sourceEventId);
+    return out;
+  }
+
+  // ── Traversals ─────────────────────────────────────────────────────
+
+  bfs(startId: string, maxDepth: number = DEFAULT_MAX_DEPTH): GraphNode[] {
+    return this.traverse(startId, maxDepth, 'bfs');
+  }
+
+  dfs(startId: string, maxDepth: number = DEFAULT_MAX_DEPTH): GraphNode[] {
+    return this.traverse(startId, maxDepth, 'dfs');
+  }
+
+  private traverse(startId: string, maxDepth: number, mode: 'bfs' | 'dfs'): GraphNode[] {
+    if (!this.nodes.has(startId) || maxDepth < 0) return [];
+    const visited = new Set<string>([startId]);
+    const out: GraphNode[] = [toGraphNode(this.nodes.get(startId)!)];
+    const frontier: { id: string; depth: number }[] = [{ id: startId, depth: 0 }];
+    while (frontier.length > 0) {
+      const next = mode === 'bfs' ? frontier.shift()! : frontier.pop()!;
+      if (next.depth >= maxDepth) continue;
+      const neighborsRaw = this.collectNeighborIds(next.id);
+      for (const neighborId of neighborsRaw) {
+        if (visited.has(neighborId)) continue;
+        const neighbor = this.nodes.get(neighborId);
+        if (!neighbor) continue;
+        visited.add(neighborId);
+        out.push(toGraphNode(neighbor));
+        frontier.push({ id: neighborId, depth: next.depth + 1 });
+      }
+    }
+    return out;
+  }
+
+  private collectNeighborIds(nodeId: string): string[] {
+    const node = this.nodes.get(nodeId);
+    if (!node) return [];
+    const ids: string[] = [];
+    const seen = new Set<string>();
+    for (const edge of node.outgoingEdges) {
+      if (!seen.has(edge.targetEventId) && edge.targetEventId !== nodeId) {
+        seen.add(edge.targetEventId);
+        ids.push(edge.targetEventId);
+      }
+    }
+    for (const edge of node.incomingEdges) {
+      if (!seen.has(edge.sourceEventId) && edge.sourceEventId !== nodeId) {
+        seen.add(edge.sourceEventId);
+        ids.push(edge.sourceEventId);
+      }
+    }
+    return ids;
+  }
+
+  // ── Shortest path (Dijkstra; weight = 1 - confidence) ─────────────
+
+  shortestPath(fromId: string, toId: string): GraphPath | null {
+    if (!this.nodes.has(fromId) || !this.nodes.has(toId)) return null;
+    if (fromId === toId) {
+      const node = toGraphNode(this.nodes.get(fromId)!);
+      return { nodes: [node], edges: [], totalConfidence: 1, dominantEdgeType: 'confirms' };
+    }
+    const result = runDijkstra(this.nodes, fromId, toId);
+    if (!result) return null;
+    return this.reconstructPath(result, fromId, toId);
+  }
+
+  private reconstructPath(
+    result: DijkstraResult,
+    fromId: string,
+    toId: string,
+  ): GraphPath {
+    const nodeIds: string[] = [];
+    const edges: EvidenceEdge[] = [];
+    let cursor: string = toId;
+    // Walk previous pointers backward until we reach the start.
+    while (true) {
+      nodeIds.unshift(cursor);
+      if (cursor === fromId) break;
+      const prev = result.previous.get(cursor);
+      if (!prev) break;
+      edges.unshift(prev.edge);
+      cursor = prev.fromId;
+    }
+    const nodes = nodeIds
+      .map((id) => this.nodes.get(id))
+      .filter((n): n is MutableNode => n !== undefined)
+      .map((n) => toGraphNode(n));
+    return {
+      nodes,
+      edges,
+      totalConfidence: edges.reduce((p, e) => p * e.confidence, 1),
+      dominantEdgeType: dominantEdgeType(edges),
+    };
+  }
+
+  // ── Filtered edge lookups ─────────────────────────────────────────
+
+  getByEdgeType(type: EvidenceEdgeType): EvidenceEdge[] {
+    const out: EvidenceEdge[] = [];
+    for (const node of this.nodes.values()) {
+      for (const edge of node.outgoingEdges) {
+        if (edge.type === type) out.push(edge);
+      }
+    }
+    return out;
+  }
+
+  getStrongEdges(minConfidence: number = DEFAULT_STRONG_CONFIDENCE): EvidenceEdge[] {
+    const out: EvidenceEdge[] = [];
+    for (const node of this.nodes.values()) {
+      for (const edge of node.outgoingEdges) {
+        if (edge.confidence >= minConfidence) out.push(edge);
+      }
+    }
+    return out;
+  }
+
+  getContradictions(): EvidenceEdge[] {
+    return this.getByEdgeType('contradicts');
+  }
+
+  // ── Confidence propagation ────────────────────────────────────────
+
+  /** BFS from `startId` (confidence 1.0). Each step multiplies by the
+   *  traversed edge's confidence. Returns the max confidence reachable
+   *  to every node — useful for "given this is real, how strongly do
+   *  we believe each neighbor"-style queries. */
+  propagateConfidence(startId: string): Map<string, number> {
+    const result = new Map<string, number>();
+    if (!this.nodes.has(startId)) return result;
+    result.set(startId, 1);
+    const queue: { id: string; confidence: number }[] = [{ id: startId, confidence: 1 }];
+    while (queue.length > 0) {
+      const next = queue.shift()!;
+      const node = this.nodes.get(next.id);
+      if (!node) continue;
+      for (const edge of node.outgoingEdges) {
+        this.relaxConfidence(edge, edge.targetEventId, next.confidence, result, queue);
+      }
+      for (const edge of node.incomingEdges) {
+        this.relaxConfidence(edge, edge.sourceEventId, next.confidence, result, queue);
+      }
+    }
+    return result;
+  }
+
+  private relaxConfidence(
+    edge: EvidenceEdge,
+    otherId: string,
+    parentConfidence: number,
+    result: Map<string, number>,
+    queue: { id: string; confidence: number }[],
+  ): void {
+    const candidate = parentConfidence * edge.confidence;
+    const current = result.get(otherId) ?? 0;
+    if (candidate <= current) return;
+    result.set(otherId, candidate);
+    queue.push({ id: otherId, confidence: candidate });
+  }
+
+  // ── Stats + lifecycle ─────────────────────────────────────────────
+
+  stats(): GraphStats {
+    const byEdgeType = emptyEdgeCounts();
+    let edgeCount = 0;
+    let confidenceSum = 0;
+    let mostConnectedId: string | null = null;
+    let mostConnectedDegree = -1;
+    let isolatedCount = 0;
+    for (const node of this.nodes.values()) {
+      for (const edge of node.outgoingEdges) {
+        byEdgeType[edge.type] += 1;
+        edgeCount += 1;
+        confidenceSum += edge.confidence;
+      }
+      const degree = node.outgoingEdges.length + node.incomingEdges.length;
+      if (degree === 0) isolatedCount += 1;
+      if (degree > mostConnectedDegree) {
+        mostConnectedDegree = degree;
+        mostConnectedId = node.id;
+      }
+    }
+    return {
+      nodeCount: this.nodes.size,
+      edgeCount,
+      byEdgeType,
+      averageConfidence: edgeCount === 0 ? 0 : Number((confidenceSum / edgeCount).toFixed(4)),
+      mostConnectedNodeId: this.nodes.size === 0 ? null : mostConnectedId,
+      isolatedNodeCount: isolatedCount,
+    };
+  }
+
+  clear(): void {
+    this.nodes.clear();
+    this.seenEdges.clear();
+  }
+
+  /** All known edge types — exposed for diagnostics + tests. */
+  edgeTypes(): readonly EvidenceEdgeType[] {
+    return EDGE_TYPES;
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function edgeKey(edge: EvidenceEdge): string {
+  const [a, b] = edge.sourceEventId < edge.targetEventId
+    ? [edge.sourceEventId, edge.targetEventId]
+    : [edge.targetEventId, edge.sourceEventId];
+  return `${edge.type}|${a}|${b}|${edge.ruleId ?? ''}`;
+}
+
+function toGraphNode(node: MutableNode): GraphNode {
+  const totalEdges = node.outgoingEdges.length + node.incomingEdges.length;
+  const aggregate = totalEdges === 0
+    ? 0
+    : ([...node.outgoingEdges, ...node.incomingEdges]
+        .reduce((acc, e) => acc + e.confidence, 0) / totalEdges);
+  return {
+    id: node.id,
+    observation: node.observation,
+    situationIds: [...node.situationIds],
+    incomingEdges: [...node.incomingEdges],
+    outgoingEdges: [...node.outgoingEdges],
+    aggregateConfidence: Number(aggregate.toFixed(4)),
+  };
+}
+
+function dominantEdgeType(edges: readonly EvidenceEdge[]): EvidenceEdgeType {
+  if (edges.length === 0) return 'confirms';
+  const counts = emptyEdgeCounts();
+  let best: EvidenceEdgeType = edges[0]!.type;
+  let bestCount = 0;
+  for (const e of edges) {
+    counts[e.type] += 1;
+    if (counts[e.type] > bestCount) {
+      best = e.type;
+      bestCount = counts[e.type];
+    }
+  }
+  return best;
+}
+
+// ── Dijkstra ─────────────────────────────────────────────────────────
+
+interface DijkstraResult {
+  previous: Map<string, { fromId: string; edge: EvidenceEdge }>;
+}
+
+interface DijkstraEdge {
+  toId: string;
+  edge: EvidenceEdge;
+}
+
+function buildAdjacency(nodes: ReadonlyMap<string, MutableNode>): Map<string, DijkstraEdge[]> {
+  const adj = new Map<string, DijkstraEdge[]>();
+  for (const node of nodes.values()) {
+    const list: DijkstraEdge[] = [];
+    for (const edge of node.outgoingEdges) {
+      list.push({ toId: edge.targetEventId, edge });
+    }
+    for (const edge of node.incomingEdges) {
+      list.push({ toId: edge.sourceEventId, edge });
+    }
+    adj.set(node.id, list);
+  }
+  return adj;
+}
+
+function runDijkstra(
+  nodes: ReadonlyMap<string, MutableNode>,
+  fromId: string,
+  toId: string,
+): DijkstraResult | null {
+  const adjacency = buildAdjacency(nodes);
+  const distances = new Map<string, number>();
+  const previous = new Map<string, { fromId: string; edge: EvidenceEdge }>();
+  const visited = new Set<string>();
+  for (const id of nodes.keys()) distances.set(id, Infinity);
+  distances.set(fromId, 0);
+  while (visited.size < nodes.size) {
+    const cursor = pickClosest(distances, visited);
+    if (cursor === null) break;
+    visited.add(cursor);
+    if (cursor === toId) return { previous };
+    const distHere = distances.get(cursor) ?? Infinity;
+    for (const { toId: nextId, edge } of adjacency.get(cursor) ?? []) {
+      if (visited.has(nextId)) continue;
+      const weight = Math.max(0, 1 - edge.confidence);
+      const candidate = distHere + weight;
+      if (candidate < (distances.get(nextId) ?? Infinity)) {
+        distances.set(nextId, candidate);
+        previous.set(nextId, { fromId: cursor, edge });
+      }
+    }
+  }
+  return previous.has(toId) ? { previous } : null;
+}
+
+function pickClosest(distances: Map<string, number>, visited: Set<string>): string | null {
+  let best: string | null = null;
+  let bestDist = Infinity;
+  for (const [id, dist] of distances) {
+    if (visited.has(id)) continue;
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = id;
+    }
+  }
+  return best === null || bestDist === Infinity ? null : best;
+}
+
+// ── Singleton ────────────────────────────────────────────────────────
+
+let _singleton: EvidenceGraphV2 | null = null;
+
+export function getEvidenceGraph(): EvidenceGraphV2 {
+  _singleton ??= new EvidenceGraphV2();
+  return _singleton;
+}
+
+export function __resetEvidenceGraphSingleton(): void {
+  _singleton = null;
+}
+
+// ── Internals exposed for tests + diagnostics ────────────────────────
+
+export const __internals = {
+  edgeKey,
+  toGraphNode,
+  dominantEdgeType,
+  runDijkstra,
+  DEFAULT_STRONG_CONFIDENCE,
+  DEFAULT_MAX_DEPTH,
+};

--- a/tests/intelligence/evidence-graph.test.mts
+++ b/tests/intelligence/evidence-graph.test.mts
@@ -1,0 +1,523 @@
+/**
+ * Tests for EvidenceGraphV2 + the assembleSituationEvidence bridge.
+ *
+ * The graph is a pure data structure — no localStorage / DOM stubs
+ * required. Each test builds its own graph + Situation, so order
+ * doesn't matter.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  EvidenceGraphV2,
+  __internals,
+  __resetEvidenceGraphSingleton,
+  getEvidenceGraph,
+  type GraphNode,
+} from '../../src/services/intelligence/evidence-graph-v2.ts';
+import type { ObservationEvent } from '../../src/services/intelligence/observation-adapters.ts';
+import type {
+  EvidenceEdge,
+  EvidenceEdgeType,
+  Situation,
+} from '../../src/services/intelligence/situation-store-v2.ts';
+import { assembleSituationEvidence } from '../../src/services/intelligence/evidence-graph-bridge.ts';
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+const NOW = 1_745_000_000_000;
+
+function makeObservation(overrides: Partial<ObservationEvent> = {}): ObservationEvent {
+  return {
+    id: 'obs',
+    sourceId: 'src',
+    domain: 'weather',
+    timestamp: NOW,
+    severity: 'MEDIUM',
+    title: 'Test observation',
+    raw: null,
+    entityIds: [],
+    tags: [],
+    ...overrides,
+  };
+}
+
+function makeEdge(
+  source: string,
+  target: string,
+  overrides: Partial<EvidenceEdge> = {},
+): EvidenceEdge {
+  return {
+    type: 'co-located',
+    sourceEventId: source,
+    targetEventId: target,
+    confidence: 0.8,
+    ...overrides,
+  };
+}
+
+function makeSituation(
+  observations: ObservationEvent[],
+  edges: EvidenceEdge[],
+  overrides: Partial<Situation> = {},
+): Situation {
+  return {
+    id: 'sit-1',
+    name: 'Test situation',
+    domain: 'weather',
+    relatedDomains: [],
+    severity: 'medium',
+    status: 'active',
+    summary: 'Test',
+    observations,
+    edges,
+    entityIds: [],
+    confidence: 0.7,
+    startedAt: new Date(NOW),
+    updatedAt: new Date(NOW),
+    tags: [],
+    ...overrides,
+  };
+}
+
+// ── buildFromSituation ────────────────────────────────────────────────
+
+test('buildFromSituation indexes all observations as nodes', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation(
+    [makeObservation({ id: 'a' }), makeObservation({ id: 'b' })],
+    [],
+  ));
+  assert.equal(graph.stats().nodeCount, 2);
+});
+
+test('buildFromSituation indexes edges on both endpoints', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation(
+    [makeObservation({ id: 'a' }), makeObservation({ id: 'b' })],
+    [makeEdge('a', 'b')],
+  ));
+  const a = graph.getNode('a')!;
+  const b = graph.getNode('b')!;
+  assert.equal(a.outgoingEdges.length, 1);
+  assert.equal(b.incomingEdges.length, 1);
+});
+
+test('buildFromSituation is idempotent on re-add', () => {
+  const graph = new EvidenceGraphV2();
+  const sit = makeSituation(
+    [makeObservation({ id: 'a' }), makeObservation({ id: 'b' })],
+    [makeEdge('a', 'b')],
+  );
+  graph.buildFromSituation(sit);
+  graph.buildFromSituation(sit);
+  assert.equal(graph.stats().edgeCount, 1);
+});
+
+test('buildFromSituations merges across multiple Situations', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituations([
+    makeSituation([makeObservation({ id: 'a' })], [], { id: 's1' }),
+    makeSituation([makeObservation({ id: 'a' }), makeObservation({ id: 'b' })], [makeEdge('a', 'b')], { id: 's2' }),
+  ]);
+  const a = graph.getNode('a')!;
+  assert.deepEqual(a.situationIds.sort(), ['s1', 's2']);
+  assert.equal(graph.stats().nodeCount, 2);
+  assert.equal(graph.stats().edgeCount, 1);
+});
+
+// ── getNode / getNeighbors ───────────────────────────────────────────
+
+test('getNode returns undefined for unknown ids', () => {
+  const graph = new EvidenceGraphV2();
+  assert.equal(graph.getNode('nope'), undefined);
+});
+
+test('getNeighbors returns adjacent nodes in both directions', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation(
+    [makeObservation({ id: 'a' }), makeObservation({ id: 'b' }), makeObservation({ id: 'c' })],
+    [makeEdge('a', 'b'), makeEdge('c', 'a')],
+  ));
+  const neighbors = graph.getNeighbors('a').map((n) => n.id).sort();
+  assert.deepEqual(neighbors, ['b', 'c']);
+});
+
+test('getNeighbors filters by edgeType', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation(
+    [makeObservation({ id: 'a' }), makeObservation({ id: 'b' }), makeObservation({ id: 'c' })],
+    [
+      makeEdge('a', 'b', { type: 'caused_by' }),
+      makeEdge('a', 'c', { type: 'contradicts' }),
+    ],
+  ));
+  const causal = graph.getNeighbors('a', ['caused_by']).map((n) => n.id);
+  assert.deepEqual(causal, ['b']);
+});
+
+test('getNeighbors returns empty when node not in graph', () => {
+  const graph = new EvidenceGraphV2();
+  assert.deepEqual(graph.getNeighbors('missing'), []);
+});
+
+// ── bfs / dfs ─────────────────────────────────────────────────────────
+
+test('bfs visits all reachable nodes in breadth-first order', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation(
+    ['a', 'b', 'c', 'd'].map((id) => makeObservation({ id })),
+    [makeEdge('a', 'b'), makeEdge('a', 'c'), makeEdge('b', 'd')],
+  ));
+  const order = graph.bfs('a').map((n) => n.id);
+  assert.equal(order[0], 'a');
+  // d (depth 2) must come after b and c (depth 1).
+  assert.ok(order.indexOf('d') > order.indexOf('b'));
+  assert.ok(order.indexOf('d') > order.indexOf('c'));
+});
+
+test('bfs respects maxDepth', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation(
+    ['a', 'b', 'c'].map((id) => makeObservation({ id })),
+    [makeEdge('a', 'b'), makeEdge('b', 'c')],
+  ));
+  const ids = graph.bfs('a', 1).map((n) => n.id).sort();
+  assert.deepEqual(ids, ['a', 'b']);
+});
+
+test('dfs visits all reachable nodes', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation(
+    ['a', 'b', 'c'].map((id) => makeObservation({ id })),
+    [makeEdge('a', 'b'), makeEdge('b', 'c')],
+  ));
+  const ids = graph.dfs('a').map((n) => n.id).sort();
+  assert.deepEqual(ids, ['a', 'b', 'c']);
+});
+
+test('dfs respects maxDepth=0 (only the start node)', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation(
+    ['a', 'b'].map((id) => makeObservation({ id })),
+    [makeEdge('a', 'b')],
+  ));
+  const ids = graph.dfs('a', 0).map((n) => n.id);
+  assert.deepEqual(ids, ['a']);
+});
+
+test('bfs / dfs return [] for unknown start ids', () => {
+  const graph = new EvidenceGraphV2();
+  assert.deepEqual(graph.bfs('nope'), []);
+  assert.deepEqual(graph.dfs('nope'), []);
+});
+
+// ── shortestPath ─────────────────────────────────────────────────────
+
+test('shortestPath finds a single-edge path', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation(
+    [makeObservation({ id: 'a' }), makeObservation({ id: 'b' })],
+    [makeEdge('a', 'b', { confidence: 0.9 })],
+  ));
+  const path = graph.shortestPath('a', 'b')!;
+  assert.equal(path.nodes.length, 2);
+  assert.equal(path.edges.length, 1);
+  assert.equal(path.totalConfidence, 0.9);
+});
+
+test('shortestPath prefers higher-confidence routes', () => {
+  const graph = new EvidenceGraphV2();
+  // Direct path a→c confidence 0.4 (weight 0.6); two-hop a→b→c
+  // confidence 0.95*0.95=0.9025 (weight 0.05+0.05=0.10) — prefer
+  // the two-hop because it has lower aggregate weight.
+  graph.buildFromSituation(makeSituation(
+    [makeObservation({ id: 'a' }), makeObservation({ id: 'b' }), makeObservation({ id: 'c' })],
+    [
+      makeEdge('a', 'c', { confidence: 0.4 }),
+      makeEdge('a', 'b', { confidence: 0.95 }),
+      makeEdge('b', 'c', { confidence: 0.95 }),
+    ],
+  ));
+  const path = graph.shortestPath('a', 'c')!;
+  assert.equal(path.nodes.length, 3);
+  assert.equal(path.edges.length, 2);
+});
+
+test('shortestPath returns single-node path when from === to', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation([makeObservation({ id: 'a' })], []));
+  const path = graph.shortestPath('a', 'a')!;
+  assert.equal(path.nodes.length, 1);
+  assert.equal(path.edges.length, 0);
+  assert.equal(path.totalConfidence, 1);
+});
+
+test('shortestPath returns null for disconnected nodes', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation(
+    [makeObservation({ id: 'a' }), makeObservation({ id: 'b' })],
+    [],
+  ));
+  assert.equal(graph.shortestPath('a', 'b'), null);
+});
+
+test('shortestPath returns null when either endpoint is missing', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation([makeObservation({ id: 'a' })], []));
+  assert.equal(graph.shortestPath('a', 'missing'), null);
+  assert.equal(graph.shortestPath('missing', 'a'), null);
+});
+
+test('shortestPath dominantEdgeType is the most frequent type along the path', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation(
+    ['a', 'b', 'c', 'd'].map((id) => makeObservation({ id })),
+    [
+      makeEdge('a', 'b', { type: 'confirms' }),
+      makeEdge('b', 'c', { type: 'confirms' }),
+      makeEdge('c', 'd', { type: 'caused_by' }),
+    ],
+  ));
+  const path = graph.shortestPath('a', 'd')!;
+  assert.equal(path.dominantEdgeType, 'confirms');
+});
+
+// ── Edge-type / strong / contradiction lookups ───────────────────────
+
+test('getByEdgeType returns only edges of that type', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation(
+    [makeObservation({ id: 'a' }), makeObservation({ id: 'b' }), makeObservation({ id: 'c' })],
+    [
+      makeEdge('a', 'b', { type: 'confirms' }),
+      makeEdge('a', 'c', { type: 'caused_by' }),
+    ],
+  ));
+  const confirms = graph.getByEdgeType('confirms');
+  assert.equal(confirms.length, 1);
+  assert.equal(confirms[0]!.targetEventId, 'b');
+});
+
+test('getStrongEdges filters by confidence threshold (default 0.7)', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation(
+    [makeObservation({ id: 'a' }), makeObservation({ id: 'b' }), makeObservation({ id: 'c' })],
+    [makeEdge('a', 'b', { confidence: 0.9 }), makeEdge('a', 'c', { confidence: 0.5 })],
+  ));
+  assert.equal(graph.getStrongEdges().length, 1);
+  assert.equal(graph.getStrongEdges(0.4).length, 2);
+});
+
+test('getContradictions returns only contradicts edges', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation(
+    [makeObservation({ id: 'a' }), makeObservation({ id: 'b' }), makeObservation({ id: 'c' })],
+    [
+      makeEdge('a', 'b', { type: 'contradicts', confidence: 0.85 }),
+      makeEdge('a', 'c', { type: 'co-located' }),
+    ],
+  ));
+  const contradictions = graph.getContradictions();
+  assert.equal(contradictions.length, 1);
+  assert.equal(contradictions[0]!.type, 'contradicts');
+});
+
+// ── propagateConfidence ─────────────────────────────────────────────
+
+test('propagateConfidence anchors the start node at 1.0', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation([makeObservation({ id: 'a' })], []));
+  const map = graph.propagateConfidence('a');
+  assert.equal(map.get('a'), 1);
+});
+
+test('propagateConfidence multiplies along a chain', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation(
+    ['a', 'b', 'c'].map((id) => makeObservation({ id })),
+    [makeEdge('a', 'b', { confidence: 0.8 }), makeEdge('b', 'c', { confidence: 0.5 })],
+  ));
+  const map = graph.propagateConfidence('a');
+  assert.equal(map.get('b'), 0.8);
+  // 1.0 * 0.8 * 0.5 = 0.4
+  assert.equal(map.get('c'), 0.4);
+});
+
+test('propagateConfidence picks the best route when alternatives exist', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation(
+    ['a', 'b', 'c'].map((id) => makeObservation({ id })),
+    [
+      makeEdge('a', 'b', { confidence: 0.9 }),
+      makeEdge('b', 'c', { confidence: 0.9 }),
+      makeEdge('a', 'c', { confidence: 0.5 }),
+    ],
+  ));
+  const map = graph.propagateConfidence('a');
+  // 0.9 * 0.9 = 0.81 vs direct 0.5; expect 0.81
+  assert.ok(map.get('c')! >= 0.8);
+});
+
+test('propagateConfidence returns empty map for unknown start ids', () => {
+  const graph = new EvidenceGraphV2();
+  const map = graph.propagateConfidence('nope');
+  assert.equal(map.size, 0);
+});
+
+// ── stats ───────────────────────────────────────────────────────────
+
+test('stats counts nodes, edges, and edge types accurately', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation(
+    ['a', 'b', 'c'].map((id) => makeObservation({ id })),
+    [
+      makeEdge('a', 'b', { type: 'confirms', confidence: 0.9 }),
+      makeEdge('a', 'c', { type: 'contradicts', confidence: 0.7 }),
+    ],
+  ));
+  const s = graph.stats();
+  assert.equal(s.nodeCount, 3);
+  assert.equal(s.edgeCount, 2);
+  assert.equal(s.byEdgeType.confirms, 1);
+  assert.equal(s.byEdgeType.contradicts, 1);
+  assert.equal(s.byEdgeType.caused_by, 0);
+  // (0.9 + 0.7) / 2 = 0.8
+  assert.equal(s.averageConfidence, 0.8);
+});
+
+test('stats identifies the most-connected node', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation(
+    ['hub', 'a', 'b'].map((id) => makeObservation({ id })),
+    [makeEdge('hub', 'a'), makeEdge('hub', 'b')],
+  ));
+  assert.equal(graph.stats().mostConnectedNodeId, 'hub');
+});
+
+test('stats counts isolated nodes', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation(
+    [makeObservation({ id: 'a' }), makeObservation({ id: 'lonely' })],
+    [],
+  ));
+  assert.equal(graph.stats().isolatedNodeCount, 2);
+});
+
+test('stats on empty graph returns zeroes + nulls', () => {
+  const s = new EvidenceGraphV2().stats();
+  assert.equal(s.nodeCount, 0);
+  assert.equal(s.edgeCount, 0);
+  assert.equal(s.mostConnectedNodeId, null);
+});
+
+// ── clear / aggregateConfidence / singleton ─────────────────────────
+
+test('clear() resets the graph to empty', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation([makeObservation({ id: 'a' })], []));
+  graph.clear();
+  assert.equal(graph.stats().nodeCount, 0);
+});
+
+test('aggregateConfidence on a node is the mean of its touching edges', () => {
+  const graph = new EvidenceGraphV2();
+  graph.buildFromSituation(makeSituation(
+    ['a', 'b', 'c'].map((id) => makeObservation({ id })),
+    [makeEdge('a', 'b', { confidence: 0.6 }), makeEdge('c', 'a', { confidence: 0.8 })],
+  ));
+  const a = graph.getNode('a')!;
+  // mean of (0.6, 0.8) = 0.7
+  assert.equal(a.aggregateConfidence, 0.7);
+});
+
+test('getEvidenceGraph returns a stable singleton', () => {
+  __resetEvidenceGraphSingleton();
+  const a = getEvidenceGraph();
+  const b = getEvidenceGraph();
+  assert.equal(a, b);
+});
+
+// ── Bridge: assembleSituationEvidence ───────────────────────────────
+
+test('assembleSituationEvidence populates confirming from strong confirms+co-located edges', () => {
+  const a = makeObservation({ id: 'a', sourceId: 'src-a' });
+  const b = makeObservation({ id: 'b', sourceId: 'src-b' });
+  const sit = makeSituation([a, b], [makeEdge('a', 'b', { type: 'confirms', confidence: 0.9 })]);
+  const out = assembleSituationEvidence(sit, { now: NOW });
+  assert.equal(out.situationId, 'sit-1');
+  assert.equal(out.confirming.length, 2);
+});
+
+test('assembleSituationEvidence populates contradicting from contradicts edges', () => {
+  const a = makeObservation({ id: 'a' });
+  const b = makeObservation({ id: 'b' });
+  const sit = makeSituation([a, b], [
+    makeEdge('a', 'b', { type: 'contradicts', confidence: 0.8, ruleId: 'opposing' }),
+  ]);
+  const out = assembleSituationEvidence(sit, { now: NOW });
+  assert.equal(out.contradicting.length, 1);
+  assert.match(out.contradicting[0]!.reason, /opposing/);
+});
+
+test('assembleSituationEvidence flags stale observations beyond their refresh budget', () => {
+  // weather budget is 10 min; observation is 30 min old
+  const oldObs = makeObservation({ id: 'a', domain: 'weather', timestamp: NOW - 30 * 60_000 });
+  const sit = makeSituation([oldObs], [], { domain: 'weather' });
+  const out = assembleSituationEvidence(sit, { now: NOW });
+  assert.equal(out.stale.length, 1);
+  assert.equal(out.stale[0]!.sourceId, oldObs.sourceId);
+});
+
+test('assembleSituationEvidence confidenceBreakdown is normalized to sum 1', () => {
+  const sit = makeSituation(
+    ['a', 'b', 'c'].map((id) => makeObservation({ id })),
+    [
+      makeEdge('a', 'b', { type: 'confirms', confidence: 0.9 }),
+      makeEdge('a', 'c', { type: 'caused_by', confidence: 0.8 }),
+    ],
+  );
+  const out = assembleSituationEvidence(sit, { now: NOW });
+  const sum = Object.values(out.confidenceBreakdown).reduce((a, b) => a + b, 0);
+  assert.ok(Math.abs(sum - 1) < 1e-3, `expected sum ~1, got ${sum}`);
+});
+
+test('assembleSituationEvidence detects missing expected signals per domain', () => {
+  // earthquake situation with no shakemap / tsunami evidence
+  const obs = makeObservation({ id: 'a', sourceId: 'usgs-earthquake', domain: 'earthquake' });
+  const sit = makeSituation([obs], [], { domain: 'earthquake' });
+  const out = assembleSituationEvidence(sit, { now: NOW });
+  const labels = out.missing.map((m) => m.expectedSignal);
+  assert.ok(labels.some((l) => l.includes('ShakeMap')));
+  assert.ok(labels.some((l) => l.includes('tsunami')));
+});
+
+test('assembleSituationEvidence lastVerified picks newest confirming source or fallback', () => {
+  const a = makeObservation({ id: 'a', timestamp: NOW - 1000 });
+  const b = makeObservation({ id: 'b', timestamp: NOW - 500 });
+  const sit = makeSituation([a, b], [makeEdge('a', 'b', { type: 'confirms', confidence: 0.9 })]);
+  const out = assembleSituationEvidence(sit, { now: NOW });
+  assert.equal(out.lastVerified, NOW - 500);
+});
+
+// ── Internals ──────────────────────────────────────────────────────
+
+test('__internals.edgeKey collapses (a→b) and (b→a) of the same type/rule', () => {
+  const k1 = __internals.edgeKey({ type: 'confirms', sourceEventId: 'a', targetEventId: 'b', confidence: 1 });
+  const k2 = __internals.edgeKey({ type: 'confirms', sourceEventId: 'b', targetEventId: 'a', confidence: 1 });
+  assert.equal(k1, k2);
+});
+
+test('__internals.dominantEdgeType falls back to confirms on empty input', () => {
+  assert.equal(__internals.dominantEdgeType([]), 'confirms');
+});
+
+// reference the unused imports so strict tsconfigs don't complain
+test('teardown — references types', () => {
+  __resetEvidenceGraphSingleton();
+  const _n: GraphNode | undefined = undefined;
+  const _t: EvidenceEdgeType = 'confirms';
+  void _n; void _t;
+  assert.ok(true);
+});


### PR DESCRIPTION
Proper graph engine on top of `SituationStoreV2`'s typed evidence edges. Adds BFS/DFS traversal, Dijkstra shortest path weighted by `(1 - edge.confidence)`, contradiction detection, and confidence-decay propagation. Includes a bridge that produces the existing `EvidenceReport`-style assembly from any v2 Situation.

### What's new

`src/services/intelligence/evidence-graph-v2.ts`
- `EvidenceGraphV2` class indexes `Situation.observations` + `Situation.edges`.
- `getNode` / `getNeighbors` (edge-type filter) for single-hop queries.
- `bfs` / `dfs` with `maxDepth` caps; both return nodes including the start.
- `shortestPath(fromId, toId)` — Dijkstra over an undirected adjacency view of typed edges, weighted by `(1 - confidence)` so high-confidence routes win. Returns `GraphPath` with `totalConfidence` (product of edge confidences) and `dominantEdgeType`.
- `propagateConfidence(startId)` — BFS that multiplies confidences along paths and keeps the best route per reachable node.
- `getByEdgeType` / `getStrongEdges(minConfidence=0.7)` / `getContradictions()` for bucket queries.
- `stats()` rollup: per-type counts, average confidence, most-connected node, isolated count.
- Singleton getter + reset hook for tests.

`src/services/intelligence/evidence-graph-bridge.ts`
- `assembleSituationEvidence(situation)` returns the `EvidenceAssembly` UX rollup the panels expect:
  - `confirming` from strong `confirms` + `co-located` edges.
  - `contradicting` from `contradicts` edges with per-rule reasons.
  - `missing` follow-on signals per domain (`earthquake` → ShakeMap / tsunami; `weather` → NWS polygon / radar; `cyber` → CISA KEV / CERT).
  - `stale` observations beyond their domain refresh budget.
  - `confidenceBreakdown` normalized so the per-edge-type values sum to 1.
  - `lastVerified` = max timestamp from confirming sources (or fall back to newest observation).

### Naming choice

Named `evidence-graph-v2.ts` rather than overwriting `evidence-graph.ts` — the existing file (PR #422) is a different module that operates on `NormalizedFact` + `EvidenceNode` from `./types` and is still load-bearing for truth-scoring. Same pattern we used for `situation-store-v2`.

### Tests

`tests/intelligence/evidence-graph.test.mts` — 42 deterministic tests, `npx tsx --test`:

- Build: node count, edge indexing on both endpoints, idempotent re-adds, multi-Situation merge.
- Single-hop: `getNeighbors` both directions + edge-type filter, missing-node fallbacks.
- Traversal: BFS visits in breadth order, DFS reaches everything, `maxDepth` cap (`bfs(_, 1)`, `dfs(_, 0)`), unknown start ids return empty.
- Shortest path: single-edge, prefers high-confidence two-hop over weak direct, self-to-self, disconnected nodes return null, missing endpoints return null, `dominantEdgeType` = most-frequent along path.
- Filters: `getByEdgeType`, `getStrongEdges` (default + custom threshold), `getContradictions`.
- Propagation: anchor at 1.0, multiply along chain, prefer better route over weak direct, missing start id returns empty.
- Stats: counts/types/avg confidence/most-connected/isolated; empty graph zero-state.
- Lifecycle: `clear`, `aggregateConfidence` mean, singleton stability.
- Bridge: confirming from strong edges, contradicting with rule reason, stale detection per domain budget, breakdown sums to 1, missing per-domain signals, `lastVerified` math.
- Internals: `edgeKey` symmetric, `dominantEdgeType` empty fallback.

`npx tsc --noEmit` clean on both root and api tsconfigs. ESLint clean after autofix (array-type style).

### Cross-agent review

Cross-agent review: claude reviewed on 2026-05-13; outcome: pass