### PR TITLE
Counterfactual replay — re-run past observations with modified assumptions

### DIFF
--- a/src/services/intelligence/counterfactual-replay-service.ts
+++ b/src/services/intelligence/counterfactual-replay-service.ts
@@ -1,0 +1,350 @@
+/**
+ * CounterfactualReplayService — "what would have happened if X were
+ * different?"
+ *
+ * Re-runs a saved bundle of past observations through `scoreEvent` (the
+ * DriverScorer) with caller-supplied field modifications applied to deep
+ * clones, then compares against the unmodified baseline to compute alert
+ * count + max severity deltas.
+ *
+ * Persistence: localStorage `wm-counterfactual-replay`, capped at 100
+ * scenarios (oldest-first eviction on overflow).
+ *
+ * Note on file location: the spec called for this in
+ * `counterfactual-replay.ts`, but that path already hosts a wired-up
+ * `CounterfactualReplayEngine` (panel + 460+ existing tests). This
+ * service is therefore in a sibling file and can coexist without
+ * disturbing the legacy engine.
+ */
+
+import type { ObservationEvent, ObservationSeverity } from '@/types/intelligence';
+import { scoreEvent, type ScoredEvent } from './driver-scorer';
+
+// ── Public types ─────────────────────────────────────────────────────────
+
+export interface Modification {
+  /** id of the ObservationEvent in the baseline this modification targets. */
+  observationId: string;
+  /**
+   * Dot-path into the event ("severity", "raw.magnitude", "location.lat").
+   * The replay engine walks the path on a deep clone of the baseline event
+   * and assigns `modifiedValue` to the leaf.
+   */
+  field: string;
+  originalValue: unknown;
+  modifiedValue: unknown;
+}
+
+export interface CounterfactualScenario {
+  id: string;
+  name: string;
+  baselineObservations: ObservationEvent[];
+  modifications: Modification[];
+  /** ms-since-epoch the replay last ran. Undefined if never replayed. */
+  replayedAt?: number;
+  result?: ReplayResult;
+}
+
+export interface ReplayResult {
+  scenarioId: string;
+  originalAlertCount: number;
+  modifiedAlertCount: number;
+  /** modifiedAlertCount - originalAlertCount. Positive = scenario produced
+   *  MORE alerts; negative = fewer; zero = no change. */
+  deltaAlertCount: number;
+  /** Maximum driver score across baseline / modified runs, in [0, 1]. */
+  originalMaxSeverity: number;
+  modifiedMaxSeverity: number;
+  /** One-line plain-English summary of the delta. */
+  summary: string;
+}
+
+// ── Tunables ─────────────────────────────────────────────────────────────
+
+/**
+ * Spec called for `wm-counterfactual-replay`, but the existing legacy
+ * `CounterfactualReplayEngine` already owns that key (and stores a
+ * differently-shaped `{ scenarios, results }` object). To avoid mutually
+ * clobbering writes during the transition, the new service uses a v1
+ * suffix until the legacy engine is retired.
+ */
+export const STORAGE_KEY = 'wm-counterfactual-replay-service-v1';
+export const MAX_SCENARIOS = 100;
+/** driverScore (in [0, 1]) at or above this counts as "would-alert". */
+export const ALERT_THRESHOLD = 0.5;
+
+const SEVERITY_INDEX: Record<ObservationSeverity, number> = {
+  INFO: 0, LOW: 1, MEDIUM: 2, HIGH: 3, CRITICAL: 4,
+};
+
+// ── Storage abstraction (testable) ────────────────────────────────────────
+
+export interface StorageLike {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem?: (key: string) => void;
+}
+
+function defaultStorage(): StorageLike | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    // Node's built-in localStorage polyfill (24+) only partially implements
+    // the Storage interface — verify getItem/setItem are real functions
+    // before trusting it.
+    const ls = localStorage as unknown as StorageLike;
+    if (typeof ls.getItem !== 'function' || typeof ls.setItem !== 'function') return null;
+    return ls;
+  } catch { return null; }
+}
+
+// ── Pure helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Deep clone an event so modifications don't leak back into the baseline.
+ * JSON round-trip is safe because ObservationEvent is data-only (the `raw`
+ * field is provider JSON in practice).
+ */
+export function cloneEvent(event: ObservationEvent): ObservationEvent {
+  // structuredClone exists on both Node 17+ and modern browsers and handles
+  // nested objects + arrays without losing prototype information the way
+  // JSON round-tripping does.
+  return structuredClone(event);
+}
+
+/**
+ * Apply one modification to a cloned event in place. Walks the `field`
+ * dot-path. No-ops if the intermediate path doesn't resolve to an object,
+ * so a typo in `field` silently doesn't crash a whole replay.
+ */
+export function applyModification(event: ObservationEvent, mod: Modification): void {
+  const parts = mod.field.split('.').filter(Boolean);
+  if (parts.length === 0) return;
+  if (parts.length === 1) {
+    (event as unknown as Record<string, unknown>)[parts[0]!] = mod.modifiedValue;
+    return;
+  }
+  let cursor: Record<string, unknown> = event as unknown as Record<string, unknown>;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const next = cursor[parts[i]!];
+    if (next === null || next === undefined || typeof next !== 'object') return;
+    cursor = next as Record<string, unknown>;
+  }
+  const leaf = parts[parts.length - 1]!;
+  cursor[leaf] = mod.modifiedValue;
+}
+
+/**
+ * Apply every modification whose `observationId` matches `event.id` to a
+ * cloned copy. Returns the modified clone (original event untouched).
+ */
+export function applyModificationsToEvent(
+  event: ObservationEvent,
+  modifications: readonly Modification[],
+): ObservationEvent {
+  const clone = cloneEvent(event);
+  for (const mod of modifications) {
+    if (mod.observationId === event.id) applyModification(clone, mod);
+  }
+  return clone;
+}
+
+export interface RunStats {
+  alertCount: number;
+  maxSeverity: number;
+}
+
+/** Pure: count alerts (driverScore >= ALERT_THRESHOLD) + max severity. */
+export function computeRunStats(scored: readonly ScoredEvent[]): RunStats {
+  let alertCount = 0;
+  let maxSeverity = 0;
+  for (const s of scored) {
+    if (s.driverScore >= ALERT_THRESHOLD) alertCount += 1;
+    if (s.driverScore > maxSeverity) maxSeverity = s.driverScore;
+  }
+  return { alertCount, maxSeverity };
+}
+
+function summarizeAlertDelta(delta: number): string {
+  if (delta === 0) return 'no change in alert count';
+  const abs = Math.abs(delta);
+  const plural = abs === 1 ? '' : 's';
+  if (delta > 0) return `${abs} more alert${plural}`;
+  return `${abs} fewer alert${plural}`;
+}
+
+function summarizeSeverityDelta(sevDelta: number): string {
+  if (sevDelta === 0) return '';
+  const sign = sevDelta > 0 ? '+' : '';
+  return ` (max severity ${sign}${(sevDelta * 100).toFixed(0)}%)`;
+}
+
+/** Produce the plain-English summary line. */
+export function buildSummary(original: RunStats, modified: RunStats): string {
+  const direction = summarizeAlertDelta(modified.alertCount - original.alertCount);
+  const sev = summarizeSeverityDelta(modified.maxSeverity - original.maxSeverity);
+  return `Counterfactual produced ${direction}${sev}.`;
+}
+
+/** Convert an ObservationSeverity ladder rung into a 0..4 index. */
+export function severityIndex(s: string): number {
+  return SEVERITY_INDEX[s.toUpperCase() as ObservationSeverity] ?? 0;
+}
+
+// ── Parsing / persistence ─────────────────────────────────────────────────
+
+export function parseScenarios(raw: string | null): CounterfactualScenario[] {
+  if (!raw) return [];
+  let parsed: unknown;
+  try { parsed = JSON.parse(raw); } catch { return []; }
+  if (!Array.isArray(parsed)) return [];
+  const out: CounterfactualScenario[] = [];
+  for (const item of parsed) {
+    if (!item || typeof item !== 'object') continue;
+    const r = item as Record<string, unknown>;
+    if (typeof r.id !== 'string' || typeof r.name !== 'string') continue;
+    if (!Array.isArray(r.baselineObservations) || !Array.isArray(r.modifications)) continue;
+    out.push({
+      id: r.id,
+      name: r.name,
+      baselineObservations: r.baselineObservations as ObservationEvent[],
+      modifications: r.modifications as Modification[],
+      replayedAt: typeof r.replayedAt === 'number' ? r.replayedAt : undefined,
+      result: (r.result && typeof r.result === 'object') ? r.result as ReplayResult : undefined,
+    });
+  }
+  return out;
+}
+
+// ── Service ──────────────────────────────────────────────────────────────
+
+let _instance: CounterfactualReplayService | null = null;
+let _idCounter = 0;
+
+/** Reset the singleton (tests only). Passing null restores lazy init. */
+export function _setInstanceForTests(instance: CounterfactualReplayService | null): void {
+  _instance = instance;
+}
+
+export function _resetIdCounter(): void { _idCounter = 0; }
+
+export class CounterfactualReplayService {
+  private scenarios = new Map<string, CounterfactualScenario>();
+  private readonly storage: StorageLike | null;
+  private readonly now: () => number;
+
+  constructor(storage: StorageLike | null = defaultStorage(), now: () => number = Date.now) {
+    this.storage = storage;
+    this.now = now;
+    this.load();
+  }
+
+  static getInstance(): CounterfactualReplayService {
+    _instance ??= new CounterfactualReplayService();
+    return _instance;
+  }
+
+  /** Create a new scenario, persist it, evict oldest if over the cap. */
+  createScenario(
+    name: string,
+    observations: readonly ObservationEvent[],
+    modifications: readonly Modification[],
+  ): CounterfactualScenario {
+    if (!name.trim()) throw new Error('counterfactual: name required');
+    const scenario: CounterfactualScenario = {
+      id: this.nextId(),
+      name: name.trim(),
+      baselineObservations: observations.map((e) => cloneEvent(e)),
+      modifications: modifications.map((m) => ({ ...m })),
+    };
+    this.scenarios.set(scenario.id, scenario);
+    this.evictOverCap();
+    this.persist();
+    return { ...scenario };
+  }
+
+  /** Run (or re-run) the replay for a scenario. Throws on unknown id. */
+  replayScenario(id: string): ReplayResult {
+    const scenario = this.scenarios.get(id);
+    if (!scenario) throw new Error(`counterfactual: unknown scenario id "${id}"`);
+
+    const originalScored = scenario.baselineObservations.map((e) => scoreEvent(e));
+    const modifiedScored = scenario.baselineObservations.map((e) =>
+      scoreEvent(applyModificationsToEvent(e, scenario.modifications)),
+    );
+
+    const original = computeRunStats(originalScored);
+    const modified = computeRunStats(modifiedScored);
+
+    const result: ReplayResult = {
+      scenarioId: scenario.id,
+      originalAlertCount: original.alertCount,
+      modifiedAlertCount: modified.alertCount,
+      deltaAlertCount: modified.alertCount - original.alertCount,
+      originalMaxSeverity: original.maxSeverity,
+      modifiedMaxSeverity: modified.maxSeverity,
+      summary: buildSummary(original, modified),
+    };
+
+    scenario.replayedAt = this.now();
+    scenario.result = result;
+    this.persist();
+    return { ...result };
+  }
+
+  getScenarios(): CounterfactualScenario[] {
+    return [...this.scenarios.values()].map((s) => ({ ...s }));
+  }
+
+  getScenario(id: string): CounterfactualScenario | undefined {
+    const s = this.scenarios.get(id);
+    return s ? { ...s } : undefined;
+  }
+
+  getResult(id: string): ReplayResult | undefined {
+    const s = this.scenarios.get(id);
+    return s?.result ? { ...s.result } : undefined;
+  }
+
+  deleteScenario(id: string): boolean {
+    if (!this.scenarios.has(id)) return false;
+    this.scenarios.delete(id);
+    this.persist();
+    return true;
+  }
+
+  /** Wipe every scenario. Test-only — no UI surface. */
+  clearAll(): void {
+    this.scenarios.clear();
+    this.persist();
+  }
+
+  size(): number { return this.scenarios.size; }
+
+  // ── Internals ────────────────────────────────────────────────────────
+
+  private nextId(): string {
+    _idCounter += 1;
+    return `cf-${this.now().toString(36)}-${_idCounter}`;
+  }
+
+  private evictOverCap(): void {
+    while (this.scenarios.size > MAX_SCENARIOS) {
+      const oldest = this.scenarios.keys().next().value;
+      if (oldest === undefined) break;
+      this.scenarios.delete(oldest);
+    }
+  }
+
+  private load(): void {
+    const raw = this.storage?.getItem(STORAGE_KEY) ?? null;
+    for (const s of parseScenarios(raw)) this.scenarios.set(s.id, s);
+  }
+
+  private persist(): void {
+    if (!this.storage) return;
+    try {
+      const arr = [...this.scenarios.values()];
+      this.storage.setItem(STORAGE_KEY, JSON.stringify(arr));
+    } catch { /* quota / disabled — best-effort */ }
+  }
+}

--- a/tests/intelligence/counterfactual-replay-service.test.mts
+++ b/tests/intelligence/counterfactual-replay-service.test.mts
@@ -1,0 +1,416 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  CounterfactualReplayService,
+  STORAGE_KEY,
+  MAX_SCENARIOS,
+  ALERT_THRESHOLD,
+  cloneEvent,
+  applyModification,
+  applyModificationsToEvent,
+  computeRunStats,
+  buildSummary,
+  severityIndex,
+  parseScenarios,
+  _setInstanceForTests,
+  _resetIdCounter,
+  type Modification,
+} from '../../src/services/intelligence/counterfactual-replay-service.ts';
+import type { ObservationEvent } from '../../src/types/intelligence.ts';
+import type { ScoredEvent } from '../../src/services/intelligence/driver-scorer.ts';
+
+const NOW = 1_700_000_000_000;
+
+function event(overrides: Partial<ObservationEvent> = {}): ObservationEvent {
+  return {
+    id: 'e1',
+    sourceId: 'usgs-earthquake',
+    domain: 'earthquake',
+    timestamp: NOW - 60_000,
+    severity: 'HIGH',
+    title: 'M5.2 near Tokyo',
+    location: { lat: 35.68, lon: 139.65 },
+    raw: { magnitude: 5.2, depth_km: 30 },
+    entityIds: [],
+    tags: [],
+    ...overrides,
+  };
+}
+
+function mod(overrides: Partial<Modification> = {}): Modification {
+  return {
+    observationId: 'e1',
+    field: 'severity',
+    originalValue: 'HIGH',
+    modifiedValue: 'CRITICAL',
+    ...overrides,
+  };
+}
+
+function fakeStorage() {
+  const map = new Map<string, string>();
+  return {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => { map.set(k, v); },
+    removeItem: (k: string) => { map.delete(k); },
+    _map: map,
+  };
+}
+
+function makeService(now: () => number = () => NOW) {
+  _resetIdCounter();
+  return new CounterfactualReplayService(fakeStorage(), now);
+}
+
+function scored(overrides: Partial<ScoredEvent> = {}): ScoredEvent {
+  return {
+    ...event(),
+    driverScore: 0.5,
+    drivers: [],
+    scoreReason: '',
+    ...overrides,
+  };
+}
+
+// ── Constants / config sanity ────────────────────────────────────────────
+
+test('MAX_SCENARIOS is 100 (spec)', () => {
+  assert.equal(MAX_SCENARIOS, 100);
+});
+
+test('ALERT_THRESHOLD is in (0, 1)', () => {
+  assert.ok(ALERT_THRESHOLD > 0 && ALERT_THRESHOLD < 1);
+});
+
+test('STORAGE_KEY is the v1 suffix (avoids legacy engine collision)', () => {
+  assert.match(STORAGE_KEY, /^wm-counterfactual-replay/);
+});
+
+// ── Pure helpers: cloneEvent ─────────────────────────────────────────────
+
+test('cloneEvent deep-clones nested objects', () => {
+  const a = event({ raw: { magnitude: 5, depth_km: 30 }, location: { lat: 1, lon: 2 } });
+  const b = cloneEvent(a);
+  assert.notStrictEqual(a, b);
+  assert.notStrictEqual(a.raw, b.raw);
+  assert.notStrictEqual(a.location, b.location);
+  assert.deepEqual(a, b);
+});
+
+test('cloneEvent: mutating clone does not affect the original', () => {
+  const a = event({ raw: { magnitude: 5 } });
+  const b = cloneEvent(a);
+  (b.raw as { magnitude: number }).magnitude = 9;
+  assert.equal((a.raw as { magnitude: number }).magnitude, 5);
+});
+
+// ── Pure helpers: applyModification ──────────────────────────────────────
+
+test('applyModification: top-level field replace', () => {
+  const e = event();
+  applyModification(e, mod({ field: 'severity', modifiedValue: 'CRITICAL' }));
+  assert.equal(e.severity, 'CRITICAL');
+});
+
+test('applyModification: nested raw.magnitude replace', () => {
+  const e = event({ raw: { magnitude: 5.2 } });
+  applyModification(e, { observationId: 'e1', field: 'raw.magnitude', originalValue: 5.2, modifiedValue: 8.5 });
+  assert.equal((e.raw as { magnitude: number }).magnitude, 8.5);
+});
+
+test('applyModification: nested location.lat replace', () => {
+  const e = event({ location: { lat: 1, lon: 2 } });
+  applyModification(e, { observationId: 'e1', field: 'location.lat', originalValue: 1, modifiedValue: 50 });
+  assert.equal(e.location?.lat, 50);
+});
+
+test('applyModification: invalid intermediate path is a silent no-op', () => {
+  const e = event({ raw: undefined });
+  applyModification(e, { observationId: 'e1', field: 'raw.magnitude', originalValue: 0, modifiedValue: 9 });
+  assert.equal(e.raw, undefined);
+});
+
+test('applyModification: empty field path is a no-op', () => {
+  const e = event();
+  applyModification(e, { observationId: 'e1', field: '', originalValue: 'HIGH', modifiedValue: 'CRITICAL' });
+  assert.equal(e.severity, 'HIGH');
+});
+
+// ── Pure helpers: applyModificationsToEvent ──────────────────────────────
+
+test('applyModificationsToEvent: only applies matching observationId', () => {
+  const e = event();
+  const out = applyModificationsToEvent(e, [
+    mod({ observationId: 'e1', modifiedValue: 'CRITICAL' }),
+    mod({ observationId: 'OTHER', modifiedValue: 'LOW' }),
+  ]);
+  assert.equal(out.severity, 'CRITICAL');
+});
+
+test('applyModificationsToEvent: leaves the original event untouched', () => {
+  const e = event();
+  applyModificationsToEvent(e, [mod({ modifiedValue: 'CRITICAL' })]);
+  assert.equal(e.severity, 'HIGH');
+});
+
+test('applyModificationsToEvent: applies multiple modifications to the same event', () => {
+  const e = event({ raw: { magnitude: 5, depth_km: 30 } });
+  const out = applyModificationsToEvent(e, [
+    { observationId: 'e1', field: 'raw.magnitude', originalValue: 5, modifiedValue: 7 },
+    { observationId: 'e1', field: 'raw.depth_km',  originalValue: 30, modifiedValue: 5 },
+  ]);
+  const r = out.raw as { magnitude: number; depth_km: number };
+  assert.equal(r.magnitude, 7);
+  assert.equal(r.depth_km, 5);
+});
+
+// ── Pure helpers: computeRunStats + buildSummary + severityIndex ─────────
+
+test('computeRunStats: counts events at or above ALERT_THRESHOLD', () => {
+  const s = computeRunStats([
+    scored({ id: 'a', driverScore: 0.2 }),
+    scored({ id: 'b', driverScore: ALERT_THRESHOLD }),
+    scored({ id: 'c', driverScore: 0.9 }),
+  ]);
+  assert.equal(s.alertCount, 2);
+});
+
+test('computeRunStats: maxSeverity is the maximum driverScore', () => {
+  const s = computeRunStats([
+    scored({ id: 'a', driverScore: 0.1 }),
+    scored({ id: 'b', driverScore: 0.7 }),
+    scored({ id: 'c', driverScore: 0.3 }),
+  ]);
+  assert.equal(s.maxSeverity, 0.7);
+});
+
+test('computeRunStats: empty input → zeros', () => {
+  assert.deepEqual(computeRunStats([]), { alertCount: 0, maxSeverity: 0 });
+});
+
+test('buildSummary: no-change phrasing', () => {
+  const s = buildSummary({ alertCount: 2, maxSeverity: 0.5 }, { alertCount: 2, maxSeverity: 0.5 });
+  assert.match(s, /no change/);
+});
+
+test('buildSummary: more-alerts phrasing', () => {
+  const s = buildSummary({ alertCount: 1, maxSeverity: 0.5 }, { alertCount: 3, maxSeverity: 0.5 });
+  assert.match(s, /2 more alerts/);
+});
+
+test('buildSummary: fewer-alerts phrasing', () => {
+  const s = buildSummary({ alertCount: 3, maxSeverity: 0.5 }, { alertCount: 1, maxSeverity: 0.5 });
+  assert.match(s, /2 fewer alerts/);
+});
+
+test('buildSummary: severity delta is shown only when non-zero', () => {
+  const sNo = buildSummary({ alertCount: 1, maxSeverity: 0.5 }, { alertCount: 1, maxSeverity: 0.5 });
+  assert.equal(sNo.includes('max severity'), false);
+  const sYes = buildSummary({ alertCount: 1, maxSeverity: 0.5 }, { alertCount: 1, maxSeverity: 0.7 });
+  assert.match(sYes, /max severity \+20%/);
+});
+
+test('severityIndex maps the ladder rungs', () => {
+  assert.equal(severityIndex('INFO'), 0);
+  assert.equal(severityIndex('LOW'), 1);
+  assert.equal(severityIndex('MEDIUM'), 2);
+  assert.equal(severityIndex('HIGH'), 3);
+  assert.equal(severityIndex('CRITICAL'), 4);
+});
+
+// ── Persistence: parseScenarios ──────────────────────────────────────────
+
+test('parseScenarios: null / malformed → []', () => {
+  assert.deepEqual(parseScenarios(null), []);
+  assert.deepEqual(parseScenarios(''), []);
+  assert.deepEqual(parseScenarios('not-json'), []);
+  assert.deepEqual(parseScenarios('{"x":1}'), []); // not an array
+});
+
+test('parseScenarios: skips entries missing required fields', () => {
+  const raw = JSON.stringify([
+    { id: 'a', name: 'A', baselineObservations: [event()], modifications: [] },
+    { id: 'b' },
+    { id: 'c', name: 'C', baselineObservations: 'not-array', modifications: [] },
+  ]);
+  const out = parseScenarios(raw);
+  assert.equal(out.length, 1);
+  assert.equal(out[0]?.id, 'a');
+});
+
+// ── Service: createScenario ──────────────────────────────────────────────
+
+test('createScenario assigns a unique id and persists', () => {
+  const svc = makeService();
+  const s = svc.createScenario('Test', [event()], [mod()]);
+  assert.ok(s.id.startsWith('cf-'));
+  assert.equal(svc.size(), 1);
+});
+
+test('createScenario rejects empty name', () => {
+  const svc = makeService();
+  assert.throws(() => svc.createScenario('   ', [event()], []));
+});
+
+test('createScenario deep-clones the input observations + modifications', () => {
+  const svc = makeService();
+  const ev = event();
+  const m = mod();
+  const s = svc.createScenario('Test', [ev], [m]);
+  // Mutating callers' refs should not leak into the stored scenario.
+  ev.severity = 'LOW';
+  m.modifiedValue = 'INFO';
+  const stored = svc.getScenario(s.id)!;
+  assert.equal(stored.baselineObservations[0]?.severity, 'HIGH');
+  assert.equal(stored.modifications[0]?.modifiedValue, 'CRITICAL');
+});
+
+// ── Service: replayScenario ──────────────────────────────────────────────
+
+test('replayScenario throws on unknown id', () => {
+  const svc = makeService();
+  assert.throws(() => svc.replayScenario('does-not-exist'));
+});
+
+test('replayScenario returns a result whose scenarioId matches the input', () => {
+  const svc = makeService();
+  const s = svc.createScenario('Test', [event()], [mod()]);
+  const result = svc.replayScenario(s.id);
+  assert.equal(result.scenarioId, s.id);
+});
+
+test('replayScenario: identity modification (HIGH→HIGH) → zero deltaAlertCount', () => {
+  const svc = makeService();
+  const s = svc.createScenario('Test', [event()], [
+    mod({ field: 'severity', originalValue: 'HIGH', modifiedValue: 'HIGH' }),
+  ]);
+  const result = svc.replayScenario(s.id);
+  assert.equal(result.deltaAlertCount, 0);
+});
+
+test('replayScenario: severity upgrade increases modified max severity', () => {
+  // Bump LOW → CRITICAL on a fresh, near-saved-place earthquake so the
+  // driver-scorer rewards the change.
+  const svc = makeService();
+  const s = svc.createScenario('Test', [event({ severity: 'LOW' })], [
+    mod({ field: 'severity', originalValue: 'LOW', modifiedValue: 'CRITICAL' }),
+  ]);
+  const result = svc.replayScenario(s.id);
+  assert.ok(result.modifiedMaxSeverity >= result.originalMaxSeverity);
+});
+
+test('replayScenario: deltaAlertCount = modified - original', () => {
+  const svc = makeService();
+  const s = svc.createScenario('Test', [event({ severity: 'LOW' })], [
+    mod({ field: 'severity', originalValue: 'LOW', modifiedValue: 'CRITICAL' }),
+  ]);
+  const result = svc.replayScenario(s.id);
+  assert.equal(result.deltaAlertCount, result.modifiedAlertCount - result.originalAlertCount);
+});
+
+test('replayScenario writes the result back into the scenario record', () => {
+  const svc = makeService();
+  const s = svc.createScenario('Test', [event()], [mod()]);
+  const result = svc.replayScenario(s.id);
+  const stored = svc.getScenario(s.id)!;
+  assert.deepEqual(stored.result, result);
+  assert.equal(typeof stored.replayedAt, 'number');
+});
+
+test('replayScenario can be called multiple times (re-runs replace prior result)', () => {
+  const svc = makeService();
+  const s = svc.createScenario('Test', [event()], [mod()]);
+  svc.replayScenario(s.id);
+  const second = svc.replayScenario(s.id);
+  const stored = svc.getScenario(s.id)!;
+  assert.deepEqual(stored.result, second);
+});
+
+// ── Service: getScenarios / getResult / deleteScenario ──────────────────
+
+test('getScenarios returns every stored scenario', () => {
+  const svc = makeService();
+  svc.createScenario('A', [event({ id: 'a' })], []);
+  svc.createScenario('B', [event({ id: 'b' })], []);
+  assert.equal(svc.getScenarios().length, 2);
+});
+
+test('getResult returns undefined until replayScenario runs', () => {
+  const svc = makeService();
+  const s = svc.createScenario('Test', [event()], [mod()]);
+  assert.equal(svc.getResult(s.id), undefined);
+  svc.replayScenario(s.id);
+  assert.ok(svc.getResult(s.id) !== undefined);
+});
+
+test('getResult returns undefined for unknown id', () => {
+  const svc = makeService();
+  assert.equal(svc.getResult('nope'), undefined);
+});
+
+test('deleteScenario removes and reports true; second call returns false', () => {
+  const svc = makeService();
+  const s = svc.createScenario('A', [event()], []);
+  assert.equal(svc.deleteScenario(s.id), true);
+  assert.equal(svc.deleteScenario(s.id), false);
+});
+
+test('clearAll empties the store', () => {
+  const svc = makeService();
+  svc.createScenario('A', [event({ id: 'a' })], []);
+  svc.createScenario('B', [event({ id: 'b' })], []);
+  svc.clearAll();
+  assert.equal(svc.size(), 0);
+});
+
+// ── Service: cap eviction ───────────────────────────────────────────────
+
+test(`evicts oldest scenarios beyond MAX_SCENARIOS (${MAX_SCENARIOS})`, () => {
+  const svc = makeService();
+  const firstId = svc.createScenario('first', [event()], []).id;
+  for (let i = 1; i < MAX_SCENARIOS; i++) {
+    svc.createScenario(`s${i}`, [event()], []);
+  }
+  // We're at the cap exactly — adding one more must evict the first.
+  svc.createScenario('overflow', [event()], []);
+  assert.equal(svc.size(), MAX_SCENARIOS);
+  assert.equal(svc.getScenario(firstId), undefined);
+});
+
+// ── Service: singleton ──────────────────────────────────────────────────
+
+test('getInstance returns the same instance on repeat calls', () => {
+  _setInstanceForTests(null);
+  const a = CounterfactualReplayService.getInstance();
+  const b = CounterfactualReplayService.getInstance();
+  assert.strictEqual(a, b);
+  _setInstanceForTests(null);
+});
+
+test('_setInstanceForTests can inject + reset the singleton', () => {
+  const stub = makeService();
+  _setInstanceForTests(stub);
+  assert.strictEqual(CounterfactualReplayService.getInstance(), stub);
+  _setInstanceForTests(null);
+  assert.notStrictEqual(CounterfactualReplayService.getInstance(), stub);
+  _setInstanceForTests(null);
+});
+
+// ── Persistence round-trip ──────────────────────────────────────────────
+
+test('persisted scenarios reload on a fresh service over the same storage', () => {
+  const storage = fakeStorage();
+  _resetIdCounter();
+  const a = new CounterfactualReplayService(storage, () => NOW);
+  a.createScenario('Test', [event()], [mod()]);
+  const b = new CounterfactualReplayService(storage, () => NOW);
+  assert.equal(b.size(), 1);
+});
+
+test('persistence writes under STORAGE_KEY', () => {
+  const storage = fakeStorage();
+  const svc = new CounterfactualReplayService(storage, () => NOW);
+  svc.createScenario('Test', [event()], [mod()]);
+  assert.ok(storage._map.get(STORAGE_KEY)?.includes('Test'));
+});


### PR DESCRIPTION
A new `CounterfactualReplayService` that takes a bundle of past `ObservationEvent`s + a list of field modifications, deep-clones the baseline, applies the modifications, re-scores with `DriverScorer`, and reports alert-count + max-severity deltas vs. the baseline run.

Answers the question: *"what would have happened if X had been different?"*

## API (spec'd)

```ts
class CounterfactualReplayService {
  static getInstance(): CounterfactualReplayService;
  createScenario(name, observations[], modifications[]): CounterfactualScenario;
  replayScenario(id): ReplayResult;
  getScenarios(): CounterfactualScenario[];
  getScenario(id): CounterfactualScenario | undefined;
  getResult(id): ReplayResult | undefined;
  deleteScenario(id): boolean;
  clearAll(): void;
  size(): number;
}

interface Modification {
  observationId: string;
  field: string;           // dot-path: "severity", "raw.magnitude", "location.lat"
  originalValue: unknown;
  modifiedValue: unknown;
}

interface ReplayResult {
  scenarioId: string;
  originalAlertCount: number;
  modifiedAlertCount: number;
  deltaAlertCount: number;
  originalMaxSeverity: number;
  modifiedMaxSeverity: number;
  summary: string;
}
```

## Architecture

```
src/services/intelligence/
  counterfactual-replay-service.ts  pure helpers + CounterfactualReplayService class
tests/intelligence/
  counterfactual-replay-service.test.mts  43 tests
```

Pure helpers (`cloneEvent`, `applyModification`, `applyModificationsToEvent`, `computeRunStats`, `buildSummary`, `severityIndex`, `parseScenarios`) are exported so tests can pin every step of the pipeline without spinning the service. The class itself is the smallest possible glue layer: a `Map<id, scenario>` + persist + replay.

## Deviations from spec (called out inline)

The spec called for the new code at `counterfactual-replay.ts`, but that path already hosts a wired-up legacy `CounterfactualReplayEngine` (panel + 460+ existing tests). Replacing it would have broken shipped behavior, so the new service ships alongside as `counterfactual-replay-service.ts`. Same reasoning for the storage key: the spec called for `wm-counterfactual-replay`, but the legacy engine owns that key with a differently-shaped `{ scenarios, results }` object, so the new service uses `wm-counterfactual-replay-service-v1` to avoid mutually-clobbering writes.

Both deviations are documented in JSDoc at the top of the file.

## Tests

**43 passing** (above the 33+ target):

- **Pure helpers** — `cloneEvent` deep-clones + isolation; `applyModification` top-level / nested / invalid-path / empty-path; `applyModificationsToEvent` matching / non-mutation / multi-mod; `computeRunStats` threshold + maxSeverity + empty; `buildSummary` no-change / more / fewer / severity delta; `severityIndex` ladder; `parseScenarios` null / malformed / missing-fields.
- **Service** — `createScenario` id format + persist + reject-empty + deep-clone-inputs; `replayScenario` unknown-id throws + scenarioId match + identity-mod-zero-delta + severity-upgrade-increases-max + delta-math + writes-back + re-run-replaces; `getScenarios` / `getResult` / `deleteScenario` / `clearAll` / `size`; `MAX_SCENARIOS` eviction (101st write evicts the first); `getInstance` singleton; persistence round-trip across fresh constructions.

Run:
```
npx tsx --test tests/intelligence/counterfactual-replay-service.test.mts
```

## Verification

- `npm run typecheck:all` — clean
- ESLint on changed files — clean
- Pre-commit hooks (lint-staged + typecheck) — pass

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass