### PR TITLE
Planetary dependency graph — map infrastructure, supply chain, and geopolitical dependencies

### DIFF
--- a/src/services/intelligence/planetary-dependency-graph.ts
+++ b/src/services/intelligence/planetary-dependency-graph.ts
@@ -1,0 +1,298 @@
+/**
+ * PlanetaryDependencyGraph — maps infrastructure, supply-chain, and
+ * geopolitical dependencies between regions and domains.
+ *
+ * Nodes represent countries, choke-points, institutions, or commodities.
+ * Edges encode typed relationships with strength (0–1) and optionality of
+ * bidirectionality.
+ *
+ * `getCascadeRisk()` runs a bounded BFS along `depends-on` edges and
+ * returns per-node cascade scores (product of edge strengths along path).
+ *
+ * Seeded at construction with 12 nodes and 15 edges covering the most
+ * globally critical chokepoints and dependencies.
+ *
+ * Pure deterministic — no DOM, no fetch.
+ * Storage key: `wm-planetary-deps`. Caps at 1000 nodes + 5000 edges.
+ */
+
+// ── Public types ──────────────────────────────────────────────────────
+
+export type NodeType =
+  | 'country'
+  | 'infrastructure'
+  | 'supply-chain'
+  | 'institution'
+  | 'commodity';
+
+export type RelationshipType =
+  | 'depends-on'
+  | 'supplies'
+  | 'controls'
+  | 'competes-with'
+  | 'allies-with';
+
+export interface DependencyNode {
+  id: string;
+  name: string;
+  type: NodeType;
+  domain: string;
+  criticalityScore: number;
+}
+
+export interface DependencyEdge {
+  id: string;
+  fromId: string;
+  toId: string;
+  relationshipType: RelationshipType;
+  strength: number;
+  bidirectional: boolean;
+}
+
+export interface CascadeResult {
+  nodeId: string;
+  cascadeScore: number;
+}
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem?(key: string): void;
+}
+
+export interface PlanetaryDependencyGraphOptions {
+  storage?: StorageLike | null;
+  /** Set false to skip the initial seed (useful for tests). */
+  seed?: boolean;
+}
+
+// ── Constants ─────────────────────────────────────────────────────────
+
+export const STORAGE_KEY = 'wm-planetary-deps';
+export const MAX_NODES = 1000;
+export const MAX_EDGES = 5000;
+
+// ── Seed data ─────────────────────────────────────────────────────────
+
+const SEED_NODES: readonly DependencyNode[] = [
+  { id: 'us',        name: 'United States',           type: 'country',        domain: 'geopolitical', criticalityScore: 0.95 },
+  { id: 'cn',        name: 'China',                   type: 'country',        domain: 'geopolitical', criticalityScore: 0.92 },
+  { id: 'eu',        name: 'European Union',          type: 'country',        domain: 'geopolitical', criticalityScore: 0.88 },
+  { id: 'sa',        name: 'Saudi Arabia',            type: 'country',        domain: 'energy',       criticalityScore: 0.82 },
+  { id: 'hormuz',    name: 'Strait of Hormuz',        type: 'infrastructure', domain: 'maritime',     criticalityScore: 0.91 },
+  { id: 'panama',    name: 'Panama Canal',            type: 'infrastructure', domain: 'maritime',     criticalityScore: 0.85 },
+  { id: 'swift',     name: 'SWIFT',                   type: 'institution',    domain: 'financial',    criticalityScore: 0.9 },
+  { id: 'tsmc',      name: 'Taiwan Semiconductor',    type: 'supply-chain',   domain: 'technology',   criticalityScore: 0.93 },
+  { id: 'shipping',  name: 'Global Shipping',         type: 'supply-chain',   domain: 'maritime',     criticalityScore: 0.87 },
+  { id: 'ixp',       name: 'Internet Exchange Points',type: 'infrastructure', domain: 'cyber',        criticalityScore: 0.83 },
+  { id: 'imf',       name: 'IMF',                     type: 'institution',    domain: 'financial',    criticalityScore: 0.8 },
+  { id: 'unsc',      name: 'UN Security Council',     type: 'institution',    domain: 'geopolitical', criticalityScore: 0.78 },
+];
+
+const SEED_EDGES: readonly DependencyEdge[] = [
+  { id: 'e01', fromId: 'eu',       toId: 'hormuz',   relationshipType: 'depends-on',    strength: 0.75, bidirectional: false },
+  { id: 'e02', fromId: 'cn',       toId: 'hormuz',   relationshipType: 'depends-on',    strength: 0.8,  bidirectional: false },
+  { id: 'e03', fromId: 'sa',       toId: 'hormuz',   relationshipType: 'controls',      strength: 0.7,  bidirectional: false },
+  { id: 'e04', fromId: 'shipping', toId: 'panama',   relationshipType: 'depends-on',    strength: 0.65, bidirectional: false },
+  { id: 'e05', fromId: 'us',       toId: 'swift',    relationshipType: 'controls',      strength: 0.85, bidirectional: false },
+  { id: 'e06', fromId: 'eu',       toId: 'swift',    relationshipType: 'depends-on',    strength: 0.8,  bidirectional: false },
+  { id: 'e07', fromId: 'us',       toId: 'tsmc',     relationshipType: 'depends-on',    strength: 0.9,  bidirectional: false },
+  { id: 'e08', fromId: 'cn',       toId: 'tsmc',     relationshipType: 'competes-with', strength: 0.7,  bidirectional: false },
+  { id: 'e09', fromId: 'eu',       toId: 'shipping', relationshipType: 'depends-on',    strength: 0.72, bidirectional: false },
+  { id: 'e10', fromId: 'us',       toId: 'ixp',      relationshipType: 'controls',      strength: 0.6,  bidirectional: false },
+  { id: 'e11', fromId: 'cn',       toId: 'ixp',      relationshipType: 'depends-on',    strength: 0.55, bidirectional: false },
+  { id: 'e12', fromId: 'us',       toId: 'imf',      relationshipType: 'controls',      strength: 0.75, bidirectional: false },
+  { id: 'e13', fromId: 'us',       toId: 'unsc',     relationshipType: 'controls',      strength: 0.65, bidirectional: false },
+  { id: 'e14', fromId: 'us',       toId: 'cn',       relationshipType: 'competes-with', strength: 0.8,  bidirectional: true  },
+  { id: 'e15', fromId: 'sa',       toId: 'eu',       relationshipType: 'supplies',      strength: 0.68, bidirectional: false },
+];
+
+// ── Storage helper ─────────────────────────────────────────────────────
+
+function resolveStorage(injected?: StorageLike | null): StorageLike | null {
+  if (injected !== undefined) return injected;
+  try {
+    const ls = (globalThis as { localStorage?: StorageLike }).localStorage;
+    return ls ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Serialized shape ──────────────────────────────────────────────────
+
+interface PersistedGraph {
+  nodes: DependencyNode[];
+  edges: DependencyEdge[];
+}
+
+// ── Service ───────────────────────────────────────────────────────────
+
+export class PlanetaryDependencyGraph {
+  private static _singleton: PlanetaryDependencyGraph | null = null;
+
+  private nodes = new Map<string, DependencyNode>();
+  private edges = new Map<string, DependencyEdge>();
+  private readonly storage: StorageLike | null;
+
+  constructor(options: PlanetaryDependencyGraphOptions = {}) {
+    this.storage = resolveStorage(options.storage);
+    this.hydrate();
+    if ((options.seed ?? true) && this.nodes.size === 0) {
+      this.runInitialSeed();
+    }
+  }
+
+  static getInstance(): PlanetaryDependencyGraph {
+    PlanetaryDependencyGraph._singleton ??= new PlanetaryDependencyGraph();
+    return PlanetaryDependencyGraph._singleton;
+  }
+
+  static _resetForTests(): void {
+    PlanetaryDependencyGraph._singleton = null;
+  }
+
+  // ── Public API ────────────────────────────────────────────────────
+
+  addNode(node: DependencyNode): void {
+    if (this.nodes.size >= MAX_NODES) return;
+    this.nodes.set(node.id, { ...node });
+    this.persist();
+  }
+
+  addEdge(edge: DependencyEdge): void {
+    if (this.edges.size >= MAX_EDGES) return;
+    this.edges.set(edge.id, { ...edge });
+    this.persist();
+  }
+
+  getNode(id: string): DependencyNode | undefined {
+    const n = this.nodes.get(id);
+    return n ? { ...n } : undefined;
+  }
+
+  /** Edges where nodeId is fromId. */
+  getDependencies(nodeId: string): DependencyEdge[] {
+    return this.collectEdges((e) => e.fromId === nodeId || (e.bidirectional && e.toId === nodeId));
+  }
+
+  /** Edges where nodeId is toId. */
+  getDependents(nodeId: string): DependencyEdge[] {
+    return this.collectEdges((e) => e.toId === nodeId || (e.bidirectional && e.fromId === nodeId));
+  }
+
+  /**
+   * BFS along depends-on edges up to `depth` hops. Returns each
+   * reachable node with cascadeScore = product of edge strengths along
+   * the shortest (highest-score) path.
+   */
+  getCascadeRisk(nodeId: string, depth = 3): CascadeResult[] {
+    const results = new Map<string, number>();
+
+    interface QueueEntry { id: string; score: number; hops: number }
+    const queue: QueueEntry[] = [{ id: nodeId, score: 1, hops: 0 }];
+    const visited = new Set<string>([nodeId]);
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      if (current.hops >= depth) continue;
+
+      for (const e of this.edges.values()) {
+        if (e.relationshipType !== 'depends-on') continue;
+        const neighbor = this.resolveNeighbor(e, current.id);
+        if (neighbor === null || visited.has(neighbor)) continue;
+        visited.add(neighbor);
+        const score = current.score * e.strength;
+        results.set(neighbor, score);
+        queue.push({ id: neighbor, score, hops: current.hops + 1 });
+      }
+    }
+
+    return [...results.entries()]
+      .map(([nId, cascadeScore]) => ({ nodeId: nId, cascadeScore }))
+      .sort((a, b) => b.cascadeScore - a.cascadeScore);
+  }
+
+  /** All nodes sorted by criticalityScore descending. */
+  getMostCritical(limit = 10): DependencyNode[] {
+    return [...this.nodes.values()]
+      .sort((a, b) => b.criticalityScore - a.criticalityScore)
+      .slice(0, limit)
+      .map((n) => ({ ...n }));
+  }
+
+  getNodeCount(): number { return this.nodes.size; }
+  getEdgeCount(): number { return this.edges.size; }
+
+  /** Clear all data and storage (test seam). */
+  resetForTesting(): void {
+    this.nodes.clear();
+    this.edges.clear();
+    if (this.storage?.removeItem) {
+      try { this.storage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
+    }
+  }
+
+  // ── Internal ──────────────────────────────────────────────────────
+
+  private collectEdges(predicate: (e: DependencyEdge) => boolean): DependencyEdge[] {
+    const out: DependencyEdge[] = [];
+    for (const e of this.edges.values()) {
+      if (predicate(e)) out.push({ ...e });
+    }
+    return out;
+  }
+
+  private resolveNeighbor(e: DependencyEdge, currentId: string): string | null {
+    if (e.fromId === currentId) return e.toId;
+    if (e.bidirectional && e.toId === currentId) return e.fromId;
+    return null;
+  }
+
+  private runInitialSeed(): void {
+    for (const n of SEED_NODES) this.nodes.set(n.id, { ...n });
+    for (const e of SEED_EDGES) this.edges.set(e.id, { ...e });
+    this.persist();
+  }
+
+  private hydrate(): void {
+    if (!this.storage) return;
+    let raw: string | null = null;
+    try { raw = this.storage.getItem(STORAGE_KEY); } catch { return; }
+    if (!raw) return;
+    let parsed: PersistedGraph | null;
+    try { parsed = JSON.parse(raw) as PersistedGraph | null; } catch { return; }
+    if (!parsed || !Array.isArray(parsed.nodes) || !Array.isArray(parsed.edges)) return;
+    for (const n of parsed.nodes) {
+      if (n && typeof n.id === 'string') this.nodes.set(n.id, { ...n });
+    }
+    for (const e of parsed.edges) {
+      if (e && typeof e.id === 'string') this.edges.set(e.id, { ...e });
+    }
+  }
+
+  private persist(): void {
+    if (!this.storage) return;
+    try {
+      const data: PersistedGraph = {
+        nodes: [...this.nodes.values()],
+        edges: [...this.edges.values()],
+      };
+      this.storage.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch { /* best effort */ }
+  }
+}
+
+// ── Convenience accessor ──────────────────────────────────────────────
+
+export function getPlanetaryDependencyGraph(): PlanetaryDependencyGraph {
+  return PlanetaryDependencyGraph.getInstance();
+}
+
+export const __internals = {
+  STORAGE_KEY,
+  MAX_NODES,
+  MAX_EDGES,
+  SEED_NODES,
+  SEED_EDGES,
+};

--- a/tests/intelligence/planetary-dependency-graph.test.mts
+++ b/tests/intelligence/planetary-dependency-graph.test.mts
@@ -1,0 +1,540 @@
+/**
+ * PlanetaryDependencyGraph — deterministic unit tests.
+ *
+ * Covers: addNode/addEdge, getDependencies/getDependents,
+ * getCascadeRisk BFS, getMostCritical, storage persist/rehydrate,
+ * capacity caps, singleton lifecycle, and seed data integrity.
+ *
+ * No DOM, no live localStorage — injectable storage throughout.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it, beforeEach } from 'node:test';
+
+import {
+  PlanetaryDependencyGraph,
+  getPlanetaryDependencyGraph,
+  __internals,
+  STORAGE_KEY,
+  MAX_NODES,
+  MAX_EDGES,
+} from '../../src/services/intelligence/planetary-dependency-graph.ts';
+import type {
+  DependencyNode,
+  DependencyEdge,
+  StorageLike,
+} from '../../src/services/intelligence/planetary-dependency-graph.ts';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+function makeStorage(initial: Record<string, string> = {}): StorageLike & {
+  store: Map<string, string>;
+} {
+  const store = new Map<string, string>(Object.entries(initial));
+  return {
+    store,
+    getItem(key: string) { return store.get(key) ?? null; },
+    setItem(key: string, value: string) { store.set(key, value); },
+    removeItem(key: string) { store.delete(key); },
+  };
+}
+
+/** Fresh graph with no seed — clean slate for most tests. */
+function makeGraph(storage: StorageLike | null = null): PlanetaryDependencyGraph {
+  return new PlanetaryDependencyGraph({ storage, seed: false });
+}
+
+function node(overrides: Partial<DependencyNode> & Pick<DependencyNode, 'id'>): DependencyNode {
+  return {
+    name: overrides.id,
+    type: 'country',
+    domain: 'geopolitical',
+    criticalityScore: 0.5,
+    ...overrides,
+  };
+}
+
+function edge(
+  id: string,
+  fromId: string,
+  toId: string,
+  overrides: Partial<DependencyEdge> = {},
+): DependencyEdge {
+  return {
+    id,
+    fromId,
+    toId,
+    relationshipType: 'depends-on',
+    strength: 0.8,
+    bidirectional: false,
+    ...overrides,
+  };
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────
+
+describe('constants', () => {
+  it('STORAGE_KEY is wm-planetary-deps', () => {
+    assert.equal(STORAGE_KEY, 'wm-planetary-deps');
+  });
+
+  it('MAX_NODES is 1000', () => {
+    assert.equal(MAX_NODES, 1000);
+  });
+
+  it('MAX_EDGES is 5000', () => {
+    assert.equal(MAX_EDGES, 5000);
+  });
+});
+
+// ── addNode ───────────────────────────────────────────────────────────────
+
+describe('addNode', () => {
+  it('stores a node and increments count', () => {
+    const g = makeGraph();
+    g.addNode(node({ id: 'us' }));
+    assert.equal(g.getNodeCount(), 1);
+  });
+
+  it('getNode returns a copy of the stored node', () => {
+    const g = makeGraph();
+    g.addNode(node({ id: 'us', criticalityScore: 0.9 }));
+    const n = g.getNode('us');
+    assert.equal(n?.id, 'us');
+    assert.equal(n?.criticalityScore, 0.9);
+  });
+
+  it('getNode returns undefined for unknown id', () => {
+    const g = makeGraph();
+    assert.equal(g.getNode('xyz'), undefined);
+  });
+
+  it('overwriting a node id replaces it', () => {
+    const g = makeGraph();
+    g.addNode(node({ id: 'us', criticalityScore: 0.5 }));
+    g.addNode(node({ id: 'us', criticalityScore: 0.9 }));
+    assert.equal(g.getNodeCount(), 1);
+    assert.equal(g.getNode('us')?.criticalityScore, 0.9);
+  });
+
+  it('accepts all NodeType values', () => {
+    const g = makeGraph();
+    const types = ['country', 'infrastructure', 'supply-chain', 'institution', 'commodity'] as const;
+    for (const type of types) {
+      g.addNode(node({ id: type, type }));
+    }
+    assert.equal(g.getNodeCount(), 5);
+  });
+});
+
+// ── addEdge ───────────────────────────────────────────────────────────────
+
+describe('addEdge', () => {
+  it('stores an edge and increments count', () => {
+    const g = makeGraph();
+    g.addEdge(edge('e1', 'a', 'b'));
+    assert.equal(g.getEdgeCount(), 1);
+  });
+
+  it('accepts all RelationshipType values', () => {
+    const g = makeGraph();
+    const types = ['depends-on', 'supplies', 'controls', 'competes-with', 'allies-with'] as const;
+    for (const [i, rt] of types.entries()) {
+      g.addEdge(edge(`e${i}`, 'a', 'b', { relationshipType: rt }));
+    }
+    assert.equal(g.getEdgeCount(), 5);
+  });
+});
+
+// ── getDependencies ───────────────────────────────────────────────────────
+
+describe('getDependencies', () => {
+  it('returns edges where nodeId is fromId', () => {
+    const g = makeGraph();
+    g.addEdge(edge('e1', 'us', 'swift'));
+    g.addEdge(edge('e2', 'eu', 'swift'));
+    const deps = g.getDependencies('us');
+    assert.equal(deps.length, 1);
+    assert.equal(deps[0]!.id, 'e1');
+  });
+
+  it('returns empty for node with no outgoing edges', () => {
+    const g = makeGraph();
+    g.addEdge(edge('e1', 'a', 'b'));
+    assert.deepEqual(g.getDependencies('b'), []);
+  });
+
+  it('includes bidirectional edges where nodeId is toId', () => {
+    const g = makeGraph();
+    g.addEdge(edge('e1', 'us', 'cn', { bidirectional: true }));
+    const deps = g.getDependencies('cn');
+    assert.equal(deps.length, 1);
+    assert.equal(deps[0]!.id, 'e1');
+  });
+
+  it('does not include non-bidirectional edge when nodeId is toId', () => {
+    const g = makeGraph();
+    g.addEdge(edge('e1', 'us', 'cn', { bidirectional: false }));
+    assert.deepEqual(g.getDependencies('cn'), []);
+  });
+
+  it('returns copies, not references', () => {
+    const g = makeGraph();
+    g.addEdge(edge('e1', 'us', 'cn'));
+    const deps = g.getDependencies('us');
+    deps[0]!.strength = 0;
+    assert.equal(g.getDependencies('us')[0]!.strength, 0.8);
+  });
+});
+
+// ── getDependents ─────────────────────────────────────────────────────────
+
+describe('getDependents', () => {
+  it('returns edges where nodeId is toId', () => {
+    const g = makeGraph();
+    g.addEdge(edge('e1', 'eu', 'swift'));
+    g.addEdge(edge('e2', 'us', 'swift'));
+    const deps = g.getDependents('swift');
+    assert.equal(deps.length, 2);
+  });
+
+  it('returns empty when no incoming edges', () => {
+    const g = makeGraph();
+    g.addEdge(edge('e1', 'us', 'swift'));
+    assert.deepEqual(g.getDependents('us'), []);
+  });
+
+  it('includes bidirectional edges where nodeId is fromId', () => {
+    const g = makeGraph();
+    g.addEdge(edge('e1', 'us', 'cn', { bidirectional: true }));
+    const deps = g.getDependents('us');
+    assert.equal(deps.length, 1);
+  });
+});
+
+// ── getCascadeRisk ────────────────────────────────────────────────────────
+
+describe('getCascadeRisk', () => {
+  it('returns empty array for node with no depends-on edges', () => {
+    const g = makeGraph();
+    g.addNode(node({ id: 'island' }));
+    assert.deepEqual(g.getCascadeRisk('island'), []);
+  });
+
+  it('direct depends-on neighbor gets strength as cascadeScore', () => {
+    const g = makeGraph();
+    g.addEdge(edge('e1', 'eu', 'hormuz', { strength: 0.75 }));
+    const results = g.getCascadeRisk('eu');
+    const h = results.find((r) => r.nodeId === 'hormuz');
+    assert.ok(h, 'hormuz should appear');
+    assert.equal(h!.cascadeScore, 0.75);
+  });
+
+  it('two-hop path score = product of edge strengths', () => {
+    const g = makeGraph();
+    g.addEdge(edge('e1', 'a', 'b', { strength: 0.8 }));
+    g.addEdge(edge('e2', 'b', 'c', { strength: 0.5 }));
+    const results = g.getCascadeRisk('a', 3);
+    const c = results.find((r) => r.nodeId === 'c');
+    assert.ok(c, 'c should appear');
+    assert.ok(Math.abs(c!.cascadeScore - 0.4) < 0.0001);
+  });
+
+  it('respects depth limit — nodes beyond depth are excluded', () => {
+    const g = makeGraph();
+    g.addEdge(edge('e1', 'a', 'b', { strength: 0.9 }));
+    g.addEdge(edge('e2', 'b', 'c', { strength: 0.9 }));
+    g.addEdge(edge('e3', 'c', 'd', { strength: 0.9 }));
+    g.addEdge(edge('e4', 'd', 'e', { strength: 0.9 }));
+    const results = g.getCascadeRisk('a', 2);
+    assert.ok(results.find((r) => r.nodeId === 'b'));
+    assert.ok(results.find((r) => r.nodeId === 'c'));
+    assert.equal(results.find((r) => r.nodeId === 'd'), undefined);
+    assert.equal(results.find((r) => r.nodeId === 'e'), undefined);
+  });
+
+  it('default depth is 3', () => {
+    const g = makeGraph();
+    g.addEdge(edge('e1', 'a', 'b', { strength: 0.9 }));
+    g.addEdge(edge('e2', 'b', 'c', { strength: 0.9 }));
+    g.addEdge(edge('e3', 'c', 'd', { strength: 0.9 }));
+    g.addEdge(edge('e4', 'd', 'e', { strength: 0.9 }));
+    const results = g.getCascadeRisk('a');
+    assert.ok(results.find((r) => r.nodeId === 'd'));
+    assert.equal(results.find((r) => r.nodeId === 'e'), undefined);
+  });
+
+  it('source node is not included in results', () => {
+    const g = makeGraph();
+    g.addEdge(edge('e1', 'a', 'b'));
+    const results = g.getCascadeRisk('a');
+    assert.equal(results.find((r) => r.nodeId === 'a'), undefined);
+  });
+
+  it('does not follow non-depends-on edges', () => {
+    const g = makeGraph();
+    g.addEdge(edge('e1', 'us', 'cn', { relationshipType: 'competes-with', strength: 0.8 }));
+    g.addEdge(edge('e2', 'us', 'swift', { relationshipType: 'controls', strength: 0.8 }));
+    const results = g.getCascadeRisk('us');
+    assert.deepEqual(results, []);
+  });
+
+  it('handles cycles without infinite loop', () => {
+    const g = makeGraph();
+    g.addEdge(edge('e1', 'a', 'b', { bidirectional: true }));
+    g.addEdge(edge('e2', 'b', 'a', { bidirectional: false }));
+    const results = g.getCascadeRisk('a', 5);
+    assert.ok(results.length <= 2);
+  });
+
+  it('results are sorted by cascadeScore descending', () => {
+    const g = makeGraph();
+    g.addEdge(edge('e1', 'root', 'low', { strength: 0.3 }));
+    g.addEdge(edge('e2', 'root', 'high', { strength: 0.9 }));
+    g.addEdge(edge('e3', 'root', 'mid', { strength: 0.6 }));
+    const results = g.getCascadeRisk('root');
+    assert.equal(results[0]!.nodeId, 'high');
+    assert.equal(results[1]!.nodeId, 'mid');
+    assert.equal(results[2]!.nodeId, 'low');
+  });
+});
+
+// ── getMostCritical ───────────────────────────────────────────────────────
+
+describe('getMostCritical', () => {
+  it('returns nodes sorted by criticalityScore descending', () => {
+    const g = makeGraph();
+    g.addNode(node({ id: 'a', criticalityScore: 0.3 }));
+    g.addNode(node({ id: 'b', criticalityScore: 0.9 }));
+    g.addNode(node({ id: 'c', criticalityScore: 0.6 }));
+    const top = g.getMostCritical(3);
+    assert.equal(top[0]!.id, 'b');
+    assert.equal(top[1]!.id, 'c');
+    assert.equal(top[2]!.id, 'a');
+  });
+
+  it('respects limit parameter', () => {
+    const g = makeGraph();
+    for (let i = 0; i < 20; i++) {
+      g.addNode(node({ id: `n${i}`, criticalityScore: i / 20 }));
+    }
+    assert.equal(g.getMostCritical(5).length, 5);
+  });
+
+  it('default limit is 10', () => {
+    const g = makeGraph();
+    for (let i = 0; i < 15; i++) {
+      g.addNode(node({ id: `n${i}` }));
+    }
+    assert.equal(g.getMostCritical().length, 10);
+  });
+
+  it('returns copies, not references', () => {
+    const g = makeGraph();
+    g.addNode(node({ id: 'a', criticalityScore: 0.8 }));
+    const top = g.getMostCritical();
+    top[0]!.criticalityScore = 0;
+    assert.equal(g.getMostCritical()[0]!.criticalityScore, 0.8);
+  });
+
+  it('returns all nodes when count < limit', () => {
+    const g = makeGraph();
+    g.addNode(node({ id: 'a' }));
+    g.addNode(node({ id: 'b' }));
+    assert.equal(g.getMostCritical(10).length, 2);
+  });
+});
+
+// ── Capacity caps ─────────────────────────────────────────────────────────
+
+describe('capacity caps', () => {
+  it('addNode silently ignores when at MAX_NODES', () => {
+    const g = makeGraph();
+    for (let i = 0; i < MAX_NODES; i++) {
+      g.addNode(node({ id: `n${i}` }));
+    }
+    assert.equal(g.getNodeCount(), MAX_NODES);
+    g.addNode(node({ id: 'overflow' }));
+    assert.equal(g.getNodeCount(), MAX_NODES);
+    assert.equal(g.getNode('overflow'), undefined);
+  });
+
+  it('addEdge silently ignores when at MAX_EDGES', () => {
+    const g = makeGraph();
+    for (let i = 0; i < MAX_EDGES; i++) {
+      g.addEdge(edge(`e${i}`, 'a', 'b'));
+    }
+    assert.equal(g.getEdgeCount(), MAX_EDGES);
+    g.addEdge(edge('overflow', 'a', 'b'));
+    assert.equal(g.getEdgeCount(), MAX_EDGES);
+  });
+});
+
+// ── Storage persist + rehydrate ───────────────────────────────────────────
+
+describe('storage', () => {
+  it('persists nodes on addNode', () => {
+    const storage = makeStorage();
+    const g = new PlanetaryDependencyGraph({ storage, seed: false });
+    g.addNode(node({ id: 'us' }));
+    assert.ok(storage.store.has(STORAGE_KEY));
+    const data = JSON.parse(storage.store.get(STORAGE_KEY)!);
+    assert.equal(data.nodes.length, 1);
+    assert.equal(data.nodes[0].id, 'us');
+  });
+
+  it('persists edges on addEdge', () => {
+    const storage = makeStorage();
+    const g = new PlanetaryDependencyGraph({ storage, seed: false });
+    g.addEdge(edge('e1', 'a', 'b'));
+    const data = JSON.parse(storage.store.get(STORAGE_KEY)!);
+    assert.equal(data.edges.length, 1);
+  });
+
+  it('rehydrates nodes from storage', () => {
+    const storage = makeStorage();
+    const g1 = new PlanetaryDependencyGraph({ storage, seed: false });
+    g1.addNode(node({ id: 'us', criticalityScore: 0.95 }));
+    const g2 = new PlanetaryDependencyGraph({ storage, seed: false });
+    assert.equal(g2.getNodeCount(), 1);
+    assert.equal(g2.getNode('us')?.criticalityScore, 0.95);
+  });
+
+  it('rehydrates edges from storage', () => {
+    const storage = makeStorage();
+    const g1 = new PlanetaryDependencyGraph({ storage, seed: false });
+    g1.addEdge(edge('e1', 'us', 'cn', { strength: 0.7 }));
+    const g2 = new PlanetaryDependencyGraph({ storage, seed: false });
+    assert.equal(g2.getEdgeCount(), 1);
+    assert.equal(g2.getDependencies('us')[0]!.strength, 0.7);
+  });
+
+  it('ignores corrupt storage gracefully', () => {
+    const storage = makeStorage({ [STORAGE_KEY]: 'not-json' });
+    assert.doesNotThrow(() => new PlanetaryDependencyGraph({ storage, seed: false }));
+  });
+
+  it('ignores storage with wrong shape', () => {
+    const storage = makeStorage({ [STORAGE_KEY]: JSON.stringify({ nodes: 'bad', edges: [] }) });
+    const g = new PlanetaryDependencyGraph({ storage, seed: false });
+    assert.equal(g.getNodeCount(), 0);
+  });
+
+  it('null storage option disables persistence', () => {
+    const g = new PlanetaryDependencyGraph({ storage: null, seed: false });
+    g.addNode(node({ id: 'us' }));
+    assert.equal(g.getNodeCount(), 1);
+  });
+
+  it('resetForTesting clears storage', () => {
+    const storage = makeStorage();
+    const g = new PlanetaryDependencyGraph({ storage, seed: false });
+    g.addNode(node({ id: 'us' }));
+    g.resetForTesting();
+    assert.equal(g.getNodeCount(), 0);
+    assert.equal(storage.store.has(STORAGE_KEY), false);
+  });
+});
+
+// ── Initial seed ──────────────────────────────────────────────────────────
+
+describe('initial seed', () => {
+  it('seed:true populates 12 nodes', () => {
+    const g = new PlanetaryDependencyGraph({ storage: null, seed: true });
+    assert.equal(g.getNodeCount(), 12);
+  });
+
+  it('seed:true populates 15 edges', () => {
+    const g = new PlanetaryDependencyGraph({ storage: null, seed: true });
+    assert.equal(g.getEdgeCount(), 15);
+  });
+
+  it('US node has criticalityScore 0.95', () => {
+    const g = new PlanetaryDependencyGraph({ storage: null, seed: true });
+    assert.equal(g.getNode('us')?.criticalityScore, 0.95);
+  });
+
+  it('TSMC node has criticalityScore 0.93', () => {
+    const g = new PlanetaryDependencyGraph({ storage: null, seed: true });
+    assert.equal(g.getNode('tsmc')?.criticalityScore, 0.93);
+  });
+
+  it('seed is skipped when storage already has nodes', () => {
+    const storage = makeStorage();
+    const g1 = new PlanetaryDependencyGraph({ storage, seed: false });
+    g1.addNode(node({ id: 'existing' }));
+    const g2 = new PlanetaryDependencyGraph({ storage, seed: true });
+    assert.equal(g2.getNodeCount(), 1);
+  });
+
+  it('all 12 canonical nodes are present', () => {
+    const g = new PlanetaryDependencyGraph({ storage: null, seed: true });
+    const ids = ['us', 'cn', 'eu', 'sa', 'hormuz', 'panama', 'swift', 'tsmc', 'shipping', 'ixp', 'imf', 'unsc'];
+    for (const id of ids) {
+      assert.ok(g.getNode(id), `missing node: ${id}`);
+    }
+  });
+
+  it('getMostCritical with seed returns TSMC or US at top', () => {
+    const g = new PlanetaryDependencyGraph({ storage: null, seed: true });
+    const top = g.getMostCritical(1);
+    assert.ok(['us', 'tsmc'].includes(top[0]!.id));
+  });
+
+  it('getCascadeRisk from EU reaches hormuz via depends-on edge', () => {
+    const g = new PlanetaryDependencyGraph({ storage: null, seed: true });
+    const risk = g.getCascadeRisk('eu');
+    assert.ok(risk.find((r) => r.nodeId === 'hormuz'));
+  });
+});
+
+// ── Singleton ─────────────────────────────────────────────────────────────
+
+describe('singleton', () => {
+  beforeEach(() => {
+    PlanetaryDependencyGraph._resetForTests();
+  });
+
+  it('getInstance returns the same instance', () => {
+    const a = PlanetaryDependencyGraph.getInstance();
+    const b = PlanetaryDependencyGraph.getInstance();
+    assert.strictEqual(a, b);
+  });
+
+  it('getPlanetaryDependencyGraph returns the singleton', () => {
+    const a = PlanetaryDependencyGraph.getInstance();
+    const b = getPlanetaryDependencyGraph();
+    assert.strictEqual(a, b);
+  });
+
+  it('_resetForTests creates a new instance on next call', () => {
+    const a = PlanetaryDependencyGraph.getInstance();
+    PlanetaryDependencyGraph._resetForTests();
+    const b = PlanetaryDependencyGraph.getInstance();
+    assert.notStrictEqual(a, b);
+  });
+});
+
+// ── __internals ───────────────────────────────────────────────────────────
+
+describe('__internals', () => {
+  it('exports SEED_NODES with 12 entries', () => {
+    assert.equal(__internals.SEED_NODES.length, 12);
+  });
+
+  it('exports SEED_EDGES with 15 entries', () => {
+    assert.equal(__internals.SEED_EDGES.length, 15);
+  });
+
+  it('all SEED_NODES have criticalityScore between 0 and 1', () => {
+    for (const n of __internals.SEED_NODES) {
+      assert.ok(n.criticalityScore >= 0 && n.criticalityScore <= 1, `${n.id} out of range`);
+    }
+  });
+
+  it('all SEED_EDGES have strength between 0 and 1', () => {
+    for (const e of __internals.SEED_EDGES) {
+      assert.ok(e.strength >= 0 && e.strength <= 1, `${e.id} out of range`);
+    }
+  });
+});


### PR DESCRIPTION
Maps 12 canonical nodes (US, China, EU, Saudi Arabia, Strait of Hormuz, Panama Canal, SWIFT, Taiwan Semiconductor, Global Shipping, Internet Exchange Points, IMF, UN Security Council) with 15 typed dependency edges.

## API

| Method | Description |
|---|---|
| `addNode(node)` | Add or replace a node (caps at 1000) |
| `addEdge(edge)` | Add an edge (caps at 5000) |
| `getDependencies(nodeId)` | Edges where nodeId is fromId (+ bidirectional) |
| `getDependents(nodeId)` | Edges where nodeId is toId (+ bidirectional) |
| `getCascadeRisk(nodeId, depth=3)` | BFS along depends-on edges; score = product of strengths |
| `getMostCritical(limit=10)` | Nodes sorted by criticalityScore desc |

## Node types

`country` · `infrastructure` · `supply-chain` · `institution` · `commodity`

## Relationship types

`depends-on` · `supplies` · `controls` · `competes-with` · `allies-with`

## Implementation notes

- `getCascadeRisk` uses visited-set BFS to handle cycles (e.g. US↔China bidirectional edge) safely
- Capacity caps (MAX_NODES=1000, MAX_EDGES=5000) are silent no-ops, not errors
- Storage key `wm-planetary-deps` persists `{nodes, edges}` as JSON
- Injectable storage + seed flag for deterministic tests

## Tests

57 tests covering all methods, BFS path-product scoring, depth limits, cycle safety, bidirectional traversal, storage persist/rehydrate, capacity caps, and seed integrity.

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass