### PR TITLE
Behavioral modeling — model population and government stress responses

### DIFF
--- a/src/services/intelligence/behavioral-modeling.ts
+++ b/src/services/intelligence/behavioral-modeling.ts
@@ -1,0 +1,554 @@
+/**
+ * BehavioralModelingService — predict how populations, governments, and
+ * institutional actors respond to different stress levels.
+ *
+ * Distinct from `behavioral-response.ts` (which tracks the time-phased
+ * response curve of a single in-flight event). This service answers a
+ * different question: given an archetype (e.g. "democratic-population")
+ * and a stress level on the 0–4 INFO/LOW/MEDIUM/HIGH/CRITICAL scale,
+ * what behavior should we expect, and how intensely?
+ *
+ * Each archetype has a hand-seeded `stressResponseCurve` of (stressLevel,
+ * responseIntensity, behaviorType) anchor points. `predictResponse`
+ * linearly interpolates intensity between anchors and picks the
+ * behaviorType of the nearest anchor. Confidence drops the further the
+ * query stress level sits from any anchor.
+ *
+ * `recordObservedBehavior` is the calibration hook: when the observed
+ * behaviorType doesn't match the prediction for that stress range,
+ * `escalationThreshold` nudges by ±0.1 (clamped 0–4) so future
+ * predictions for that archetype shift.
+ *
+ * Pure / deterministic / no DOM / no fetch. Injectable Storage.
+ */
+
+// ── Public types ─────────────────────────────────────────────────────────
+
+export type BehaviorType = 'compliance' | 'adaptation' | 'resistance' | 'collapse';
+
+export interface StressPoint {
+  /** Stress on the 0–4 INFO/LOW/MEDIUM/HIGH/CRITICAL scale. */
+  stressLevel: number;
+  /** 0–1 normalized response intensity at this stress level. */
+  responseIntensity: number;
+  /** Qualitative behavior at this stress level. */
+  behaviorType: BehaviorType;
+}
+
+export interface BehavioralArchetype {
+  id: string;
+  name: string;
+  description: string;
+  /** Hand-seeded anchor points sorted ascending by stressLevel. */
+  stressResponseCurve: StressPoint[];
+  /** Plain-English examples of what the archetype typically does. */
+  typicalReactions: string[];
+  /**
+   * Stress level at which the archetype's behavior tips from
+   * compliance/adaptation into resistance/collapse. Used by callers to
+   * flag "this archetype is about to flip"; adjusted by
+   * `recordObservedBehavior` when reality disagrees with predictions.
+   */
+  escalationThreshold: number;
+}
+
+export interface BehavioralPrediction {
+  archetypeId: string;
+  region: string;
+  stressLevel: number;
+  predictedBehavior: string;
+  responseIntensity: number;
+  behaviorType: BehaviorType;
+  /** 0–1: nearer to an anchor → higher confidence. */
+  confidence: number;
+}
+
+export interface BehavioralObservation {
+  archetypeId: string;
+  region: string;
+  stressLevel: number;
+  actualBehaviorType: BehaviorType;
+  observedAt: number;
+}
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem?(key: string): void;
+}
+
+export interface BehavioralModelingOptions {
+  storage?: StorageLike | null;
+  now?: () => number;
+}
+
+// ── Constants ────────────────────────────────────────────────────────────
+
+export const STORAGE_KEY = 'wm-behavioral-modeling';
+export const MAX_OBSERVATIONS = 200;
+export const THRESHOLD_NUDGE = 0.1;
+export const STRESS_MIN = 0;
+export const STRESS_MAX = 4;
+
+const DEFAULT_REGION = 'global';
+
+// ── Seed archetypes ──────────────────────────────────────────────────────
+
+function seedArchetypes(): BehavioralArchetype[] {
+  return [
+    {
+      id: 'democratic-population',
+      name: 'Democratic Population',
+      description:
+        'Citizens in liberal democracies with strong civil-society institutions, free press, and a tradition of collective action.',
+      stressResponseCurve: [
+        { stressLevel: 0, responseIntensity: 0.05, behaviorType: 'compliance' },
+        { stressLevel: 1, responseIntensity: 0.2, behaviorType: 'compliance' },
+        { stressLevel: 2, responseIntensity: 0.5, behaviorType: 'adaptation' },
+        { stressLevel: 3, responseIntensity: 0.75, behaviorType: 'resistance' },
+        { stressLevel: 4, responseIntensity: 0.95, behaviorType: 'resistance' },
+      ],
+      typicalReactions: [
+        'organize peaceful protests and petition campaigns',
+        'shift consumption patterns and hoard essentials',
+        'pressure elected representatives via media and town halls',
+        'form mutual-aid networks for the affected',
+      ],
+      escalationThreshold: 2.8,
+    },
+    {
+      id: 'authoritarian-population',
+      name: 'Authoritarian Population',
+      description:
+        'Citizens under regimes that suppress dissent — visible compliance masks a much higher latent stress response.',
+      stressResponseCurve: [
+        { stressLevel: 0, responseIntensity: 0.02, behaviorType: 'compliance' },
+        { stressLevel: 1, responseIntensity: 0.08, behaviorType: 'compliance' },
+        { stressLevel: 2, responseIntensity: 0.25, behaviorType: 'compliance' },
+        { stressLevel: 3, responseIntensity: 0.55, behaviorType: 'adaptation' },
+        { stressLevel: 4, responseIntensity: 0.9, behaviorType: 'collapse' },
+      ],
+      typicalReactions: [
+        'public compliance with private hoarding and emigration prep',
+        'underground networks and informal trade',
+        'sudden, rare flashpoints that surprise observers',
+        'regime brittleness that fails catastrophically once tipped',
+      ],
+      escalationThreshold: 3.4,
+    },
+    {
+      id: 'democratic-government',
+      name: 'Democratic Government',
+      description:
+        'Elected governments accountable to voters, media, and courts — slower to act but more legitimate when they do.',
+      stressResponseCurve: [
+        { stressLevel: 0, responseIntensity: 0.1, behaviorType: 'compliance' },
+        { stressLevel: 1, responseIntensity: 0.3, behaviorType: 'compliance' },
+        { stressLevel: 2, responseIntensity: 0.55, behaviorType: 'adaptation' },
+        { stressLevel: 3, responseIntensity: 0.8, behaviorType: 'adaptation' },
+        { stressLevel: 4, responseIntensity: 0.95, behaviorType: 'resistance' },
+      ],
+      typicalReactions: [
+        'invoke emergency powers under existing statutes',
+        'fiscal stimulus and targeted relief programs',
+        'diplomatic coordination with allies',
+        'fall back on judicial review when actions overreach',
+      ],
+      escalationThreshold: 3,
+    },
+    {
+      id: 'authoritarian-government',
+      name: 'Authoritarian Government',
+      description:
+        'Regimes optimized for regime survival — quick coercive action, opaque decision making, prone to overreach.',
+      stressResponseCurve: [
+        { stressLevel: 0, responseIntensity: 0.15, behaviorType: 'compliance' },
+        { stressLevel: 1, responseIntensity: 0.4, behaviorType: 'adaptation' },
+        { stressLevel: 2, responseIntensity: 0.7, behaviorType: 'resistance' },
+        { stressLevel: 3, responseIntensity: 0.88, behaviorType: 'resistance' },
+        { stressLevel: 4, responseIntensity: 0.98, behaviorType: 'collapse' },
+      ],
+      typicalReactions: [
+        'mass arrests and information blackouts',
+        'mobilize internal security and paramilitary forces',
+        'scapegoat external adversaries to rally support',
+        'lethal crackdowns once regime survival is threatened',
+      ],
+      escalationThreshold: 2.2,
+    },
+    {
+      id: 'international-institution',
+      name: 'International Institution',
+      description:
+        'Multilateral bodies (UN, IMF, WHO, NATO) — slow consensus mechanics, ceiling on coercive power.',
+      stressResponseCurve: [
+        { stressLevel: 0, responseIntensity: 0.05, behaviorType: 'compliance' },
+        { stressLevel: 1, responseIntensity: 0.15, behaviorType: 'compliance' },
+        { stressLevel: 2, responseIntensity: 0.35, behaviorType: 'adaptation' },
+        { stressLevel: 3, responseIntensity: 0.55, behaviorType: 'adaptation' },
+        { stressLevel: 4, responseIntensity: 0.7, behaviorType: 'adaptation' },
+      ],
+      typicalReactions: [
+        'convene emergency sessions and issue resolutions',
+        'release humanitarian funds and deploy observers',
+        'sanction violators within the limits of member consensus',
+        'broker ceasefires and negotiation channels',
+      ],
+      escalationThreshold: 3.5,
+    },
+    {
+      id: 'market-actor',
+      name: 'Market Actor',
+      description:
+        'Banks, asset managers, and corporates — risk-aversion kicks in early, herd dynamics amplify late.',
+      stressResponseCurve: [
+        { stressLevel: 0, responseIntensity: 0.1, behaviorType: 'compliance' },
+        { stressLevel: 1, responseIntensity: 0.35, behaviorType: 'adaptation' },
+        { stressLevel: 2, responseIntensity: 0.65, behaviorType: 'adaptation' },
+        { stressLevel: 3, responseIntensity: 0.85, behaviorType: 'resistance' },
+        { stressLevel: 4, responseIntensity: 1, behaviorType: 'collapse' },
+      ],
+      typicalReactions: [
+        'rebalance into defensive assets and raise cash',
+        'tighten lending standards and hoard liquidity',
+        'short the affected sector or geography',
+        'fire-sale assets once margin calls cascade',
+      ],
+      escalationThreshold: 2.5,
+    },
+  ];
+}
+
+// ── Storage helpers ──────────────────────────────────────────────────────
+
+function defaultStorage(): StorageLike {
+  if (typeof globalThis !== 'undefined') {
+    const g = globalThis as { localStorage?: StorageLike };
+    if (g.localStorage) return g.localStorage;
+  }
+  return {
+    getItem: () => null,
+    setItem: () => undefined,
+  };
+}
+
+interface PersistedStore {
+  archetypes: BehavioralArchetype[];
+  observations: BehavioralObservation[];
+}
+
+// ── Service ──────────────────────────────────────────────────────────────
+
+export class BehavioralModelingService {
+  private static instance: BehavioralModelingService | undefined;
+
+  private readonly storage: StorageLike;
+  private readonly now: () => number;
+  private archetypes = new Map<string, BehavioralArchetype>();
+  private observations: BehavioralObservation[] = [];
+
+  private constructor(options: BehavioralModelingOptions = {}) {
+    this.storage = options.storage ?? defaultStorage();
+    this.now = options.now ?? (() => Date.now());
+    this.hydrate();
+    this.seedIfEmpty();
+  }
+
+  static getInstance(): BehavioralModelingService {
+    BehavioralModelingService.instance ??= new BehavioralModelingService();
+    return BehavioralModelingService.instance;
+  }
+
+  static createForTesting(options: BehavioralModelingOptions = {}): BehavioralModelingService {
+    return new BehavioralModelingService(options);
+  }
+
+  /** Reset the process-wide singleton. Tests-only. */
+  static resetForTesting(): void {
+    BehavioralModelingService.instance = undefined;
+  }
+
+  // ── Read ────────────────────────────────────────────────────────────────
+
+  getArchetypes(): BehavioralArchetype[] {
+    return [...this.archetypes.values()].map((a) => cloneArchetype(a));
+  }
+
+  getArchetype(id: string): BehavioralArchetype | undefined {
+    const a = this.archetypes.get(id);
+    return a ? cloneArchetype(a) : undefined;
+  }
+
+  getObservations(): BehavioralObservation[] {
+    return this.observations.map((o) => ({ ...o }));
+  }
+
+  // ── Predict ────────────────────────────────────────────────────────────
+
+  predictResponse(
+    archetypeId: string,
+    stressLevel: number,
+    region: string = DEFAULT_REGION,
+  ): BehavioralPrediction {
+    const archetype = this.archetypes.get(archetypeId);
+    if (!archetype) {
+      throw new Error(`Unknown archetype id: "${archetypeId}"`);
+    }
+    if (!Number.isFinite(stressLevel)) {
+      throw new TypeError(`stressLevel must be a finite number; got ${stressLevel}`);
+    }
+
+    const clamped = clamp(stressLevel, STRESS_MIN, STRESS_MAX);
+    const interp = interpolate(archetype.stressResponseCurve, clamped);
+    const nearest = nearestAnchor(archetype.stressResponseCurve, clamped);
+    const confidence = clamp(1 - Math.abs(clamped - nearest.stressLevel) / STRESS_MAX, 0, 1);
+
+    return {
+      archetypeId,
+      region,
+      stressLevel: clamped,
+      predictedBehavior: describeBehavior(archetype, interp.behaviorType, interp.responseIntensity),
+      responseIntensity: interp.responseIntensity,
+      behaviorType: interp.behaviorType,
+      confidence,
+    };
+  }
+
+  // ── Calibrate ──────────────────────────────────────────────────────────
+
+  recordObservedBehavior(
+    archetypeId: string,
+    stressLevel: number,
+    actualBehaviorType: BehaviorType,
+    region: string = DEFAULT_REGION,
+  ): BehavioralObservation {
+    const archetype = this.archetypes.get(archetypeId);
+    if (!archetype) {
+      throw new Error(`Unknown archetype id: "${archetypeId}"`);
+    }
+    if (!Number.isFinite(stressLevel)) {
+      throw new TypeError(`stressLevel must be a finite number; got ${stressLevel}`);
+    }
+
+    const clamped = clamp(stressLevel, STRESS_MIN, STRESS_MAX);
+    const observation: BehavioralObservation = {
+      archetypeId,
+      region,
+      stressLevel: clamped,
+      actualBehaviorType,
+      observedAt: this.now(),
+    };
+
+    this.observations.push(observation);
+    if (this.observations.length > MAX_OBSERVATIONS) {
+      this.observations.splice(0, this.observations.length - MAX_OBSERVATIONS);
+    }
+
+    const predicted = interpolate(archetype.stressResponseCurve, clamped);
+    if (predicted.behaviorType !== actualBehaviorType) {
+      const direction = nudgeDirection(predicted.behaviorType, actualBehaviorType);
+      const next = clamp(
+        archetype.escalationThreshold + direction * THRESHOLD_NUDGE,
+        STRESS_MIN,
+        STRESS_MAX,
+      );
+      const updated: BehavioralArchetype = { ...archetype, escalationThreshold: next };
+      this.archetypes.set(archetypeId, updated);
+    }
+
+    this.persist();
+    return { ...observation };
+  }
+
+  // ── Persistence ────────────────────────────────────────────────────────
+
+  private hydrate(): void {
+    let raw: string | null = null;
+    try {
+      raw = this.storage.getItem(STORAGE_KEY);
+    } catch {
+      raw = null;
+    }
+    if (!raw) return;
+    try {
+      const parsed = JSON.parse(raw) as PersistedStore;
+      if (Array.isArray(parsed.archetypes)) {
+        for (const a of parsed.archetypes) {
+          if (isArchetype(a)) this.archetypes.set(a.id, a);
+        }
+      }
+      if (Array.isArray(parsed.observations)) {
+        this.observations = parsed.observations
+          .filter((o) => isObservation(o))
+          .slice(-MAX_OBSERVATIONS);
+      }
+    } catch {
+      // Corrupt payload — drop it.
+    }
+  }
+
+  private seedIfEmpty(): void {
+    if (this.archetypes.size > 0) return;
+    for (const a of seedArchetypes()) this.archetypes.set(a.id, a);
+    this.persist();
+  }
+
+  private persist(): void {
+    const payload: PersistedStore = {
+      archetypes: [...this.archetypes.values()],
+      observations: this.observations,
+    };
+    try {
+      this.storage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    } catch {
+      // Best-effort; ignore quota / serialization errors.
+    }
+  }
+}
+
+// ── Pure helpers (exported for tests) ────────────────────────────────────
+
+export function interpolate(
+  curve: readonly StressPoint[],
+  stressLevel: number,
+): { responseIntensity: number; behaviorType: BehaviorType } {
+  if (curve.length === 0) {
+    return { responseIntensity: 0, behaviorType: 'compliance' };
+  }
+  const sorted = [...curve].sort((a, b) => a.stressLevel - b.stressLevel);
+  const first = sorted[0]!;
+  const last = sorted[sorted.length - 1]!;
+
+  if (stressLevel <= first.stressLevel) {
+    return { responseIntensity: first.responseIntensity, behaviorType: first.behaviorType };
+  }
+  if (stressLevel >= last.stressLevel) {
+    return { responseIntensity: last.responseIntensity, behaviorType: last.behaviorType };
+  }
+
+  for (let i = 0; i < sorted.length - 1; i += 1) {
+    const lo = sorted[i]!;
+    const hi = sorted[i + 1]!;
+    if (stressLevel >= lo.stressLevel && stressLevel <= hi.stressLevel) {
+      const span = hi.stressLevel - lo.stressLevel;
+      const t = span === 0 ? 0 : (stressLevel - lo.stressLevel) / span;
+      const responseIntensity =
+        lo.responseIntensity + t * (hi.responseIntensity - lo.responseIntensity);
+      // Behavior type follows the nearest anchor on the segment.
+      const behaviorType = t < 0.5 ? lo.behaviorType : hi.behaviorType;
+      return { responseIntensity, behaviorType };
+    }
+  }
+  // Should be unreachable thanks to the boundary guards above.
+  return { responseIntensity: last.responseIntensity, behaviorType: last.behaviorType };
+}
+
+export function nearestAnchor(
+  curve: readonly StressPoint[],
+  stressLevel: number,
+): StressPoint {
+  if (curve.length === 0) {
+    return { stressLevel: 0, responseIntensity: 0, behaviorType: 'compliance' };
+  }
+  let best = curve[0]!;
+  let bestDist = Math.abs(stressLevel - best.stressLevel);
+  for (let i = 1; i < curve.length; i += 1) {
+    const p = curve[i]!;
+    const d = Math.abs(stressLevel - p.stressLevel);
+    if (d < bestDist) {
+      best = p;
+      bestDist = d;
+    }
+  }
+  return best;
+}
+
+const BEHAVIOR_RANK: Record<BehaviorType, number> = {
+  compliance: 0,
+  adaptation: 1,
+  resistance: 2,
+  collapse: 3,
+};
+
+/**
+ * Determine which direction to nudge the escalation threshold.
+ *
+ *   actual MORE intense than predicted → archetype escalates sooner than
+ *   we thought → lower the threshold (negative).
+ *
+ *   actual LESS intense than predicted → archetype is more resilient
+ *   than we thought → raise the threshold (positive).
+ */
+export function nudgeDirection(
+  predicted: BehaviorType,
+  actual: BehaviorType,
+): number {
+  const delta = BEHAVIOR_RANK[actual] - BEHAVIOR_RANK[predicted];
+  if (delta > 0) return -1;
+  if (delta < 0) return 1;
+  return 0;
+}
+
+function describeBehavior(
+  archetype: BehavioralArchetype,
+  behaviorType: BehaviorType,
+  intensity: number,
+): string {
+  const pct = Math.round(intensity * 100);
+  switch (behaviorType) {
+    case 'compliance': {
+      return `${archetype.name}: largely compliant (${pct}% intensity) — expect baseline behavior with minor adjustments.`;
+    }
+    case 'adaptation': {
+      return `${archetype.name}: actively adapting (${pct}% intensity) — expect policy shifts, hedging, and reallocation.`;
+    }
+    case 'resistance': {
+      return `${archetype.name}: resisting (${pct}% intensity) — expect protest, dissent, or coercive pushback.`;
+    }
+    case 'collapse': {
+      return `${archetype.name}: at risk of collapse (${pct}% intensity) — expect cascading failure or regime breakdown.`;
+    }
+  }
+}
+
+function clamp(value: number, lo: number, hi: number): number {
+  if (value < lo) return lo;
+  if (value > hi) return hi;
+  return value;
+}
+
+function cloneArchetype(a: BehavioralArchetype): BehavioralArchetype {
+  return {
+    ...a,
+    stressResponseCurve: a.stressResponseCurve.map((p) => ({ ...p })),
+    typicalReactions: [...a.typicalReactions],
+  };
+}
+
+function isArchetype(value: unknown): value is BehavioralArchetype {
+  if (!value || typeof value !== 'object') return false;
+  const a = value as Record<string, unknown>;
+  return (
+    typeof a.id === 'string' &&
+    typeof a.name === 'string' &&
+    typeof a.description === 'string' &&
+    Array.isArray(a.stressResponseCurve) &&
+    Array.isArray(a.typicalReactions) &&
+    typeof a.escalationThreshold === 'number'
+  );
+}
+
+function isObservation(value: unknown): value is BehavioralObservation {
+  if (!value || typeof value !== 'object') return false;
+  const o = value as Record<string, unknown>;
+  return (
+    typeof o.archetypeId === 'string' &&
+    typeof o.region === 'string' &&
+    typeof o.stressLevel === 'number' &&
+    (o.actualBehaviorType === 'compliance' ||
+      o.actualBehaviorType === 'adaptation' ||
+      o.actualBehaviorType === 'resistance' ||
+      o.actualBehaviorType === 'collapse') &&
+    typeof o.observedAt === 'number'
+  );
+}

--- a/tests/intelligence/behavioral-modeling.test.mts
+++ b/tests/intelligence/behavioral-modeling.test.mts
@@ -1,0 +1,463 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  BehavioralModelingService,
+  MAX_OBSERVATIONS,
+  STORAGE_KEY,
+  STRESS_MAX,
+  THRESHOLD_NUDGE,
+  interpolate,
+  nearestAnchor,
+  nudgeDirection,
+  type BehavioralArchetype,
+  type StorageLike,
+  type StressPoint,
+} from '../../src/services/intelligence/behavioral-modeling.ts';
+
+const NOW = 1_700_000_000_000;
+
+function memoryStorage(): StorageLike & { dump(): string | null } {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (k) => store[k] ?? null,
+    setItem: (k, v) => { store[k] = v; },
+    removeItem: (k) => { delete store[k]; },
+    dump: () => store[STORAGE_KEY] ?? null,
+  };
+}
+
+function freshService(now: number = NOW) {
+  return BehavioralModelingService.createForTesting({
+    storage: memoryStorage(),
+    now: () => now,
+  });
+}
+
+const SEED_IDS = [
+  'democratic-population',
+  'authoritarian-population',
+  'democratic-government',
+  'authoritarian-government',
+  'international-institution',
+  'market-actor',
+] as const;
+
+// ── Singleton + lifecycle ───────────────────────────────────────────────
+
+describe('BehavioralModelingService — singleton', () => {
+  beforeEach(() => {
+    BehavioralModelingService.resetForTesting();
+  });
+
+  it('getInstance returns the same instance', () => {
+    const a = BehavioralModelingService.getInstance();
+    const b = BehavioralModelingService.getInstance();
+    assert.equal(a, b);
+  });
+
+  it('createForTesting returns an independent instance', () => {
+    const a = BehavioralModelingService.getInstance();
+    const b = BehavioralModelingService.createForTesting({ storage: memoryStorage() });
+    assert.notEqual(a, b);
+  });
+
+  it('resetForTesting clears the singleton', () => {
+    const a = BehavioralModelingService.getInstance();
+    BehavioralModelingService.resetForTesting();
+    const b = BehavioralModelingService.getInstance();
+    assert.notEqual(a, b);
+  });
+});
+
+// ── Seed archetypes ──────────────────────────────────────────────────────
+
+describe('BehavioralModelingService — seeding', () => {
+  it('seeds exactly 6 archetypes on first run', () => {
+    const svc = freshService();
+    assert.equal(svc.getArchetypes().length, 6);
+  });
+
+  it('seeds the 6 canonical archetype ids', () => {
+    const svc = freshService();
+    const ids = new Set(svc.getArchetypes().map((a) => a.id));
+    for (const id of SEED_IDS) assert.ok(ids.has(id), `missing ${id}`);
+  });
+
+  it('each seed has a name, description, curve, reactions, threshold', () => {
+    const svc = freshService();
+    for (const a of svc.getArchetypes()) {
+      assert.ok(a.name.length > 0, `${a.id} missing name`);
+      assert.ok(a.description.length > 0, `${a.id} missing description`);
+      assert.ok(a.stressResponseCurve.length >= 2, `${a.id} curve too short`);
+      assert.ok(a.typicalReactions.length > 0, `${a.id} no reactions`);
+      assert.ok(
+        a.escalationThreshold >= 0 && a.escalationThreshold <= STRESS_MAX,
+        `${a.id} threshold out of range`,
+      );
+    }
+  });
+
+  it('every seed curve has monotonically non-decreasing intensity', () => {
+    const svc = freshService();
+    for (const a of svc.getArchetypes()) {
+      const sorted = [...a.stressResponseCurve].sort((x, y) => x.stressLevel - y.stressLevel);
+      for (let i = 1; i < sorted.length; i += 1) {
+        assert.ok(
+          sorted[i]!.responseIntensity >= sorted[i - 1]!.responseIntensity - 1e-9,
+          `${a.id} intensity drops at index ${i}`,
+        );
+      }
+    }
+  });
+
+  it('persists seed archetypes to storage on first run', () => {
+    const storage = memoryStorage();
+    BehavioralModelingService.createForTesting({ storage, now: () => NOW });
+    const raw = storage.dump();
+    assert.ok(raw, 'storage should be written');
+    const parsed = JSON.parse(raw!);
+    assert.equal(parsed.archetypes.length, 6);
+  });
+
+  it('does not re-seed when storage already has archetypes', () => {
+    const storage = memoryStorage();
+    const svc1 = BehavioralModelingService.createForTesting({ storage, now: () => NOW });
+    svc1.recordObservedBehavior('market-actor', 4, 'collapse');
+    const before = svc1.getObservations().length;
+    const svc2 = BehavioralModelingService.createForTesting({ storage, now: () => NOW });
+    assert.equal(svc2.getObservations().length, before, 'observations should rehydrate');
+  });
+});
+
+// ── Read helpers ─────────────────────────────────────────────────────────
+
+describe('BehavioralModelingService — read', () => {
+  it('getArchetypes returns a deep clone (mutation does not leak)', () => {
+    const svc = freshService();
+    const a = svc.getArchetypes()[0]!;
+    a.escalationThreshold = -999;
+    a.stressResponseCurve[0]!.responseIntensity = -999;
+    const fresh = svc.getArchetypes()[0]!;
+    assert.notEqual(fresh.escalationThreshold, -999);
+    assert.notEqual(fresh.stressResponseCurve[0]!.responseIntensity, -999);
+  });
+
+  it('getArchetype returns undefined for unknown id', () => {
+    const svc = freshService();
+    assert.equal(svc.getArchetype('does-not-exist'), undefined);
+  });
+
+  it('getArchetype returns the canonical record by id', () => {
+    const svc = freshService();
+    const got = svc.getArchetype('democratic-population');
+    assert.equal(got?.id, 'democratic-population');
+  });
+});
+
+// ── predictResponse ──────────────────────────────────────────────────────
+
+describe('BehavioralModelingService — predictResponse', () => {
+  it('throws on unknown archetype', () => {
+    const svc = freshService();
+    assert.throws(() => svc.predictResponse('nope', 2));
+  });
+
+  it('throws on non-finite stress level', () => {
+    const svc = freshService();
+    assert.throws(() => svc.predictResponse('democratic-population', Number.NaN));
+  });
+
+  it('clamps stress below 0 to 0', () => {
+    const svc = freshService();
+    const p = svc.predictResponse('democratic-population', -1);
+    assert.equal(p.stressLevel, 0);
+  });
+
+  it('clamps stress above 4 to 4', () => {
+    const svc = freshService();
+    const p = svc.predictResponse('democratic-population', 99);
+    assert.equal(p.stressLevel, STRESS_MAX);
+  });
+
+  it('returns the anchor intensity for an on-anchor query', () => {
+    const svc = freshService();
+    const p = svc.predictResponse('market-actor', 4);
+    const anchor = svc.getArchetype('market-actor')!
+      .stressResponseCurve.find((c) => c.stressLevel === 4)!;
+    assert.equal(p.responseIntensity, anchor.responseIntensity);
+  });
+
+  it('linearly interpolates intensity between two anchors', () => {
+    const svc = freshService();
+    const arch = svc.getArchetype('democratic-population')!;
+    const a1 = arch.stressResponseCurve.find((p) => p.stressLevel === 1)!;
+    const a2 = arch.stressResponseCurve.find((p) => p.stressLevel === 2)!;
+    const mid = svc.predictResponse('democratic-population', 1.5);
+    const expected = (a1.responseIntensity + a2.responseIntensity) / 2;
+    assert.ok(
+      Math.abs(mid.responseIntensity - expected) < 1e-9,
+      `expected ~${expected}, got ${mid.responseIntensity}`,
+    );
+  });
+
+  it('confidence is 1 when querying exactly on an anchor', () => {
+    const svc = freshService();
+    const p = svc.predictResponse('democratic-population', 2);
+    assert.equal(p.confidence, 1);
+  });
+
+  it('confidence drops with distance from nearest anchor', () => {
+    const svc = freshService();
+    const onAnchor = svc.predictResponse('democratic-population', 2);
+    const offAnchor = svc.predictResponse('democratic-population', 2.5);
+    assert.ok(offAnchor.confidence < onAnchor.confidence);
+  });
+
+  it('confidence stays within [0, 1]', () => {
+    const svc = freshService();
+    for (let s = 0; s <= 4; s += 0.25) {
+      const p = svc.predictResponse('democratic-population', s);
+      assert.ok(p.confidence >= 0 && p.confidence <= 1, `s=${s} → ${p.confidence}`);
+    }
+  });
+
+  it('predictedBehavior includes archetype name and behavior summary', () => {
+    const svc = freshService();
+    const p = svc.predictResponse('authoritarian-government', 3);
+    assert.match(p.predictedBehavior, /Authoritarian Government/);
+    assert.match(p.predictedBehavior, /intensity/);
+  });
+
+  it('defaults region to "global" and honors override', () => {
+    const svc = freshService();
+    assert.equal(svc.predictResponse('market-actor', 2).region, 'global');
+    assert.equal(svc.predictResponse('market-actor', 2, 'EU').region, 'EU');
+  });
+
+  it('behaviorType escalates with stress for archetypes that flip', () => {
+    const svc = freshService();
+    const low = svc.predictResponse('authoritarian-population', 0);
+    const high = svc.predictResponse('authoritarian-population', 4);
+    assert.equal(low.behaviorType, 'compliance');
+    assert.equal(high.behaviorType, 'collapse');
+  });
+});
+
+// ── recordObservedBehavior ───────────────────────────────────────────────
+
+describe('BehavioralModelingService — recordObservedBehavior', () => {
+  it('throws on unknown archetype', () => {
+    const svc = freshService();
+    assert.throws(() => svc.recordObservedBehavior('nope', 2, 'compliance'));
+  });
+
+  it('throws on non-finite stress level', () => {
+    const svc = freshService();
+    assert.throws(() =>
+      svc.recordObservedBehavior('democratic-population', Number.POSITIVE_INFINITY, 'compliance'),
+    );
+  });
+
+  it('appends an observation with timestamp from the injected clock', () => {
+    let t = NOW;
+    const svc = BehavioralModelingService.createForTesting({
+      storage: memoryStorage(),
+      now: () => t,
+    });
+    t = NOW + 42;
+    const obs = svc.recordObservedBehavior('market-actor', 2, 'adaptation');
+    assert.equal(obs.observedAt, NOW + 42);
+    assert.equal(svc.getObservations().length, 1);
+  });
+
+  it('observations ring-buffer caps at MAX_OBSERVATIONS', () => {
+    const svc = freshService();
+    for (let i = 0; i < MAX_OBSERVATIONS + 25; i += 1) {
+      svc.recordObservedBehavior('market-actor', 2, 'adaptation');
+    }
+    assert.equal(svc.getObservations().length, MAX_OBSERVATIONS);
+  });
+
+  it('does not nudge threshold when prediction matches observation', () => {
+    const svc = freshService();
+    const before = svc.getArchetype('democratic-population')!.escalationThreshold;
+    // At stress 1 the prediction is 'compliance' for democratic-population.
+    svc.recordObservedBehavior('democratic-population', 1, 'compliance');
+    const after = svc.getArchetype('democratic-population')!.escalationThreshold;
+    assert.equal(before, after);
+  });
+
+  it('lowers threshold when observed is MORE intense than predicted', () => {
+    const svc = freshService();
+    const before = svc.getArchetype('democratic-population')!.escalationThreshold;
+    // At stress 1 the prediction is 'compliance' — observe resistance instead.
+    svc.recordObservedBehavior('democratic-population', 1, 'resistance');
+    const after = svc.getArchetype('democratic-population')!.escalationThreshold;
+    assert.ok(after < before, `expected drop, got ${before} → ${after}`);
+    assert.ok(Math.abs((before - after) - THRESHOLD_NUDGE) < 1e-9);
+  });
+
+  it('raises threshold when observed is LESS intense than predicted', () => {
+    const svc = freshService();
+    const before = svc.getArchetype('market-actor')!.escalationThreshold;
+    // At stress 4 the prediction is 'collapse' — observe compliance instead.
+    svc.recordObservedBehavior('market-actor', 4, 'compliance');
+    const after = svc.getArchetype('market-actor')!.escalationThreshold;
+    assert.ok(after > before, `expected rise, got ${before} → ${after}`);
+    assert.ok(Math.abs((after - before) - THRESHOLD_NUDGE) < 1e-9);
+  });
+
+  it('threshold stays clamped within [0, 4] after many nudges', () => {
+    const svc = freshService();
+    for (let i = 0; i < 200; i += 1) {
+      svc.recordObservedBehavior('democratic-population', 0, 'collapse');
+    }
+    const t = svc.getArchetype('democratic-population')!.escalationThreshold;
+    assert.ok(t >= 0 && t <= 4, `out of bounds: ${t}`);
+  });
+
+  it('persists observations across rehydration', () => {
+    const storage = memoryStorage();
+    const svc1 = BehavioralModelingService.createForTesting({ storage, now: () => NOW });
+    svc1.recordObservedBehavior('market-actor', 2.5, 'adaptation');
+    const svc2 = BehavioralModelingService.createForTesting({ storage, now: () => NOW });
+    assert.equal(svc2.getObservations().length, 1);
+    assert.equal(svc2.getObservations()[0]!.archetypeId, 'market-actor');
+  });
+
+  it('persists threshold updates across rehydration', () => {
+    const storage = memoryStorage();
+    const svc1 = BehavioralModelingService.createForTesting({ storage, now: () => NOW });
+    svc1.recordObservedBehavior('democratic-population', 1, 'resistance');
+    const updated = svc1.getArchetype('democratic-population')!.escalationThreshold;
+    const svc2 = BehavioralModelingService.createForTesting({ storage, now: () => NOW });
+    assert.equal(svc2.getArchetype('democratic-population')!.escalationThreshold, updated);
+  });
+});
+
+// ── Pure helpers ─────────────────────────────────────────────────────────
+
+describe('interpolate — pure helper', () => {
+  const curve: StressPoint[] = [
+    { stressLevel: 0, responseIntensity: 0,   behaviorType: 'compliance' },
+    { stressLevel: 2, responseIntensity: 0.5, behaviorType: 'adaptation' },
+    { stressLevel: 4, responseIntensity: 1,   behaviorType: 'collapse' },
+  ];
+
+  it('returns the first anchor below the lowest stress level', () => {
+    const r = interpolate(curve, -5);
+    assert.equal(r.responseIntensity, 0);
+    assert.equal(r.behaviorType, 'compliance');
+  });
+
+  it('returns the last anchor above the highest stress level', () => {
+    const r = interpolate(curve, 99);
+    assert.equal(r.responseIntensity, 1);
+    assert.equal(r.behaviorType, 'collapse');
+  });
+
+  it('interpolates linearly between two anchors', () => {
+    const r = interpolate(curve, 1);
+    assert.ok(Math.abs(r.responseIntensity - 0.25) < 1e-9);
+  });
+
+  it('picks the closer anchor for behaviorType on a segment', () => {
+    assert.equal(interpolate(curve, 0.5).behaviorType, 'compliance');
+    assert.equal(interpolate(curve, 1.5).behaviorType, 'adaptation');
+  });
+
+  it('handles an empty curve safely', () => {
+    const r = interpolate([], 2);
+    assert.equal(r.responseIntensity, 0);
+    assert.equal(r.behaviorType, 'compliance');
+  });
+
+  it('handles a single-point curve', () => {
+    const single: StressPoint[] = [{ stressLevel: 2, responseIntensity: 0.7, behaviorType: 'adaptation' }];
+    const r = interpolate(single, 3);
+    assert.equal(r.responseIntensity, 0.7);
+    assert.equal(r.behaviorType, 'adaptation');
+  });
+});
+
+describe('nearestAnchor — pure helper', () => {
+  const curve: StressPoint[] = [
+    { stressLevel: 0, responseIntensity: 0,   behaviorType: 'compliance' },
+    { stressLevel: 2, responseIntensity: 0.5, behaviorType: 'adaptation' },
+    { stressLevel: 4, responseIntensity: 1,   behaviorType: 'collapse' },
+  ];
+
+  it('returns the closest anchor by stress distance', () => {
+    assert.equal(nearestAnchor(curve, 2.4).stressLevel, 2);
+    assert.equal(nearestAnchor(curve, 3.1).stressLevel, 4);
+  });
+
+  it('returns a default anchor for an empty curve', () => {
+    const a = nearestAnchor([], 1);
+    assert.equal(a.stressLevel, 0);
+    assert.equal(a.behaviorType, 'compliance');
+  });
+});
+
+describe('nudgeDirection — pure helper', () => {
+  it('returns -1 when observed is more intense than predicted', () => {
+    assert.equal(nudgeDirection('compliance', 'resistance'), -1);
+  });
+
+  it('returns +1 when observed is less intense than predicted', () => {
+    assert.equal(nudgeDirection('collapse', 'compliance'), 1);
+  });
+
+  it('returns 0 when observed matches predicted', () => {
+    assert.equal(nudgeDirection('adaptation', 'adaptation'), 0);
+  });
+});
+
+// ── Storage robustness ──────────────────────────────────────────────────
+
+describe('BehavioralModelingService — storage robustness', () => {
+  it('survives a corrupt persisted payload', () => {
+    const storage: StorageLike = {
+      getItem: () => '{not-json',
+      setItem: () => {},
+    };
+    const svc = BehavioralModelingService.createForTesting({ storage, now: () => NOW });
+    assert.equal(svc.getArchetypes().length, 6);
+  });
+
+  it('ignores setItem errors from a throwing storage', () => {
+    const storage: StorageLike = {
+      getItem: () => null,
+      setItem: () => { throw new Error('quota'); },
+    };
+    assert.doesNotThrow(() => {
+      const svc = BehavioralModelingService.createForTesting({ storage, now: () => NOW });
+      svc.recordObservedBehavior('market-actor', 2, 'adaptation');
+    });
+  });
+
+  it('rehydrates only valid archetypes and observations', () => {
+    const garbage = JSON.stringify({
+      archetypes: [
+        { id: 'good', name: 'Good', description: 'd',
+          stressResponseCurve: [], typicalReactions: [], escalationThreshold: 1 },
+        { id: 42 }, // not a valid archetype
+      ],
+      observations: [
+        { archetypeId: 'good', region: 'r', stressLevel: 1,
+          actualBehaviorType: 'compliance', observedAt: NOW },
+        { nope: true },
+      ],
+    });
+    const storage: StorageLike = {
+      getItem: (k) => k === STORAGE_KEY ? garbage : null,
+      setItem: () => {},
+    };
+    const svc = BehavioralModelingService.createForTesting({ storage, now: () => NOW });
+    // 1 hydrated + 6 not re-seeded because archetypes was non-empty: only 'good' survives.
+    const ids = svc.getArchetypes().map((a: BehavioralArchetype) => a.id);
+    assert.ok(ids.includes('good'));
+    assert.equal(svc.getObservations().length, 1);
+  });
+});


### PR DESCRIPTION
Adds `BehavioralModelingService` — predicts how populations, governments, and institutional actors respond to different stress levels (0–4 INFO/LOW/MEDIUM/HIGH/CRITICAL).

### Why a new service
Distinct from `behavioral-response.ts` (which tracks the time-phased shock → mobilization → adaptation → normalization → resilience curve of a single in-flight event). This service answers a different question: **given an archetype and a stress level, what behavior should we expect, and how intensely?**

### What's in the box
- `src/services/intelligence/behavioral-modeling.ts`:
  - Singleton with `getInstance()` + `createForTesting()` + `resetForTesting()`
  - 6 hand-seeded archetypes — democratic-population, authoritarian-population, democratic-government, authoritarian-government, international-institution, market-actor — each with its own `stressResponseCurve`, `typicalReactions`, and `escalationThreshold`
  - `predictResponse` linearly interpolates intensity between anchors and picks behaviorType from the nearest anchor on the segment; confidence = `1 − abs(stress − nearest anchor) / 4`
  - `recordObservedBehavior` nudges `escalationThreshold` by ±`THRESHOLD_NUDGE` (0.1) when the observed behavior is more / less intense than predicted (clamped to 0–4)
  - Persists archetypes + observations to `wm-behavioral-modeling` IDB key; ring-buffer cap **200** observations; survives corrupt payloads
  - Pure deterministic; no DOM / no fetch; injectable `StorageLike` + `now()` clock
- `tests/intelligence/behavioral-modeling.test.mts` — **48 unit tests** (well over the 33+ target) covering singleton lifecycle, seeding shape + monotonicity, prediction interpolation, confidence shape, threshold calibration nudges, persistence rehydration, and storage robustness

### Validation
- `npx tsx --test tests/intelligence/behavioral-modeling.test.mts` → **48/48 pass**
- Husky pre-commit hook ran clean (`typecheck:all` + lint-staged ESLint)

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass