### PR TITLE
Scenario library — replay past crisis events to test the intelligence pipeline

### DIFF
--- a/src/services/intelligence/scenario-library.ts
+++ b/src/services/intelligence/scenario-library.ts
@@ -1,0 +1,546 @@
+/**
+ * Scenario Library — curated historical crisis scenarios for replaying
+ * ObservationEvent sequences through the intelligence pipeline.
+ *
+ * Each built-in scenario captures a real-world event (Fukushima, COVID,
+ * Suez blockage, Ukraine invasion, Morocco earthquake) as a deterministic
+ * sequence of ObservationEvents. Custom scenarios can be added at runtime
+ * and are persisted to storage (key: `wm-scenario-library`). The library
+ * caps at 50 total entries, dropping oldest custom scenarios first.
+ *
+ * Pure module — no DOM, no fetch, no globals at import time.
+ */
+
+import type { ObservationEvent } from '@/types/intelligence';
+
+// ── Public types ──────────────────────────────────────────────────────
+
+export interface Scenario {
+  id: string;
+  name: string;
+  description: string;
+  domain: string;
+  region: string;
+  startDate: string;
+  durationHours: number;
+  observations: ObservationEvent[];
+  expectedSituations: string[];
+  tags: string[];
+}
+
+export interface ScenarioReplay {
+  scenarioId: string;
+  replayId: string;
+  startedAt: number;
+  currentIndex: number;
+  totalEvents: number;
+  status: 'running' | 'paused' | 'completed';
+  emittedObservations: ObservationEvent[];
+}
+
+// ── Storage interface ─────────────────────────────────────────────────
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+// ── Constants ─────────────────────────────────────────────────────────
+
+const STORAGE_KEY = 'wm-scenario-library';
+const MAX_TOTAL_SCENARIOS = 50;
+
+// ── Built-in scenarios ────────────────────────────────────────────────
+
+const BUILT_IN_SCENARIOS: readonly Scenario[] = [
+  {
+    id: 'fukushima-2011',
+    name: '2011 Fukushima Daiichi Nuclear Disaster',
+    description: 'M9.0 earthquake + tsunami triggered a nuclear cooling failure and radiation release at the Fukushima Daiichi plant.',
+    domain: 'natural_disaster',
+    region: 'Japan',
+    startDate: '2011-03-11',
+    durationHours: 72,
+    tags: ['earthquake', 'tsunami', 'nuclear', 'radiation', 'evacuation'],
+    expectedSituations: [
+      'Major seismic event detected near populated coastline',
+      'Tsunami warning issued for Pacific coast',
+      'Nuclear facility cooling system failure',
+      'Radiation release risk elevated',
+    ],
+    observations: [
+      {
+        id: 'fukushima-obs-1',
+        sourceId: 'usgs-seismic',
+        domain: 'natural_disaster',
+        timestamp: Date.parse('2011-03-11T05:46:23Z'),
+        severity: 'CRITICAL',
+        title: 'M9.0 earthquake near Tōhoku coast — major seismic event',
+        raw: { magnitude: 9, depth: 29, mmi: 'IX' },
+        entityIds: ['tohoku-coast', 'japan-eq-2011'],
+        tags: ['earthquake', 'magnitude-9'],
+        location: { lat: 38.3, lon: 142.37, radiusKm: 50 },
+      },
+      {
+        id: 'fukushima-obs-2',
+        sourceId: 'jma-tsunami',
+        domain: 'natural_disaster',
+        timestamp: Date.parse('2011-03-11T05:49:00Z'),
+        severity: 'CRITICAL',
+        title: 'Tsunami warning issued — estimated 10 m wave height for Pacific coast',
+        raw: { waveHeightM: 10, affectedCoasts: ['Miyagi', 'Iwate', 'Fukushima'] },
+        entityIds: ['pacific-coast-japan'],
+        tags: ['tsunami', 'warning'],
+        location: { lat: 37.7, lon: 141, radiusKm: 200 },
+      },
+      {
+        id: 'fukushima-obs-3',
+        sourceId: 'nisa-nuclear',
+        domain: 'natural_disaster',
+        timestamp: Date.parse('2011-03-11T15:30:00Z'),
+        severity: 'HIGH',
+        title: 'Fukushima Daiichi Units 1–3 cooling system failure — emergency declared',
+        raw: { units: [1, 2, 3], coolantLoss: true, emergencyLevel: 3 },
+        entityIds: ['fukushima-daiichi-plant', 'tepco'],
+        tags: ['nuclear', 'cooling-failure', 'ines-3'],
+      },
+      {
+        id: 'fukushima-obs-4',
+        sourceId: 'nisa-nuclear',
+        domain: 'natural_disaster',
+        timestamp: Date.parse('2011-03-12T03:36:00Z'),
+        severity: 'CRITICAL',
+        title: 'Hydrogen explosion at Unit 1 — radiation release confirmed',
+        raw: { unit: 1, explosionType: 'hydrogen', radiationMicroSvH: 1015 },
+        entityIds: ['fukushima-daiichi-plant'],
+        tags: ['nuclear', 'explosion', 'radiation'],
+        location: { lat: 37.42, lon: 141.03, radiusKm: 5 },
+      },
+      {
+        id: 'fukushima-obs-5',
+        sourceId: 'npa-japan',
+        domain: 'natural_disaster',
+        timestamp: Date.parse('2011-03-12T05:44:00Z'),
+        severity: 'CRITICAL',
+        title: 'Evacuation order expanded to 20 km radius around Fukushima Daiichi',
+        raw: { radiusKm: 20, affectedPopulation: 78_000 },
+        entityIds: ['fukushima-prefecture', 'japan-government'],
+        tags: ['evacuation', 'radiation', 'emergency'],
+        location: { lat: 37.42, lon: 141.03, radiusKm: 20 },
+      },
+    ],
+  },
+  {
+    id: 'covid-2020',
+    name: '2020 COVID-19 Emergence',
+    description: 'Novel coronavirus emergence in Wuhan, China escalating from cluster outbreak to global pandemic.',
+    domain: 'health',
+    region: 'Global',
+    startDate: '2020-01-01',
+    durationHours: 720,
+    tags: ['pandemic', 'coronavirus', 'outbreak', 'who', 'zoonotic'],
+    expectedSituations: [
+      'Novel pathogen emergence detected',
+      'Cluster outbreak exceeds containment threshold',
+      'Cross-border transmission risk elevated',
+    ],
+    observations: [
+      {
+        id: 'covid-obs-1',
+        sourceId: 'who-event-information-site',
+        domain: 'health',
+        timestamp: Date.parse('2020-01-05T00:00:00Z'),
+        severity: 'MEDIUM',
+        title: 'China reports cluster of pneumonia cases of unknown etiology in Wuhan',
+        raw: { cases: 44, location: 'Wuhan, Hubei', status: 'under investigation' },
+        entityIds: ['wuhan-china', 'china-cdc'],
+        tags: ['pneumonia', 'cluster', 'unknown-etiology'],
+        location: { lat: 30.59, lon: 114.31, radiusKm: 50 },
+      },
+      {
+        id: 'covid-obs-2',
+        sourceId: 'who-event-information-site',
+        domain: 'health',
+        timestamp: Date.parse('2020-01-09T00:00:00Z'),
+        severity: 'HIGH',
+        title: 'Novel coronavirus (2019-nCoV) identified as cause of Wuhan pneumonia cluster',
+        raw: { pathogen: '2019-nCoV', betacoronavirus: true, genomicSequence: true },
+        entityIds: ['wuhan-china', 'who'],
+        tags: ['coronavirus', 'novel-pathogen', 'identified'],
+      },
+      {
+        id: 'covid-obs-3',
+        sourceId: 'who-event-information-site',
+        domain: 'health',
+        timestamp: Date.parse('2020-01-22T00:00:00Z'),
+        severity: 'HIGH',
+        title: 'WHO emergency committee convened — human-to-human transmission confirmed',
+        raw: { humanTransmission: true, cases: 547, deaths: 17 },
+        entityIds: ['who', 'china-cdc'],
+        tags: ['human-to-human', 'transmission', 'who-emergency'],
+      },
+      {
+        id: 'covid-obs-4',
+        sourceId: 'china-nac',
+        domain: 'health',
+        timestamp: Date.parse('2020-01-23T02:00:00Z'),
+        severity: 'HIGH',
+        title: 'Wuhan placed under quarantine — travel restrictions issued',
+        raw: { city: 'Wuhan', populationAffected: 11_000_000, transportClosed: true },
+        entityIds: ['wuhan-china', 'china-government'],
+        tags: ['quarantine', 'travel-restriction', 'lockdown'],
+        location: { lat: 30.59, lon: 114.31, radiusKm: 50 },
+      },
+      {
+        id: 'covid-obs-5',
+        sourceId: 'ecdc-surveillance',
+        domain: 'health',
+        timestamp: Date.parse('2020-01-30T00:00:00Z'),
+        severity: 'CRITICAL',
+        title: 'WHO declares Public Health Emergency of International Concern — cross-border spread confirmed in 18 countries',
+        raw: { pheic: true, countriesAffected: 18, casesGlobal: 9976 },
+        entityIds: ['who', 'global'],
+        tags: ['pheic', 'global-spread', 'emergency'],
+      },
+    ],
+  },
+  {
+    id: 'suez-2021',
+    name: '2021 Suez Canal Blockage',
+    description: 'Container ship Ever Given ran aground in the Suez Canal, blocking the waterway for six days and disrupting global trade.',
+    domain: 'logistics',
+    region: 'Suez Canal',
+    startDate: '2021-03-23',
+    durationHours: 144,
+    tags: ['maritime', 'shipping', 'supply-chain', 'canal-blockage', 'trade'],
+    expectedSituations: [
+      'Critical maritime chokepoint blocked',
+      'Global supply chain disruption risk elevated',
+    ],
+    observations: [
+      {
+        id: 'suez-obs-1',
+        sourceId: 'ais-marinetraffic',
+        domain: 'logistics',
+        timestamp: Date.parse('2021-03-23T07:40:00Z'),
+        severity: 'HIGH',
+        title: 'Ever Given (MMSI 353136000) grounded — vessel blocking Suez Canal',
+        raw: { mmsi: '353136000', vesselName: 'Ever Given', heading: 'aground', speedKnots: 0 },
+        entityIds: ['ever-given-353136000', 'suez-canal'],
+        tags: ['vessel-grounding', 'canal-blockage'],
+        location: { lat: 30.03, lon: 32.55, radiusKm: 2 },
+      },
+      {
+        id: 'suez-obs-2',
+        sourceId: 'sca-authority',
+        domain: 'logistics',
+        timestamp: Date.parse('2021-03-23T09:00:00Z'),
+        severity: 'CRITICAL',
+        title: 'Suez Canal Authority suspends transit — canal closed in both directions',
+        raw: { status: 'closed', directionAffected: 'both', vesselQueue: 0 },
+        entityIds: ['suez-canal-authority', 'suez-canal'],
+        tags: ['canal-closed', 'shipping-halt'],
+        location: { lat: 30, lon: 32.55, radiusKm: 100 },
+      },
+      {
+        id: 'suez-obs-3',
+        sourceId: 'ais-marinetraffic',
+        domain: 'logistics',
+        timestamp: Date.parse('2021-03-25T12:00:00Z'),
+        severity: 'HIGH',
+        title: 'Vessel queue reaches 300+ ships — shipping delays estimated 10+ days',
+        raw: { vesselQueue: 321, delayEstimateDays: 10, cargoTypesAffected: ['container', 'bulk', 'tanker'] },
+        entityIds: ['suez-canal', 'global-shipping'],
+        tags: ['shipping-delay', 'queue', 'supply-chain'],
+      },
+      {
+        id: 'suez-obs-4',
+        sourceId: 'bloomberg-commodities',
+        domain: 'logistics',
+        timestamp: Date.parse('2021-03-26T08:00:00Z'),
+        severity: 'MEDIUM',
+        title: 'Oil and commodity supply impact — Brent crude +3%, European LNG spot price elevated',
+        raw: { brentChangePct: 3.1, lngImpact: true, commoditiesAffected: ['oil', 'lng', 'grain'] },
+        entityIds: ['brent-crude', 'global-commodities'],
+        tags: ['commodity-impact', 'oil-price', 'supply-shock'],
+      },
+    ],
+  },
+  {
+    id: 'ukraine-2022',
+    name: '2022 Ukraine Invasion',
+    description: 'Russian military forces crossed into Ukraine on multiple fronts, triggering the largest armed conflict in Europe since WWII.',
+    domain: 'geopolitical',
+    region: 'Eastern Europe',
+    startDate: '2022-02-24',
+    durationHours: 48,
+    tags: ['conflict', 'military', 'invasion', 'energy', 'refugee'],
+    expectedSituations: [
+      'Armed conflict outbreak detected',
+      'Energy supply disruption risk elevated',
+      'Regional refugee crisis developing',
+    ],
+    observations: [
+      {
+        id: 'ukraine-obs-1',
+        sourceId: 'acled-conflict',
+        domain: 'geopolitical',
+        timestamp: Date.parse('2022-02-23T22:00:00Z'),
+        severity: 'HIGH',
+        title: 'Large-scale Russian troop movement across Ukrainian border — multiple crossing points',
+        raw: { crossingPoints: ['Kharkiv', 'Sumy', 'Zaporizhzhia', 'Crimea'], troopCount: 'est. 190,000' },
+        entityIds: ['russia', 'ukraine', 'nato'],
+        tags: ['troop-movement', 'military', 'invasion-start'],
+        location: { lat: 49.9, lon: 36.2, radiusKm: 500 },
+      },
+      {
+        id: 'ukraine-obs-2',
+        sourceId: 'acled-conflict',
+        domain: 'geopolitical',
+        timestamp: Date.parse('2022-02-24T03:00:00Z'),
+        severity: 'CRITICAL',
+        title: 'Russian missile strikes on Ukrainian cities — Kyiv, Kharkiv, Odessa targeted',
+        raw: { citiesStruck: ['Kyiv', 'Kharkiv', 'Odessa', 'Mariupol'], strikeType: 'missile+artillery' },
+        entityIds: ['russia', 'ukraine', 'kyiv'],
+        tags: ['missile-strike', 'military-attack', 'armed-conflict'],
+        location: { lat: 50.45, lon: 30.52, radiusKm: 300 },
+      },
+      {
+        id: 'ukraine-obs-3',
+        sourceId: 'iea-energy',
+        domain: 'geopolitical',
+        timestamp: Date.parse('2022-02-24T08:00:00Z'),
+        severity: 'HIGH',
+        title: 'European natural gas and oil supply threat — Russia-Ukraine pipeline routes at risk',
+        raw: { pipelinesAtRisk: ['Nord Stream', 'Soyuz', 'Brotherhood'], naturalGasSharePct: 40 },
+        entityIds: ['gazprom', 'europe-energy', 'nord-stream'],
+        tags: ['energy-supply', 'natural-gas', 'pipeline-risk'],
+      },
+      {
+        id: 'ukraine-obs-4',
+        sourceId: 'unhcr-displacement',
+        domain: 'geopolitical',
+        timestamp: Date.parse('2022-02-25T12:00:00Z'),
+        severity: 'HIGH',
+        title: 'Mass civilian displacement — 100,000+ refugees crossing into Poland, Moldova, Romania',
+        raw: { refugeeCount: 100_000, destinationCountries: ['Poland', 'Moldova', 'Romania', 'Slovakia'] },
+        entityIds: ['ukraine', 'unhcr', 'poland'],
+        tags: ['refugee', 'displacement', 'humanitarian'],
+        location: { lat: 50.07, lon: 22, radiusKm: 300 },
+      },
+    ],
+  },
+  {
+    id: 'morocco-2023',
+    name: '2023 Morocco Earthquake',
+    description: 'M6.8 earthquake struck the High Atlas mountains near Marrakech, causing widespread building collapse and casualties.',
+    domain: 'natural_disaster',
+    region: 'Morocco',
+    startDate: '2023-09-08',
+    durationHours: 24,
+    tags: ['earthquake', 'collapse', 'search-and-rescue', 'humanitarian', 'atlas'],
+    expectedSituations: [
+      'Major seismic event in populated region',
+      'Mass casualty event — humanitarian response required',
+    ],
+    observations: [
+      {
+        id: 'morocco-obs-1',
+        sourceId: 'usgs-seismic',
+        domain: 'natural_disaster',
+        timestamp: Date.parse('2023-09-08T22:11:01Z'),
+        severity: 'HIGH',
+        title: 'M6.8 earthquake — High Atlas mountains, Morocco, depth 18 km',
+        raw: { magnitude: 6.8, depth: 18, mmi: 'VIII', epicenter: 'Ighil, Al Haouz' },
+        entityIds: ['high-atlas-morocco', 'morocco-cnrst'],
+        tags: ['earthquake', 'magnitude-6'],
+        location: { lat: 31.07, lon: -8.41, radiusKm: 30 },
+      },
+      {
+        id: 'morocco-obs-2',
+        sourceId: 'gdacs-disaster',
+        domain: 'natural_disaster',
+        timestamp: Date.parse('2023-09-08T23:00:00Z'),
+        severity: 'CRITICAL',
+        title: 'Structural collapse reports from Marrakech medina and Al Haouz villages — mass casualty event',
+        raw: { collapseLocations: ['Marrakech medina', 'Al Haouz', 'Taroudant'], estimatedCasualties: 1000 },
+        entityIds: ['marrakech', 'al-haouz', 'morocco'],
+        tags: ['structural-collapse', 'mass-casualty', 'historic-district'],
+        location: { lat: 31.63, lon: -8, radiusKm: 100 },
+      },
+      {
+        id: 'morocco-obs-3',
+        sourceId: 'moroccan-civil-protection',
+        domain: 'natural_disaster',
+        timestamp: Date.parse('2023-09-09T04:00:00Z'),
+        severity: 'HIGH',
+        title: 'Search and rescue operations launched — army and civil protection deployed',
+        raw: { searchTeams: 24, armyDeployed: true, areasSearched: ['Al Haouz', 'Marrakech', 'Taroudant'] },
+        entityIds: ['morocco-government', 'moroccan-army'],
+        tags: ['search-and-rescue', 'emergency-response', 'military-deployment'],
+      },
+      {
+        id: 'morocco-obs-4',
+        sourceId: 'ocha-humanitarian',
+        domain: 'natural_disaster',
+        timestamp: Date.parse('2023-09-09T10:00:00Z'),
+        severity: 'HIGH',
+        title: 'Morocco requests international aid — death toll exceeds 2,000',
+        raw: { deathToll: 2122, injured: 2421, displaced: 300_000, aidRequested: ['Spain', 'France', 'UK', 'Qatar'] },
+        entityIds: ['morocco', 'ocha', 'international-aid'],
+        tags: ['international-aid', 'death-toll', 'displacement', 'humanitarian-crisis'],
+      },
+    ],
+  },
+];
+
+// ── Service ────────────────────────────────────────────────────────────
+
+export class ScenarioLibrary {
+  private static _singleton: ScenarioLibrary | null = null;
+
+  private custom: Scenario[] = [];
+  private replays = new Map<string, ScenarioReplay>();
+  private storage: StorageLike;
+  private hydrated = false;
+
+  private constructor(storage: StorageLike = (globalThis as { localStorage?: StorageLike }).localStorage ?? nullStorage()) {
+    this.storage = storage;
+  }
+
+  static getInstance(): ScenarioLibrary {
+    ScenarioLibrary._singleton ??= new ScenarioLibrary();
+    return ScenarioLibrary._singleton;
+  }
+
+  static createForTesting(storage: StorageLike): ScenarioLibrary {
+    return new ScenarioLibrary(storage);
+  }
+
+  static _resetForTests(): void {
+    ScenarioLibrary._singleton = null;
+  }
+
+  // ── Scenarios ──────────────────────────────────────────────────────
+
+  getScenarios(): Scenario[] {
+    this.ensureHydrated();
+    return [...BUILT_IN_SCENARIOS, ...this.custom];
+  }
+
+  addScenario(scenario: Scenario): void {
+    this.ensureHydrated();
+    this.custom.push(scenario);
+    this.enforceMaxCap();
+    this.persist();
+  }
+
+  // ── Replay ─────────────────────────────────────────────────────────
+
+  startReplay(scenarioId: string): ScenarioReplay {
+    this.ensureHydrated();
+    const scenario = this.findScenario(scenarioId);
+    if (!scenario) {
+      throw new Error(`ScenarioLibrary: unknown scenarioId "${scenarioId}"`);
+    }
+    const replayId = `${scenarioId}-${Date.now()}`;
+    const replay: ScenarioReplay = {
+      scenarioId,
+      replayId,
+      startedAt: Date.now(),
+      currentIndex: 0,
+      totalEvents: scenario.observations.length,
+      status: 'running',
+      emittedObservations: [],
+    };
+    this.replays.set(replayId, replay);
+    return { ...replay, emittedObservations: [] };
+  }
+
+  tick(replayId: string): ObservationEvent | null {
+    const replay = this.replays.get(replayId);
+    if (!replay) return null;
+    if (replay.status === 'paused' || replay.status === 'completed') return null;
+
+    const scenario = this.findScenario(replay.scenarioId);
+    if (!scenario) return null;
+
+    if (replay.currentIndex >= scenario.observations.length) {
+      replay.status = 'completed';
+      return null;
+    }
+
+    const event = scenario.observations[replay.currentIndex]!;
+    replay.emittedObservations.push(event);
+    replay.currentIndex += 1;
+
+    if (replay.currentIndex >= scenario.observations.length) {
+      replay.status = 'completed';
+    }
+
+    return event;
+  }
+
+  pauseReplay(replayId: string): void {
+    const replay = this.replays.get(replayId);
+    if (replay?.status === 'running') {
+      replay.status = 'paused';
+    }
+  }
+
+  resumeReplay(replayId: string): void {
+    const replay = this.replays.get(replayId);
+    if (replay?.status === 'paused') {
+      replay.status = 'running';
+    }
+  }
+
+  // ── Internal ───────────────────────────────────────────────────────
+
+  private findScenario(id: string): Scenario | undefined {
+    const builtin = BUILT_IN_SCENARIOS.find((s) => s.id === id);
+    if (builtin) return builtin;
+    return this.custom.find((s) => s.id === id);
+  }
+
+  private enforceMaxCap(): void {
+    const builtInCount = BUILT_IN_SCENARIOS.length;
+    const maxCustom = MAX_TOTAL_SCENARIOS - builtInCount;
+    while (this.custom.length > maxCustom) {
+      this.custom.shift();
+    }
+  }
+
+  private persist(): void {
+    try {
+      this.storage.setItem(STORAGE_KEY, JSON.stringify(this.custom));
+    } catch {
+      // storage unavailable — continue without persistence
+    }
+  }
+
+  private ensureHydrated(): void {
+    if (this.hydrated) return;
+    this.hydrated = true;
+    let raw: string | null = null;
+    try { raw = this.storage.getItem(STORAGE_KEY); } catch { return; }
+    if (!raw) return;
+    let parsed: Scenario[] | null;
+    try { parsed = JSON.parse(raw) as Scenario[] | null; } catch { return; }
+    if (!Array.isArray(parsed)) return;
+    for (const entry of parsed) {
+      if (entry && typeof entry.id === 'string' && Array.isArray(entry.observations)) {
+        this.custom.push(entry as Scenario);
+      }
+    }
+  }
+}
+
+// ── Null storage fallback ─────────────────────────────────────────────
+
+function nullStorage(): StorageLike {
+  return {
+    getItem: () => null,
+    setItem: () => undefined,
+  };
+}

--- a/src/services/intelligence/scenario-library.ts
+++ b/src/services/intelligence/scenario-library.ts
@@ -1,16 +1,3 @@
-/**
- * Scenario Library — curated historical crisis scenarios for replaying
- * ObservationEvent sequences through the intelligence pipeline.
- *
- * Each built-in scenario captures a real-world event (Fukushima, COVID,
- * Suez blockage, Ukraine invasion, Morocco earthquake) as a deterministic
- * sequence of ObservationEvents. Custom scenarios can be added at runtime
- * and are persisted to storage (key: `wm-scenario-library`). The library
- * caps at 50 total entries, dropping oldest custom scenarios first.
- *
- * Pure module — no DOM, no fetch, no globals at import time.
- */
-
 import type { ObservationEvent } from '@/types/intelligence';
 
 // ── Public types ──────────────────────────────────────────────────────
@@ -481,6 +468,12 @@ export class ScenarioLibrary {
     return event;
   }
 
+  getReplay(replayId: string): ScenarioReplay | null {
+    const r = this.replays.get(replayId);
+    if (!r) return null;
+    return { ...r, emittedObservations: [...r.emittedObservations] };
+  }
+
   pauseReplay(replayId: string): void {
     const replay = this.replays.get(replayId);
     if (replay?.status === 'running') {
@@ -529,7 +522,16 @@ export class ScenarioLibrary {
     try { parsed = JSON.parse(raw) as Scenario[] | null; } catch { return; }
     if (!Array.isArray(parsed)) return;
     for (const entry of parsed) {
-      if (entry && typeof entry.id === 'string' && Array.isArray(entry.observations)) {
+      if (
+        entry &&
+        typeof entry.id === 'string' &&
+        typeof entry.name === 'string' &&
+        typeof entry.domain === 'string' &&
+        typeof entry.durationHours === 'number' &&
+        Array.isArray(entry.tags) &&
+        Array.isArray(entry.observations) &&
+        Array.isArray(entry.expectedSituations)
+      ) {
         this.custom.push(entry as Scenario);
       }
     }

--- a/tests/intelligence/scenario-library.test.mts
+++ b/tests/intelligence/scenario-library.test.mts
@@ -1,0 +1,475 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  ScenarioLibrary,
+  type Scenario,
+} from '../../src/services/intelligence/scenario-library.js';
+import type { ObservationEvent } from '../../src/types/intelligence.js';
+
+// ── Storage mock ──────────────────────────────────────────────────────
+
+function makeStorage(): {
+  getItem(k: string): string | null;
+  setItem(k: string, v: string): void;
+  store: Map<string, string>;
+} {
+  const store = new Map<string, string>();
+  return {
+    store,
+    getItem: (k) => store.get(k) ?? null,
+    setItem: (k, v) => store.set(k, v),
+  };
+}
+
+function makeScenario(id: string): Scenario {
+  const obs: ObservationEvent = {
+    id: `${id}-obs-1`,
+    sourceId: 'test-source',
+    domain: 'natural_disaster',
+    timestamp: Date.parse('2025-01-01T00:00:00Z'),
+    severity: 'HIGH',
+    title: `Test event for ${id}`,
+    raw: {},
+    entityIds: ['entity-1'],
+    tags: ['test'],
+  };
+  return {
+    id,
+    name: `Scenario ${id}`,
+    description: `Test scenario ${id}`,
+    domain: 'natural_disaster',
+    region: 'Test Region',
+    startDate: '2025-01-01',
+    durationHours: 24,
+    observations: [obs],
+    expectedSituations: ['Test situation expected'],
+    tags: ['test'],
+  };
+}
+
+// ── getScenarios ──────────────────────────────────────────────────────
+
+describe('getScenarios', () => {
+  it('returns exactly 5 built-in scenarios with empty storage', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const scenarios = lib.getScenarios();
+    assert.equal(scenarios.length, 5);
+  });
+
+  it('all built-in scenarios have required fields', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    for (const s of lib.getScenarios()) {
+      assert.ok(typeof s.id === 'string' && s.id.length > 0, `${s.id} id`);
+      assert.ok(typeof s.name === 'string' && s.name.length > 0, `${s.id} name`);
+      assert.ok(typeof s.description === 'string', `${s.id} description`);
+      assert.ok(typeof s.domain === 'string' && s.domain.length > 0, `${s.id} domain`);
+      assert.ok(typeof s.region === 'string', `${s.id} region`);
+      assert.ok(typeof s.startDate === 'string', `${s.id} startDate`);
+      assert.ok(typeof s.durationHours === 'number', `${s.id} durationHours`);
+      assert.ok(Array.isArray(s.observations), `${s.id} observations`);
+      assert.ok(Array.isArray(s.expectedSituations), `${s.id} expectedSituations`);
+      assert.ok(Array.isArray(s.tags), `${s.id} tags`);
+    }
+  });
+
+  it('all built-in scenarios have observations', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    for (const s of lib.getScenarios()) {
+      assert.ok(s.observations.length > 0, `${s.id} should have at least one observation`);
+    }
+  });
+
+  it('each built-in scenario has at least 3 observations', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    for (const s of lib.getScenarios()) {
+      assert.ok(s.observations.length >= 3, `${s.id} should have at least 3 observations, got ${s.observations.length}`);
+    }
+  });
+});
+
+// ── startReplay ──────────────────────────────────────────────────────
+
+describe('startReplay', () => {
+  it('returns a replay with the correct scenarioId', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const replay = lib.startReplay('fukushima-2011');
+    assert.equal(replay.scenarioId, 'fukushima-2011');
+  });
+
+  it('returns a replay with status running', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const replay = lib.startReplay('fukushima-2011');
+    assert.equal(replay.status, 'running');
+  });
+
+  it('returns a replay with currentIndex 0', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const replay = lib.startReplay('fukushima-2011');
+    assert.equal(replay.currentIndex, 0);
+  });
+
+  it('returns a replay with empty emittedObservations', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const replay = lib.startReplay('fukushima-2011');
+    assert.deepEqual(replay.emittedObservations, []);
+  });
+
+  it('totalEvents matches the scenario observation count', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const scenarios = lib.getScenarios();
+    const fukushima = scenarios.find((s) => s.id === 'fukushima-2011')!;
+    const replay = lib.startReplay('fukushima-2011');
+    assert.equal(replay.totalEvents, fukushima.observations.length);
+  });
+
+  it('throws on unknown scenarioId', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    assert.throws(() => lib.startReplay('nonexistent-scenario-xyz'), /unknown scenarioId/);
+  });
+});
+
+// ── tick ──────────────────────────────────────────────────────────────
+
+describe('tick', () => {
+  it('advances currentIndex on each call', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const replay = lib.startReplay('fukushima-2011');
+    lib.tick(replay.replayId);
+    lib.tick(replay.replayId);
+    // Check that the second tick returns a different observation from the first
+    const third = lib.tick(replay.replayId);
+    assert.ok(third !== null);
+  });
+
+  it('returns correct ObservationEvent in order', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const scenarios = lib.getScenarios();
+    const fukushima = scenarios.find((s) => s.id === 'fukushima-2011')!;
+    const replay = lib.startReplay('fukushima-2011');
+    const first = lib.tick(replay.replayId);
+    assert.equal(first?.id, fukushima.observations[0]!.id);
+    const second = lib.tick(replay.replayId);
+    assert.equal(second?.id, fukushima.observations[1]!.id);
+  });
+
+  it('returns null when all events have been emitted', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const replay = lib.startReplay('morocco-2023');
+    const scenarios = lib.getScenarios();
+    const morocco = scenarios.find((s) => s.id === 'morocco-2023')!;
+    // Exhaust all events
+    for (let i = 0; i < morocco.observations.length; i++) {
+      lib.tick(replay.replayId);
+    }
+    const result = lib.tick(replay.replayId);
+    assert.equal(result, null);
+  });
+
+  it('returns null when paused', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const replay = lib.startReplay('fukushima-2011');
+    lib.pauseReplay(replay.replayId);
+    const result = lib.tick(replay.replayId);
+    assert.equal(result, null);
+  });
+
+  it('sets status to completed after last event', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const replay = lib.startReplay('morocco-2023');
+    const scenarios = lib.getScenarios();
+    const morocco = scenarios.find((s) => s.id === 'morocco-2023')!;
+    for (let i = 0; i < morocco.observations.length; i++) {
+      lib.tick(replay.replayId);
+    }
+    // After exhausting, tick again to check status
+    lib.tick(replay.replayId);
+    // Verify via tick returning null (completed)
+    assert.equal(lib.tick(replay.replayId), null);
+  });
+
+  it('emittedObservations grows with each tick', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const replay = lib.startReplay('suez-2021');
+    lib.tick(replay.replayId);
+    lib.tick(replay.replayId);
+    // We can verify by ticking and checking that subsequent null appears only when exhausted
+    const third = lib.tick(replay.replayId);
+    assert.ok(third !== null);
+  });
+
+  it('returns null for unknown replayId', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    assert.equal(lib.tick('nonexistent-replay-id'), null);
+  });
+});
+
+// ── pauseReplay / resumeReplay ────────────────────────────────────────
+
+describe('pauseReplay / resumeReplay', () => {
+  it('pause sets status to paused', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const replay = lib.startReplay('fukushima-2011');
+    lib.pauseReplay(replay.replayId);
+    assert.equal(lib.tick(replay.replayId), null);
+  });
+
+  it('tick returns null while paused', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const replay = lib.startReplay('fukushima-2011');
+    lib.pauseReplay(replay.replayId);
+    assert.equal(lib.tick(replay.replayId), null);
+    assert.equal(lib.tick(replay.replayId), null);
+  });
+
+  it('resume allows tick to emit observations again', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const replay = lib.startReplay('fukushima-2011');
+    lib.pauseReplay(replay.replayId);
+    assert.equal(lib.tick(replay.replayId), null);
+    lib.resumeReplay(replay.replayId);
+    const event = lib.tick(replay.replayId);
+    assert.ok(event !== null);
+  });
+
+  it('resume on completed replay is a no-op (tick still returns null)', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const replay = lib.startReplay('morocco-2023');
+    const scenarios = lib.getScenarios();
+    const morocco = scenarios.find((s) => s.id === 'morocco-2023')!;
+    for (let i = 0; i < morocco.observations.length; i++) {
+      lib.tick(replay.replayId);
+    }
+    lib.resumeReplay(replay.replayId);
+    assert.equal(lib.tick(replay.replayId), null);
+  });
+});
+
+// ── addScenario ──────────────────────────────────────────────────────
+
+describe('addScenario', () => {
+  it('custom scenario appears in getScenarios', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const custom = makeScenario('my-custom-scenario');
+    lib.addScenario(custom);
+    const found = lib.getScenarios().find((s) => s.id === 'my-custom-scenario');
+    assert.ok(found !== undefined);
+  });
+
+  it('persists custom scenario to storage', () => {
+    const storage = makeStorage();
+    const lib = ScenarioLibrary.createForTesting(storage);
+    lib.addScenario(makeScenario('persist-test'));
+    const raw = storage.store.get('wm-scenario-library');
+    assert.ok(raw !== undefined, 'storage should have a value after addScenario');
+    const parsed = JSON.parse(raw!) as Scenario[];
+    assert.ok(Array.isArray(parsed));
+    assert.ok(parsed.some((s) => s.id === 'persist-test'));
+  });
+
+  it('enforces max 50 total — drops oldest custom, never built-ins', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    // 5 built-ins already; add 46 custom = 51 total → should drop to 50
+    for (let i = 0; i < 46; i++) {
+      lib.addScenario(makeScenario(`overflow-${i}`));
+    }
+    const scenarios = lib.getScenarios();
+    assert.equal(scenarios.length, 50);
+    // All built-ins must be present
+    const ids = new Set(scenarios.map((s) => s.id));
+    assert.ok(ids.has('fukushima-2011'), 'fukushima built-in must survive cap enforcement');
+    assert.ok(ids.has('covid-2020'), 'covid built-in must survive cap enforcement');
+    assert.ok(ids.has('suez-2021'), 'suez built-in must survive cap enforcement');
+    assert.ok(ids.has('ukraine-2022'), 'ukraine built-in must survive cap enforcement');
+    assert.ok(ids.has('morocco-2023'), 'morocco built-in must survive cap enforcement');
+    // The oldest custom should have been dropped (overflow-0)
+    assert.ok(!ids.has('overflow-0'), 'oldest custom scenario should have been dropped');
+  });
+});
+
+// ── storage ───────────────────────────────────────────────────────────
+
+describe('storage', () => {
+  it('custom scenarios survive getInstance() reconstruction from storage', () => {
+    const storage = makeStorage();
+    const lib1 = ScenarioLibrary.createForTesting(storage);
+    lib1.addScenario(makeScenario('survives-restart'));
+
+    const lib2 = ScenarioLibrary.createForTesting(storage);
+    const found = lib2.getScenarios().find((s) => s.id === 'survives-restart');
+    assert.ok(found !== undefined, 'custom scenario should survive reconstruction');
+  });
+
+  it('built-ins are always present even with empty storage', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const scenarios = lib.getScenarios();
+    assert.equal(scenarios.length, 5);
+  });
+
+  it('corrupt storage blob is ignored and built-ins still load', () => {
+    const storage = makeStorage();
+    storage.store.set('wm-scenario-library', 'NOT_VALID_JSON{{{');
+    const lib = ScenarioLibrary.createForTesting(storage);
+    assert.equal(lib.getScenarios().length, 5);
+  });
+});
+
+// ── built-in scenario content ─────────────────────────────────────────
+
+describe('built-in scenario content', () => {
+  it('fukushima has domain natural_disaster', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const s = lib.getScenarios().find((x) => x.id === 'fukushima-2011')!;
+    assert.equal(s.domain, 'natural_disaster');
+  });
+
+  it('ukraine has domain geopolitical', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const s = lib.getScenarios().find((x) => x.id === 'ukraine-2022')!;
+    assert.equal(s.domain, 'geopolitical');
+  });
+
+  it('covid has domain health', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const s = lib.getScenarios().find((x) => x.id === 'covid-2020')!;
+    assert.equal(s.domain, 'health');
+  });
+
+  it('suez has domain logistics', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const s = lib.getScenarios().find((x) => x.id === 'suez-2021')!;
+    assert.equal(s.domain, 'logistics');
+  });
+
+  it('morocco has domain natural_disaster', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const s = lib.getScenarios().find((x) => x.id === 'morocco-2023')!;
+    assert.equal(s.domain, 'natural_disaster');
+  });
+
+  it('fukushima startDate is 2011-03-11', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const s = lib.getScenarios().find((x) => x.id === 'fukushima-2011')!;
+    assert.equal(s.startDate, '2011-03-11');
+  });
+
+  it('ukraine startDate is 2022-02-24', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const s = lib.getScenarios().find((x) => x.id === 'ukraine-2022')!;
+    assert.equal(s.startDate, '2022-02-24');
+  });
+
+  it('suez has region Suez Canal', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const s = lib.getScenarios().find((x) => x.id === 'suez-2021')!;
+    assert.equal(s.region, 'Suez Canal');
+  });
+
+  it('fukushima has expectedSituations mentioning nuclear', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    const s = lib.getScenarios().find((x) => x.id === 'fukushima-2011')!;
+    const hasNuclear = s.expectedSituations.some((e) => e.toLowerCase().includes('nuclear'));
+    assert.ok(hasNuclear, 'fukushima should have a nuclear-related expected situation');
+  });
+});
+
+// ── ObservationEvent shape ────────────────────────────────────────────
+
+describe('ObservationEvent shape', () => {
+  const VALID_SEVERITIES = new Set(['INFO', 'LOW', 'MEDIUM', 'HIGH', 'CRITICAL']);
+
+  it('all built-in observations have valid severity', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    for (const s of lib.getScenarios()) {
+      for (const obs of s.observations) {
+        assert.ok(
+          VALID_SEVERITIES.has(obs.severity),
+          `${s.id}/${obs.id} has invalid severity "${obs.severity}"`,
+        );
+      }
+    }
+  });
+
+  it('all built-in observations have entityIds array', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    for (const s of lib.getScenarios()) {
+      for (const obs of s.observations) {
+        assert.ok(
+          Array.isArray(obs.entityIds),
+          `${s.id}/${obs.id} entityIds must be an array`,
+        );
+      }
+    }
+  });
+
+  it('all built-in observations have tags array', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    for (const s of lib.getScenarios()) {
+      for (const obs of s.observations) {
+        assert.ok(
+          Array.isArray(obs.tags),
+          `${s.id}/${obs.id} tags must be an array`,
+        );
+      }
+    }
+  });
+
+  it('all built-in observations have timestamp as a number', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    for (const s of lib.getScenarios()) {
+      for (const obs of s.observations) {
+        assert.ok(
+          typeof obs.timestamp === 'number' && Number.isFinite(obs.timestamp),
+          `${s.id}/${obs.id} timestamp must be a finite number`,
+        );
+      }
+    }
+  });
+
+  it('all built-in observations have a non-empty id', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    for (const s of lib.getScenarios()) {
+      for (const obs of s.observations) {
+        assert.ok(
+          typeof obs.id === 'string' && obs.id.length > 0,
+          `${s.id} has observation with empty id`,
+        );
+      }
+    }
+  });
+
+  it('all built-in observations have a non-empty title', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    for (const s of lib.getScenarios()) {
+      for (const obs of s.observations) {
+        assert.ok(
+          typeof obs.title === 'string' && obs.title.length > 0,
+          `${s.id}/${obs.id} title must be non-empty`,
+        );
+      }
+    }
+  });
+
+  it('all built-in observations have a sourceId string', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    for (const s of lib.getScenarios()) {
+      for (const obs of s.observations) {
+        assert.ok(
+          typeof obs.sourceId === 'string' && obs.sourceId.length > 0,
+          `${s.id}/${obs.id} sourceId must be non-empty`,
+        );
+      }
+    }
+  });
+
+  it('CRITICAL severity observations exist across built-in scenarios', () => {
+    const lib = ScenarioLibrary.createForTesting(makeStorage());
+    let criticalCount = 0;
+    for (const s of lib.getScenarios()) {
+      for (const obs of s.observations) {
+        if (obs.severity === 'CRITICAL') criticalCount++;
+      }
+    }
+    assert.ok(criticalCount > 0, 'should have at least one CRITICAL observation across all built-ins');
+  });
+});

--- a/tests/intelligence/scenario-library.test.mts
+++ b/tests/intelligence/scenario-library.test.mts
@@ -182,20 +182,18 @@ describe('tick', () => {
     for (let i = 0; i < morocco.observations.length; i++) {
       lib.tick(replay.replayId);
     }
-    // After exhausting, tick again to check status
-    lib.tick(replay.replayId);
-    // Verify via tick returning null (completed)
-    assert.equal(lib.tick(replay.replayId), null);
+    assert.equal(lib.getReplay(replay.replayId)!.status, 'completed');
   });
 
   it('emittedObservations grows with each tick', () => {
     const lib = ScenarioLibrary.createForTesting(makeStorage());
     const replay = lib.startReplay('suez-2021');
     lib.tick(replay.replayId);
+    assert.equal(lib.getReplay(replay.replayId)!.emittedObservations.length, 1);
     lib.tick(replay.replayId);
-    // We can verify by ticking and checking that subsequent null appears only when exhausted
-    const third = lib.tick(replay.replayId);
-    assert.ok(third !== null);
+    assert.equal(lib.getReplay(replay.replayId)!.emittedObservations.length, 2);
+    lib.tick(replay.replayId);
+    assert.equal(lib.getReplay(replay.replayId)!.emittedObservations.length, 3);
   });
 
   it('returns null for unknown replayId', () => {


### PR DESCRIPTION
Adds `ScenarioLibrary` — a singleton service that ships five built-in historical crisis scenarios (Fukushima 2011, COVID-19 emergence 2020, Suez Canal blockage 2021, Ukraine invasion 2022, Morocco earthquake 2023) and a step-by-step replay engine for exercising the intelligence pipeline against known event sequences.

## What's in the box

- `src/services/intelligence/scenario-library.ts` — `ScenarioLibrary` with `getInstance()`, `createForTesting(storage)`, `getScenarios()`, `startReplay()`, `tick()`, `pauseReplay()`, `resumeReplay()`, `getReplay()`, and `addScenario()`.
- `tests/intelligence/scenario-library.test.mts` — 44 tests covering all state-machine transitions, built-in scenario content, storage persistence/reconstruction, and corrupt-blob resilience.

## Design notes

- `ObservationEvent` sourced from `src/types/intelligence.ts` (new uppercase-severity type) — consistent with all recent intelligence services.
- Injectable `StorageLike` keeps tests fully isolated from `localStorage`.
- Max-50-scenario cap protects built-ins: only oldest custom scenarios are dropped.
- `getReplay()` exposes a shallow copy so callers can observe live state without mutating internal replay state.

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass