### PR TITLE
feat(intelligence): unified intelligence feed API + sidecar what-changed fix

### DIFF
--- a/api/__tests__/intelligence-feed.test.mjs
+++ b/api/__tests__/intelligence-feed.test.mjs
@@ -1,0 +1,320 @@
+/**
+ * Tests for api/intelligence/feed.js
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { invokeHandler, mockFetch } from './_test-utils.mjs';
+
+let handler;
+let feedCache;
+try {
+  const mod = await import('../intelligence/feed.js');
+  handler = mod.default;
+  feedCache = mod.cache;
+} catch (err) {
+  console.warn('Handler intelligence/feed.js failed to import:', err.message);
+  handler = null;
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const USGS_EMPTY = { type: 'FeatureCollection', features: [], metadata: {} };
+const NWS_EMPTY  = { type: 'FeatureCollection', features: [] };
+
+const USGS_TWO = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      id: 'eq-high',
+      type: 'Feature',
+      properties: { mag: 6.8, place: 'Near Tokyo', time: Date.now() - 1_000 },
+      geometry: { type: 'Point', coordinates: [139.7, 35.7, 15] },
+    },
+    {
+      id: 'eq-low',
+      type: 'Feature',
+      properties: { mag: 2.6, place: 'Nevada', time: Date.now() - 60_000 },
+      geometry: { type: 'Point', coordinates: [-115.1, 36.2, 8] },
+    },
+  ],
+};
+
+const NWS_ONE = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      id: 'nws-1',
+      type: 'Feature',
+      properties: {
+        id: 'nws-tornado-1',
+        event: 'Tornado Warning',
+        headline: 'Tornado Warning for Cook County',
+        sent: new Date(Date.now() - 2 * 60_000).toISOString(),
+        severity: 'Extreme',
+      },
+      geometry: null,
+    },
+  ],
+};
+
+function freshMocks() {
+  return new Map([
+    ['earthquake.usgs.gov', { status: 200, json: USGS_EMPTY }],
+    ['api.weather.gov', { status: 200, json: NWS_EMPTY }],
+  ]);
+}
+
+// ── Basic response shape ───────────────────────────────────────────────────────
+
+test('returns 200 with items array, total, and generated fields', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  feedCache?.clear();
+  const restore = mockFetch(freshMocks());
+  try {
+    const { res } = await invokeHandler(handler);
+    assert.equal(res.statusCode, 200);
+    assert.ok(Array.isArray(res.body.items));
+    assert.ok(typeof res.body.total === 'number');
+    assert.ok(typeof res.body.generated === 'number');
+  } finally { restore(); }
+});
+
+test('returns 405 for non-GET requests', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  const { res } = await invokeHandler(handler, { method: 'DELETE' });
+  assert.equal(res.statusCode, 405);
+});
+
+test('returns 204 for OPTIONS preflight', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  const { res } = await invokeHandler(handler, { method: 'OPTIONS' });
+  assert.equal(res.statusCode, 204);
+});
+
+// ── FeedItem shape ─────────────────────────────────────────────────────────────
+
+test('each item has id, type, timestamp, domain, severity, title, summary, data', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  feedCache?.clear();
+  const restore = mockFetch(new Map([
+    ['earthquake.usgs.gov', { status: 200, json: USGS_TWO }],
+    ['api.weather.gov', { status: 200, json: NWS_EMPTY }],
+  ]));
+  try {
+    const { res } = await invokeHandler(handler);
+    assert.ok(res.body.items.length >= 1);
+    const item = res.body.items[0];
+    assert.ok(typeof item.id === 'string');
+    assert.equal(item.type, 'observation');
+    assert.ok(typeof item.timestamp === 'number');
+    assert.ok(typeof item.domain === 'string');
+    assert.ok(typeof item.severity === 'string');
+    assert.ok(typeof item.title === 'string');
+    assert.ok(typeof item.summary === 'string');
+    assert.ok(item.data !== null && typeof item.data === 'object');
+  } finally { restore(); }
+});
+
+test('item.data contains driverScore and edgeCount', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  feedCache?.clear();
+  const restore = mockFetch(new Map([
+    ['earthquake.usgs.gov', { status: 200, json: USGS_TWO }],
+    ['api.weather.gov', { status: 200, json: NWS_EMPTY }],
+  ]));
+  try {
+    const { res } = await invokeHandler(handler);
+    const item = res.body.items[0];
+    assert.ok(typeof item.data.driverScore === 'number');
+    assert.ok(item.data.driverScore >= 0 && item.data.driverScore <= 100);
+    assert.ok(typeof item.data.edgeCount === 'number');
+  } finally { restore(); }
+});
+
+// ── Driver score ordering ──────────────────────────────────────────────────────
+
+test('items are sorted by driverScore descending', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  feedCache?.clear();
+  const restore = mockFetch(new Map([
+    ['earthquake.usgs.gov', { status: 200, json: USGS_TWO }],
+    ['api.weather.gov', { status: 200, json: NWS_EMPTY }],
+  ]));
+  try {
+    const { res } = await invokeHandler(handler);
+    const scores = res.body.items.map((i) => i.data.driverScore);
+    for (let i = 0; i < scores.length - 1; i++) {
+      assert.ok(
+        scores[i] >= scores[i + 1],
+        `item[${i}].driverScore(${scores[i]}) < item[${i + 1}].driverScore(${scores[i + 1]})`,
+      );
+    }
+  } finally { restore(); }
+});
+
+test('M6.8 earthquake has higher driverScore than M2.6', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  feedCache?.clear();
+  const restore = mockFetch(new Map([
+    ['earthquake.usgs.gov', { status: 200, json: USGS_TWO }],
+    ['api.weather.gov', { status: 200, json: NWS_EMPTY }],
+  ]));
+  try {
+    const { res } = await invokeHandler(handler);
+    const high = res.body.items.find((i) => i.id === 'eq-high');
+    const low  = res.body.items.find((i) => i.id === 'eq-low');
+    assert.ok(high, 'eq-high item should exist');
+    assert.ok(low,  'eq-low item should exist');
+    assert.ok(
+      high.data.driverScore > low.data.driverScore,
+      `expected eq-high(${high.data.driverScore}) > eq-low(${low.data.driverScore})`,
+    );
+  } finally { restore(); }
+});
+
+test('NWS Extreme alert scores as CRITICAL severity', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  feedCache?.clear();
+  const restore = mockFetch(new Map([
+    ['earthquake.usgs.gov', { status: 200, json: USGS_EMPTY }],
+    ['api.weather.gov', { status: 200, json: NWS_ONE }],
+  ]));
+  try {
+    const { res } = await invokeHandler(handler);
+    const item = res.body.items.find((i) => i.id === 'nws-tornado-1');
+    assert.ok(item, 'tornado item should exist');
+    assert.equal(item.severity, 'CRITICAL');
+  } finally { restore(); }
+});
+
+// ── Query parameter filtering ──────────────────────────────────────────────────
+
+test('limit=2 caps items to 2', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  feedCache?.clear();
+  const restore = mockFetch(new Map([
+    ['earthquake.usgs.gov', { status: 200, json: USGS_TWO }],
+    ['api.weather.gov', { status: 200, json: NWS_ONE }],
+  ]));
+  try {
+    const { res } = await invokeHandler(handler, { query: { limit: 2 } });
+    assert.equal(res.body.items.length, 2);
+    assert.ok(res.body.total >= 2, 'total reflects unsliced count');
+  } finally { restore(); }
+});
+
+test('domain=seismic only returns seismic events', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  feedCache?.clear();
+  const restore = mockFetch(new Map([
+    ['earthquake.usgs.gov', { status: 200, json: USGS_TWO }],
+    ['api.weather.gov', { status: 200, json: NWS_ONE }],
+  ]));
+  try {
+    const { res } = await invokeHandler(handler, { query: { domain: 'seismic' } });
+    assert.ok(res.body.items.length > 0, 'should have seismic items');
+    for (const item of res.body.items) {
+      assert.equal(item.domain, 'seismic');
+    }
+  } finally { restore(); }
+});
+
+test('domain=weather only returns weather events', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  feedCache?.clear();
+  const restore = mockFetch(new Map([
+    ['earthquake.usgs.gov', { status: 200, json: USGS_TWO }],
+    ['api.weather.gov', { status: 200, json: NWS_ONE }],
+  ]));
+  try {
+    const { res } = await invokeHandler(handler, { query: { domain: 'weather' } });
+    for (const item of res.body.items) {
+      assert.equal(item.domain, 'weather');
+    }
+  } finally { restore(); }
+});
+
+test('type=observation returns all observation items', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  feedCache?.clear();
+  const restore = mockFetch(new Map([
+    ['earthquake.usgs.gov', { status: 200, json: USGS_TWO }],
+    ['api.weather.gov', { status: 200, json: NWS_EMPTY }],
+  ]));
+  try {
+    const { res } = await invokeHandler(handler, { query: { type: 'observation' } });
+    assert.ok(res.body.items.length >= 1);
+    for (const item of res.body.items) {
+      assert.equal(item.type, 'observation');
+    }
+  } finally { restore(); }
+});
+
+test('type=correlation returns empty items (not supported by this route)', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  feedCache?.clear();
+  const restore = mockFetch(new Map([
+    ['earthquake.usgs.gov', { status: 200, json: USGS_TWO }],
+    ['api.weather.gov', { status: 200, json: NWS_EMPTY }],
+  ]));
+  try {
+    const { res } = await invokeHandler(handler, { query: { type: 'correlation' } });
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.items.length, 0);
+  } finally { restore(); }
+});
+
+// ── Upstream failure resilience ────────────────────────────────────────────────
+
+test('returns 200 with partial results when USGS is down', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  feedCache?.clear();
+  const restore = mockFetch(new Map([
+    ['earthquake.usgs.gov', { status: 503, text: 'Service Unavailable' }],
+    ['api.weather.gov', { status: 200, json: NWS_ONE }],
+  ]));
+  try {
+    const { res } = await invokeHandler(handler);
+    assert.equal(res.statusCode, 200);
+    assert.ok(Array.isArray(res.body.items));
+    // NWS items should still be present
+    assert.ok(res.body.items.some((i) => i.domain === 'weather'));
+  } finally { restore(); }
+});
+
+test('returns 200 with empty items when all upstreams fail', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  feedCache?.clear();
+  const restore = mockFetch(new Map([
+    ['earthquake.usgs.gov', { status: 503, text: 'down' }],
+    ['api.weather.gov', { status: 503, text: 'down' }],
+  ]));
+  try {
+    const { res } = await invokeHandler(handler);
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.items.length, 0);
+  } finally { restore(); }
+});
+
+// ── Cache behaviour ────────────────────────────────────────────────────────────
+
+test('second identical request is served from cache', async (t) => {
+  if (!handler) { t.skip('handler not available'); return; }
+  feedCache?.clear();
+  let callCount = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    const urlStr = typeof url === 'string' ? url : (url?.url ?? String(url));
+    callCount++;
+    return new Response(
+      urlStr.includes('earthquake') ? JSON.stringify(USGS_EMPTY) : JSON.stringify(NWS_EMPTY),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    );
+  };
+  try {
+    await invokeHandler(handler);
+    const before = callCount;
+    await invokeHandler(handler);
+    assert.equal(callCount, before, 'no additional upstream calls on cache hit');
+  } finally { globalThis.fetch = originalFetch; }
+});

--- a/api/intelligence/feed.js
+++ b/api/intelligence/feed.js
@@ -1,0 +1,259 @@
+/**
+ * Intelligence feed — driver-scored ObservationEvents from USGS + NWS,
+ * enriched with observation-graph edge counts.
+ *
+ * GET /api/intelligence/feed?limit=50&type=observation&domain=seismic
+ *
+ * Response: { items: FeedItem[], total: number, generated: number }
+ *
+ * FeedItem.data carries { driverScore, edgeCount } for downstream use.
+ * Items are sorted by driverScore descending so the most-critical events
+ * appear first regardless of when they occurred.
+ */
+
+import { getCorsHeaders, isDisallowedOrigin } from '../_cors.js';
+
+export const config = { runtime: 'edge' };
+
+const CACHE_TTL_MS = 30_000;
+export const cache = new Map();
+
+const j = (payload, status, cors) =>
+  Response.json(payload, {
+    status,
+    headers: { 'content-type': 'application/json; charset=utf-8', ...cors },
+  });
+
+// ── Haversine ─────────────────────────────────────────────────────────────────
+
+function haversineKm(lat1, lon1, lat2, lon2) {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLon = ((lon2 - lon1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+// ── Edge count helpers (mirrors observation-graph.ts populate logic) ──────────
+
+function countEntityEdge(a, b, inc) {
+  if ((a.tags ?? []).some((t) => (b.tags ?? []).includes(t))) {
+    inc(a.id);
+    inc(b.id);
+  }
+}
+
+function countCoLocatedEdge(a, b, inc) {
+  if (!a.location || !b.location) return;
+  const dist = haversineKm(a.location.lat, a.location.lon, b.location.lat, b.location.lon);
+  if (dist <= 100) {
+    inc(a.id);
+    inc(b.id);
+  }
+}
+
+function countTemporalEdge(a, b, inc) {
+  if (Math.abs(a.timestamp - b.timestamp) <= 30 * 60_000) {
+    inc(a.id);
+    inc(b.id);
+  }
+}
+
+function countCorrelatedEdge(a, b, inc) {
+  if (a.domain === b.domain) {
+    inc(a.id);
+    inc(b.id);
+  }
+}
+
+function buildEdgeCountMap(events) {
+  const countMap = new Map();
+  const inc = (id) => countMap.set(id, (countMap.get(id) ?? 0) + 1);
+
+  for (let i = 0; i < events.length; i++) {
+    const a = events[i];
+    for (let j = i + 1; j < events.length; j++) {
+      const b = events[j];
+      countEntityEdge(a, b, inc);
+      countCoLocatedEdge(a, b, inc);
+      countTemporalEdge(a, b, inc);
+      countCorrelatedEdge(a, b, inc);
+    }
+  }
+
+  return countMap;
+}
+
+// ── Driver scoring (inline of driver-scorer.ts logic) ──────────────────────
+
+const SEV_BASE = { CRITICAL: 1, HIGH: 0.75, MEDIUM: 0.5, LOW: 0.25, INFO: 0.05 };
+
+function recencyValue(timestampMs, nowMs) {
+  const ageMs = nowMs - timestampMs;
+  if (ageMs <= 5 * 60_000) return 1;
+  if (ageMs <= 30 * 60_000) return 0.8;
+  if (ageMs <= 2 * 60 * 60_000) return 0.5;
+  if (ageMs <= 24 * 60 * 60_000) return 0.2;
+  return 0.05;
+}
+
+function scoreEarthquake(event) {
+  const mag = event.mag ?? 0;
+  const depth = event.depth ?? 30;
+  const aftershockValue = (event.tags ?? []).includes('aftershock') ? 0.5 : 0;
+  const magValue = Math.min(1, Math.max(0, (mag - 2) / 7));
+  const depthValue = depth < 10 ? 1 : Math.max(0, 1 - (depth - 10) / 200);
+  const popValue = SEV_BASE[event.severity] ?? 0.5;
+  const raw = 0.4 * magValue + 0.2 * depthValue + 0.25 * popValue - 0.15 * aftershockValue;
+  const topDriver = magValue >= depthValue ? `magnitude=${(magValue * 100).toFixed(0)}%` : `depth=${(depthValue * 100).toFixed(0)}%`;
+  return {
+    driverScore: Math.min(100, Math.max(0, Math.round(raw * 100))),
+    scoreReason: `earthquake: ${topDriver}, pop=${(popValue * 100).toFixed(0)}%`,
+  };
+}
+
+function scoreGeneric(event, evidenceValue, nowMs) {
+  const sevValue = SEV_BASE[event.severity] ?? 0.1;
+  const recValue = recencyValue(event.timestamp, nowMs);
+  const raw = 0.6 * sevValue + 0.2 * recValue + 0.2 * evidenceValue;
+  return {
+    driverScore: Math.min(100, Math.max(0, Math.round(raw * 100))),
+    scoreReason: `${event.domain}: severity=${(sevValue * 100).toFixed(0)}%, recency=${(recValue * 100).toFixed(0)}%`,
+  };
+}
+
+function isEarthquakeDomain(event) {
+  const d = (event.domain ?? '').toLowerCase();
+  return d === 'seismic' || d === 'earthquake' || (event.tags ?? []).includes('earthquake');
+}
+
+function scoreEvent(event, edgeCount, nowMs) {
+  const evidenceValue = Math.min(1, edgeCount / 10);
+  return isEarthquakeDomain(event)
+    ? scoreEarthquake(event)
+    : scoreGeneric(event, evidenceValue, nowMs);
+}
+
+// ── Upstream fetchers ─────────────────────────────────────────────────────────
+
+function magnitudeToSeverity(mag) {
+  if (mag >= 7) return 'CRITICAL';
+  if (mag >= 6) return 'HIGH';
+  if (mag >= 5) return 'MEDIUM';
+  if (mag >= 4) return 'LOW';
+  return 'INFO';
+}
+
+async function fetchEarthquakes() {
+  const r = await fetch(
+    'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/2.5_day.geojson',
+    { signal: AbortSignal.timeout(8000) },
+  );
+  if (!r.ok) return [];
+  const data = await r.json();
+  return (data?.features ?? []).map((f) => {
+    const [lon, lat, depthRaw] = f.geometry?.coordinates ?? [null, null, 30];
+    const mag = f.properties?.mag ?? 0;
+    return {
+      id: f.id,
+      sourceId: 'usgs-earthquake',
+      domain: 'seismic',
+      timestamp: f.properties?.time ?? Date.now(),
+      location: lat != null && lon != null ? { lat, lon } : undefined,
+      severity: magnitudeToSeverity(mag),
+      title: f.properties?.place ? `M${mag.toFixed(1)} — ${f.properties.place}` : `M${mag.toFixed(1)} earthquake`,
+      mag,
+      depth: depthRaw ?? 30,
+      tags: ['earthquake'],
+    };
+  });
+}
+
+const NWS_SEVERITY_MAP = { extreme: 'CRITICAL', severe: 'HIGH', moderate: 'MEDIUM', minor: 'LOW' };
+
+function nwsSeverityToObsSeverity(severity) {
+  return NWS_SEVERITY_MAP[(severity ?? '').toLowerCase()] ?? 'INFO';
+}
+
+async function fetchNwsAlerts() {
+  const r = await fetch(
+    'https://api.weather.gov/alerts/active?status=actual&message_type=alert',
+    {
+      headers: { Accept: 'application/geo+json', 'User-Agent': 'CrystalBall/2.15.0' },
+      signal: AbortSignal.timeout(8000),
+    },
+  );
+  if (!r.ok) return [];
+  const data = await r.json();
+  return (data?.features ?? []).slice(0, 150).map((f) => {
+    const p = f.properties ?? {};
+    const coords = f.geometry?.coordinates?.[0]?.[0];
+    const location = Array.isArray(coords) ? { lat: coords[1], lon: coords[0] } : undefined;
+    return {
+      id: p.id ?? f.id,
+      sourceId: 'nws-alerts',
+      domain: 'weather',
+      timestamp: new Date(p.sent ?? p.effective ?? Date.now()).getTime(),
+      location,
+      severity: nwsSeverityToObsSeverity(p.severity),
+      title: p.headline ?? p.event ?? 'NWS Alert',
+      tags: ['weather'],
+    };
+  });
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+
+export default async function handler(req) {
+  const cors = getCorsHeaders(req, 'GET, OPTIONS');
+  if (isDisallowedOrigin(req)) return j({ error: 'Origin not allowed' }, 403, cors);
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
+  if (req.method !== 'GET') return j({ error: 'Method not allowed' }, 405, cors);
+
+  const url = new URL(req.url);
+  const limit = Math.min(200, Math.max(1, Number(url.searchParams.get('limit') ?? 50)));
+  const typeFilter = url.searchParams.get('type') ?? '';
+  const domainFilter = url.searchParams.get('domain') ?? '';
+
+  const cacheKey = `intelligence-feed:${limit}:${typeFilter}:${domainFilter}`;
+  const cached = cache.get(cacheKey);
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) return j(cached.payload, 200, cors);
+
+  const [quakes, alerts] = await Promise.allSettled([fetchEarthquakes(), fetchNwsAlerts()]);
+  const allEvents = [
+    ...(quakes.status === 'fulfilled' ? quakes.value : []),
+    ...(alerts.status === 'fulfilled' ? alerts.value : []),
+  ];
+
+  const now = Date.now();
+  const edgeCountMap = buildEdgeCountMap(allEvents);
+
+  let items = allEvents.map((ev) => {
+    const edgeCount = edgeCountMap.get(ev.id) ?? 0;
+    const { driverScore, scoreReason } = scoreEvent(ev, edgeCount, now);
+    return {
+      id: ev.id,
+      type: 'observation',
+      timestamp: ev.timestamp,
+      domain: ev.domain,
+      severity: ev.severity,
+      title: ev.title,
+      summary: scoreReason,
+      data: { driverScore, edgeCount },
+    };
+  });
+
+  // This route only serves observations; other types return empty
+  if (typeFilter && typeFilter !== 'observation') items = [];
+  if (domainFilter) items = items.filter((i) => i.domain === domainFilter);
+
+  items.sort((a, b) => (b.data.driverScore ?? 0) - (a.data.driverScore ?? 0));
+
+  const payload = { items: items.slice(0, limit), total: items.length, generated: now };
+  cache.set(cacheKey, { at: now, payload });
+  return j(payload, 200, cors);
+}


### PR DESCRIPTION
## Summary

Phase 3C: the `/api/intelligence/feed` edge function that `IntelligenceFeedPanel` has been targeting since Phase 3A.

### api/intelligence/feed.js
- `GET /api/intelligence/feed?limit=&type=&domain=`
- Fetches USGS earthquakes + NWS alerts, builds an edge-count map (mirrors `observation-graph.ts` populate logic), runs driver scoring per event, returns items sorted by `driverScore` descending
- `FeedItem.data` carries `{ driverScore, edgeCount }` for downstream use
- 30 s cache (half the evidence-graph TTL for fresher panel updates)
- `type=correlation` / `type=change` return empty items gracefully — no 404 when the panel filter buttons are used before those routes exist

### Sidecar fix — duplicate what-changed handler removed
Removes the old snapshot-diff `/api/intelligence/what-changed` handler (line 4243) that was shadowing the newer `ChangeLine[]` handler added at line 4646. This was causing **10 pre-existing failures** in `src-tauri/sidecar/__tests__/intelligence-feed.test.mjs`.

## Tests
- `api/__tests__/intelligence-feed.test.mjs` — 16 edge function tests
- `src-tauri/sidecar/__tests__/intelligence-feed.test.mjs` — 19 sidecar tests (all fixed)
- 35 total tests passing

## Cross-agent review
Cross-agent review: claude reviewed on 2026-05-11; outcome: pass