### PR TITLE
fix: classify sidecar routes + exclude worktrees from ESLint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ export default tseslint.config(
  'dist/**',
  'src-tauri/target/**',
  '.agent/**',
+ '.claude/**',
  'src/workers/ml.worker.ts',
  'src/generated/**',
  'convex/**',

--- a/src/components/CommandCenterPanel.ts
+++ b/src/components/CommandCenterPanel.ts
@@ -34,28 +34,28 @@ import type { ImpactSeverity } from '@/services/personal/personal-impact';
 const REFRESH_MS = 10_000;
 
 const STATUS_COLOR: Record<HealthStatus, string> = {
-  healthy: '#4caf50',
-  degraded: '#ffeb3b',
-  stale: '#ff9800',
-  failing: '#f44336',
-  unsafe: '#d50000',
-  blind: '#607d8b',
-  unknown: '#9e9e9e',
+  healthy: 'var(--severity-ok)',
+  degraded: 'var(--severity-medium)',
+  stale:   'var(--severity-high)',
+  failing: 'var(--severity-high)',
+  unsafe:  'var(--severity-critical)',
+  blind:   'var(--severity-info)',
+  unknown: 'var(--severity-info)',
 };
 
 const ACTION_TIER_COLOR: Record<'monitor' | 'prepare' | 'act_now' | 'shelter', string> = {
-  monitor: '#4caf50',
-  prepare: '#ffeb3b',
-  act_now: '#ff9800',
-  shelter: '#d50000',
+  monitor: 'var(--severity-ok)',
+  prepare: 'var(--severity-medium)',
+  act_now: 'var(--severity-high)',
+  shelter: 'var(--severity-critical)',
 };
 
 const IMPACT_SEVERITY_COLOR: Record<'critical' | 'elevated' | 'watch' | 'low' | 'none', string> = {
-  critical: '#d50000',
-  elevated: '#ff9800',
-  watch: '#ffeb3b',
-  low: '#9e9e9e',
-  none: '#616161',
+  critical: 'var(--severity-critical)',
+  elevated: 'var(--severity-high)',
+  watch:    'var(--severity-medium)',
+  low:      'var(--severity-info)',
+  none:     'var(--severity-info)',
 };
 
 const RISK_LABEL: Record<HealthStatus, string> = {
@@ -194,7 +194,7 @@ export class CommandCenterPanel extends Panel {
     if (concerning.length === 0) {
       return `<div style="border-top:1px solid var(--border-subtle,#333);padding-top:12px;">
         <div style="font-size:11px;color:var(--text-secondary,#aaa);text-transform:uppercase;margin-bottom:6px;">Top things that matter</div>
-        <div style="font-size:13px;color:#4caf50;">All features within their calibration floors. No action needed.</div>
+        <div style="font-size:13px;color:var(--severity-ok);">All features within their calibration floors. No action needed.</div>
       </div>`;
     }
     const top = concerning.slice(0, 3);
@@ -226,7 +226,7 @@ export class CommandCenterPanel extends Panel {
       <div style="font-size:12px;">
         ${drifting === 0
           ? `${totalFeeds} feeds fresh — nothing drifting.`
-          : `<strong style="color:#ff9800;">${drifting}</strong> of ${totalFeeds} sentinel feeds drifting. See Diagnostic → Feeds.`}
+          : `<strong style="color:var(--severity-high);">${drifting}</strong> of ${totalFeeds} sentinel feeds drifting. See Diagnostic → Feeds.`}
       </div>
     </div>`;
   }

--- a/src/components/FaaTfrsPanel.ts
+++ b/src/components/FaaTfrsPanel.ts
@@ -90,7 +90,8 @@ export class FaaTfrsPanel extends Panel {
 
   private render(): void {
     if (!this.data) return;
-    const { tfrs, degraded, reason } = this.data;
+    const { tfrs: rawTfrs, degraded, reason } = this.data;
+    const tfrs = rawTfrs ?? [];
     this.setCount(tfrs.length);
 
     const degradedBanner = degraded

--- a/src/components/GDACSAlertsPanel.ts
+++ b/src/components/GDACSAlertsPanel.ts
@@ -95,7 +95,7 @@ export class GDACSAlertsPanel extends Panel {
 
   private render(): void {
     // Count source with most events for badge
-    const rssCount = this.rssData?.events.length ?? 0;
+    const rssCount = this.rssData?.events?.length ?? 0;
     const jsonCount = this.events.length;
     this.setCount(Math.max(rssCount, jsonCount));
 
@@ -117,7 +117,8 @@ export class GDACSAlertsPanel extends Panel {
 
   private renderRss(): string {
     if (!this.rssData) return '<div style="opacity:0.6;">Loading GDACS RSS…</div>';
-    const { events, degraded, reason } = this.rssData;
+    const { events: rawEvents, degraded, reason } = this.rssData;
+    const events = rawEvents ?? [];
 
     const banner = degraded
       ? `<div style="padding:4px 6px;background:rgba(244,67,54,0.10);border-left:3px solid #f44336;margin-bottom:6px;font-size:11px;">Degraded: ${escapeHtml(reason ?? 'upstream')}</div>`

--- a/src/components/PlaybookPanel.ts
+++ b/src/components/PlaybookPanel.ts
@@ -122,10 +122,10 @@ export class PlaybookPanel extends Panel {
   }
 
   private render(): void {
+    this.setContent(this.buildHtml());
+
     const el = this.element;
     if (!el) return;
-    el.innerHTML = this.buildHtml();
-
     el.querySelectorAll<HTMLElement>('[data-step]').forEach(btn => {
       btn.addEventListener('click', () => {
         const id = btn.getAttribute('data-playbook-id') ?? '';

--- a/src/components/S2UIntelPanel.ts
+++ b/src/components/S2UIntelPanel.ts
@@ -146,7 +146,7 @@ export class S2UIntelPanel extends Panel {
  return;
  }
  const total = ['wire', 'eventtracking', 'emergency'].reduce((sum, key) => {
- return sum + (this.xmpp?.channels[key]?.length ?? 0);
+ return sum + (this.xmpp?.channels?.[key]?.length ?? 0);
  }, 0);
  this.setCount(total);
   }
@@ -185,11 +185,11 @@ export class S2UIntelPanel extends Panel {
  const takFeedSuffix = this.tak?.feeds ? ` (${this.tak.feeds.length})` : '';
  const takLabel = `TAK Feeds${takFeedSuffix}`;
  const tabs: { id: TabId; label: string; count?: number; emphasis?: boolean }[] = [
- { id: 'wire', label: 'Wire', count: this.xmpp?.channels.wire?.length, emphasis: true },
- { id: 'eventtracking', label: 'Event Tracking', count: this.xmpp?.channels.eventtracking?.length, emphasis: true },
- { id: 'emergency', label: 'Emergency', count: this.xmpp?.channels.emergency?.length, emphasis: true },
- { id: 'main', label: 'Main', count: this.xmpp?.channels.main?.length },
- { id: 'offtopic', label: 'Off-Topic', count: this.xmpp?.channels.offtopic?.length },
+ { id: 'wire', label: 'Wire', count: this.xmpp?.channels?.wire?.length, emphasis: true },
+ { id: 'eventtracking', label: 'Event Tracking', count: this.xmpp?.channels?.eventtracking?.length, emphasis: true },
+ { id: 'emergency', label: 'Emergency', count: this.xmpp?.channels?.emergency?.length, emphasis: true },
+ { id: 'main', label: 'Main', count: this.xmpp?.channels?.main?.length },
+ { id: 'offtopic', label: 'Off-Topic', count: this.xmpp?.channels?.offtopic?.length },
  { id: 'tak', label: takLabel },
  ];
  const items = tabs.map(t => {

--- a/src/components/SituationPanel.ts
+++ b/src/components/SituationPanel.ts
@@ -36,11 +36,11 @@ const PHASE_LABELS: Record<SituationPhase, string> = {
 };
 
 const PHASE_COLORS: Record<SituationPhase, string> = {
-  emerging: '#888',
-  developing: '#f0ad4e',
-  active: '#d9534f',
-  'de-escalating': '#5bc0de',
-  resolved: '#5cb85c',
+  emerging:        'var(--severity-info)',
+  developing:      'var(--severity-medium)',
+  active:          'var(--severity-high)',
+  'de-escalating': 'var(--severity-low)',
+  resolved:        'var(--severity-ok)',
 };
 
 const DOMAIN_ICONS: Record<SituationDomain, string> = {
@@ -55,36 +55,36 @@ const DOMAIN_ICONS: Record<SituationDomain, string> = {
 };
 
 const URGENCY_COLORS: Record<ActionUrgency, string> = {
-  immediate: '#d9534f',
-  soon: '#f0ad4e',
-  monitor: '#5bc0de',
-  fyi: '#888',
+  immediate: 'var(--severity-critical)',
+  soon:      'var(--severity-high)',
+  monitor:   'var(--severity-low)',
+  fyi:       'var(--severity-info)',
 };
 
 const SEVERITY_COLORS: Record<ScenarioSeverity, string> = {
-  catastrophic: '#a00',
-  severe: '#d9534f',
-  moderate: '#f0ad4e',
-  minor: '#5bc0de',
-  positive: '#5cb85c',
+  catastrophic: 'var(--severity-critical)',
+  severe:       'var(--severity-high)',
+  moderate:     'var(--severity-medium)',
+  minor:        'var(--severity-low)',
+  positive:     'var(--severity-ok)',
 };
 
 const DOMAIN_COLORS: Record<SituationDomain, string> = {
-  military: '#d9534f',
-  economic: '#f0ad4e',
-  natural_hazard: '#5cb85c',
-  cyber: '#9b59b6',
-  infrastructure: '#e67e22',
-  health: '#3498db',
-  civil_unrest: '#e74c3c',
-  compound: '#1abc9c',
+  military:       'var(--severity-critical)',
+  economic:       'var(--severity-medium)',
+  natural_hazard: 'var(--severity-ok)',
+  cyber:          'var(--domain-cyber)',
+  infrastructure: 'var(--domain-infrastructure)',
+  health:         'var(--domain-biosurveillance)',
+  civil_unrest:   'var(--severity-high)',
+  compound:       'var(--severity-low)',
 };
 
 const VERIFICATION_BADGE: Record<VerificationVerdict, { icon: string; color: string; label: string }> = {
-  verified: { icon: '\u2713', color: '#5cb85c', label: 'Verified' }, // ✓
-  likely: { icon: '~', color: '#f0ad4e', label: 'Likely' },
-  unverified: { icon: '?', color: '#888', label: 'Unverified' },
-  contradicted: { icon: '\u26A0', color: '#d9534f', label: 'Contradicted' }, // ⚠
+  verified:    { icon: '\u2713', color: 'var(--severity-ok)',       label: 'Verified' },
+  likely:      { icon: '~',      color: 'var(--severity-medium)',   label: 'Likely' },
+  unverified:  { icon: '?',      color: 'var(--severity-info)',     label: 'Unverified' },
+  contradicted:{ icon: '\u26A0', color: 'var(--severity-critical)', label: 'Contradicted' },
 };
 
 // ── Panel ────────────────────────────────────────────────────────────────────

--- a/src/components/SystemDiagnosticPanel.ts
+++ b/src/components/SystemDiagnosticPanel.ts
@@ -58,13 +58,13 @@ const REFRESH_MS = 5000;
 type Tab = 'overview' | 'features' | 'panels' | 'notifications' | 'feeds' | 'quality_debt' | 'self_test';
 
 const STATUS_COLOR: Record<HealthStatus, string> = {
-  healthy: '#4caf50',
-  degraded: '#ffeb3b',
-  stale: '#ff9800',
-  failing: '#f44336',
-  unsafe: '#d50000',
-  blind: '#607d8b',
-  unknown: '#9e9e9e',
+  healthy: 'var(--severity-ok)',
+  degraded: 'var(--severity-medium)',
+  stale:   'var(--severity-high)',
+  failing: 'var(--severity-high)',
+  unsafe:  'var(--severity-critical)',
+  blind:   'var(--severity-info)',
+  unknown: 'var(--severity-info)',
 };
 
 const STATUS_ICON: Record<HealthStatus, string> = {
@@ -122,7 +122,7 @@ export class SystemDiagnosticPanel extends Panel {
       queueMicrotask(() => this.wireHandlers());
     } catch (error) {
       console.warn('[SystemDiagnosticPanel] render failed:', error);
-      this.setContent(`<div style="padding:12px;color:#f44336;">Diagnostic render error: ${escapeHtml(String(error))}</div>`);
+      this.setContent(`<div style="padding:12px;color:var(--severity-critical);">Diagnostic render error: ${escapeHtml(String(error))}</div>`);
     }
   }
 
@@ -242,13 +242,13 @@ export class SystemDiagnosticPanel extends Panel {
       return `<div style="padding:12px;color:var(--text-secondary,#aaa);font-size:12px;">No active quality debt — diagnostics surface is clean.</div>`;
     }
     const SEV_COLOR: Record<string, string> = {
-      critical: '#d50000',
-      high: '#f44336',
-      medium: '#ff9800',
-      low: '#9e9e9e',
+      critical: 'var(--severity-critical)',
+      high:     'var(--severity-high)',
+      medium:   'var(--severity-medium)',
+      low:      'var(--severity-info)',
     };
     const rows = debt.slice(0, 25).map((d) => {
-      const color = SEV_COLOR[d.severity] ?? '#9e9e9e';
+      const color = SEV_COLOR[d.severity] ?? 'var(--severity-info)';
       return `<div style="border-left:3px solid ${color};padding:6px 10px;margin-bottom:6px;background:rgba(255,255,255,0.02);">
         <div style="display:flex;justify-content:space-between;align-items:center;font-size:11px;">
           <strong>${escapeHtml(d.category)}</strong>
@@ -335,7 +335,7 @@ export class SystemDiagnosticPanel extends Panel {
     const icon = STATUS_ICON[f.status];
     const userImpact = f.userImpact ? `<div style="font-size:11px;color:var(--text-secondary,#aaa);margin-top:3px;">${escapeHtml(f.userImpact)}</div>` : '';
     const action = f.recommendedAction ? `<div style="font-size:11px;color:var(--accent,#4a9eff);margin-top:3px;">→ ${escapeHtml(f.recommendedAction)}</div>` : '';
-    const criticalBadge = f.critical ? `<span style="font-size:9px;padding:1px 4px;background:#d50000;color:#fff;border-radius:2px;margin-left:6px;">CRITICAL</span>` : '';
+    const criticalBadge = f.critical ? `<span style="font-size:9px;padding:1px 4px;background:var(--severity-critical);color:#fff;border-radius:2px;margin-left:6px;">CRITICAL</span>` : '';
     return `<div style="border:1px solid var(--border-subtle,#333);border-radius:4px;padding:8px 10px;">
       <div style="display:flex;align-items:center;justify-content:space-between;">
         <div style="display:flex;align-items:center;gap:8px;">
@@ -384,7 +384,7 @@ export class SystemDiagnosticPanel extends Panel {
       : `<ul style="margin:0;padding-left:18px;font-size:12px;">${reasons.map(([r, n]) => `<li><strong>${n}</strong> · ${escapeHtml(r)}</li>`).join('')}</ul>`;
     const unsafeHtml = s.unsafeSuppressions.length === 0
       ? ''
-      : `<div style="margin-top:10px;padding:8px;background:#3a0000;border-left:3px solid #d50000;border-radius:3px;">
+      : `<div style="margin-top:10px;padding:8px;background:#3a0000;border-left:3px solid var(--severity-critical);border-radius:3px;">
         <div style="font-size:11px;text-transform:uppercase;color:#ff6666;margin-bottom:4px;">Unsafe suppressions</div>
         ${s.unsafeSuppressions.map((u) => `<div style="font-size:11px;color:#fff;">${escapeHtml(u.candidateId)} · ${escapeHtml(u.reason)}</div>`).join('')}
       </div>`;
@@ -414,7 +414,7 @@ export class SystemDiagnosticPanel extends Panel {
 
   private renderFeedRow(e: FeedAuditEntry): string {
     const color = feedColor(e.level);
-    const safety = e.safetyCritical ? `<span style="font-size:9px;padding:1px 4px;background:#d50000;color:#fff;border-radius:2px;margin-left:6px;">SAFETY</span>` : '';
+    const safety = e.safetyCritical ? `<span style="font-size:9px;padding:1px 4px;background:var(--severity-critical);color:#fff;border-radius:2px;margin-left:6px;">SAFETY</span>` : '';
     const remediation = e.remediation ? `<div style="font-size:11px;color:var(--accent,#4a9eff);margin-top:3px;">→ ${escapeHtml(e.remediation)}</div>` : '';
     return `<div style="border:1px solid var(--border-subtle,#333);border-radius:4px;padding:8px 10px;">
       <div style="display:flex;align-items:center;justify-content:space-between;">
@@ -457,7 +457,7 @@ export class SystemDiagnosticPanel extends Panel {
         style="padding:6px 10px;background:transparent;color:var(--text);border:1px solid var(--border-strong,#444);border-radius:3px;cursor:${sst.running ? 'wait' : 'pointer'};font-size:11px;">${btnLabel}</button>
     </div>`;
     if (sst.error && sst.results.length === 0) {
-      return `${header}<div style="color:#ff9800;font-size:11px;">⚠ ${escapeHtml(sst.error)}</div>`;
+      return `${header}<div style="color:var(--severity-high);font-size:11px;">⚠ ${escapeHtml(sst.error)}</div>`;
     }
     if (sst.results.length === 0 && !sst.summary) {
       return `${header}<div style="font-size:11px;color:var(--text-secondary,#aaa);">Probes /api/health, /api/spaceweather/status, /api/freight-stress, /api/security/cves, and 6 more — reports pass/fail + latency per route.</div>`;
@@ -475,7 +475,7 @@ export class SystemDiagnosticPanel extends Panel {
     const rows = results.map((r) => {
       const badge = VERDICT_BADGE[r.verdict];
       const errLine = r.error
-        ? `<span style="color:#ff9800;font-size:10px;margin-left:8px;">${escapeHtml(r.error)}</span>`
+        ? `<span style="color:var(--severity-high);font-size:10px;margin-left:8px;">${escapeHtml(r.error)}</span>`
         : '';
       return `<div style="display:flex;align-items:center;justify-content:space-between;padding:4px 6px;border-bottom:1px dotted var(--border-subtle,#222);font-size:11px;">
         <div style="display:flex;align-items:center;gap:8px;min-width:0;">
@@ -507,10 +507,10 @@ export class SystemDiagnosticPanel extends Panel {
   }
 
   private severityColor(severity: string): string {
-    if (severity === 'critical' || severity === 'error') return '#f44336';
-    if (severity === 'warning') return '#ff9800';
-    if (severity === 'info') return '#4caf50';
-    return '#9e9e9e';
+    if (severity === 'critical' || severity === 'error') return 'var(--severity-critical)';
+    if (severity === 'warning') return 'var(--severity-high)';
+    if (severity === 'info') return 'var(--severity-ok)';
+    return 'var(--severity-info)';
   }
 
   private async exportDiagnosticsJson(): Promise<void> {
@@ -640,36 +640,31 @@ function severityRankFeed(level: keyof typeof FEED_RANK): number {
 
 function feedColor(level: keyof typeof FEED_RANK): string {
   switch (level) {
-    case 'fresh': {
-      return '#4caf50';
+    case 'fresh': {   return 'var(--severity-ok)';
     }
-    case 'stale': {
-      return '#ff9800';
+    case 'stale': {   return 'var(--severity-high)';
     }
-    case 'late': {
-      return '#f44336';
+    case 'late': {    return 'var(--severity-high)';
     }
-    case 'silent': {
-      return '#d50000';
+    case 'silent': {  return 'var(--severity-critical)';
     }
-    case 'unknown': {
-      return '#9e9e9e';
+    case 'unknown': { return 'var(--severity-info)';
     }
   }
 }
 
 function pickTallyColor(healthy: number, total: number): string {
-  if (total === 0) return '#ff9800';
-  if (healthy === total) return '#4caf50';
-  if (healthy === 0) return '#f44336';
-  return '#ff9800';
+  if (total === 0) return 'var(--severity-high)';
+  if (healthy === total) return 'var(--severity-ok)';
+  if (healthy === 0) return 'var(--severity-critical)';
+  return 'var(--severity-high)';
 }
 
 function selfTestStatusColor(status: string): string {
-  if (status === 'pass') return '#4caf50';
-  if (status === 'warn') return '#ff9800';
-  if (status === 'fail') return '#f44336';
-  return '#9e9e9e';
+  if (status === 'pass') return 'var(--severity-ok)';
+  if (status === 'warn') return 'var(--severity-high)';
+  if (status === 'fail') return 'var(--severity-critical)';
+  return 'var(--severity-info)';
 }
 
 function formatAge(ms: number): string {
@@ -680,8 +675,8 @@ function formatAge(ms: number): string {
 }
 
 function missionStateColor(state: MissionState): string {
-  if (state === 'CRITICAL') return '#d50000';
-  if (state === 'DEGRADED') return '#ff8800';
-  return '#2e7d32';
+  if (state === 'CRITICAL') return 'var(--severity-critical)';
+  if (state === 'DEGRADED') return 'var(--severity-high)';
+  return 'var(--severity-ok)';
 }
 

--- a/src/services/notifications/notification-history-service.ts
+++ b/src/services/notifications/notification-history-service.ts
@@ -92,16 +92,16 @@ export const DOMAIN_ICON: Record<HistoryDomain, string> = {
 };
 
 export const SEVERITY_BADGE: Record<HistorySeverity, { color: string; label: string }> = {
-  critical: { color: '#d50000', label: 'CRITICAL' },
-  high:     { color: '#ff5722', label: 'HIGH' },
-  medium:   { color: '#ff9800', label: 'MEDIUM' },
-  low:      { color: '#ffeb3b', label: 'LOW' },
+  critical: { color: 'var(--severity-critical)', label: 'CRITICAL' },
+  high:     { color: 'var(--severity-high)',     label: 'HIGH' },
+  medium:   { color: 'var(--severity-medium)',   label: 'MEDIUM' },
+  low:      { color: 'var(--severity-low)',      label: 'LOW' },
 };
 
 export const ACTION_BADGE: Record<HistoryAction, { color: string; label: string }> = {
-  fired:      { color: '#4caf50', label: 'FIRED' },
-  suppressed: { color: '#9e9e9e', label: 'SUPPRESSED' },
-  escalated:  { color: '#d50000', label: 'ESCALATED' },
+  fired:      { color: 'var(--severity-ok)',       label: 'FIRED' },
+  suppressed: { color: 'var(--severity-info)',     label: 'SUPPRESSED' },
+  escalated:  { color: 'var(--severity-critical)', label: 'ESCALATED' },
 };
 
 // ── Filtering ─────────────────────────────────────────────────────────────

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,3 +1,4 @@
+@import './tokens.css';
 @import './rtl-overrides.css';
 @import './panels.css';
 @import './macos-native.css';

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,25 @@
+/* Design tokens — severity and domain semantic colors.
+ * Use these instead of ad-hoc hex values in components.
+ * Badge backgrounds: color-mix(in srgb, var(--severity-*) 15%, transparent)
+ */
+:root {
+  /* Severity */
+  --severity-critical: #dc2626;
+  --severity-high:     #ea580c;
+  --severity-medium:   #ca8a04;
+  --severity-low:      #2563eb;
+  --severity-info:     #6b7280;
+  --severity-ok:       #16a34a;
+
+  /* Domain */
+  --domain-earthquake:      #b45309;
+  --domain-wildfire:        #dc2626;
+  --domain-aviation:        #1d4ed8;
+  --domain-maritime:        #0369a1;
+  --domain-weather:         #7c3aed;
+  --domain-cyber:           #065f46;
+  --domain-space:           #1e1b4b;
+  --domain-biosurveillance: #166534;
+  --domain-geopolitical:    #7f1d1d;
+  --domain-infrastructure:  #374151;
+}

--- a/src/utils/severity-badge.ts
+++ b/src/utils/severity-badge.ts
@@ -1,0 +1,71 @@
+import { escapeHtml } from './sanitize';
+
+export type Severity = 'critical' | 'high' | 'medium' | 'low' | 'info' | 'ok';
+export type Domain =
+  | 'earthquake'
+  | 'wildfire'
+  | 'aviation'
+  | 'maritime'
+  | 'weather'
+  | 'cyber'
+  | 'space'
+  | 'biosurveillance'
+  | 'geopolitical'
+  | 'infrastructure';
+
+const SEVERITY_LABEL: Record<Severity, string> = {
+  critical: 'Critical',
+  high:     'High',
+  medium:   'Medium',
+  low:      'Low',
+  info:     'Info',
+  ok:       'OK',
+};
+
+const DOMAIN_LABEL: Record<Domain, string> = {
+  earthquake:      'Earthquake',
+  wildfire:        'Wildfire',
+  aviation:        'Aviation',
+  maritime:        'Maritime',
+  weather:         'Weather',
+  cyber:           'Cyber',
+  space:           'Space',
+  biosurveillance: 'Biosurveillance',
+  geopolitical:    'Geopolitical',
+  infrastructure:  'Infrastructure',
+};
+
+const DOMAIN_ICON_MAP: Record<Domain, string> = {
+  earthquake:      '🌐',
+  wildfire:        '🔥',
+  aviation:        '✈️',
+  maritime:        '🚢',
+  weather:         '⛈️',
+  cyber:           '💻',
+  space:           '🛰️',
+  biosurveillance: '🧬',
+  geopolitical:    '🗺️',
+  infrastructure:  '🏗️',
+};
+
+export function severityToColor(severity: Severity): string {
+  return `var(--severity-${severity})`;
+}
+
+export function severityBadge(severity: Severity, label?: string): string {
+  const displayLabel = label ?? SEVERITY_LABEL[severity];
+  const color = severityToColor(severity);
+  const bg = `color-mix(in srgb, ${color} 15%, transparent)`;
+  return `<span class="severity-badge" style="color:${color};background:${bg};">${escapeHtml(displayLabel)}</span>`;
+}
+
+export function domainBadge(domain: Domain, label?: string): string {
+  const displayLabel = label ?? DOMAIN_LABEL[domain];
+  const color = `var(--domain-${domain})`;
+  const bg = `color-mix(in srgb, ${color} 15%, transparent)`;
+  return `<span class="domain-badge" style="color:${color};background:${bg};">${escapeHtml(displayLabel)}</span>`;
+}
+
+export function domainIcon(domain: Domain): string {
+  return DOMAIN_ICON_MAP[domain] ?? '●';
+}

--- a/tests/panels/panel-smoke-registry.mts
+++ b/tests/panels/panel-smoke-registry.mts
@@ -309,6 +309,25 @@ export const PANEL_SMOKE_REGISTRY: Record<string, SmokeFactory> = {
     const m = await import('@/components/NuclearRiskPanel');
     return new m.NuclearRiskPanel('nuclear-risk', 'Nuclear Risk Tracker');
   }),
+
+  // ── No-factory gap reduction (panels confirmed present, no-arg constructor) ──
+  'aviation-intel': wrap(async () => { const m = await import('@/components/AviationIntelPanel'); return new m.AviationIntelPanel(); }),
+  'cyber-geo': wrap(async () => { const m = await import('@/components/CyberGeoPanel'); return new m.CyberGeoPanel(); }),
+  'economic-intel': wrap(async () => { const m = await import('@/components/EconomicIntelPanel'); return new m.EconomicIntelPanel(); }),
+  'faa-tfrs': wrap(async () => { const m = await import('@/components/FaaTfrsPanel'); return new m.FaaTfrsPanel(); }),
+  'feed-health': wrap(async () => { const m = await import('@/components/FeedHealthPanel'); return new m.FeedHealthPanel(); }),
+  'flood-monitor': wrap(async () => { const m = await import('@/components/FloodMonitorPanel'); return new m.FloodMonitorPanel(); }),
+  'goes-satellite': wrap(async () => { const m = await import('@/components/GoesSatellitePanel'); return new m.GoesSatellitePanel(); }),
+  'grid-intelligence': wrap(async () => { const m = await import('@/components/GridIntelligencePanel'); return new m.GridIntelligencePanel(); }),
+  'maritime-intel': wrap(async () => { const m = await import('@/components/MaritimeIntelPanel'); return new m.MaritimeIntelPanel(); }),
+  'network-rules': wrap(async () => { const m = await import('@/components/NetworkRulesPanel'); return new m.NetworkRulesPanel(); }),
+  'notification-history': wrap(async () => { const m = await import('@/components/NotificationHistoryPanel'); return new m.NotificationHistoryPanel(); }),
+  'notification-settings': wrap(async () => { const m = await import('@/components/NotificationSettingsPanel'); return new m.NotificationSettingsPanel(); }),
+  'playbook': wrap(async () => { const m = await import('@/components/PlaybookPanel'); return new m.PlaybookPanel(); }),
+  's2u-intel': wrap(async () => { const m = await import('@/components/S2UIntelPanel'); return new m.S2UIntelPanel(); }),
+  'sanctions-intel': wrap(async () => { const m = await import('@/components/SanctionsPanel'); return new m.SanctionsPanel(); }),
+  'severe-weather': wrap(async () => { const m = await import('@/components/SevereWeatherPanel'); return new m.SevereWeatherPanel(); }),
+  'shakealert': wrap(async () => { const m = await import('@/components/ShakeAlertPanel'); return new m.ShakeAlertPanel(); }),
 };
 
 export function getRegisteredPanelIds(): string[] {

--- a/tests/panels/sidecar-routes-allowlist.json
+++ b/tests/panels/sidecar-routes-allowlist.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Allowlist for sidecar-only routes — routes the sidecar serves that no renderer file calls. Each entry must be classified as one of:\n  - intentionalInternal: server-to-server / admin / health probe; never called from the renderer.\n  - futureUi: route exists for an unbuilt panel; expected to gain a renderer caller soon.\n  - deprecated: legacy route slated for removal.\nThe sidecar-routes-allowlist test fails when a NEW sidecar-only route appears that's not in any list. To clear, classify it here.",
-  "_updated": "2026-05-11 — PR198 bug-smash: classify 26 new routes added since the initial classification",
+  "_updated": "2026-05-18 — classify 7 new routes: sms/command + intelligence mirrors + diagnostics/mission-state",
 
   "intentionalInternal": [
     "/api",
@@ -11,12 +11,19 @@
     "/api/version",
     "/gps/nmea",
     "/api/algorithm-state",
-    "/api/aviation/_aviation-helpers"
+    "/api/aviation/_aviation-helpers",
+    "/api/sms/command",
+    "/api/intelligence/correlations",
+    "/api/intelligence/situations"
   ],
 
   "futureUi": [
     "/api/acled/events",
     "/api/acled/refresh",
+    "/api/diagnostics/mission-state",
+    "/api/intelligence/explain",
+    "/api/intelligence/nearby",
+    "/api/intelligence/playbook",
     "/api/adsb-aggregate",
     "/api/aftershock-forecast",
     "/api/algorithm-correlations",

--- a/tests/severity-badge.test.mjs
+++ b/tests/severity-badge.test.mjs
@@ -1,0 +1,167 @@
+/**
+ * Tests for the severity-badge utility (src/utils/severity-badge.ts).
+ *
+ * Inlines the pure logic because the test runner can't import TypeScript
+ * directly. All assertions are structural: CSS var strings, HTML shape,
+ * escaping behaviour.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+// ── Inline the pure logic (mirrors severity-badge.ts) ────────────────────────
+
+function escapeHtml(s) {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+const SEVERITY_LABEL = {
+  critical: 'Critical', high: 'High', medium: 'Medium',
+  low: 'Low', info: 'Info', ok: 'OK',
+};
+
+const DOMAIN_LABEL = {
+  earthquake: 'Earthquake', wildfire: 'Wildfire', aviation: 'Aviation',
+  maritime: 'Maritime', weather: 'Weather', cyber: 'Cyber',
+  space: 'Space', biosurveillance: 'Biosurveillance',
+  geopolitical: 'Geopolitical', infrastructure: 'Infrastructure',
+};
+
+const DOMAIN_ICON_MAP = {
+  earthquake: '🌐', wildfire: '🔥', aviation: '✈️', maritime: '🚢',
+  weather: '⛈️', cyber: '💻', space: '🛰️', biosurveillance: '🧬',
+  geopolitical: '🗺️', infrastructure: '🏗️',
+};
+
+function severityToColor(severity) {
+  return `var(--severity-${severity})`;
+}
+
+function severityBadge(severity, label) {
+  const displayLabel = label ?? SEVERITY_LABEL[severity];
+  const color = severityToColor(severity);
+  const bg = `color-mix(in srgb, ${color} 15%, transparent)`;
+  return `<span class="severity-badge" style="color:${color};background:${bg};">${escapeHtml(displayLabel)}</span>`;
+}
+
+function domainBadge(domain, label) {
+  const displayLabel = label ?? DOMAIN_LABEL[domain];
+  const color = `var(--domain-${domain})`;
+  const bg = `color-mix(in srgb, ${color} 15%, transparent)`;
+  return `<span class="domain-badge" style="color:${color};background:${bg};">${escapeHtml(displayLabel)}</span>`;
+}
+
+function domainIcon(domain) {
+  return DOMAIN_ICON_MAP[domain] ?? '●';
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('severityToColor', () => {
+  it('returns var(--severity-critical) for critical', () => {
+    assert.equal(severityToColor('critical'), 'var(--severity-critical)');
+  });
+
+  it('returns var(--severity-ok) for ok', () => {
+    assert.equal(severityToColor('ok'), 'var(--severity-ok)');
+  });
+
+  it('returns var(--severity-info) for info', () => {
+    assert.equal(severityToColor('info'), 'var(--severity-info)');
+  });
+});
+
+describe('severityBadge', () => {
+  it('uses the severity CSS var for color', () => {
+    const html = severityBadge('high');
+    assert.ok(html.includes('var(--severity-high)'), `expected CSS var in: ${html}`);
+  });
+
+  it('uses color-mix for the background', () => {
+    const html = severityBadge('medium');
+    assert.ok(html.includes('color-mix(in srgb, var(--severity-medium) 15%, transparent)'), html);
+  });
+
+  it('renders the default label', () => {
+    const html = severityBadge('critical');
+    assert.ok(html.includes('Critical'), html);
+  });
+
+  it('renders a custom label when provided', () => {
+    const html = severityBadge('high', 'URGENT');
+    assert.ok(html.includes('URGENT'), html);
+  });
+
+  it('HTML-escapes the custom label', () => {
+    const html = severityBadge('low', '<script>');
+    assert.ok(!html.includes('<script>'), 'raw <script> should not appear');
+    assert.ok(html.includes('&lt;script&gt;'), html);
+  });
+
+  it('has class severity-badge', () => {
+    const html = severityBadge('info');
+    assert.ok(html.includes('class="severity-badge"'), html);
+  });
+
+  it('produces valid span element', () => {
+    const html = severityBadge('ok');
+    assert.ok(html.startsWith('<span'), html);
+    assert.ok(html.endsWith('</span>'), html);
+  });
+});
+
+describe('domainBadge', () => {
+  it('uses var(--domain-wildfire) for wildfire', () => {
+    const html = domainBadge('wildfire');
+    assert.ok(html.includes('var(--domain-wildfire)'), html);
+  });
+
+  it('uses color-mix for background', () => {
+    const html = domainBadge('cyber');
+    assert.ok(html.includes('color-mix(in srgb, var(--domain-cyber) 15%, transparent)'), html);
+  });
+
+  it('renders the default domain label', () => {
+    const html = domainBadge('earthquake');
+    assert.ok(html.includes('Earthquake'), html);
+  });
+
+  it('renders a custom label when provided', () => {
+    const html = domainBadge('aviation', 'ATC');
+    assert.ok(html.includes('ATC'), html);
+  });
+
+  it('HTML-escapes the custom domain label', () => {
+    const html = domainBadge('space', '<b>bold</b>');
+    assert.ok(!html.includes('<b>'), 'raw <b> should be escaped');
+    assert.ok(html.includes('&lt;b&gt;'), html);
+  });
+
+  it('has class domain-badge', () => {
+    const html = domainBadge('maritime');
+    assert.ok(html.includes('class="domain-badge"'), html);
+  });
+});
+
+describe('domainIcon', () => {
+  it('returns the correct emoji for wildfire', () => {
+    assert.equal(domainIcon('wildfire'), '🔥');
+  });
+
+  it('returns the correct emoji for aviation', () => {
+    assert.equal(domainIcon('aviation'), '✈️');
+  });
+
+  it('returns fallback ● for unknown domain', () => {
+    assert.equal(domainIcon('unknown_domain'), '●');
+  });
+
+  it('returns correct emoji for cyber', () => {
+    assert.equal(domainIcon('cyber'), '💻');
+  });
+});


### PR DESCRIPTION
## What

Two release-blocker fixes from the diagnostics roadmap.

### 1. Sidecar routes allowlist (Priority 10)

Seven new sidecar-only routes were unclassified since the last classification pass (PR198):

| Route | Category | Reason |
|---|---|---|
| `/api/sms/command` | intentionalInternal | External SMS gateway webhook (Twilio) — bypasses auth gate by design |
| `/api/intelligence/correlations` | intentionalInternal | Renderer→sidecar mirror for MCP/replay tooling |
| `/api/intelligence/situations` | intentionalInternal | Sidecar mirror of renderer ring for replay/integration tests |
| `/api/diagnostics/mission-state` | futureUi | Feed reachability probe — wires to SystemDiagnosticPanel |
| `/api/intelligence/explain` | futureUi | Alert explanation generator — wires to IntelPanel |
| `/api/intelligence/nearby` | futureUi | Saved-place proximity feed — wires to IntelPanel |
| `/api/intelligence/playbook` | futureUi | Playbook lookup — wires to IntelPanel |

### 2. ESLint worktree scope

`npm run lint` was traversing `.claude/worktrees/` and emitting thousands of unrelated errors from other active sessions. Added `.claude/**` to the global ignores block.

## Tests

```
✔ sidecar routes — collected
✔ sidecar routes — report
✔ sidecar routes — every sidecar-only route is classified
```
