### PR TITLE
Global rhythm engine — baseline circadian/weekly/seasonal patterns per domain

### DIFF
--- a/src/services/intelligence/global-rhythm-engine.ts
+++ b/src/services/intelligence/global-rhythm-engine.ts
@@ -1,0 +1,352 @@
+/**
+ * GlobalRhythmEngine — models baseline circadian (hourly), weekly,
+ * and seasonal (ISO-week) activity patterns per domain so that
+ * downstream consumers can score anomalies relative to the expected
+ * rhythm.
+ *
+ * Each domain has three sliding rhythm windows:
+ *   - hourly: 24 buckets indexed by UTC hour-of-day
+ *   - daily:  7  buckets indexed by UTC day-of-week (0=Sun..6=Sat)
+ *   - weekly: 52 buckets indexed by ISO week-of-year (1..52)
+ *
+ * Each bucket maintains a Welford running mean + variance so that
+ * `record()` is O(1) and numerically stable across many samples.
+ *
+ * Pure deterministic; no DOM, no fetch. Injectable Storage keeps
+ * tests hermetic.
+ */
+
+// ── Public types ─────────────────────────────────────────────────────
+
+export interface RhythmBucket {
+  mean: number;
+  variance: number;
+  stddev: number;
+  sampleCount: number;
+}
+
+export interface DomainRhythm {
+  domain: string;
+  hourly: RhythmBucket[];   // length 24
+  daily: RhythmBucket[];    // length 7
+  weekly: RhythmBucket[];   // length 52
+}
+
+export interface RhythmExpectation {
+  hourlyMean: number;
+  hourlyStddev: number;
+  dailyMean: number;
+  dailyStddev: number;
+  weeklyMean: number;
+  weeklyStddev: number;
+  compositeExpected: number;
+}
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+export interface GlobalRhythmEngineOptions {
+  storage?: StorageLike | null;
+  maxEntries?: number;
+  seed?: boolean;
+}
+
+// ── Constants ────────────────────────────────────────────────────────
+
+export const STORAGE_KEY = 'wm-global-rhythms';
+export const MAX_ENTRIES = 500;
+export const STDDEV_FLOOR = 0.1;
+export const HOURLY_WEIGHT = 0.5;
+export const DAILY_WEIGHT = 0.3;
+export const WEEKLY_WEIGHT = 0.2;
+
+const HOURS = 24;
+const DAYS = 7;
+const WEEKS = 52;
+
+export const SEED_DOMAINS: readonly string[] = [
+  'cyber', 'weather', 'geopolitical', 'maritime',
+  'aviation', 'health', 'financial', 'seismic',
+];
+
+// Per-domain hand-tuned baseline activity profile. Numbers are in the
+// "expected events per query window" scale; downstream consumers care
+// about *relative* deviation, not absolute units.
+interface SeedProfile {
+  hourly: readonly number[];      // length 24
+  daily: readonly number[];       // length 7  (Sun..Sat)
+  weekly: readonly number[];      // length 52
+}
+
+function tunedProfile(
+  base: number,
+  hourlyShape: readonly number[],
+  dailyShape: readonly number[],
+): SeedProfile {
+  const hourly = hourlyShape.map((m) => Math.max(0.1, base * m));
+  const daily = dailyShape.map((m) => Math.max(0.1, base * m));
+  const weekly = Array.from({ length: WEEKS }, () => base);
+  return { hourly, daily, weekly };
+}
+
+// Hourly shapes (length 24, peak business hours):
+const BUSINESS_HOURS_SHAPE = [
+  0.4, 0.3, 0.3, 0.3, 0.3, 0.4, 0.6, 0.9, 1.2, 1.4, 1.5, 1.6,
+  1.5, 1.5, 1.4, 1.3, 1.2, 1.1, 1, 0.9, 0.8, 0.7, 0.6, 0.5,
+];
+const NIGHT_HEAVY_SHAPE = [
+  1.4, 1.5, 1.5, 1.4, 1.2, 1, 0.8, 0.6, 0.5, 0.5, 0.6, 0.7,
+  0.8, 0.9, 1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.5, 1.5, 1.4, 1.4,
+];
+const FLAT_SHAPE = Array.from({ length: HOURS }, () => 1);
+
+// Daily shapes (Sun=0 .. Sat=6):
+const WEEKDAY_HEAVY = [0.6, 1.2, 1.3, 1.3, 1.3, 1.3, 0.7];
+const FLAT_DAY = [1, 1, 1, 1, 1, 1, 1];
+
+const SEED_PROFILES: Record<string, SeedProfile> = {
+  cyber: tunedProfile(8, BUSINESS_HOURS_SHAPE, WEEKDAY_HEAVY),
+  weather: tunedProfile(12, FLAT_SHAPE, FLAT_DAY),
+  geopolitical: tunedProfile(6, BUSINESS_HOURS_SHAPE, WEEKDAY_HEAVY),
+  maritime: tunedProfile(4, FLAT_SHAPE, FLAT_DAY),
+  aviation: tunedProfile(20, BUSINESS_HOURS_SHAPE, FLAT_DAY),
+  health: tunedProfile(5, FLAT_SHAPE, FLAT_DAY),
+  financial: tunedProfile(15, BUSINESS_HOURS_SHAPE, WEEKDAY_HEAVY),
+  seismic: tunedProfile(3, NIGHT_HEAVY_SHAPE, FLAT_DAY),
+};
+
+// ── Bucket math ──────────────────────────────────────────────────────
+
+function newBucket(): RhythmBucket {
+  return { mean: 0, variance: 0, stddev: 0, sampleCount: 0 };
+}
+
+function welfordUpdate(bucket: RhythmBucket, sample: number): void {
+  bucket.sampleCount += 1;
+  const delta = sample - bucket.mean;
+  bucket.mean += delta / bucket.sampleCount;
+  const delta2 = sample - bucket.mean;
+  // Maintain M2 in `variance` until we publish; finalize stddev below.
+  bucket.variance += delta * delta2;
+  bucket.stddev = bucket.sampleCount < 2
+    ? STDDEV_FLOOR
+    : Math.max(STDDEV_FLOOR, Math.sqrt(bucket.variance / (bucket.sampleCount - 1)));
+}
+
+function emptyDomainRhythm(domain: string): DomainRhythm {
+  return {
+    domain,
+    hourly: Array.from({ length: HOURS }, () => newBucket()),
+    daily: Array.from({ length: DAYS }, () => newBucket()),
+    weekly: Array.from({ length: WEEKS }, () => newBucket()),
+  };
+}
+
+function seedDomainRhythm(domain: string): DomainRhythm {
+  const profile = SEED_PROFILES[domain];
+  const rhythm = emptyDomainRhythm(domain);
+  if (!profile) return rhythm;
+  for (let h = 0; h < HOURS; h++) welfordUpdate(rhythm.hourly[h]!, profile.hourly[h] ?? 0);
+  for (let d = 0; d < DAYS; d++) welfordUpdate(rhythm.daily[d]!, profile.daily[d] ?? 0);
+  for (let w = 0; w < WEEKS; w++) welfordUpdate(rhythm.weekly[w]!, profile.weekly[w] ?? 0);
+  return rhythm;
+}
+
+// ── Time → bucket indices (UTC) ──────────────────────────────────────
+
+function hourIndex(timestamp: number): number {
+  return new Date(timestamp).getUTCHours();
+}
+
+function dayIndex(timestamp: number): number {
+  return new Date(timestamp).getUTCDay();
+}
+
+// ISO week number (1..52, clamping 53 → 52 for bucket math).
+function weekIndex(timestamp: number): number {
+  const d = new Date(timestamp);
+  const utcDate = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  // Shift to nearest Thursday: ISO weeks belong to the year of their Thursday.
+  const dayNum = (utcDate.getUTCDay() + 6) % 7; // Mon=0..Sun=6
+  utcDate.setUTCDate(utcDate.getUTCDate() - dayNum + 3);
+  const firstThursday = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 4));
+  const firstThursdayDayNum = (firstThursday.getUTCDay() + 6) % 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() - firstThursdayDayNum + 3);
+  const diffMs = utcDate.getTime() - firstThursday.getTime();
+  const week = 1 + Math.round(diffMs / (7 * 24 * 60 * 60 * 1000));
+  if (week < 1) return 0;
+  if (week > WEEKS) return WEEKS - 1;
+  return week - 1;
+}
+
+// ── Engine ──────────────────────────────────────────────────────────
+
+interface PersistedState {
+  rhythms: DomainRhythm[];
+}
+
+export class GlobalRhythmEngine {
+  private readonly storage: StorageLike | null;
+  private readonly maxEntries: number;
+  private readonly rhythms = new Map<string, DomainRhythm>();
+  private readonly insertionOrder: string[] = [];
+
+  constructor(opts: GlobalRhythmEngineOptions = {}) {
+    this.storage = opts.storage === undefined ? defaultStorage() : opts.storage;
+    this.maxEntries = opts.maxEntries ?? MAX_ENTRIES;
+    this.hydrate();
+    if (opts.seed) this.seedAll();
+  }
+
+  static getInstance(): GlobalRhythmEngine {
+    singleton ??= new GlobalRhythmEngine({ seed: true });
+    return singleton;
+  }
+
+  record(domain: string, count: number, timestamp: number): void {
+    const rhythm = this.getOrCreate(domain);
+    welfordUpdate(rhythm.hourly[hourIndex(timestamp)]!, count);
+    welfordUpdate(rhythm.daily[dayIndex(timestamp)]!, count);
+    welfordUpdate(rhythm.weekly[weekIndex(timestamp)]!, count);
+    this.persist();
+  }
+
+  getExpected(domain: string, timestamp: number): RhythmExpectation {
+    const rhythm = this.rhythms.get(domain);
+    if (!rhythm) {
+      return {
+        hourlyMean: 0, hourlyStddev: STDDEV_FLOOR,
+        dailyMean: 0, dailyStddev: STDDEV_FLOOR,
+        weeklyMean: 0, weeklyStddev: STDDEV_FLOOR,
+        compositeExpected: 0,
+      };
+    }
+    const h = rhythm.hourly[hourIndex(timestamp)]!;
+    const d = rhythm.daily[dayIndex(timestamp)]!;
+    const w = rhythm.weekly[weekIndex(timestamp)]!;
+    const compositeExpected = HOURLY_WEIGHT * h.mean + DAILY_WEIGHT * d.mean + WEEKLY_WEIGHT * w.mean;
+    return {
+      hourlyMean: h.mean,
+      hourlyStddev: h.stddev,
+      dailyMean: d.mean,
+      dailyStddev: d.stddev,
+      weeklyMean: w.mean,
+      weeklyStddev: w.stddev,
+      compositeExpected,
+    };
+  }
+
+  getDeviation(domain: string, count: number, timestamp: number): number {
+    const expected = this.getExpected(domain, timestamp);
+    const compositeStddev = Math.max(
+      STDDEV_FLOOR,
+      HOURLY_WEIGHT * expected.hourlyStddev
+        + DAILY_WEIGHT * expected.dailyStddev
+        + WEEKLY_WEIGHT * expected.weeklyStddev,
+    );
+    return (count - expected.compositeExpected) / compositeStddev;
+  }
+
+  getDomainRhythms(): DomainRhythm[] {
+    return [...this.rhythms.values()].map((r) => cloneRhythm(r));
+  }
+
+  clear(): void {
+    this.rhythms.clear();
+    this.insertionOrder.length = 0;
+    this.persist();
+  }
+
+  // ── Internals ─────────────────────────────────────────────────────
+
+  private getOrCreate(domain: string): DomainRhythm {
+    const existing = this.rhythms.get(domain);
+    if (existing) return existing;
+    const created = emptyDomainRhythm(domain);
+    this.addRhythm(created);
+    return created;
+  }
+
+  private addRhythm(rhythm: DomainRhythm): void {
+    this.rhythms.set(rhythm.domain, rhythm);
+    this.insertionOrder.push(rhythm.domain);
+    while (this.insertionOrder.length > this.maxEntries) {
+      const evict = this.insertionOrder.shift();
+      if (evict !== undefined) this.rhythms.delete(evict);
+    }
+  }
+
+  private seedAll(): void {
+    for (const domain of SEED_DOMAINS) {
+      if (this.rhythms.has(domain)) continue;
+      this.addRhythm(seedDomainRhythm(domain));
+    }
+    this.persist();
+  }
+
+  private hydrate(): void {
+    if (!this.storage) return;
+    try {
+      const raw = this.storage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as PersistedState;
+      if (!parsed || !Array.isArray(parsed.rhythms)) return;
+      for (const r of parsed.rhythms) {
+        if (this.isValidRhythm(r)) this.addRhythm(r);
+      }
+    } catch {
+      this.rhythms.clear();
+      this.insertionOrder.length = 0;
+    }
+  }
+
+  private isValidRhythm(r: unknown): r is DomainRhythm {
+    if (typeof r !== 'object' || r === null) return false;
+    const obj = r as { domain?: unknown; hourly?: unknown; daily?: unknown; weekly?: unknown };
+    return typeof obj.domain === 'string'
+      && Array.isArray(obj.hourly) && obj.hourly.length === HOURS
+      && Array.isArray(obj.daily) && obj.daily.length === DAYS
+      && Array.isArray(obj.weekly) && obj.weekly.length === WEEKS;
+  }
+
+  private persist(): void {
+    if (!this.storage) return;
+    try {
+      const serial: PersistedState = { rhythms: [...this.rhythms.values()] };
+      this.storage.setItem(STORAGE_KEY, JSON.stringify(serial));
+    } catch {
+      // non-fatal
+    }
+  }
+}
+
+// ── Lazy singleton ──────────────────────────────────────────────────
+
+let singleton: GlobalRhythmEngine | undefined;
+
+export function resetForTests(): void {
+  singleton = undefined;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function cloneBucket(b: RhythmBucket): RhythmBucket {
+  return { mean: b.mean, variance: b.variance, stddev: b.stddev, sampleCount: b.sampleCount };
+}
+
+function cloneRhythm(r: DomainRhythm): DomainRhythm {
+  return {
+    domain: r.domain,
+    hourly: r.hourly.map((b) => cloneBucket(b)),
+    daily: r.daily.map((b) => cloneBucket(b)),
+    weekly: r.weekly.map((b) => cloneBucket(b)),
+  };
+}
+
+function defaultStorage(): StorageLike | null {
+  if (typeof globalThis === 'undefined') return null;
+  const ls = (globalThis as { localStorage?: StorageLike }).localStorage;
+  return ls ?? null;
+}

--- a/tests/intelligence/global-rhythm-engine.test.mts
+++ b/tests/intelligence/global-rhythm-engine.test.mts
@@ -1,0 +1,407 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  GlobalRhythmEngine,
+  resetForTests,
+  STORAGE_KEY,
+  MAX_ENTRIES,
+  SEED_DOMAINS,
+  STDDEV_FLOOR,
+  type RhythmExpectation,
+} from '../../src/services/intelligence/global-rhythm-engine.ts';
+
+// Pick a fixed UTC anchor whose properties we know:
+// 2024-01-08 00:00:00 UTC — a Monday (UTC), week 02 ISO, hour 0.
+const MON_W2_T0 = Date.UTC(2024, 0, 8, 0, 0, 0);
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+
+function memoryStorage(): { getItem(k: string): string | null; setItem(k: string, v: string): void; data: Map<string, string> } {
+  const data = new Map<string, string>();
+  return {
+    data,
+    getItem(k: string): string | null { return data.get(k) ?? null; },
+    setItem(k: string, v: string): void { data.set(k, v); },
+  };
+}
+
+describe('GlobalRhythmEngine — basic record', () => {
+  beforeEach(() => { resetForTests(); });
+
+  it('record increments hourly bucket count', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    eng.record('cyber', 10, MON_W2_T0); // hour 0
+    const expected = eng.getExpected('cyber', MON_W2_T0);
+    assert.ok(expected.hourlyMean > 0);
+    assert.equal(expected.hourlyMean, 10);
+  });
+
+  it('multiple records to the same bucket use Welford running mean', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    // Three observations into the SAME bucket (Monday hour 0, week 02)
+    eng.record('cyber', 10, MON_W2_T0);
+    eng.record('cyber', 20, MON_W2_T0 + WEEK); // same hour, same DOW, week+1
+    eng.record('cyber', 30, MON_W2_T0 + 2 * WEEK);
+    const expected = eng.getExpected('cyber', MON_W2_T0);
+    // Hourly bucket at hour-0 has all three; mean = 20
+    assert.equal(expected.hourlyMean, 20);
+    // Sample variance of [10, 20, 30] = 200/2 = 100, stddev = 10
+    assert.ok(Math.abs(expected.hourlyStddev - 10) < 0.01);
+  });
+
+  it('record updates each of the 3 windows independently', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    eng.record('cyber', 5, MON_W2_T0); // hour=0, DOW=Mon, week=02
+    const exp = eng.getExpected('cyber', MON_W2_T0);
+    assert.equal(exp.hourlyMean, 5);
+    assert.equal(exp.dailyMean, 5);
+    assert.equal(exp.weeklyMean, 5);
+  });
+});
+
+describe('GlobalRhythmEngine — bucket bucketing', () => {
+  beforeEach(() => { resetForTests(); });
+
+  it('different hours land in different hourly buckets', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    eng.record('cyber', 10, MON_W2_T0);           // hour 0
+    eng.record('cyber', 100, MON_W2_T0 + 12 * HOUR); // hour 12 same day
+    const at0 = eng.getExpected('cyber', MON_W2_T0);
+    const at12 = eng.getExpected('cyber', MON_W2_T0 + 12 * HOUR);
+    assert.equal(at0.hourlyMean, 10);
+    assert.equal(at12.hourlyMean, 100);
+  });
+
+  it('different days land in different daily buckets', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    eng.record('cyber', 7, MON_W2_T0);             // Mon
+    eng.record('cyber', 70, MON_W2_T0 + 2 * DAY);  // Wed
+    const mon = eng.getExpected('cyber', MON_W2_T0);
+    const wed = eng.getExpected('cyber', MON_W2_T0 + 2 * DAY);
+    assert.equal(mon.dailyMean, 7);
+    assert.equal(wed.dailyMean, 70);
+  });
+
+  it('different ISO weeks land in different weekly buckets', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    eng.record('cyber', 1, MON_W2_T0);             // week 02
+    eng.record('cyber', 100, MON_W2_T0 + 5 * WEEK); // ~5 weeks later
+    const w2 = eng.getExpected('cyber', MON_W2_T0);
+    const wLater = eng.getExpected('cyber', MON_W2_T0 + 5 * WEEK);
+    assert.equal(w2.weeklyMean, 1);
+    assert.equal(wLater.weeklyMean, 100);
+  });
+
+  it('hourly bucket wraps modulo 24', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    // hour 0 and hour 24 (= next day hour 0) should hit the same hourly bucket
+    eng.record('cyber', 10, MON_W2_T0);
+    eng.record('cyber', 30, MON_W2_T0 + DAY); // next day, hour 0
+    const exp = eng.getExpected('cyber', MON_W2_T0);
+    assert.equal(exp.hourlyMean, 20);
+  });
+});
+
+describe('GlobalRhythmEngine — getExpected and compositeExpected', () => {
+  beforeEach(() => { resetForTests(); });
+
+  it('empty domain returns zero expectations', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    const exp = eng.getExpected('never-seen', MON_W2_T0);
+    assert.equal(exp.hourlyMean, 0);
+    assert.equal(exp.dailyMean, 0);
+    assert.equal(exp.weeklyMean, 0);
+    assert.equal(exp.compositeExpected, 0);
+  });
+
+  it('compositeExpected is 0.5*hourly + 0.3*daily + 0.2*weekly', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    // Place independent values into each window by using non-overlapping time points
+    // Hour-of-day 0 / DOW Mon / Week 2 — record value 10 at MON_W2_T0
+    eng.record('cyber', 10, MON_W2_T0);
+    // Hour-of-day 5 / DOW Tue / Week 2 — record 20 (boosts daily Tue + hourly5 + week2)
+    eng.record('cyber', 20, MON_W2_T0 + DAY + 5 * HOUR);
+    // For a query AT MON_W2_T0 (hour 0, Mon, week 02):
+    //  hourly bucket 0  -> mean 10
+    //  daily bucket Mon -> mean 10
+    //  weekly bucket 02 -> mean (10+20)/2 = 15
+    const exp = eng.getExpected('cyber', MON_W2_T0);
+    assert.equal(exp.hourlyMean, 10);
+    assert.equal(exp.dailyMean, 10);
+    assert.equal(exp.weeklyMean, 15);
+    const composite = 0.5 * 10 + 0.3 * 10 + 0.2 * 15;
+    assert.ok(Math.abs(exp.compositeExpected - composite) < 1e-6);
+  });
+
+  it('getExpected returns stddev with floor STDDEV_FLOOR for single-sample bucket', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    eng.record('cyber', 10, MON_W2_T0);
+    const exp = eng.getExpected('cyber', MON_W2_T0);
+    // Single sample → variance 0 → stddev floored
+    assert.equal(exp.hourlyStddev, STDDEV_FLOOR);
+    assert.equal(exp.dailyStddev, STDDEV_FLOOR);
+    assert.equal(exp.weeklyStddev, STDDEV_FLOOR);
+  });
+});
+
+describe('GlobalRhythmEngine — getDeviation z-score', () => {
+  beforeEach(() => { resetForTests(); });
+
+  it('exact-mean observation has zero deviation', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    for (let i = 0; i < 5; i++) eng.record('cyber', 10, MON_W2_T0 + i * WEEK);
+    const dev = eng.getDeviation('cyber', 10, MON_W2_T0);
+    assert.ok(Math.abs(dev) < 1e-6);
+  });
+
+  it('above-mean observation has positive deviation', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    for (let i = 0; i < 5; i++) eng.record('cyber', 10, MON_W2_T0 + i * WEEK);
+    const dev = eng.getDeviation('cyber', 50, MON_W2_T0);
+    assert.ok(dev > 0);
+  });
+
+  it('below-mean observation has negative deviation', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    for (let i = 0; i < 5; i++) eng.record('cyber', 10, MON_W2_T0 + i * WEEK);
+    const dev = eng.getDeviation('cyber', 0, MON_W2_T0);
+    assert.ok(dev < 0);
+  });
+
+  it('deviation divides by composite stddev that respects floor', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    eng.record('cyber', 10, MON_W2_T0);
+    // Single sample → composite stddev = floor; deviation = (50 - composite_mean) / floor
+    const dev = eng.getDeviation('cyber', 50, MON_W2_T0);
+    assert.ok(Number.isFinite(dev));
+    assert.ok(dev !== 0);
+  });
+
+  it('deviation for unknown domain falls back to absolute count', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    const dev = eng.getDeviation('mystery-domain', 7, MON_W2_T0);
+    // composite expected is 0, stddev is floor — deviation = 7 / floor
+    assert.equal(dev, 7 / STDDEV_FLOOR);
+  });
+});
+
+describe('GlobalRhythmEngine — getDomainRhythms', () => {
+  beforeEach(() => { resetForTests(); });
+
+  it('returns one entry per recorded domain', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    eng.record('cyber', 1, MON_W2_T0);
+    eng.record('weather', 2, MON_W2_T0);
+    const rhythms = eng.getDomainRhythms();
+    const domains = rhythms.map((r) => r.domain).sort((a, b) => a.localeCompare(b));
+    assert.ok(domains.includes('cyber'));
+    assert.ok(domains.includes('weather'));
+  });
+
+  it('each rhythm carries hourly/daily/weekly bucket arrays', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    eng.record('cyber', 5, MON_W2_T0);
+    const rhythms = eng.getDomainRhythms();
+    const cyber = rhythms.find((r) => r.domain === 'cyber');
+    assert.equal(cyber?.hourly.length, 24);
+    assert.equal(cyber?.daily.length, 7);
+    assert.equal(cyber?.weekly.length, 52);
+  });
+
+  it('bucket entries expose mean + sampleCount', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    eng.record('cyber', 10, MON_W2_T0);
+    eng.record('cyber', 20, MON_W2_T0 + WEEK);
+    const rhythms = eng.getDomainRhythms();
+    const cyber = rhythms.find((r) => r.domain === 'cyber');
+    const hourBucket = cyber?.hourly[0];
+    assert.equal(hourBucket?.mean, 15);
+    assert.equal(hourBucket?.sampleCount, 2);
+  });
+
+  it('returns defensive copies', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    eng.record('cyber', 10, MON_W2_T0);
+    const first = eng.getDomainRhythms();
+    first[0]!.hourly[0]!.mean = 99999;
+    const second = eng.getDomainRhythms();
+    assert.notEqual(second[0]?.hourly[0]?.mean, 99999);
+  });
+});
+
+describe('GlobalRhythmEngine — seed domains', () => {
+  beforeEach(() => { resetForTests(); });
+
+  it('SEED_DOMAINS lists all 8 expected domains', () => {
+    assert.deepEqual(
+      [...SEED_DOMAINS].sort((a, b) => a.localeCompare(b)),
+      ['aviation', 'cyber', 'financial', 'geopolitical', 'health', 'maritime', 'seismic', 'weather'],
+    );
+  });
+
+  it('seeded engine pre-populates all 8 domains', () => {
+    const eng = new GlobalRhythmEngine({ storage: null, seed: true });
+    const rhythms = eng.getDomainRhythms();
+    for (const seed of SEED_DOMAINS) {
+      assert.ok(rhythms.some((r) => r.domain === seed), `missing seed: ${seed}`);
+    }
+  });
+
+  it('non-seeded engine has no domains until record is called', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    assert.equal(eng.getDomainRhythms().length, 0);
+  });
+
+  it('seed produces non-zero baseline mean for each seed domain', () => {
+    const eng = new GlobalRhythmEngine({ storage: null, seed: true });
+    for (const seed of SEED_DOMAINS) {
+      const exp: RhythmExpectation = eng.getExpected(seed, MON_W2_T0);
+      assert.ok(exp.compositeExpected > 0, `${seed} composite should be > 0`);
+    }
+  });
+});
+
+describe('GlobalRhythmEngine — persistence', () => {
+  beforeEach(() => { resetForTests(); });
+
+  it('domains persist + hydrate', () => {
+    const storage = memoryStorage();
+    const eng1 = new GlobalRhythmEngine({ storage });
+    eng1.record('cyber', 42, MON_W2_T0);
+    const eng2 = new GlobalRhythmEngine({ storage });
+    const exp = eng2.getExpected('cyber', MON_W2_T0);
+    assert.equal(exp.hourlyMean, 42);
+  });
+
+  it('Welford state survives hydrate (mean + variance preserved)', () => {
+    const storage = memoryStorage();
+    const eng1 = new GlobalRhythmEngine({ storage });
+    eng1.record('cyber', 10, MON_W2_T0);
+    eng1.record('cyber', 20, MON_W2_T0 + WEEK);
+    const eng2 = new GlobalRhythmEngine({ storage });
+    // Continue with third sample → mean should become 20 across all three
+    eng2.record('cyber', 30, MON_W2_T0 + 2 * WEEK);
+    const exp = eng2.getExpected('cyber', MON_W2_T0);
+    assert.equal(exp.hourlyMean, 20);
+  });
+
+  it('storage key is wm-global-rhythms', () => {
+    assert.equal(STORAGE_KEY, 'wm-global-rhythms');
+  });
+
+  it('max entries is 500', () => {
+    assert.equal(MAX_ENTRIES, 500);
+  });
+
+  it('malformed persisted state recovers gracefully', () => {
+    const storage = memoryStorage();
+    storage.setItem(STORAGE_KEY, '{not json');
+    const eng = new GlobalRhythmEngine({ storage });
+    assert.equal(eng.getDomainRhythms().length, 0);
+    eng.record('cyber', 5, MON_W2_T0);
+    assert.equal(eng.getExpected('cyber', MON_W2_T0).hourlyMean, 5);
+  });
+
+  it('null storage means no persistence side effects', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    eng.record('cyber', 5, MON_W2_T0);
+    assert.equal(eng.getExpected('cyber', MON_W2_T0).hourlyMean, 5);
+  });
+});
+
+describe('GlobalRhythmEngine — getInstance singleton', () => {
+  beforeEach(() => { resetForTests(); });
+
+  it('getInstance returns the same instance across calls', () => {
+    const a = GlobalRhythmEngine.getInstance();
+    const b = GlobalRhythmEngine.getInstance();
+    assert.equal(a, b);
+  });
+
+  it('resetForTests clears the singleton', () => {
+    const a = GlobalRhythmEngine.getInstance();
+    resetForTests();
+    const b = GlobalRhythmEngine.getInstance();
+    assert.notEqual(a, b);
+  });
+
+  it('getInstance pre-seeds the 8 domains', () => {
+    const eng = GlobalRhythmEngine.getInstance();
+    const rhythms = eng.getDomainRhythms();
+    assert.ok(rhythms.length >= 8);
+  });
+});
+
+describe('GlobalRhythmEngine — capacity', () => {
+  beforeEach(() => { resetForTests(); });
+
+  it('honors maxEntries override', () => {
+    const eng = new GlobalRhythmEngine({ storage: null, maxEntries: 3 });
+    eng.record('a', 1, MON_W2_T0);
+    eng.record('b', 1, MON_W2_T0);
+    eng.record('c', 1, MON_W2_T0);
+    eng.record('d', 1, MON_W2_T0);
+    eng.record('e', 1, MON_W2_T0);
+    const rhythms = eng.getDomainRhythms();
+    assert.ok(rhythms.length <= 3);
+  });
+});
+
+describe('GlobalRhythmEngine — variance edge cases', () => {
+  beforeEach(() => { resetForTests(); });
+
+  it('identical samples keep stddev at floor', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    for (let i = 0; i < 5; i++) eng.record('cyber', 10, MON_W2_T0 + i * WEEK);
+    const exp = eng.getExpected('cyber', MON_W2_T0);
+    assert.equal(exp.hourlyMean, 10);
+    assert.equal(exp.hourlyStddev, STDDEV_FLOOR);
+  });
+
+  it('sampleCount on a bucket reflects every record routed to it', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    for (let i = 0; i < 7; i++) eng.record('cyber', 5, MON_W2_T0 + i * WEEK);
+    const rhythms = eng.getDomainRhythms();
+    const cyber = rhythms.find((r) => r.domain === 'cyber');
+    assert.equal(cyber?.hourly[0]?.sampleCount, 7);
+  });
+
+  it('per-domain state is independent', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    eng.record('cyber', 100, MON_W2_T0);
+    eng.record('weather', 5, MON_W2_T0);
+    const cyber = eng.getExpected('cyber', MON_W2_T0);
+    const weather = eng.getExpected('weather', MON_W2_T0);
+    assert.equal(cyber.hourlyMean, 100);
+    assert.equal(weather.hourlyMean, 5);
+  });
+
+  it('Sunday and Saturday land in different daily buckets', () => {
+    const eng = new GlobalRhythmEngine({ storage: null });
+    // Monday is MON_W2_T0 → Sunday is -1 day, Saturday is -2 days
+    const sunday = MON_W2_T0 - DAY;
+    const saturday = MON_W2_T0 - 2 * DAY;
+    eng.record('cyber', 11, sunday);
+    eng.record('cyber', 99, saturday);
+    const sunExp = eng.getExpected('cyber', sunday);
+    const satExp = eng.getExpected('cyber', saturday);
+    assert.equal(sunExp.dailyMean, 11);
+    assert.equal(satExp.dailyMean, 99);
+  });
+});
+
+describe('GlobalRhythmEngine — clear', () => {
+  beforeEach(() => { resetForTests(); });
+
+  it('clear empties domains and persists', () => {
+    const storage = memoryStorage();
+    const eng = new GlobalRhythmEngine({ storage });
+    eng.record('cyber', 5, MON_W2_T0);
+    eng.clear();
+    assert.equal(eng.getDomainRhythms().length, 0);
+    const eng2 = new GlobalRhythmEngine({ storage });
+    assert.equal(eng2.getDomainRhythms().length, 0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `GlobalRhythmEngine` — a per-domain baseline model of circadian (hourly), weekly (day-of-week), and seasonal (ISO-week) activity patterns so anomaly scorers can compare incoming counts to the **expected rhythm** rather than to a flat average.

## Architecture

- Three sliding windows per domain, each with a fixed bucket count:
  - **hourly** — 24 buckets indexed by UTC hour-of-day (0–23)
  - **daily** — 7 buckets indexed by UTC day-of-week (0=Sun..6=Sat)
  - **weekly** — 52 buckets indexed by ISO week-of-year (1–52)
- Each bucket maintains a **Welford running mean + sample variance** so `record()` stays O(1) and numerically stable across many samples. Stddev is floored at `STDDEV_FLOOR = 0.1` to keep z-scores well-defined with few samples.
- `getExpected(domain, ts)` returns per-window mean+stddev plus a composite expected count: `compositeExpected = 0.5 * hourly + 0.3 * daily + 0.2 * weekly`.
- `getDeviation(domain, count, ts)` returns a z-score against the composite, using the same weighted blend of stddevs (also floored).
- 8 seed domains (cyber, weather, geopolitical, maritime, aviation, health, financial, seismic) come pre-tuned with credible circadian + weekly shapes (business-hours peak, weekday-heavy, night-heavy seismic, etc.) so the engine has a useful baseline on first boot.
- Singleton at `GlobalRhythmEngine.getInstance()` (pre-seeds the 8 domains). Tests construct fresh `new GlobalRhythmEngine(...)` instances with injectable storage to stay hermetic.
- `wm-global-rhythms` storage, `MAX_ENTRIES = 500` with FIFO eviction.

## Tests

38 tests in `tests/intelligence/global-rhythm-engine.test.mts` cover:
- record increments hourly + daily + weekly windows
- Welford running mean across multiple samples in one bucket
- Different hours / days / ISO weeks land in distinct buckets
- Hour bucket wraps modulo 24
- compositeExpected math (0.5/0.3/0.2 weights)
- Empty domain returns zero expectations
- Single-sample bucket reports floored stddev
- z-score: zero deviation at the mean, positive above, negative below
- Unknown domain falls back to `count / floor`
- getDomainRhythms LIFO copies with full bucket arrays + sampleCount
- SEED_DOMAINS lists all 8; seed=true populates them; non-seed engine starts empty
- Persistence + hydration; Welford state survives reload
- `STORAGE_KEY = 'wm-global-rhythms'`, `MAX_ENTRIES = 500`
- Malformed-state recovery
- Singleton identity + reset; getInstance pre-seeds
- maxEntries override evicts FIFO
- Identical samples keep stddev at floor
- Per-domain state independence
- Sunday vs Saturday daily-bucket separation
- clear() empties domains and persists empty

## Preview verification

**Unavailable / not applicable** — service-only change (no UI surface).

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass