### PR TITLE
fix: phase 0 release blockers — GDACS crash guard, sidecar audit, CHANGELOG sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to Crystal Ball are documented here.
 
 ## [Unreleased]
 
+## [2.20.0] - 2026-05-15
+
+### Added
+
+- **Driver-based scoring** (PR #475): evidence-weighted severity engine that replaces the legacy threshold math — every score now carries a per-driver breakdown the panel can render.
+- **Learn stage — outcome feedback loop** (PR #481): user actions (dismiss / acted-on / escalated / confirmed-real / false-positive) feed a per-domain calibration that recommends attention multipliers.
+- **Evidence graph traversal** (PR #483): typed-edge BFS / DFS, shortest path, and confidence propagation over the situation evidence graph.
+- **Panel lens** (PR #484): context-sensitive panels focus on the currently-active Situation when one is set.
+- **Assumption tracking** (PR #485): every model output is annotated with the assumptions + confidence it depended on.
+
+## [2.19.0] - 2026-05-14
+
+### Added
+
+- **Notification history panel** (PR #477): full provenance + suppression audit trail for delivered notifications.
+- **What Changed v2** (PR #478): world-state diff engine with typed deltas, replacing the v1 string-diff approach.
+- **Situation Store v2** (PR #480): named Situations aggregated from correlated cross-domain signals, with a stable evidence graph.
+
+### Changed
+
+- **Native macOS chrome** (PR #476): window-vibrancy `HudWindow`, transparent titlebar overlay, traffic-light safe-zone CSS. Preserves existing decorations to keep traffic lights visible.
+
+## [2.18.0] - 2026-05-13
+
+### Added
+
+- **Entity registry** (PR #468): canonical identity layer across ships, aircraft, people, and organizations so cross-domain signals can resolve to a single actor.
+- **Explain stage** (PR #467): "why this alert" explanations attached to every notification.
+- **Observation adapters** (PR #469): all feeds normalize to a single `ObservationEvent` schema at the boundary.
+- **Correlate stage** (PR #470): cross-domain signal joining with 8 built-in correlation rules.
+- **Progressive disclosure** (PR #471): summary → detail → raw layering at every panel level.
+- **Notification settings UI** (PR #472): per-domain mute / threshold / channel controls.
+
 ## [2.17.0] - 2026-05-13
 
 ### Added

--- a/src/components/GDACSAlertsPanel.ts
+++ b/src/components/GDACSAlertsPanel.ts
@@ -95,9 +95,13 @@ export class GDACSAlertsPanel extends Panel {
     this.unsubscribeLens = null;
   }
 
-  // Legacy: fed from data-loader via JSON API
-  public update(events: GDACSEvent[]): void {
-    this.events = events;
+  // Legacy: fed from data-loader via JSON API.
+  // Guard against a malformed envelope (missing / non-array `events`)
+  // so the renderer doesn't blow up on `this.events.length` /
+  // `this.events.slice(...)` downstream. Mirrors the RSS path's
+  // normalizeGdacsRssEnvelope safety net.
+  public update(events: GDACSEvent[] | null | undefined): void {
+    this.events = Array.isArray(events) ? events : [];
     this.render();
   }
 

--- a/tests/panels/sidecar-routes-allowlist.json
+++ b/tests/panels/sidecar-routes-allowlist.json
@@ -29,6 +29,7 @@
     "/api/intelligence/brief/generate",
     "/api/intelligence/correlations/event",
     "/api/intelligence/evidence-graph",
+    "/api/intelligence/entities",
     "/api/intelligence/explain",
     "/api/intelligence/explain-alerts",
     "/api/command-center/recent-changes",


### PR DESCRIPTION
Three small Phase 0 cleanups in one commit so the release-doctor + sidecar-routes audit gates stay green.

## What's here

1. **GDACSAlertsPanel.update() — guard against malformed JSON-API envelopes**
   The RSS path was already protected by `normalizeGdacsRssEnvelope` (it coerces missing / non-array `events` to `[]` at the boundary), but the legacy JSON-API `update()` blindly assigned the incoming `events` argument to `this.events`. A malformed envelope (events missing / undefined / non-array) then crashed downstream at `this.events.length` / `this.events.slice`. Now wraps with `Array.isArray`, mirroring the RSS path's defensive normalisation.

2. **sidecar-routes-allowlist — classify `/api/intelligence/entities`**
   `/api/sms/command` was already classified as `intentionalInternal` with a documented `_reasons` entry — no change needed there. The audit test was failing on a different unclassified route: `/api/intelligence/entities` (the entity-registry renderer→sidecar mirror that landed but never got added to the audit allowlist). Now classified under `intentionalInternal` alongside the other renderer-mirror routes.

3. **CHANGELOG.md — backfill v2.18.0 / v2.19.0 / v2.20.0**
   Three missing version entries added with the existing format (### Added / ### Changed / ### Security sections, concise PR-anchored bullets). Content derived from `git log` between tags. README has no version badge, so nothing to sync there.

## Verification

- `npx tsc --noEmit` — clean
- `npx tsx --test tests/panels/sidecar-routes-audit.test.mts` — **3 / 3** (previously failing on the unclassified entities route)
- `npx tsx --test src/services/gdacs/__tests__/rss-normalize.test.mts` — **6 / 6**
- Pre-commit hooks (conflict markers, secret scan, JSON lint, Markdown lint, full `typecheck:all`, eslint --fix --quiet) — all clean

Cross-agent review: claude reviewed on 2026-05-17; outcome: pass