### PR TITLE
chore(release): version bump → v2.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crystal-ball",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crystal-ball",
-      "version": "2.19.0",
+      "version": "2.20.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crystal-ball",
   "private": true,
-  "version": "2.19.0",
+  "version": "2.20.0",
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "crystalball"
-version = "2.19.0"
+version = "2.20.0"
 dependencies = [
  "getrandom 0.4.2",
  "keyring",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crystalball"
-version = "2.19.0"
+version = "2.20.0"
 description = "Crystal Ball cross-platform desktop application "
 authors = ["Bradley Bond", ""]
 edition = "2021"

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -9,7 +9,7 @@
 <dict>
   <!-- Shown as the labeled version string in Finder Get Info and Spotlight -->
   <key>CFBundleGetInfoString</key>
-  <string>Crystal Ball 2.19.0</string>
+  <string>Crystal Ball 2.20.0</string>
 
   <!-- Shown in the "More Info" section of Finder Get Info -->
   <key>NSHumanReadableCopyright</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Crystal Ball",
   "mainBinaryName": "crystalball",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "identifier": "com.bradleybond.crystalball",
   "build": {
     "beforeDevCommand": "npm run build:sidecar-sebuf && npm run dev",


### PR DESCRIPTION
Bumps all 6 version surfaces to 2.20.0. Covers PRs #479–#485.