### PR TITLE
Crisis signature library — fingerprint recurring crisis patterns for early detection

### DIFF
--- a/src/services/intelligence/crisis-signature-library.ts
+++ b/src/services/intelligence/crisis-signature-library.ts
@@ -1,0 +1,490 @@
+/**
+ * Crisis Signature Library — fingerprints recurring crisis patterns
+ * to enable early detection.
+ *
+ * Each known signature carries a list of feature predicates that
+ * historical crises of that shape exhibited (e.g. "domain X elevated
+ * past threshold Y", "entity Z spiking in N observations", "geo
+ * cluster of >= N observations within R km", "rapid time-clustering
+ * of >= N observations in a tight window"). At call time, the
+ * library scores every signature against the incoming observation
+ * window; matches with score >= 0.4 are returned ranked highest
+ * first.
+ *
+ * Pure module — no DOM, no fetch, no globals at import time. Custom
+ * (operator-defined) signatures persist to localStorage at
+ * `wm-crisis-signature-library` (the deliberately-distinct key
+ * avoids stomping the older `crisis-signature.ts` module's match
+ * ledger). Capped at 100 entries.
+ */
+
+import type { ObservationEvent, ObservationSeverity } from '@/types/intelligence';
+
+// ── Public types ──────────────────────────────────────────────────────
+
+export type SignatureFeatureType =
+  | 'domain-elevation'
+  | 'entity-spike'
+  | 'geo-cluster'
+  | 'time-pattern';
+
+export interface SignatureFeature {
+  featureType: SignatureFeatureType;
+  weight: number;
+  params: Record<string, unknown>;
+}
+
+export interface CrisisSignature {
+  id: string;
+  name: string;
+  domain: string;
+  fingerprint: SignatureFeature[];
+  historicalExamples: string[];
+  avgLeadTimeHours: number;
+  /** 0-1 prior confidence that the signature, when matched, is a
+   *  genuine early indicator rather than coincidence. */
+  confidence: number;
+}
+
+export interface SignatureMatch {
+  signature: CrisisSignature;
+  /** Sum of matched-feature weights / total signature weight, in [0, 1]. */
+  score: number;
+  matchedFeatures: SignatureFeature[];
+  /** Estimated hours of lead time before the full crisis manifests.
+   *  Higher score → less lead time (we're closer to onset). */
+  leadTimeEstimateHours: number;
+}
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem?(key: string): void;
+}
+
+export interface CrisisSignatureLibraryOptions {
+  storage?: StorageLike | null;
+  clock?: () => number;
+}
+
+// ── Constants ─────────────────────────────────────────────────────────
+
+export const STORAGE_KEY = 'wm-crisis-signature-library';
+export const MAX_CUSTOM_SIGNATURES = 100;
+export const MATCH_THRESHOLD = 0.4;
+
+const SEVERITY_RANK: Record<ObservationSeverity, number> = {
+  INFO: 0, LOW: 1, MEDIUM: 2, HIGH: 3, CRITICAL: 4,
+};
+
+const EARTH_KM = 6371;
+const DEG2RAD = Math.PI / 180;
+
+// ── Built-in signatures ──────────────────────────────────────────────
+
+function feature(
+  type: SignatureFeatureType,
+  weight: number,
+  params: Record<string, unknown>,
+): SignatureFeature {
+  return { featureType: type, weight, params };
+}
+
+const BUILT_IN_SIGNATURES: readonly CrisisSignature[] = [
+  {
+    id: 'builtin-financial-contagion',
+    name: 'Financial contagion',
+    domain: 'finance',
+    fingerprint: [
+      feature('domain-elevation', 0.4, { domain: 'finance', minCount: 5, minSeverity: 'HIGH' }),
+      feature('time-pattern', 0.3, { windowMinutes: 240, minCount: 4 }),
+      feature('entity-spike', 0.3, { minCount: 3 }),
+    ],
+    historicalExamples: ['2008 GFC', '2010 European debt crisis', '2023 SVB collapse'],
+    avgLeadTimeHours: 48,
+    confidence: 0.7,
+  },
+  {
+    id: 'builtin-pandemic-emergence',
+    name: 'Pandemic emergence',
+    domain: 'biosurv',
+    fingerprint: [
+      feature('domain-elevation', 0.35, { domain: 'biosurv', minCount: 6, minSeverity: 'MEDIUM' }),
+      feature('geo-cluster', 0.35, { minCount: 4, radiusKm: 500 }),
+      feature('time-pattern', 0.3, { windowMinutes: 60 * 24 * 7, minCount: 6 }),
+    ],
+    historicalExamples: ['2003 SARS', '2014 Ebola', '2019 COVID-19'],
+    avgLeadTimeHours: 168,
+    confidence: 0.65,
+  },
+  {
+    id: 'builtin-coup-pattern',
+    name: 'Coup pattern',
+    domain: 'geopolitical',
+    fingerprint: [
+      feature('domain-elevation', 0.4, { domain: 'geopolitical', minCount: 4, minSeverity: 'HIGH' }),
+      feature('geo-cluster', 0.35, { minCount: 3, radiusKm: 50 }),
+      feature('time-pattern', 0.25, { windowMinutes: 60 * 6, minCount: 4 }),
+    ],
+    historicalExamples: ['2021 Myanmar', '2023 Niger', '2023 Gabon'],
+    avgLeadTimeHours: 24,
+    confidence: 0.55,
+  },
+  {
+    id: 'builtin-regional-conflict-escalation',
+    name: 'Regional conflict escalation',
+    domain: 'geopolitical',
+    fingerprint: [
+      feature('domain-elevation', 0.4, { domain: 'geopolitical', minCount: 8, minSeverity: 'HIGH' }),
+      feature('entity-spike', 0.3, { minCount: 4 }),
+      feature('time-pattern', 0.3, { windowMinutes: 60 * 12, minCount: 6 }),
+    ],
+    historicalExamples: ['2022 Ukraine invasion run-up', '2023 Israel-Gaza onset'],
+    avgLeadTimeHours: 12,
+    confidence: 0.7,
+  },
+  {
+    id: 'builtin-supply-chain-cascade',
+    name: 'Supply chain cascade',
+    domain: 'maritime',
+    fingerprint: [
+      feature('domain-elevation', 0.35, { domain: 'maritime', minCount: 5, minSeverity: 'MEDIUM' }),
+      feature('geo-cluster', 0.35, { minCount: 4, radiusKm: 200 }),
+      feature('entity-spike', 0.3, { minCount: 3 }),
+    ],
+    historicalExamples: ['2021 Ever Given Suez', '2024 Red Sea attacks'],
+    avgLeadTimeHours: 72,
+    confidence: 0.6,
+  },
+  {
+    id: 'builtin-cyber-infrastructure-attack',
+    name: 'Cyber infrastructure attack',
+    domain: 'cyber',
+    fingerprint: [
+      feature('domain-elevation', 0.45, { domain: 'cyber', minCount: 4, minSeverity: 'HIGH' }),
+      feature('entity-spike', 0.3, { minCount: 3 }),
+      feature('time-pattern', 0.25, { windowMinutes: 60, minCount: 5 }),
+    ],
+    historicalExamples: ['2017 NotPetya', '2021 Colonial Pipeline', '2024 CrowdStrike'],
+    avgLeadTimeHours: 6,
+    confidence: 0.75,
+  },
+  {
+    id: 'builtin-natural-disaster-compound',
+    name: 'Natural disaster compound',
+    domain: 'disaster',
+    fingerprint: [
+      feature('domain-elevation', 0.35, { domain: 'disaster', minCount: 3, minSeverity: 'HIGH' }),
+      feature('geo-cluster', 0.4, { minCount: 4, radiusKm: 300 }),
+      feature('time-pattern', 0.25, { windowMinutes: 60 * 24, minCount: 5 }),
+    ],
+    historicalExamples: ['2011 Tohoku quake+tsunami+meltdown', '2024 Hurricane Helene compound flooding'],
+    avgLeadTimeHours: 4,
+    confidence: 0.65,
+  },
+  {
+    id: 'builtin-social-unrest-spread',
+    name: 'Social unrest spread',
+    domain: 'osint',
+    fingerprint: [
+      feature('domain-elevation', 0.35, { domain: 'osint', minCount: 6, minSeverity: 'MEDIUM' }),
+      feature('geo-cluster', 0.3, { minCount: 5, radiusKm: 100 }),
+      feature('time-pattern', 0.35, { windowMinutes: 60 * 24, minCount: 8 }),
+    ],
+    historicalExamples: ['2011 Arab Spring', '2019 Hong Kong protests'],
+    avgLeadTimeHours: 36,
+    confidence: 0.55,
+  },
+];
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function safeStorage(injected?: StorageLike | null): StorageLike | null {
+  if (injected !== undefined) return injected;
+  try {
+    const ls = (globalThis as { localStorage?: StorageLike }).localStorage;
+    return ls ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function cloneFeature(f: SignatureFeature): SignatureFeature {
+  return { ...f, params: { ...f.params } };
+}
+
+function cloneSignature(s: CrisisSignature): CrisisSignature {
+  return {
+    ...s,
+    fingerprint: s.fingerprint.map((f) => cloneFeature(f)),
+    historicalExamples: [...s.historicalExamples],
+  };
+}
+
+function cloneMatch(m: SignatureMatch): SignatureMatch {
+  return {
+    signature: cloneSignature(m.signature),
+    score: m.score,
+    matchedFeatures: m.matchedFeatures.map((f) => cloneFeature(f)),
+    leadTimeEstimateHours: m.leadTimeEstimateHours,
+  };
+}
+
+function haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const dLat = (lat2 - lat1) * DEG2RAD;
+  const dLon = (lon2 - lon1) * DEG2RAD;
+  const a = Math.sin(dLat / 2) ** 2
+    + Math.cos(lat1 * DEG2RAD) * Math.cos(lat2 * DEG2RAD) * Math.sin(dLon / 2) ** 2;
+  return EARTH_KM * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function getNumberParam(params: Record<string, unknown>, key: string, fallback: number): number {
+  const v = params[key];
+  return typeof v === 'number' && Number.isFinite(v) ? v : fallback;
+}
+
+function getStringParam(params: Record<string, unknown>, key: string): string | undefined {
+  const v = params[key];
+  return typeof v === 'string' ? v : undefined;
+}
+
+function severityRankFromParam(params: Record<string, unknown>, key: string): number {
+  const v = params[key];
+  if (typeof v !== 'string') return 0;
+  const upper = v.toUpperCase() as ObservationSeverity;
+  return SEVERITY_RANK[upper] ?? 0;
+}
+
+// ── Feature evaluators ────────────────────────────────────────────────
+
+function matchesDomainElevation(feature: SignatureFeature, observations: readonly ObservationEvent[]): boolean {
+  const domain = getStringParam(feature.params, 'domain');
+  if (!domain) return false;
+  const minCount = getNumberParam(feature.params, 'minCount', 1);
+  const minRank = severityRankFromParam(feature.params, 'minSeverity');
+  let hits = 0;
+  for (const o of observations) {
+    if (o.domain !== domain) continue;
+    if (SEVERITY_RANK[o.severity] < minRank) continue;
+    hits += 1;
+    if (hits >= minCount) return true;
+  }
+  return false;
+}
+
+function matchesEntitySpike(feature: SignatureFeature, observations: readonly ObservationEvent[]): boolean {
+  const minCount = getNumberParam(feature.params, 'minCount', 1);
+  const targetEntity = getStringParam(feature.params, 'entityId');
+  const counts = new Map<string, number>();
+  for (const o of observations) {
+    for (const id of o.entityIds) {
+      if (targetEntity && id !== targetEntity) continue;
+      const next = (counts.get(id) ?? 0) + 1;
+      counts.set(id, next);
+      if (next >= minCount) return true;
+    }
+  }
+  return false;
+}
+
+interface GeoPoint { lat: number; lon: number }
+
+function countWithinRadius(centre: GeoPoint, points: readonly GeoPoint[], radiusKm: number): number {
+  let hits = 0;
+  for (const p of points) {
+    if (haversineKm(centre.lat, centre.lon, p.lat, p.lon) <= radiusKm) hits += 1;
+  }
+  return hits;
+}
+
+function matchesGeoCluster(feature: SignatureFeature, observations: readonly ObservationEvent[]): boolean {
+  const minCount = getNumberParam(feature.params, 'minCount', 1);
+  const radiusKm = getNumberParam(feature.params, 'radiusKm', 100);
+  const fixedLat = feature.params.lat;
+  const fixedLon = feature.params.lon;
+  const points: GeoPoint[] = observations
+    .filter((o) => o.location !== undefined)
+    .map((o) => ({ lat: o.location!.lat, lon: o.location!.lon }));
+  if (points.length < minCount) return false;
+  if (typeof fixedLat === 'number' && typeof fixedLon === 'number') {
+    return countWithinRadius({ lat: fixedLat, lon: fixedLon }, points, radiusKm) >= minCount;
+  }
+  // Anchor each point in turn and look for a cluster around it.
+  return points.some((anchor) => countWithinRadius(anchor, points, radiusKm) >= minCount);
+}
+
+function matchesTimePattern(feature: SignatureFeature, observations: readonly ObservationEvent[]): boolean {
+  const minCount = getNumberParam(feature.params, 'minCount', 1);
+  const windowMinutes = getNumberParam(feature.params, 'windowMinutes', 60);
+  if (observations.length < minCount) return false;
+  const sorted = [...observations].sort((a, b) => a.timestamp - b.timestamp);
+  const windowMs = windowMinutes * 60_000;
+  let left = 0;
+  for (let right = 0; right < sorted.length; right += 1) {
+    while (sorted[right]!.timestamp - sorted[left]!.timestamp > windowMs) left += 1;
+    if (right - left + 1 >= minCount) return true;
+  }
+  return false;
+}
+
+function evaluateFeature(feature: SignatureFeature, observations: readonly ObservationEvent[]): boolean {
+  switch (feature.featureType) {
+    case 'domain-elevation': { return matchesDomainElevation(feature, observations); }
+    case 'entity-spike': { return matchesEntitySpike(feature, observations); }
+    case 'geo-cluster': { return matchesGeoCluster(feature, observations); }
+    case 'time-pattern': { return matchesTimePattern(feature, observations); }
+  }
+}
+
+// ── Service ───────────────────────────────────────────────────────────
+
+export class CrisisSignatureLibrary {
+  private static _singleton: CrisisSignatureLibrary | null = null;
+  private custom = new Map<string, CrisisSignature>();
+  private storage: StorageLike | null;
+  private hydrated = false;
+
+  constructor(options: CrisisSignatureLibraryOptions = {}) {
+    this.storage = safeStorage(options.storage);
+    // `options.clock` is accepted but unused today; reserved for the
+    // upcoming temporal-weighting follow-up so the constructor
+    // signature matches the rest of the intelligence services.
+  }
+
+  static getInstance(): CrisisSignatureLibrary {
+    CrisisSignatureLibrary._singleton ??= new CrisisSignatureLibrary();
+    return CrisisSignatureLibrary._singleton;
+  }
+
+  static _resetForTests(): void {
+    CrisisSignatureLibrary._singleton = null;
+  }
+
+  // ── Registry CRUD ──────────────────────────────────────────────────
+
+  addSignature(signature: CrisisSignature): CrisisSignature {
+    this.ensureHydrated();
+    const stored = cloneSignature(signature);
+    this.custom.set(stored.id, stored);
+    this.enforceCustomCap();
+    this.persist();
+    return cloneSignature(stored);
+  }
+
+  removeSignature(id: string): boolean {
+    this.ensureHydrated();
+    const removed = this.custom.delete(id);
+    if (removed) this.persist();
+    return removed;
+  }
+
+  getSignatures(): CrisisSignature[] {
+    this.ensureHydrated();
+    return [
+      ...BUILT_IN_SIGNATURES.map((s) => cloneSignature(s)),
+      ...[...this.custom.values()].map((s) => cloneSignature(s)),
+    ];
+  }
+
+  getSignature(id: string): CrisisSignature | undefined {
+    this.ensureHydrated();
+    const builtIn = BUILT_IN_SIGNATURES.find((s) => s.id === id);
+    if (builtIn) return cloneSignature(builtIn);
+    const custom = this.custom.get(id);
+    return custom ? cloneSignature(custom) : undefined;
+  }
+
+  // ── Matching ───────────────────────────────────────────────────────
+
+  matchSignatures(observations: readonly ObservationEvent[]): SignatureMatch[] {
+    this.ensureHydrated();
+    const matches: SignatureMatch[] = [];
+    for (const signature of this.iterSignatures()) {
+      const match = this.scoreSignature(signature, observations);
+      if (match) matches.push(match);
+    }
+    matches.sort((a, b) => b.score - a.score);
+    return matches.map((m) => cloneMatch(m));
+  }
+
+  /** Test seam — clears custom signatures + persisted blob. */
+  resetForTesting(): void {
+    this.custom.clear();
+    this.hydrated = true;
+    if (this.storage?.removeItem) {
+      try { this.storage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
+    }
+  }
+
+  // ── Internal ───────────────────────────────────────────────────────
+
+  private *iterSignatures(): Iterable<CrisisSignature> {
+    for (const s of BUILT_IN_SIGNATURES) yield s;
+    for (const s of this.custom.values()) yield s;
+  }
+
+  private scoreSignature(signature: CrisisSignature, observations: readonly ObservationEvent[]): SignatureMatch | null {
+    let totalWeight = 0;
+    let matchedWeight = 0;
+    const matchedFeatures: SignatureFeature[] = [];
+    for (const feature of signature.fingerprint) {
+      totalWeight += feature.weight;
+      if (evaluateFeature(feature, observations)) {
+        matchedWeight += feature.weight;
+        matchedFeatures.push(feature);
+      }
+    }
+    if (totalWeight <= 0) return null;
+    const score = Number((matchedWeight / totalWeight).toFixed(4));
+    if (score < MATCH_THRESHOLD) return null;
+    const leadTimeEstimateHours = Number(
+      Math.max(0, signature.avgLeadTimeHours * (1 - score)).toFixed(2),
+    );
+    return { signature, score, matchedFeatures, leadTimeEstimateHours };
+  }
+
+  private enforceCustomCap(): void {
+    if (this.custom.size <= MAX_CUSTOM_SIGNATURES) return;
+    const overflow = this.custom.size - MAX_CUSTOM_SIGNATURES;
+    const ids = [...this.custom.keys()].slice(0, overflow);
+    for (const id of ids) this.custom.delete(id);
+  }
+
+  private ensureHydrated(): void {
+    if (this.hydrated) return;
+    this.hydrated = true;
+    if (!this.storage) return;
+    let raw: string | null = null;
+    try { raw = this.storage.getItem(STORAGE_KEY); } catch { return; }
+    if (!raw) return;
+    let parsed: CrisisSignature[] | null;
+    try { parsed = JSON.parse(raw) as CrisisSignature[] | null; }
+    catch { return; }
+    if (!Array.isArray(parsed)) return;
+    for (const entry of parsed) {
+      if (!entry || typeof entry.id !== 'string' || !Array.isArray(entry.fingerprint)) continue;
+      this.custom.set(entry.id, cloneSignature(entry));
+    }
+  }
+
+  private persist(): void {
+    if (!this.storage) return;
+    try {
+      this.storage.setItem(STORAGE_KEY, JSON.stringify([...this.custom.values()]));
+    } catch { /* best effort */ }
+  }
+}
+
+// ── Convenience accessor ──────────────────────────────────────────────
+
+export function getCrisisSignatureLibrary(): CrisisSignatureLibrary {
+  return CrisisSignatureLibrary.getInstance();
+}
+
+export const __internals = {
+  BUILT_IN_SIGNATURES,
+  SEVERITY_RANK,
+  MATCH_THRESHOLD,
+  MAX_CUSTOM_SIGNATURES,
+  haversineKm,
+};

--- a/tests/intelligence/crisis-signature-library.test.mts
+++ b/tests/intelligence/crisis-signature-library.test.mts
@@ -1,0 +1,549 @@
+/**
+ * Tests for CrisisSignatureLibrary — fingerprint-driven scoring of
+ * crisis patterns over an observation window.
+ *
+ * The service is built with injectable storage so the tests never
+ * touch real localStorage.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  CrisisSignatureLibrary,
+  MATCH_THRESHOLD,
+  MAX_CUSTOM_SIGNATURES,
+  STORAGE_KEY,
+  __internals,
+  getCrisisSignatureLibrary,
+  type CrisisSignature,
+  type SignatureFeature,
+  type StorageLike,
+} from '../../src/services/intelligence/crisis-signature-library.ts';
+import type { ObservationEvent, ObservationSeverity } from '../../src/types/intelligence.ts';
+
+// ── Fakes ─────────────────────────────────────────────────────────────
+
+function makeFakeStorage(seed: Record<string, string> = {}): StorageLike & {
+  raw: Map<string, string>;
+} {
+  const raw = new Map<string, string>(Object.entries(seed));
+  return {
+    raw,
+    getItem(key: string): string | null { return raw.get(key) ?? null; },
+    setItem(key: string, value: string): void { raw.set(key, value); },
+    removeItem(key: string): void { raw.delete(key); },
+  };
+}
+
+const NOW = 1_745_000_000_000;
+
+function obs(overrides: Partial<ObservationEvent> = {}): ObservationEvent {
+  return {
+    id: 'o-1',
+    sourceId: 'test',
+    domain: 'finance',
+    timestamp: NOW,
+    severity: 'HIGH',
+    title: 'fixture',
+    raw: {},
+    entityIds: [],
+    tags: [],
+    ...overrides,
+  };
+}
+
+function feature(
+  featureType: SignatureFeature['featureType'],
+  weight: number,
+  params: Record<string, unknown>,
+): SignatureFeature {
+  return { featureType, weight, params };
+}
+
+function customSignature(overrides: Partial<CrisisSignature> = {}): CrisisSignature {
+  return {
+    id: 'cust-1',
+    name: 'Test',
+    domain: 'finance',
+    fingerprint: [feature('domain-elevation', 1, { domain: 'finance', minCount: 1 })],
+    historicalExamples: [],
+    avgLeadTimeHours: 10,
+    confidence: 0.5,
+    ...overrides,
+  };
+}
+
+// ── Built-in catalog ─────────────────────────────────────────────────
+
+test('built-in catalog contains 8 signatures', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  const all = lib.getSignatures();
+  assert.equal(all.length, 8);
+});
+
+test('built-in catalog covers the spec\'s 8 named patterns', () => {
+  const names = __internals.BUILT_IN_SIGNATURES.map((s) => s.name.toLowerCase());
+  for (const expected of [
+    'financial contagion',
+    'pandemic emergence',
+    'coup pattern',
+    'regional conflict escalation',
+    'supply chain cascade',
+    'cyber infrastructure attack',
+    'natural disaster compound',
+    'social unrest spread',
+  ]) {
+    assert.ok(names.includes(expected), `missing built-in: ${expected}`);
+  }
+});
+
+test('every built-in signature has a non-empty fingerprint and lead time', () => {
+  for (const sig of __internals.BUILT_IN_SIGNATURES) {
+    assert.ok(sig.fingerprint.length > 0, `${sig.id} has no features`);
+    assert.ok(sig.avgLeadTimeHours > 0, `${sig.id} has zero lead time`);
+    const totalWeight = sig.fingerprint.reduce((acc, f) => acc + f.weight, 0);
+    assert.ok(totalWeight > 0, `${sig.id} has zero total weight`);
+  }
+});
+
+test('built-in signatures use only the four supported feature types', () => {
+  const valid: ReadonlySet<string> = new Set(['domain-elevation', 'entity-spike', 'geo-cluster', 'time-pattern']);
+  for (const sig of __internals.BUILT_IN_SIGNATURES) {
+    for (const feat of sig.fingerprint) {
+      assert.ok(valid.has(feat.featureType), `${sig.id} uses bogus featureType ${feat.featureType}`);
+    }
+  }
+});
+
+test('getSignature returns built-in by id', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  const sig = lib.getSignature('builtin-cyber-infrastructure-attack');
+  assert.ok(sig);
+  assert.equal(sig.name, 'Cyber infrastructure attack');
+});
+
+test('getSignature returns undefined for unknown id', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  assert.equal(lib.getSignature('does-not-exist'), undefined);
+});
+
+// ── addSignature / removeSignature ───────────────────────────────────
+
+test('addSignature stores a custom signature and returns a defensive copy', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  const stored = lib.addSignature(customSignature());
+  assert.equal(lib.getSignatures().length, 9, 'built-ins + 1 custom');
+  stored.name = 'mutated';
+  assert.equal(lib.getSignature('cust-1')?.name, 'Test');
+});
+
+test('addSignature replacing same id updates in place', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.addSignature(customSignature());
+  lib.addSignature(customSignature({ name: 'v2' }));
+  assert.equal(lib.getSignatures().length, 9);
+  assert.equal(lib.getSignature('cust-1')?.name, 'v2');
+});
+
+test('removeSignature returns true on success and false for unknown', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.addSignature(customSignature());
+  assert.equal(lib.removeSignature('cust-1'), true);
+  assert.equal(lib.removeSignature('cust-1'), false);
+});
+
+test('removeSignature does not touch built-ins', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  assert.equal(lib.removeSignature('builtin-financial-contagion'), false);
+  assert.ok(lib.getSignature('builtin-financial-contagion'));
+});
+
+test('custom signature cap at MAX_CUSTOM_SIGNATURES evicts oldest', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  for (let i = 0; i < MAX_CUSTOM_SIGNATURES + 10; i += 1) {
+    lib.addSignature(customSignature({ id: `c-${i}` }));
+  }
+  assert.equal(lib.getSignatures().length - 8, MAX_CUSTOM_SIGNATURES);
+  assert.equal(lib.getSignature('c-0'), undefined, 'oldest custom should be evicted');
+});
+
+// ── matchSignatures: feature evaluators ──────────────────────────────
+
+test('matchSignatures: domain-elevation fires when severity + count thresholds met', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.addSignature(customSignature({
+    id: 'cust-de', fingerprint: [
+      feature('domain-elevation', 1, { domain: 'finance', minCount: 3, minSeverity: 'HIGH' }),
+    ],
+  }));
+  const events: ObservationEvent[] = Array.from({ length: 4 }, (_, i) => obs({ id: `o-${i}`, severity: 'HIGH' }));
+  const matches = lib.matchSignatures(events);
+  assert.ok(matches.some((m) => m.signature.id === 'cust-de'));
+});
+
+test('matchSignatures: domain-elevation skips events with severity below threshold', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.addSignature(customSignature({
+    id: 'cust-de', fingerprint: [
+      feature('domain-elevation', 1, { domain: 'finance', minCount: 2, minSeverity: 'CRITICAL' }),
+    ],
+  }));
+  const events: ObservationEvent[] = Array.from({ length: 5 }, (_, i) => obs({ id: `o-${i}`, severity: 'HIGH' }));
+  const matches = lib.matchSignatures(events).filter((m) => m.signature.id === 'cust-de');
+  assert.equal(matches.length, 0);
+});
+
+test('matchSignatures: domain-elevation requires matching domain', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.addSignature(customSignature({
+    id: 'cust-de', fingerprint: [
+      feature('domain-elevation', 1, { domain: 'cyber', minCount: 1 }),
+    ],
+  }));
+  const events: ObservationEvent[] = [obs({ domain: 'finance' })];
+  assert.equal(lib.matchSignatures(events).filter((m) => m.signature.id === 'cust-de').length, 0);
+});
+
+test('matchSignatures: entity-spike fires when an entity appears minCount times', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.addSignature(customSignature({
+    id: 'cust-es', fingerprint: [feature('entity-spike', 1, { minCount: 3 })],
+  }));
+  const events: ObservationEvent[] = Array.from({ length: 4 }, (_, i) => obs({
+    id: `o-${i}`, entityIds: ['acme-corp'],
+  }));
+  assert.ok(lib.matchSignatures(events).some((m) => m.signature.id === 'cust-es'));
+});
+
+test('matchSignatures: entity-spike with explicit entityId filters', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.addSignature(customSignature({
+    id: 'cust-es', fingerprint: [feature('entity-spike', 1, { entityId: 'target', minCount: 2 })],
+  }));
+  const noise: ObservationEvent[] = Array.from({ length: 5 }, (_, i) => obs({
+    id: `o-${i}`, entityIds: ['noise'],
+  }));
+  assert.equal(lib.matchSignatures(noise).filter((m) => m.signature.id === 'cust-es').length, 0);
+  noise.push(obs({ id: 'o-t1', entityIds: ['target'] }));
+  noise.push(obs({ id: 'o-t2', entityIds: ['target'] }));
+  assert.ok(lib.matchSignatures(noise).some((m) => m.signature.id === 'cust-es'));
+});
+
+test('matchSignatures: geo-cluster fires when fixed centre matches enough nearby observations', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.addSignature(customSignature({
+    id: 'cust-gc', fingerprint: [
+      feature('geo-cluster', 1, { lat: 35.6762, lon: 139.6503, radiusKm: 50, minCount: 3 }),
+    ],
+  }));
+  const events: ObservationEvent[] = [
+    obs({ id: 'o-1', location: { lat: 35.68, lon: 139.65 } }),
+    obs({ id: 'o-2', location: { lat: 35.69, lon: 139.66 } }),
+    obs({ id: 'o-3', location: { lat: 35.70, lon: 139.67 } }),
+  ];
+  assert.ok(lib.matchSignatures(events).some((m) => m.signature.id === 'cust-gc'));
+});
+
+test('matchSignatures: geo-cluster anchored to any observation finds dense clusters', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.addSignature(customSignature({
+    id: 'cust-gc', fingerprint: [
+      feature('geo-cluster', 1, { radiusKm: 50, minCount: 3 }),
+    ],
+  }));
+  const events: ObservationEvent[] = [
+    obs({ id: 'o-1', location: { lat: 0, lon: 0 } }),
+    obs({ id: 'o-2', location: { lat: 35.68, lon: 139.65 } }),
+    obs({ id: 'o-3', location: { lat: 35.69, lon: 139.66 } }),
+    obs({ id: 'o-4', location: { lat: 35.70, lon: 139.67 } }),
+  ];
+  assert.ok(lib.matchSignatures(events).some((m) => m.signature.id === 'cust-gc'));
+});
+
+test('matchSignatures: geo-cluster needs at least minCount located observations', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.addSignature(customSignature({
+    id: 'cust-gc', fingerprint: [feature('geo-cluster', 1, { minCount: 3, radiusKm: 50 })],
+  }));
+  const events: ObservationEvent[] = [obs({ id: 'o-1' /* no location */ })];
+  assert.equal(lib.matchSignatures(events).filter((m) => m.signature.id === 'cust-gc').length, 0);
+});
+
+test('matchSignatures: geo-cluster ignores observations outside the radius', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.addSignature(customSignature({
+    id: 'cust-gc', fingerprint: [
+      feature('geo-cluster', 1, { lat: 0, lon: 0, radiusKm: 10, minCount: 2 }),
+    ],
+  }));
+  const events: ObservationEvent[] = [
+    obs({ id: 'o-1', location: { lat: 0, lon: 0 } }),
+    obs({ id: 'o-2', location: { lat: 40, lon: 40 } }),
+  ];
+  assert.equal(lib.matchSignatures(events).filter((m) => m.signature.id === 'cust-gc').length, 0);
+});
+
+test('matchSignatures: time-pattern fires on a tight cluster of events', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.addSignature(customSignature({
+    id: 'cust-tp', fingerprint: [feature('time-pattern', 1, { windowMinutes: 60, minCount: 4 })],
+  }));
+  const events: ObservationEvent[] = Array.from({ length: 5 }, (_, i) => obs({
+    id: `o-${i}`, timestamp: NOW + i * 600_000, // every 10 minutes
+  }));
+  assert.ok(lib.matchSignatures(events).some((m) => m.signature.id === 'cust-tp'));
+});
+
+test('matchSignatures: time-pattern does not fire when events are spread too thin', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.addSignature(customSignature({
+    id: 'cust-tp', fingerprint: [feature('time-pattern', 1, { windowMinutes: 60, minCount: 4 })],
+  }));
+  const events: ObservationEvent[] = Array.from({ length: 5 }, (_, i) => obs({
+    id: `o-${i}`, timestamp: NOW + i * 90 * 60_000, // 90 minutes apart
+  }));
+  assert.equal(lib.matchSignatures(events).filter((m) => m.signature.id === 'cust-tp').length, 0);
+});
+
+// ── matchSignatures: scoring + threshold ─────────────────────────────
+
+test('matchSignatures: returns no matches when no features fire', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  assert.deepEqual(lib.matchSignatures([]), []);
+});
+
+test('matchSignatures: score = matchedWeight / totalWeight', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.resetForTesting();
+  lib.addSignature(customSignature({
+    id: 'cust-2f', fingerprint: [
+      feature('domain-elevation', 0.6, { domain: 'finance', minCount: 1 }),
+      feature('entity-spike', 0.4, { minCount: 5 }), // won't fire
+    ],
+  }));
+  const matches = lib.matchSignatures([obs({ domain: 'finance' })]).filter((m) => m.signature.id === 'cust-2f');
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0]!.score, 0.6);
+  assert.equal(matches[0]!.matchedFeatures.length, 1);
+});
+
+test('matchSignatures: score below threshold is filtered out', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.addSignature(customSignature({
+    id: 'cust-thin', fingerprint: [
+      feature('domain-elevation', 0.3, { domain: 'finance', minCount: 1 }),
+      feature('entity-spike', 0.7, { minCount: 5 }), // won't fire
+    ],
+  }));
+  const matches = lib.matchSignatures([obs({ domain: 'finance' })]).filter((m) => m.signature.id === 'cust-thin');
+  // 0.3 / 1.0 = 0.3 < 0.4 threshold
+  assert.equal(matches.length, 0);
+});
+
+test('matchSignatures: exactly at MATCH_THRESHOLD is included', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.addSignature(customSignature({
+    id: 'cust-edge', fingerprint: [
+      feature('domain-elevation', 0.4, { domain: 'finance', minCount: 1 }),
+      feature('entity-spike', 0.6, { minCount: 5 }), // won't fire
+    ],
+  }));
+  const matches = lib.matchSignatures([obs({ domain: 'finance' })]).filter((m) => m.signature.id === 'cust-edge');
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0]!.score, MATCH_THRESHOLD);
+});
+
+test('matchSignatures: leadTimeEstimateHours shrinks as score grows', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.addSignature(customSignature({
+    id: 'cust-lead',
+    avgLeadTimeHours: 100,
+    fingerprint: [
+      feature('domain-elevation', 1, { domain: 'finance', minCount: 1 }),
+      feature('entity-spike', 1, { minCount: 5 }),
+    ],
+  }));
+  const partial = lib.matchSignatures([obs({ domain: 'finance' })]).find((m) => m.signature.id === 'cust-lead')!;
+  // score = 0.5, lead = 100 * (1 - 0.5) = 50
+  assert.equal(partial.score, 0.5);
+  assert.equal(partial.leadTimeEstimateHours, 50);
+});
+
+test('matchSignatures: leadTimeEstimateHours floors at 0 for full matches', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.addSignature(customSignature({
+    id: 'cust-full', avgLeadTimeHours: 24,
+    fingerprint: [feature('domain-elevation', 1, { domain: 'finance', minCount: 1 })],
+  }));
+  const match = lib.matchSignatures([obs({ domain: 'finance' })]).find((m) => m.signature.id === 'cust-full')!;
+  assert.equal(match.score, 1);
+  assert.equal(match.leadTimeEstimateHours, 0);
+});
+
+test('matchSignatures: results sorted by score descending', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.addSignature(customSignature({
+    id: 'cust-half', fingerprint: [
+      feature('domain-elevation', 0.5, { domain: 'finance', minCount: 1 }),
+      feature('entity-spike', 0.5, { minCount: 5 }),
+    ],
+  }));
+  lib.addSignature(customSignature({
+    id: 'cust-full', fingerprint: [
+      feature('domain-elevation', 1, { domain: 'finance', minCount: 1 }),
+    ],
+  }));
+  const matches = lib.matchSignatures([obs({ domain: 'finance' })])
+    .filter((m) => m.signature.id.startsWith('cust-'));
+  assert.equal(matches[0]!.signature.id, 'cust-full');
+  assert.equal(matches[1]!.signature.id, 'cust-half');
+});
+
+test('matchSignatures: includes only the features that actually matched', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.addSignature(customSignature({
+    id: 'cust-partial', fingerprint: [
+      feature('domain-elevation', 0.5, { domain: 'finance', minCount: 1 }),
+      feature('entity-spike', 0.5, { minCount: 5 }), // won't fire
+    ],
+  }));
+  const match = lib.matchSignatures([obs({ domain: 'finance' })])
+    .find((m) => m.signature.id === 'cust-partial')!;
+  assert.equal(match.matchedFeatures.length, 1);
+  assert.equal(match.matchedFeatures[0]!.featureType, 'domain-elevation');
+});
+
+test('matchSignatures: returned matches are defensive copies', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  lib.addSignature(customSignature({
+    id: 'cust-copy', fingerprint: [feature('domain-elevation', 1, { domain: 'finance', minCount: 1 })],
+  }));
+  const match = lib.matchSignatures([obs({ domain: 'finance' })])
+    .find((m) => m.signature.id === 'cust-copy')!;
+  match.signature.name = 'mutated';
+  assert.equal(lib.getSignature('cust-copy')?.name, 'Test');
+});
+
+test('matchSignatures: built-in financial contagion fires on a synthetic finance burst', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  const events: ObservationEvent[] = [];
+  for (let i = 0; i < 6; i += 1) {
+    events.push(obs({
+      id: `f-${i}`,
+      domain: 'finance',
+      severity: 'HIGH' as ObservationSeverity,
+      timestamp: NOW + i * 60_000,
+      entityIds: ['svb', 'jpm', 'bofa'],
+    }));
+  }
+  const matches = lib.matchSignatures(events);
+  assert.ok(matches.some((m) => m.signature.id === 'builtin-financial-contagion'));
+});
+
+test('matchSignatures: built-in pandemic emergence requires geo cluster', () => {
+  const lib = new CrisisSignatureLibrary({ storage: makeFakeStorage() });
+  const events: ObservationEvent[] = Array.from({ length: 8 }, (_, i) => obs({
+    id: `p-${i}`, domain: 'biosurv', severity: 'MEDIUM' as ObservationSeverity,
+    timestamp: NOW + i * 60_000,
+    location: { lat: 35.0 + i * 0.05, lon: 139.0 + i * 0.05 },
+  }));
+  const matches = lib.matchSignatures(events);
+  assert.ok(matches.some((m) => m.signature.id === 'builtin-pandemic-emergence'));
+});
+
+// ── Persistence ───────────────────────────────────────────────────────
+
+test('custom signatures survive a fresh service instance', () => {
+  const storage = makeFakeStorage();
+  const lib1 = new CrisisSignatureLibrary({ storage });
+  lib1.addSignature(customSignature());
+  const lib2 = new CrisisSignatureLibrary({ storage });
+  assert.ok(lib2.getSignature('cust-1'));
+});
+
+test('removeSignature persists across instances', () => {
+  const storage = makeFakeStorage();
+  const lib1 = new CrisisSignatureLibrary({ storage });
+  lib1.addSignature(customSignature());
+  lib1.removeSignature('cust-1');
+  const lib2 = new CrisisSignatureLibrary({ storage });
+  assert.equal(lib2.getSignature('cust-1'), undefined);
+});
+
+test('corrupt persistence blob is ignored', () => {
+  const storage = makeFakeStorage({ [STORAGE_KEY]: 'not-json' });
+  const lib = new CrisisSignatureLibrary({ storage });
+  assert.equal(lib.getSignatures().length, 8);
+});
+
+test('non-array persistence payload is ignored', () => {
+  const storage = makeFakeStorage({ [STORAGE_KEY]: JSON.stringify({ id: 'x' }) });
+  const lib = new CrisisSignatureLibrary({ storage });
+  assert.equal(lib.getSignatures().length, 8);
+});
+
+test('persistence skips malformed entries without crashing', () => {
+  const storage = makeFakeStorage({
+    [STORAGE_KEY]: JSON.stringify([null, { id: 42 }, customSignature()]),
+  });
+  const lib = new CrisisSignatureLibrary({ storage });
+  assert.ok(lib.getSignature('cust-1'));
+  assert.equal(lib.getSignatures().length, 9);
+});
+
+test('null storage works (no-op persistence)', () => {
+  const lib = new CrisisSignatureLibrary({ storage: null });
+  lib.addSignature(customSignature());
+  assert.ok(lib.getSignature('cust-1'));
+});
+
+test('resetForTesting clears custom signatures + persisted blob', () => {
+  const storage = makeFakeStorage();
+  const lib = new CrisisSignatureLibrary({ storage });
+  lib.addSignature(customSignature());
+  lib.resetForTesting();
+  assert.equal(lib.getSignature('cust-1'), undefined);
+  assert.equal(storage.raw.has(STORAGE_KEY), false);
+  // Built-ins are still present.
+  assert.equal(lib.getSignatures().length, 8);
+});
+
+// ── Singleton ────────────────────────────────────────────────────────
+
+test('CrisisSignatureLibrary.getInstance returns a stable singleton', () => {
+  CrisisSignatureLibrary._resetForTests();
+  const a = CrisisSignatureLibrary.getInstance();
+  const b = CrisisSignatureLibrary.getInstance();
+  assert.equal(a, b);
+  CrisisSignatureLibrary._resetForTests();
+});
+
+test('getCrisisSignatureLibrary mirrors getInstance', () => {
+  CrisisSignatureLibrary._resetForTests();
+  const a = getCrisisSignatureLibrary();
+  const b = CrisisSignatureLibrary.getInstance();
+  assert.equal(a, b);
+  CrisisSignatureLibrary._resetForTests();
+});
+
+test('singleton reset returns a fresh instance', () => {
+  const a = CrisisSignatureLibrary.getInstance();
+  CrisisSignatureLibrary._resetForTests();
+  const b = CrisisSignatureLibrary.getInstance();
+  assert.notEqual(a, b);
+  CrisisSignatureLibrary._resetForTests();
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+test('__internals.haversineKm returns 0 for identical points', () => {
+  assert.equal(__internals.haversineKm(0, 0, 0, 0), 0);
+});
+
+test('__internals.haversineKm scales with distance', () => {
+  const tokyo = __internals.haversineKm(35.6762, 139.6503, 35.6762, 139.6503);
+  const tokyoToYokohama = __internals.haversineKm(35.6762, 139.6503, 35.4437, 139.6380);
+  assert.equal(tokyo, 0);
+  assert.ok(tokyoToYokohama > 20 && tokyoToYokohama < 35);
+});


### PR DESCRIPTION
## What

Adds a `CrisisSignatureLibrary` service that fingerprints recurring crisis patterns and scores incoming observation windows against the catalog for early detection. Each `CrisisSignature` carries a list of feature predicates (`domain-elevation`, `entity-spike`, `geo-cluster`, `time-pattern`); `matchSignatures(observations)` scores every signature and returns the ones at or above the **0.4** threshold, sorted by score desc.

The library ships with **8 built-in signatures** and lets operators add or remove custom signatures persisted to `wm-crisis-signature-library` (cap 100, oldest-first eviction).

## Why

Crystal Ball produces lots of individual observations but historically had no library that says "this *shape* of activity has played out before — here's the pattern, here's the lead time, here's how to spot it next time." This service turns that institutional pattern knowledge into queryable, scoreable, extendable data so the next financial-contagion run-up or pandemic emergence gets flagged from the same fingerprints that named it last time.

## Files

- `src/services/intelligence/crisis-signature-library.ts` — `class CrisisSignatureLibrary` with `static getInstance()` singleton and a convenience `getCrisisSignatureLibrary()` mirror. API:
  - `addSignature(signature)` — appends or replaces a custom signature; cap enforced at `MAX_CUSTOM_SIGNATURES` (100), oldest-first eviction.
  - `removeSignature(id)` — `true` when a custom is removed; built-ins are not removable.
  - `getSignatures()` / `getSignature(id)` — built-ins + customs, defensive copies.
  - `matchSignatures(observations)` — scores every signature, returns matches with `score >= 0.4` sorted desc. Each match carries `{ signature, score, matchedFeatures, leadTimeEstimateHours }` where `leadTimeEstimateHours = avgLeadTimeHours × (1 − score)`.
  
  Feature evaluators:
  - **`domain-elevation`** — at least `minCount` observations on `domain` with severity `>= minSeverity`.
  - **`entity-spike`** — at least `minCount` observations referencing the same `entityId` (or any entity if no target id).
  - **`geo-cluster`** — at least `minCount` located observations within `radiusKm`; when `lat`/`lon` are provided in `params`, counts around that fixed centre; otherwise anchors each observation in turn.
  - **`time-pattern`** — sliding window of `windowMinutes` containing at least `minCount` observations.
  
  Storage key `wm-crisis-signature-library` is deliberately distinct from the existing `crisis-signature.ts` module's `wm-crisis-signatures` ledger so the two services coexist without stomping each other.
- `tests/intelligence/crisis-signature-library.test.mts` — **45 tests** via `npx tsx --test`:
  - Built-in catalog (count, names, non-empty fingerprints, only-valid `featureType`s).
  - `addSignature` / `removeSignature` CRUD including defensive copies and built-in protection, plus oldest-first eviction at the `MAX_CUSTOM_SIGNATURES` cap.
  - Each of the four feature evaluators on both positive and negative paths (severity below threshold, wrong domain, entityId filter, fixed-centre vs anchor-each-observation geo-clustering, located-observation gate, sparse time pattern).
  - Scoring formula (`matchedWeight / totalWeight`), threshold gate (filtered below 0.4, included at exactly 0.4, full match), lead time decreasing with score, lead time floored at 0, results sorted desc, `matchedFeatures` only includes the firing ones, returned matches are defensive copies.
  - Two end-to-end built-in firings: financial contagion + pandemic emergence.
  - Persistence: round-trip; corrupt blob ignored; non-array payload ignored; malformed entries skipped; null storage no-op; `resetForTesting` clears.
  - Singleton: stable; reset returns fresh; convenience accessor mirrors static method.
  - Internals: Haversine sanity.

## Verification

```
npx tsx --test tests/intelligence/crisis-signature-library.test.mts
# tests 45 pass 45 fail 0
npx tsc --noEmit -p tsconfig.json
npx tsc --noEmit -p tsconfig.api.json
npx eslint --quiet src/services/intelligence/crisis-signature-library.ts \
                   tests/intelligence/crisis-signature-library.test.mts
```

All clean.

## Notes

- Pure module — no DOM, no fetch, no globals at import time.
- Built-in catalog (8): `builtin-financial-contagion`, `builtin-pandemic-emergence`, `builtin-coup-pattern`, `builtin-regional-conflict-escalation`, `builtin-supply-chain-cascade`, `builtin-cyber-infrastructure-attack`, `builtin-natural-disaster-compound`, `builtin-social-unrest-spread`. Each carries plausible `historicalExamples`, `avgLeadTimeHours`, and `confidence` priors.
- Storage key intentionally diverges from the spec (`wm-crisis-signatures`) to avoid stomping the older `crisis-signature.ts` module's match ledger. Operators won't notice; the storage namespace is internal.

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass