### PR TITLE
fix(docs): bump README panel count to 240 after little-snitch registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,8 +336,8 @@ All sounds are synthesized with Web Audio API -- no audio files in the repo:
 
 | Metric | Value | Source |
 |--------|-------|--------|
-| Panels (full variant) | 239 | `src/config/panels.ts` |
-| Default panel inventory | `239 full / 35 tech / 31 finance / 10 happy` | `src/config/panels.ts` |
+| Panels (full variant) | 240 | `src/config/panels.ts` |
+| Default panel inventory | `240 full / 35 tech / 31 finance / 10 happy` | `src/config/panels.ts` |
 | God's Vision map layers | 70 (26 on by default) | `src/types/index.ts` MapLayers |
 | Panel categories | 19 | `src/config/panels.ts` PANEL_CATEGORY_MAP |
 | Product variants | 4 | `src/config/variant.ts` |


### PR DESCRIPTION
Follows PR #575 which registered little-snitch in panels.ts. The README inventory row still showed 239.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>