### PR TITLE
Civilization pulse — composite real-time global system health score

### DIFF
--- a/src/services/intelligence/civilization-pulse.ts
+++ b/src/services/intelligence/civilization-pulse.ts
@@ -249,3 +249,312 @@ function defaultStorage(): StorageLike | null {
   const ls = (globalThis as { localStorage?: StorageLike }).localStorage;
   return ls ?? null;
 }
+
+// ── CivilizationPulseService ────────────────────────────────────────
+//
+// Sibling of CivilizationPulseEngine above. The Engine consumes
+// `ObservationEvent[]` snapshots and outputs `PulseReading`. The
+// Service consumes severity-level updates per domain and outputs a
+// `CivilizationPulse` rolled across an internal 10-sample window per
+// domain, with a weighted composite + status band + delta vs the last
+// persisted pulse.
+//
+// Persisted at SERVICE_STORAGE_KEY (`wm-civilization-pulse-service`)
+// so the two co-exist without trampling each other.
+
+export type PulseStatus = 'nominal' | 'elevated' | 'stressed' | 'critical';
+export type PulseDomainTrend = 'improving' | 'stable' | 'degrading';
+
+export interface PulseDomain {
+  domain: string;
+  weight: number;
+  currentScore: number;
+  trend: PulseDomainTrend;
+  lastUpdated: number;
+}
+
+export interface CivilizationPulse {
+  compositeScore: number;
+  status: PulseStatus;
+  domains: PulseDomain[];
+  deltaFromPrevious: number;
+  timestamp: number;
+}
+
+export interface CivilizationPulseServiceOptions {
+  storage?: StorageLike | null;
+  now?: () => number;
+  maxHistory?: number;
+}
+
+export const SERVICE_STORAGE_KEY = 'wm-civilization-pulse-service';
+export const SERVICE_MAX_HISTORY = 200;
+export const DOMAIN_SAMPLE_WINDOW = 10;
+export const TREND_LOOKBACK = 5;
+export const TREND_DELTA_THRESHOLD = 0.05;
+const DEFAULT_NEW_DOMAIN_WEIGHT = 0.05;
+
+export const SEVERITY_TO_SCORE: Record<number, number> = {
+  0: 1, 1: 0.8, 2: 0.6, 3: 0.3, 4: 0,
+};
+
+export const PULSE_DOMAIN_WEIGHTS: Record<string, number> = {
+  geopolitical: 0.2,
+  economic: 0.18,
+  health: 0.15,
+  cyber: 0.15,
+  climate: 0.12,
+  social: 0.1,
+  infrastructure: 0.05,
+  space: 0.05,
+};
+
+export const PULSE_STATUS_THRESHOLDS: Record<Exclude<PulseStatus, 'critical'>, number> = {
+  nominal: 0.7,
+  elevated: 0.5,
+  stressed: 0.3,
+};
+
+interface DomainState {
+  domain: string;
+  weight: number;
+  samples: number[];
+  scoreHistory: number[];
+  currentScore: number;
+  lastUpdated: number;
+}
+
+interface ServicePersistedState {
+  domains: DomainState[];
+  history: CivilizationPulse[];
+}
+
+export class CivilizationPulseService {
+  private readonly storage: StorageLike | null;
+  private readonly clock: () => number;
+  private readonly maxHistory: number;
+  private readonly domains = new Map<string, DomainState>();
+  private readonly history: CivilizationPulse[] = [];
+
+  constructor(opts: CivilizationPulseServiceOptions = {}) {
+    this.storage = opts.storage === undefined ? defaultStorage() : opts.storage;
+    this.clock = opts.now ?? Date.now;
+    this.maxHistory = opts.maxHistory ?? SERVICE_MAX_HISTORY;
+    this.hydrate();
+    this.seedMissing();
+  }
+
+  static getInstance(): CivilizationPulseService {
+    serviceSingleton ??= new CivilizationPulseService();
+    return serviceSingleton;
+  }
+
+  update(domain: string, severityLevel: number): void {
+    const clamped = clampSeverity(severityLevel);
+    const score = SEVERITY_TO_SCORE[clamped] ?? 0;
+    const state = this.getOrCreateDomain(domain);
+    state.samples.push(score);
+    while (state.samples.length > DOMAIN_SAMPLE_WINDOW) state.samples.shift();
+    state.currentScore = mean(state.samples);
+    state.scoreHistory.push(state.currentScore);
+    while (state.scoreHistory.length > DOMAIN_SAMPLE_WINDOW + TREND_LOOKBACK) state.scoreHistory.shift();
+    state.lastUpdated = this.clock();
+    this.persist();
+  }
+
+  getPulse(): CivilizationPulse {
+    const timestamp = this.clock();
+    const domains = this.buildDomainsView();
+    const compositeScore = weightedComposite(domains);
+    const status = statusFor(compositeScore);
+    const previous = this.history[this.history.length - 1];
+    const deltaFromPrevious = previous ? compositeScore - previous.compositeScore : 0;
+    const pulse: CivilizationPulse = {
+      compositeScore,
+      status,
+      domains,
+      deltaFromPrevious,
+      timestamp,
+    };
+    this.history.push(pulse);
+    while (this.history.length > this.maxHistory) this.history.shift();
+    this.persist();
+    return clonePulse(pulse);
+  }
+
+  getDomains(): PulseDomain[] {
+    return this.buildDomainsView().sort((a, b) => a.currentScore - b.currentScore);
+  }
+
+  getHistory(limit?: number): CivilizationPulse[] {
+    const reversed: CivilizationPulse[] = [];
+    for (let i = this.history.length - 1; i >= 0; i--) {
+      reversed.push(clonePulse(this.history[i]!));
+      if (limit && reversed.length >= limit) break;
+    }
+    return reversed;
+  }
+
+  clear(): void {
+    this.domains.clear();
+    this.history.length = 0;
+    this.seedMissing();
+    this.persist();
+  }
+
+  // ── Internals ─────────────────────────────────────────────────────
+
+  private getOrCreateDomain(domain: string): DomainState {
+    const existing = this.domains.get(domain);
+    if (existing) return existing;
+    const created: DomainState = {
+      domain,
+      weight: PULSE_DOMAIN_WEIGHTS[domain] ?? DEFAULT_NEW_DOMAIN_WEIGHT,
+      samples: [],
+      scoreHistory: [],
+      currentScore: 1,
+      lastUpdated: this.clock(),
+    };
+    this.domains.set(domain, created);
+    return created;
+  }
+
+  private seedMissing(): void {
+    const now = this.clock();
+    for (const [domain, weight] of Object.entries(PULSE_DOMAIN_WEIGHTS)) {
+      if (this.domains.has(domain)) continue;
+      this.domains.set(domain, {
+        domain,
+        weight,
+        samples: [],
+        scoreHistory: [],
+        currentScore: 1,
+        lastUpdated: now,
+      });
+    }
+  }
+
+  private buildDomainsView(): PulseDomain[] {
+    const out: PulseDomain[] = [];
+    for (const state of this.domains.values()) {
+      out.push({
+        domain: state.domain,
+        weight: state.weight,
+        currentScore: state.currentScore,
+        trend: domainTrendFor(state),
+        lastUpdated: state.lastUpdated,
+      });
+    }
+    return out;
+  }
+
+  private hydrate(): void {
+    if (!this.storage) return;
+    try {
+      const raw = this.storage.getItem(SERVICE_STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as ServicePersistedState;
+      if (!parsed || !Array.isArray(parsed.domains) || !Array.isArray(parsed.history)) return;
+      for (const d of parsed.domains) {
+        const restored = restoreDomainState(d, this.clock());
+        if (restored) this.domains.set(restored.domain, restored);
+      }
+      for (const h of parsed.history) this.history.push(h);
+      while (this.history.length > this.maxHistory) this.history.shift();
+    } catch {
+      this.domains.clear();
+      this.history.length = 0;
+    }
+  }
+
+  private persist(): void {
+    if (!this.storage) return;
+    try {
+      const serial: ServicePersistedState = {
+        domains: [...this.domains.values()],
+        history: this.history,
+      };
+      this.storage.setItem(SERVICE_STORAGE_KEY, JSON.stringify(serial));
+    } catch {
+      // non-fatal
+    }
+  }
+}
+
+let serviceSingleton: CivilizationPulseService | undefined;
+
+export function resetServiceForTests(): void {
+  serviceSingleton = undefined;
+}
+
+// ── Service helpers ──────────────────────────────────────────────────
+
+function clampSeverity(severity: number): number {
+  if (!Number.isFinite(severity)) return 0;
+  if (severity < 0) return 0;
+  if (severity > 4) return 4;
+  return Math.round(severity);
+}
+
+function mean(values: readonly number[]): number {
+  if (values.length === 0) return 1;
+  let total = 0;
+  for (const v of values) total += v;
+  return total / values.length;
+}
+
+function weightedComposite(domains: readonly PulseDomain[]): number {
+  let weightTotal = 0;
+  let scoreTotal = 0;
+  for (const d of domains) {
+    weightTotal += d.weight;
+    scoreTotal += d.weight * d.currentScore;
+  }
+  if (weightTotal <= 0) return 0;
+  const score = scoreTotal / weightTotal;
+  if (score < 0) return 0;
+  if (score > 1) return 1;
+  return score;
+}
+
+function statusFor(score: number): PulseStatus {
+  if (score >= PULSE_STATUS_THRESHOLDS.nominal) return 'nominal';
+  if (score >= PULSE_STATUS_THRESHOLDS.elevated) return 'elevated';
+  if (score >= PULSE_STATUS_THRESHOLDS.stressed) return 'stressed';
+  return 'critical';
+}
+
+function domainTrendFor(state: DomainState): PulseDomainTrend {
+  if (state.scoreHistory.length <= TREND_LOOKBACK) return 'stable';
+  const lookback = state.scoreHistory.slice(-TREND_LOOKBACK - 1, -1);
+  if (lookback.length === 0) return 'stable';
+  const baseline = mean(lookback);
+  const delta = state.currentScore - baseline;
+  if (delta > TREND_DELTA_THRESHOLD) return 'improving';
+  if (delta < -TREND_DELTA_THRESHOLD) return 'degrading';
+  return 'stable';
+}
+
+function restoreDomainState(d: unknown, fallbackTimestamp: number): DomainState | null {
+  if (typeof d !== 'object' || d === null) return null;
+  const raw = d as Partial<DomainState>;
+  if (typeof raw.domain !== 'string') return null;
+  return {
+    domain: raw.domain,
+    weight: typeof raw.weight === 'number' ? raw.weight : DEFAULT_NEW_DOMAIN_WEIGHT,
+    samples: Array.isArray(raw.samples) ? raw.samples : [],
+    scoreHistory: Array.isArray(raw.scoreHistory) ? raw.scoreHistory : [],
+    currentScore: typeof raw.currentScore === 'number' ? raw.currentScore : 1,
+    lastUpdated: typeof raw.lastUpdated === 'number' ? raw.lastUpdated : fallbackTimestamp,
+  };
+}
+
+function clonePulse(p: CivilizationPulse): CivilizationPulse {
+  return {
+    compositeScore: p.compositeScore,
+    status: p.status,
+    domains: p.domains.map((d) => ({ ...d })),
+    deltaFromPrevious: p.deltaFromPrevious,
+    timestamp: p.timestamp,
+  };
+}

--- a/tests/intelligence/civilization-pulse-service.test.mts
+++ b/tests/intelligence/civilization-pulse-service.test.mts
@@ -1,0 +1,408 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  CivilizationPulseService,
+  resetServiceForTests,
+  SERVICE_STORAGE_KEY,
+  SERVICE_MAX_HISTORY,
+  SEVERITY_TO_SCORE,
+  PULSE_DOMAIN_WEIGHTS,
+  PULSE_STATUS_THRESHOLDS,
+  type CivilizationPulse,
+} from '../../src/services/intelligence/civilization-pulse.ts';
+
+const T0 = 1_780_000_000_000;
+
+function memoryStorage(): { getItem(k: string): string | null; setItem(k: string, v: string): void; data: Map<string, string> } {
+  const data = new Map<string, string>();
+  return {
+    data,
+    getItem(k: string): string | null { return data.get(k) ?? null; },
+    setItem(k: string, v: string): void { data.set(k, v); },
+  };
+}
+
+describe('CivilizationPulseService — seed domains', () => {
+  beforeEach(() => { resetServiceForTests(); });
+
+  it('seeds 8 pulse domains with the expected weights', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    const domains = svc.getDomains().map((d) => d.domain).sort((a, b) => a.localeCompare(b));
+    assert.deepEqual(
+      domains,
+      ['climate', 'cyber', 'economic', 'geopolitical', 'health', 'infrastructure', 'social', 'space'],
+    );
+  });
+
+  it('seed weights match the spec', () => {
+    assert.equal(PULSE_DOMAIN_WEIGHTS.geopolitical, 0.2);
+    assert.equal(PULSE_DOMAIN_WEIGHTS.economic, 0.18);
+    assert.equal(PULSE_DOMAIN_WEIGHTS.health, 0.15);
+    assert.equal(PULSE_DOMAIN_WEIGHTS.cyber, 0.15);
+    assert.equal(PULSE_DOMAIN_WEIGHTS.climate, 0.12);
+    assert.equal(PULSE_DOMAIN_WEIGHTS.social, 0.1);
+    assert.equal(PULSE_DOMAIN_WEIGHTS.infrastructure, 0.05);
+    assert.equal(PULSE_DOMAIN_WEIGHTS.space, 0.05);
+  });
+
+  it('weights sum to 1.0', () => {
+    const sum = Object.values(PULSE_DOMAIN_WEIGHTS).reduce((a, b) => a + b, 0);
+    assert.ok(Math.abs(sum - 1) < 1e-9);
+  });
+
+  it('initial domain scores default to 1.0 (nominal)', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    for (const d of svc.getDomains()) assert.equal(d.currentScore, 1);
+  });
+
+  it('initial trend is stable for every seeded domain', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    for (const d of svc.getDomains()) assert.equal(d.trend, 'stable');
+  });
+});
+
+describe('CivilizationPulseService — severity → score mapping', () => {
+  beforeEach(() => { resetServiceForTests(); });
+
+  it('SEVERITY_TO_SCORE matches the spec', () => {
+    assert.equal(SEVERITY_TO_SCORE[0], 1);
+    assert.equal(SEVERITY_TO_SCORE[1], 0.8);
+    assert.equal(SEVERITY_TO_SCORE[2], 0.6);
+    assert.equal(SEVERITY_TO_SCORE[3], 0.3);
+    assert.equal(SEVERITY_TO_SCORE[4], 0);
+  });
+
+  it('update with severity 0 sets domain score to 1.0', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    svc.update('cyber', 0);
+    const cyber = svc.getDomains().find((d) => d.domain === 'cyber');
+    assert.equal(cyber?.currentScore, 1);
+  });
+
+  it('update with severity 4 sets domain score to 0', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    svc.update('cyber', 4);
+    const cyber = svc.getDomains().find((d) => d.domain === 'cyber');
+    assert.equal(cyber?.currentScore, 0);
+  });
+
+  it('update with severity 2 rolls into the 10-sample mean', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    // First update overwrites the seed default 1.0
+    svc.update('cyber', 2); // → 0.6 mean of [0.6]
+    let cyber = svc.getDomains().find((d) => d.domain === 'cyber');
+    assert.equal(cyber?.currentScore, 0.6);
+    // Second update adds another sample
+    svc.update('cyber', 2); // → mean of [0.6, 0.6] = 0.6
+    cyber = svc.getDomains().find((d) => d.domain === 'cyber');
+    assert.equal(cyber?.currentScore, 0.6);
+  });
+
+  it('update rolls mean across mixed severities', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    svc.update('cyber', 0); // 1.0
+    svc.update('cyber', 4); // 0.0  → mean 0.5
+    const cyber = svc.getDomains().find((d) => d.domain === 'cyber');
+    assert.ok(Math.abs((cyber?.currentScore ?? 0) - 0.5) < 1e-9);
+  });
+
+  it('out-of-range severity clamps to nearest valid bucket', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    svc.update('cyber', -1);
+    let cyber = svc.getDomains().find((d) => d.domain === 'cyber');
+    assert.equal(cyber?.currentScore, 1); // severity clamped to 0 → 1.0
+    resetServiceForTests();
+    const svc2 = new CivilizationPulseService({ now: () => T0, storage: null });
+    svc2.update('cyber', 99);
+    cyber = svc2.getDomains().find((d) => d.domain === 'cyber');
+    assert.equal(cyber?.currentScore, 0); // severity clamped to 4 → 0.0
+  });
+
+  it('rolling window caps at 10 samples', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    for (let i = 0; i < 15; i++) svc.update('cyber', 4); // all 0.0
+    // Adding two 1.0s should pull the mean up to (0*8 + 1*2)/10 = 0.2
+    svc.update('cyber', 0);
+    svc.update('cyber', 0);
+    const cyber = svc.getDomains().find((d) => d.domain === 'cyber');
+    assert.ok(Math.abs((cyber?.currentScore ?? -1) - 0.2) < 1e-9);
+  });
+
+  it('update unknown domain auto-registers it with default weight', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    svc.update('mystery-domain', 2);
+    const m = svc.getDomains().find((d) => d.domain === 'mystery-domain');
+    assert.ok(m);
+    assert.equal(m?.currentScore, 0.6);
+    assert.ok((m?.weight ?? 0) > 0);
+  });
+
+  it('update sets lastUpdated to clock()', () => {
+    let t = T0;
+    const svc = new CivilizationPulseService({ now: () => t, storage: null });
+    t += 5000;
+    svc.update('cyber', 2);
+    const cyber = svc.getDomains().find((d) => d.domain === 'cyber');
+    assert.equal(cyber?.lastUpdated, T0 + 5000);
+  });
+});
+
+describe('CivilizationPulseService — getPulse composite', () => {
+  beforeEach(() => { resetServiceForTests(); });
+
+  it('initial pulse is 1.0 nominal (all domains at default score)', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    const pulse = svc.getPulse();
+    assert.ok(Math.abs(pulse.compositeScore - 1) < 1e-9);
+    assert.equal(pulse.status, 'nominal');
+  });
+
+  it('compositeScore is weighted across domains', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    // Knock cyber (weight 0.15) down to 0 — others stay at 1.0
+    svc.update('cyber', 4);
+    const pulse = svc.getPulse();
+    const expected = 1 - PULSE_DOMAIN_WEIGHTS.cyber; // 0.85
+    assert.ok(Math.abs(pulse.compositeScore - expected) < 1e-9);
+  });
+
+  it('status status bucket: nominal >= 0.7', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    svc.update('cyber', 4); // drops 0.15 → composite 0.85
+    assert.equal(svc.getPulse().status, 'nominal');
+  });
+
+  it('status status bucket: elevated 0.5..0.7', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    // Drop geopolitical(0.2) + economic(0.18) + health(0.15) → composite 1 - 0.53 = 0.47 (stressed)
+    // Drop geopolitical(0.2) + cyber(0.15) → composite 1 - 0.35 = 0.65 (elevated)
+    svc.update('geopolitical', 4);
+    svc.update('cyber', 4);
+    assert.equal(svc.getPulse().status, 'elevated');
+  });
+
+  it('status status bucket: stressed 0.3..0.5', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    // Drop geopolitical(0.2) + economic(0.18) + cyber(0.15) → 0.53 stressed
+    svc.update('geopolitical', 4);
+    svc.update('economic', 4);
+    svc.update('cyber', 4);
+    assert.equal(svc.getPulse().status, 'stressed');
+  });
+
+  it('status status bucket: critical < 0.3', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    // Drop all 8 seed domains to 0 → composite 0
+    for (const domain of Object.keys(PULSE_DOMAIN_WEIGHTS)) svc.update(domain, 4);
+    assert.equal(svc.getPulse().status, 'critical');
+  });
+
+  it('PULSE_STATUS_THRESHOLDS match the spec', () => {
+    assert.equal(PULSE_STATUS_THRESHOLDS.nominal, 0.7);
+    assert.equal(PULSE_STATUS_THRESHOLDS.elevated, 0.5);
+    assert.equal(PULSE_STATUS_THRESHOLDS.stressed, 0.3);
+  });
+
+  it('compositeScore is between 0 and 1 inclusive', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    svc.update('cyber', 2);
+    svc.update('economic', 1);
+    const p = svc.getPulse();
+    assert.ok(p.compositeScore >= 0 && p.compositeScore <= 1);
+  });
+});
+
+describe('CivilizationPulseService — deltaFromPrevious', () => {
+  beforeEach(() => { resetServiceForTests(); });
+
+  it('first pulse has deltaFromPrevious 0', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    assert.equal(svc.getPulse().deltaFromPrevious, 0);
+  });
+
+  it('deltaFromPrevious reflects change since last persisted pulse', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    svc.getPulse(); // persist baseline 1.0
+    svc.update('cyber', 4); // → 0.85
+    const next = svc.getPulse();
+    assert.ok(Math.abs(next.deltaFromPrevious - (0.85 - 1)) < 1e-9);
+  });
+
+  it('deltaFromPrevious can be positive when recovering', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    svc.update('cyber', 4); // 0.85
+    svc.getPulse(); // persist 0.85
+    svc.update('cyber', 0); // back toward 1.0 (rolling mean of [0,1] = 0.5 → composite 1 - 0.15*0.5 = 0.925)
+    const next = svc.getPulse();
+    assert.ok(next.deltaFromPrevious > 0);
+  });
+});
+
+describe('CivilizationPulseService — trend detection', () => {
+  beforeEach(() => { resetServiceForTests(); });
+
+  it('trend is stable when score barely moves', () => {
+    let t = T0;
+    const svc = new CivilizationPulseService({ now: () => t, storage: null });
+    // Push the cyber domain's history with a tiny mid-range jitter
+    for (let i = 0; i < 6; i++) {
+      svc.update('cyber', 2); // 0.6
+      t += 1000;
+    }
+    const cyber = svc.getDomains().find((d) => d.domain === 'cyber');
+    assert.equal(cyber?.trend, 'stable');
+  });
+
+  it('trend is degrading when current score is well below 5-back average', () => {
+    let t = T0;
+    const svc = new CivilizationPulseService({ now: () => t, storage: null });
+    // 5 good samples
+    for (let i = 0; i < 5; i++) { svc.update('cyber', 0); t += 1000; } // score 1.0
+    // Then a worse sample drops the rolling mean
+    svc.update('cyber', 4); t += 1000; // mean now ~ (1*5 + 0)/6 = 0.833
+    svc.update('cyber', 4);            // mean now (1*5 + 0*2)/7 = 0.714 → still > 0.5 trip vs older 1.0
+    const cyber = svc.getDomains().find((d) => d.domain === 'cyber');
+    assert.equal(cyber?.trend, 'degrading');
+  });
+
+  it('trend is improving when current score is well above 5-back average', () => {
+    let t = T0;
+    const svc = new CivilizationPulseService({ now: () => t, storage: null });
+    for (let i = 0; i < 5; i++) { svc.update('cyber', 4); t += 1000; } // score 0
+    svc.update('cyber', 0); t += 1000; // mean (0*5 + 1)/6 = 0.166
+    svc.update('cyber', 0);            // mean (0*5 + 1*2)/7 = 0.285
+    const cyber = svc.getDomains().find((d) => d.domain === 'cyber');
+    assert.equal(cyber?.trend, 'improving');
+  });
+});
+
+describe('CivilizationPulseService — getDomains ordering', () => {
+  beforeEach(() => { resetServiceForTests(); });
+
+  it('getDomains returns worst-first', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    svc.update('cyber', 4);     // → 0
+    svc.update('economic', 2);  // → 0.6
+    const domains = svc.getDomains();
+    assert.equal(domains[0]?.domain, 'cyber');
+    assert.ok((domains[0]?.currentScore ?? 1) <= (domains[1]?.currentScore ?? 0));
+  });
+
+  it('getDomains returns defensive copies', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    const first = svc.getDomains();
+    first[0]!.currentScore = -999;
+    const second = svc.getDomains();
+    assert.notEqual(second[0]?.currentScore, -999);
+  });
+});
+
+describe('CivilizationPulseService — getHistory + ring buffer', () => {
+  beforeEach(() => { resetServiceForTests(); });
+
+  it('SERVICE_MAX_HISTORY is 200', () => {
+    assert.equal(SERVICE_MAX_HISTORY, 200);
+  });
+
+  it('history caps at maxHistory', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null, maxHistory: 3 });
+    for (let i = 0; i < 6; i++) svc.getPulse();
+    assert.equal(svc.getHistory().length, 3);
+  });
+
+  it('history is LIFO (latest first)', () => {
+    let t = T0;
+    const svc = new CivilizationPulseService({ now: () => t, storage: null });
+    svc.getPulse(); t += 1000;
+    svc.update('cyber', 4); svc.getPulse(); t += 1000;
+    svc.update('cyber', 0); const last = svc.getPulse();
+    const history = svc.getHistory();
+    assert.equal(history[0]?.timestamp, last.timestamp);
+  });
+});
+
+describe('CivilizationPulseService — persistence', () => {
+  beforeEach(() => { resetServiceForTests(); });
+
+  it('domain state + history persists + hydrates', () => {
+    const storage = memoryStorage();
+    const svc1 = new CivilizationPulseService({ now: () => T0, storage });
+    svc1.update('cyber', 4);
+    svc1.getPulse();
+    const svc2 = new CivilizationPulseService({ now: () => T0, storage });
+    const cyber = svc2.getDomains().find((d) => d.domain === 'cyber');
+    assert.equal(cyber?.currentScore, 0);
+    assert.equal(svc2.getHistory().length, 1);
+  });
+
+  it('storage key is wm-civilization-pulse-service (sibling of legacy engine)', () => {
+    assert.equal(SERVICE_STORAGE_KEY, 'wm-civilization-pulse-service');
+  });
+
+  it('malformed persisted state recovers gracefully', () => {
+    const storage = memoryStorage();
+    storage.setItem(SERVICE_STORAGE_KEY, '{not json');
+    const svc = new CivilizationPulseService({ now: () => T0, storage });
+    // Should re-seed defaults
+    assert.equal(svc.getDomains().length, 8);
+    assert.equal(svc.getPulse().status, 'nominal');
+  });
+
+  it('null storage means no persistence', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    svc.update('cyber', 4);
+    const cyber = svc.getDomains().find((d) => d.domain === 'cyber');
+    assert.equal(cyber?.currentScore, 0);
+  });
+});
+
+describe('CivilizationPulseService — getInstance singleton', () => {
+  beforeEach(() => { resetServiceForTests(); });
+
+  it('getInstance returns the same instance across calls', () => {
+    const a = CivilizationPulseService.getInstance();
+    const b = CivilizationPulseService.getInstance();
+    assert.equal(a, b);
+  });
+
+  it('resetServiceForTests clears the singleton', () => {
+    const a = CivilizationPulseService.getInstance();
+    resetServiceForTests();
+    const b = CivilizationPulseService.getInstance();
+    assert.notEqual(a, b);
+  });
+});
+
+describe('CivilizationPulseService — clear', () => {
+  beforeEach(() => { resetServiceForTests(); });
+
+  it('clear resets domain scores to defaults and empties history', () => {
+    const storage = memoryStorage();
+    const svc = new CivilizationPulseService({ now: () => T0, storage });
+    svc.update('cyber', 4);
+    svc.getPulse();
+    svc.clear();
+    const cyber = svc.getDomains().find((d) => d.domain === 'cyber');
+    assert.equal(cyber?.currentScore, 1);
+    assert.equal(svc.getHistory().length, 0);
+    // Verify persisted state matches
+    const svc2 = new CivilizationPulseService({ now: () => T0, storage });
+    assert.equal(svc2.getHistory().length, 0);
+  });
+});
+
+describe('CivilizationPulseService — pulse shape', () => {
+  beforeEach(() => { resetServiceForTests(); });
+
+  it('getPulse returns a CivilizationPulse with all expected fields', () => {
+    const svc = new CivilizationPulseService({ now: () => T0, storage: null });
+    const pulse: CivilizationPulse = svc.getPulse();
+    assert.ok(typeof pulse.compositeScore === 'number');
+    assert.ok(typeof pulse.status === 'string');
+    assert.ok(Array.isArray(pulse.domains));
+    assert.equal(pulse.domains.length, 8);
+    assert.ok(typeof pulse.deltaFromPrevious === 'number');
+    assert.equal(pulse.timestamp, T0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `CivilizationPulseService` — a composite real-time health score (0–1) for the global system, weighted across 8 monitored domains. It coexists as a **sibling** to the existing `CivilizationPulseEngine` in the same file: the Engine consumes `ObservationEvent[]` snapshots, while this Service consumes severity-level updates per domain and produces a rolled, status-banded composite.

## Naming / storage key (sibling pattern)

Because the existing `CivilizationPulseEngine` already owns the `wm-civilization-pulse` localStorage key with a different shape, the new service uses the distinct key `wm-civilization-pulse-service` so the two coexist without trampling each other's persisted state. Same playbook used for the prior `active-learning-queue` / `meta-confidence-calibration` sibling additions. Tests live at `tests/intelligence/civilization-pulse-service.test.mts`; legacy engine tests at `tests/intelligence/civilization-pulse.test.mts` are untouched.

## Architecture

- 8 seed domains with spec weights (geopolitical 0.20, economic 0.18, health 0.15, cyber 0.15, climate 0.12, social 0.10, infrastructure 0.05, space 0.05) summing exactly to 1.0.
- `update(domain, severityLevel)`: severity 0–4 maps to a domain score (`0→1.0, 1→0.8, 2→0.6, 3→0.3, 4→0.0`) and rolls into a 10-sample sliding mean per domain. Out-of-range severities clamp to the nearest valid bucket. Unknown domains auto-register with a default weight.
- `getPulse()` returns `{ compositeScore, status, domains, deltaFromPrevious, timestamp }`. Status bands: `>=0.7 nominal`, `>=0.5 elevated`, `>=0.3 stressed`, else `critical`. `deltaFromPrevious` is computed against the last persisted snapshot.
- `getDomains()` returns the 8 (or more) domains sorted **worst-first** (lowest score first).
- Per-domain `trend`: compares the current score to a 5-sample-ago average; delta > +0.05 = improving, < -0.05 = degrading, else stable.
- Ring-buffered history at `SERVICE_MAX_HISTORY = 200`.
- `CivilizationPulseService.getInstance()` singleton (sibling singleton — does not conflict with the engine's `getCivilizationPulseEngine()` accessor).
- Injectable `Storage` + `clock` keep tests hermetic.

## Tests

41 tests in `tests/intelligence/civilization-pulse-service.test.mts` cover:
- Seed domains list + spec weights + weights sum to 1.0
- Initial scores default to 1.0; initial trend stable
- `SEVERITY_TO_SCORE` mapping exact match
- update with severity 0..4 produces expected score; mixed severities roll the mean
- Out-of-range severity clamps; rolling window caps at 10 samples
- Unknown domain auto-registers; `lastUpdated` reflects `clock()`
- compositeScore is weighted across domains; bounded `[0, 1]`
- Status bucket coverage: nominal / elevated / stressed / critical
- `PULSE_STATUS_THRESHOLDS` exact values
- `deltaFromPrevious` is 0 on first pulse; tracks change since previous; can be positive on recovery
- Trend detection: stable / degrading / improving
- `getDomains()` is worst-first; returns defensive copies
- History ring buffer caps at `SERVICE_MAX_HISTORY` (200) and is LIFO
- Persistence + hydration; `SERVICE_STORAGE_KEY = 'wm-civilization-pulse-service'`
- Malformed-state recovery; null storage works
- Singleton identity + reset
- `clear()` resets scores and empties history
- Pulse shape contract

The 36 pre-existing `CivilizationPulseEngine` tests still pass (77 total in the file).

## Preview verification

**Unavailable / not applicable** — service-only change with no UI surface.

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass