### PR TITLE
fix(panels): register little-snitch panel in config and panelKeys

### DIFF
--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -62,6 +62,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'cyber-threats': { name: 'Cyber Threats', enabled: true, priority: 2 },
   'threat-inbox': { name: 'Threat Inbox', enabled: true, priority: 2 },
   'local-ids': { name: 'Local IDS', enabled: true, priority: 2 },
+  'little-snitch': { name: 'Little Snitch', enabled: true, priority: 2 },
   'comms-health': { name: 'Communications Health', enabled: true, priority: 2 },
   'power-grid': { name: 'Power Grid', enabled: true, priority: 2 },
   'macro-signals': { name: 'Market Radar', enabled: true, priority: 2 },
@@ -1065,7 +1066,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   },
   dataTracking: {
  labelKey: 'header.panelCatDataTracking',
- panelKeys: ['monitors', 'cyber-threats', 'threat-inbox', 'local-ids', 'comms-health', 'power-grid', 'grid-intelligence', 'cve-tracker', 'vulners-cve', 'hibp-breaches', 'ipinfo-lookup', 'ucdp-events', 'nuclear-risk', 'airstrikes', 'displacement', 'security-advisories', 'bitcoin-abuse', 'reddit-osint', 'network-rules', 's2u-intel', 'oref-sirens', 'space-weather', 'spaceflight-news', 'space-launches', 'population-exposure', 'internet-disruptions', 'air-traffic', 'threat-intel-hub', 'phishstats-feed', 'urlscan-threats', 'pulsedive-intel', 'geo-intel', 'dark-web', 'anomaly-detection', 'financial-contagion', 'supply-chain-impact', 'nuclear-monitor', 'sigint-panel', 'dark-vessel', 'ics-ot-dashboard', 'ioc-manager', 'network-topology', 'stix-taxii', 'custom-geofence', 'sanctions-crossref', 'emergency-broadcast', 'satellite-change', 'ripe-ncc', 'ripe-atlas', 'aerospace-reentry', 'satellite-intel'],
+ panelKeys: ['monitors', 'cyber-threats', 'threat-inbox', 'local-ids', 'little-snitch', 'comms-health', 'power-grid', 'grid-intelligence', 'cve-tracker', 'vulners-cve', 'hibp-breaches', 'ipinfo-lookup', 'ucdp-events', 'nuclear-risk', 'airstrikes', 'displacement', 'security-advisories', 'bitcoin-abuse', 'reddit-osint', 'network-rules', 's2u-intel', 'oref-sirens', 'space-weather', 'spaceflight-news', 'space-launches', 'population-exposure', 'internet-disruptions', 'air-traffic', 'threat-intel-hub', 'phishstats-feed', 'urlscan-threats', 'pulsedive-intel', 'geo-intel', 'dark-web', 'anomaly-detection', 'financial-contagion', 'supply-chain-impact', 'nuclear-monitor', 'sigint-panel', 'dark-vessel', 'ics-ot-dashboard', 'ioc-manager', 'network-topology', 'stix-taxii', 'custom-geofence', 'sanctions-crossref', 'emergency-broadcast', 'satellite-change', 'ripe-ncc', 'ripe-atlas', 'aerospace-reentry', 'satellite-intel'],
  variants: ['full'],
   },
   hazards: {


### PR DESCRIPTION
## Summary

`LittleSnitchPanel`, `loadLittleSnitch()`, and the `App.ts` schedule were all fully implemented, but `src/config/panels.ts` was missing the panel definition and `panelKeys` entry, causing the `panel-wiring.test.mjs` assertion to fail.

## Changes

- `src/config/panels.ts`: add `'little-snitch': { name: 'Little Snitch', enabled: true, priority: 2 }` next to `'local-ids'`
- `src/config/panels.ts`: add `'little-snitch'` to the `dataTracking` `panelKeys` array after `'local-ids'`

## Validation

```
npm run test:data   # panel-wiring test: little-snitch ✔
npm run typecheck:all  # clean
```

Cross-agent review: claude reviewed on 2026-05-19; outcome: pass