### PR TITLE
Maritime superpower panel — deep intelligence view for maritime domain

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -362,6 +362,7 @@ import { FinancialSuperpowerPanel } from '@/components/FinancialSuperpowerPanel'
 import { ShortageDetailPanel } from '@/components/ShortageDetailPanel';
 import { WeatherHazardPanel } from '@/components/WeatherHazardPanel';
 import { MaritimeIntelPanel } from '@/components/MaritimeIntelPanel';
+import { MaritimeSuperpowerPanel } from '@/components/MaritimeSuperpowerPanel';
 import { TradeRouteRiskScorerPanel } from '@/components/TradeRouteRiskScorerPanel';
 import { SupplyChainDisruptionPanel } from '@/components/SupplyChainDisruptionPanel';
 import { InfraRiskMatrixPanel } from '@/components/InfraRiskMatrixPanel';
@@ -1500,6 +1501,7 @@ export class PanelLayoutManager implements AppModule {
  });
  this.ctx.panels['weather-hazard'] = new WeatherHazardPanel();
  this.ctx.panels['maritime-intel'] = new MaritimeIntelPanel();
+ this.ctx.panels['maritime-superpower'] = new MaritimeSuperpowerPanel();
  this.ctx.panels['trade-route-risk-scorer'] = new TradeRouteRiskScorerPanel();
  this.ctx.panels['supply-chain-disruption'] = new SupplyChainDisruptionPanel();
  this.ctx.panels['infra-risk-matrix'] = new InfraRiskMatrixPanel();

--- a/src/components/MaritimeSuperpowerPanel.ts
+++ b/src/components/MaritimeSuperpowerPanel.ts
@@ -1,16 +1,4 @@
 /* eslint-disable sonarjs/no-nested-template-literals, sonarjs/no-nested-conditional */
-/**
- * Maritime Superpower Panel — deep intelligence view for the maritime domain.
- *
- * Surfaces five intelligence layers:
- *   1. Vessel Anomaly Tracker  — AIS gaps, spoofing, sanctioned waters
- *   2. Chokepoint Status       — 5 strategic straits + risk + wait time
- *   3. Piracy & Incident Map   — active maritime piracy situations
- *   4. Sanctions Evasion Watch — OFAC matches + flags of convenience
- *   5. Port Disruption Index   — port congestion situations
- *
- * Pure deterministic helpers are exported for unit tests.
- */
 
 import { Panel } from './Panel';
 import { escapeHtml } from '@/utils/sanitize';
@@ -48,15 +36,15 @@ interface SituationLike {
 
 // ── Chokepoint catalogue ──────────────────────────────────────────────────────
 
-const CHOKEPOINT_NAMES = [
-  'Suez Canal',
-  'Strait of Hormuz',
-  'Strait of Malacca',
-  'Bab-el-Mandeb',
-  'Panama Canal',
-] as const;
+const CHOKEPOINTS: { name: string; keywords: string[] }[] = [
+  { name: 'Suez Canal',        keywords: ['suez'] },
+  { name: 'Strait of Hormuz',  keywords: ['hormuz'] },
+  { name: 'Strait of Malacca', keywords: ['malacca'] },
+  { name: 'Bab-el-Mandeb',     keywords: ['bab', 'mandeb', 'mandab'] },
+  { name: 'Panama Canal',      keywords: ['panama'] },
+];
 
-type ChokepointName = typeof CHOKEPOINT_NAMES[number];
+type ChokepointName = 'Suez Canal' | 'Strait of Hormuz' | 'Strait of Malacca' | 'Bab-el-Mandeb' | 'Panama Canal';
 
 // ── Exported pure helpers (tested without DOM) ────────────────────────────────
 
@@ -88,13 +76,12 @@ export function classifyVesselAnomalies(vessels: LegacyEntity[]): { name: string
 }
 
 export function buildChokepointRows(routes: TradeRoute[]): { name: ChokepointName; risk: RiskLevel; waitTime: string }[] {
-  return CHOKEPOINT_NAMES.map((cpName) => {
+  return CHOKEPOINTS.map(({ name: cpName, keywords }) => {
     const match = routes.find((r) =>
-      r.name.toLowerCase().includes(cpName.toLowerCase().split(' ')[0]!) ||
-      cpName.toLowerCase().includes(r.name.toLowerCase())
+      keywords.some((kw) => r.name.toLowerCase().includes(kw))
     );
-    if (!match) return { name: cpName, risk: 'minimal' as RiskLevel, waitTime: 'N/A' };
-    return { name: cpName, risk: match.riskLevel, waitTime: waitTimeForRisk(match.riskLevel) };
+    if (!match) return { name: cpName as ChokepointName, risk: 'minimal' as RiskLevel, waitTime: 'N/A' };
+    return { name: cpName as ChokepointName, risk: match.riskLevel, waitTime: waitTimeForRisk(match.riskLevel) };
   });
 }
 
@@ -207,7 +194,4 @@ export class MaritimeSuperpowerPanel extends Panel {
 </div>`;
   }
 
-  override destroy(): void {
-    super.destroy();
-  }
 }

--- a/src/components/MaritimeSuperpowerPanel.ts
+++ b/src/components/MaritimeSuperpowerPanel.ts
@@ -1,0 +1,213 @@
+/* eslint-disable sonarjs/no-nested-template-literals, sonarjs/no-nested-conditional */
+/**
+ * Maritime Superpower Panel — deep intelligence view for the maritime domain.
+ *
+ * Surfaces five intelligence layers:
+ *   1. Vessel Anomaly Tracker  — AIS gaps, spoofing, sanctioned waters
+ *   2. Chokepoint Status       — 5 strategic straits + risk + wait time
+ *   3. Piracy & Incident Map   — active maritime piracy situations
+ *   4. Sanctions Evasion Watch — OFAC matches + flags of convenience
+ *   5. Port Disruption Index   — port congestion situations
+ *
+ * Pure deterministic helpers are exported for unit tests.
+ */
+
+import { Panel } from './Panel';
+import { escapeHtml } from '@/utils/sanitize';
+import { situationEngine } from '@/services/situation-engine';
+import { queryEntities, type LegacyEntity } from '@/services/intelligence/entity-registry';
+import {
+  getTradeRouteRiskScorerService,
+  type TradeRoute,
+  type RiskLevel,
+} from '@/services/intelligence/trade-route-risk-scorer';
+import type { Situation } from '@/services/situation-types';
+
+// ── Local safe wrapper ────────────────────────────────────────────────────────
+
+function safe<T>(fn: () => T): T | undefined {
+  try { return fn(); } catch { return undefined; }
+}
+
+// ── Extended Situation shape (fields that may be present on enriched records) ─
+// Defined as a plain object (not extending Situation) so the looser `domain`
+// string type doesn't conflict with the SituationDomain union.
+
+interface SituationLike {
+  title: string;
+  /** Optional freeform name; falls back to title. */
+  name?: string;
+  /** Domain may carry 'maritime' on enriched records. */
+  domain: string;
+  /** Optional tags for domain-specific filtering. */
+  tags?: string[];
+  /** Optional severity label. */
+  severity?: string;
+  geo?: { label?: string };
+}
+
+// ── Chokepoint catalogue ──────────────────────────────────────────────────────
+
+const CHOKEPOINT_NAMES = [
+  'Suez Canal',
+  'Strait of Hormuz',
+  'Strait of Malacca',
+  'Bab-el-Mandeb',
+  'Panama Canal',
+] as const;
+
+type ChokepointName = typeof CHOKEPOINT_NAMES[number];
+
+// ── Exported pure helpers (tested without DOM) ────────────────────────────────
+
+export function waitTimeForRisk(level: string): string {
+  switch (level) {
+    case 'minimal': { return '< 4h';
+    }
+    case 'elevated': { return '8–24h';
+    }
+    case 'high': { return '24–48h';
+    }
+    case 'critical': { return '48h+';
+    }
+    default: { return 'N/A';
+    }
+  }
+}
+
+export function classifyVesselAnomalies(vessels: LegacyEntity[]): { name: string; flags: string[] }[] {
+  const result: { name: string; flags: string[] }[] = [];
+  for (const v of vessels) {
+    const flags: string[] = [];
+    if (v.meta.aisGap === true) flags.push('AIS gap');
+    if (v.meta.spoofing === true) flags.push('spoofing');
+    if (v.meta.sanctionedWaters === true) flags.push('sanctioned waters');
+    if (flags.length > 0) result.push({ name: v.name, flags });
+  }
+  return result;
+}
+
+export function buildChokepointRows(routes: TradeRoute[]): { name: ChokepointName; risk: RiskLevel; waitTime: string }[] {
+  return CHOKEPOINT_NAMES.map((cpName) => {
+    const match = routes.find((r) =>
+      r.name.toLowerCase().includes(cpName.toLowerCase().split(' ')[0]!) ||
+      cpName.toLowerCase().includes(r.name.toLowerCase())
+    );
+    if (!match) return { name: cpName, risk: 'minimal' as RiskLevel, waitTime: 'N/A' };
+    return { name: cpName, risk: match.riskLevel, waitTime: waitTimeForRisk(match.riskLevel) };
+  });
+}
+
+export function derivePiracyIncidents(situations: Situation[]): { name: string; location?: string }[] {
+  return (situations as SituationLike[])
+    .filter((s) =>
+      s.domain === 'maritime' &&
+      (s.tags?.some((t) => t.includes('piracy')) === true || (s.name ?? s.title).toLowerCase().includes('pira'))
+    )
+    .map((s) => ({ name: s.name ?? s.title, location: s.geo?.label }));
+}
+
+export function deriveSanctionsVessels(vessels: LegacyEntity[]): { name: string; reasons: string[] }[] {
+  const result: { name: string; reasons: string[] }[] = [];
+  for (const v of vessels) {
+    const reasons: string[] = [];
+    if (v.meta.ofacMatch === true) reasons.push('OFAC SDN match');
+    if (v.meta.flagOfConvenience === true) reasons.push('flag of convenience');
+    if (reasons.length > 0) result.push({ name: v.name, reasons });
+  }
+  return result;
+}
+
+export function derivePortDisruptions(situations: Situation[]): { name: string; severity: string }[] {
+  return (situations as SituationLike[])
+    .filter((s) =>
+      s.domain === 'maritime' &&
+      (s.tags?.some((t) => t.includes('port') || t.includes('congestion')) === true ||
+        (s.name ?? s.title).toLowerCase().includes('port'))
+    )
+    .map((s) => ({ name: s.name ?? s.title, severity: s.severity ?? 'unknown' }));
+}
+
+// ── Panel ─────────────────────────────────────────────────────────────────────
+
+export class MaritimeSuperpowerPanel extends Panel {
+  constructor() {
+    super({ id: 'maritime-superpower', title: 'Maritime Intelligence' });
+    this.refresh();
+  }
+
+  refresh(): void {
+    const vessels = safe(() => queryEntities({ kind: 'ship' })) ?? [];
+    const scorer = safe(() => getTradeRouteRiskScorerService());
+    const maritimeRoutes = safe(() => scorer?.getAllRoutes({ type: 'maritime' })) ?? [];
+    const situations = safe(() => situationEngine.getSituations()) ?? [];
+
+    const anomalies = classifyVesselAnomalies(vessels);
+    const chokepoints = buildChokepointRows(maritimeRoutes);
+    const piracy = derivePiracyIncidents(situations);
+    const sanctioned = deriveSanctionsVessels(vessels);
+    const portDisruptions = derivePortDisruptions(situations);
+
+    this.setContent(this.buildHtml(anomalies, chokepoints, piracy, sanctioned, portDisruptions));
+    this.markFresh();
+  }
+
+  private buildHtml(
+    anomalies: ReturnType<typeof classifyVesselAnomalies>,
+    chokepoints: ReturnType<typeof buildChokepointRows>,
+    piracy: ReturnType<typeof derivePiracyIncidents>,
+    sanctioned: ReturnType<typeof deriveSanctionsVessels>,
+    portDisruptions: ReturnType<typeof derivePortDisruptions>,
+  ): string {
+    return `<div class="maritime-superpower">
+  <section class="ms-section">
+    <h3 class="ms-section-title">Vessel Anomaly Tracker</h3>
+    ${anomalies.length === 0
+      ? '<p class="ms-empty">No active incidents</p>'
+      : anomalies.map((v) => `<div class="ms-vessel">
+      <span class="ms-vessel-name">${escapeHtml(v.name)}</span>
+      <span class="ms-anomaly-flags">${escapeHtml(v.flags.join(', '))}</span>
+    </div>`).join('\n    ')}
+  </section>
+  <section class="ms-section">
+    <h3 class="ms-section-title">Chokepoint Status</h3>
+    ${chokepoints.map((cp) => `<div class="ms-chokepoint" data-risk="${escapeHtml(cp.risk)}">
+      <span class="ms-chokepoint-name">${escapeHtml(cp.name)}</span>
+      <span class="ms-risk-badge ms-risk-${escapeHtml(cp.risk)}">${escapeHtml(cp.risk)}</span>
+      <span class="ms-wait-time">${escapeHtml(cp.waitTime)}</span>
+    </div>`).join('\n    ')}
+  </section>
+  <section class="ms-section">
+    <h3 class="ms-section-title">Piracy &amp; Incident Map</h3>
+    ${piracy.length === 0
+      ? '<p class="ms-empty">No active incidents</p>'
+      : piracy.map((p) => `<div class="ms-piracy-incident">
+      <span class="ms-incident-name">${escapeHtml(p.name)}</span>
+      ${p.location == null ? '' : `<span class="ms-incident-location">${escapeHtml(p.location)}</span>`}
+    </div>`).join('\n    ')}
+  </section>
+  <section class="ms-section">
+    <h3 class="ms-section-title">Sanctions Evasion Watch</h3>
+    ${sanctioned.length === 0
+      ? '<p class="ms-empty">No active incidents</p>'
+      : sanctioned.map((v) => `<div class="ms-sanctions-vessel">
+      <span class="ms-vessel-name">${escapeHtml(v.name)}</span>
+      <span class="ms-sanctions-reason">${escapeHtml(v.reasons.join(', '))}</span>
+    </div>`).join('\n    ')}
+  </section>
+  <section class="ms-section">
+    <h3 class="ms-section-title">Port Disruption Index</h3>
+    ${portDisruptions.length === 0
+      ? '<p class="ms-empty">No active incidents</p>'
+      : portDisruptions.map((s) => `<div class="ms-port-disruption">
+      <span class="ms-port-name">${escapeHtml(s.name)}</span>
+      <span class="ms-severity-badge">${escapeHtml(s.severity)}</span>
+    </div>`).join('\n    ')}
+  </section>
+</div>`;
+  }
+
+  override destroy(): void {
+    super.destroy();
+  }
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -24,6 +24,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'strategic-posture': { name: 'AI Strategic Posture', enabled: true, priority: 1 },
   insights: { name: 'AI Insights', enabled: true, priority: 1 },
   'maritime-intel': { name: 'Maritime Intel', enabled: true, priority: 1 },
+  'maritime-superpower': { name: 'Maritime Intelligence', enabled: true, priority: 1 },
   'supply-chain-disruption': { name: 'Supply Chain Disruption', enabled: true, priority: 1 },
   cii: { name: 'Country Instability', enabled: true, priority: 1 },
   'geo-hubs': { name: 'Geopolitical Hubs', enabled: true, priority: 1 },

--- a/tests/components/maritime-superpower-panel.test.mts
+++ b/tests/components/maritime-superpower-panel.test.mts
@@ -1,0 +1,272 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  classifyVesselAnomalies,
+  buildChokepointRows,
+  waitTimeForRisk,
+  derivePortDisruptions,
+  deriveSanctionsVessels,
+  derivePiracyIncidents,
+} from '../../src/components/MaritimeSuperpowerPanel.js';
+import type { LegacyEntity } from '../../src/services/intelligence/entity-registry.js';
+import type { TradeRoute } from '../../src/services/intelligence/trade-route-risk-scorer.js';
+import type { Situation } from '../../src/services/situation-types.js';
+
+// ── Fixture helpers ──────────────────────────────────────────────────────────
+
+function makeVessel(id: string, name: string, meta: Record<string, unknown> = {}): LegacyEntity {
+  return { id, kind: 'ship', name, lastSeenAt: Date.now(), meta };
+}
+
+function makeSituation(overrides: Partial<Situation> & { domain?: string; name?: string; tags?: string[]; severity?: string } = {}): Situation {
+  return {
+    id: 'sit-1',
+    title: overrides.name ?? 'Test Situation',
+    summary: 'Test summary',
+    phase: 'active',
+    domain: (overrides.domain ?? 'military') as Situation['domain'],
+    confidence: 0.7,
+    geo: { lat: 0, lon: 0, label: 'Test Location', countries: [], radiusKm: 100 },
+    signalIds: [],
+    signals: [],
+    domainDiversity: 1,
+    evidence: null,
+    scenarios: [],
+    actions: [],
+    causalChainId: null,
+    firstSeen: Date.now(),
+    lastUpdated: Date.now(),
+    reassessmentCount: 0,
+    ...overrides,
+  } as unknown as Situation;
+}
+
+function makeRoute(overrides: Partial<TradeRoute> = {}): TradeRoute {
+  return {
+    id: 'route-1',
+    name: 'Test Route',
+    type: 'maritime',
+    lat: 0,
+    lon: 0,
+    radiusKm: 50,
+    annualTradeUsd: 100_000_000,
+    riskScore: 0,
+    riskLevel: 'minimal',
+    lastUpdatedAt: Date.now(),
+    contributingFactors: [],
+    ...overrides,
+  };
+}
+
+// ── waitTimeForRisk ──────────────────────────────────────────────────────────
+
+describe('waitTimeForRisk', () => {
+  it('returns < 4h for minimal', () => {
+    assert.equal(waitTimeForRisk('minimal'), '< 4h');
+  });
+
+  it('returns 8–24h for elevated', () => {
+    assert.equal(waitTimeForRisk('elevated'), '8–24h');
+  });
+
+  it('returns 24–48h for high', () => {
+    assert.equal(waitTimeForRisk('high'), '24–48h');
+  });
+
+  it('returns 48h+ for critical', () => {
+    assert.equal(waitTimeForRisk('critical'), '48h+');
+  });
+
+  it('returns N/A for unknown level', () => {
+    assert.equal(waitTimeForRisk('unknown'), 'N/A');
+  });
+});
+
+// ── classifyVesselAnomalies ──────────────────────────────────────────────────
+
+describe('classifyVesselAnomalies', () => {
+  it('returns empty array for no vessels', () => {
+    assert.deepEqual(classifyVesselAnomalies([]), []);
+  });
+
+  it('detects AIS gap', () => {
+    const vessels = [makeVessel('v1', 'MV Atlas', { aisGap: true })];
+    const result = classifyVesselAnomalies(vessels);
+    assert.equal(result.length, 1);
+    assert.ok(result[0]!.flags.includes('AIS gap'));
+  });
+
+  it('detects spoofing', () => {
+    const vessels = [makeVessel('v2', 'MV Bravo', { spoofing: true })];
+    const result = classifyVesselAnomalies(vessels);
+    assert.equal(result.length, 1);
+    assert.ok(result[0]!.flags.includes('spoofing'));
+  });
+
+  it('detects sanctioned waters', () => {
+    const vessels = [makeVessel('v3', 'MV Charlie', { sanctionedWaters: true })];
+    const result = classifyVesselAnomalies(vessels);
+    assert.equal(result.length, 1);
+    assert.ok(result[0]!.flags.includes('sanctioned waters'));
+  });
+
+  it('filters out non-anomalous vessels', () => {
+    const vessels = [makeVessel('v4', 'MV Clean', {})];
+    assert.deepEqual(classifyVesselAnomalies(vessels), []);
+  });
+
+  it('includes all flags when vessel has multiple anomalies', () => {
+    const vessels = [makeVessel('v5', 'MV Delta', { aisGap: true, spoofing: true, sanctionedWaters: true })];
+    const result = classifyVesselAnomalies(vessels);
+    assert.equal(result.length, 1);
+    assert.ok(result[0]!.flags.includes('AIS gap'));
+    assert.ok(result[0]!.flags.includes('spoofing'));
+    assert.ok(result[0]!.flags.includes('sanctioned waters'));
+    assert.equal(result[0]!.flags.length, 3);
+  });
+});
+
+// ── buildChokepointRows ──────────────────────────────────────────────────────
+
+describe('buildChokepointRows', () => {
+  it('returns all 5 chokepoints when no routes provided', () => {
+    const rows = buildChokepointRows([]);
+    assert.equal(rows.length, 5);
+  });
+
+  it('defaults to minimal risk and N/A wait time when no matching route', () => {
+    const rows = buildChokepointRows([]);
+    for (const row of rows) {
+      assert.equal(row.risk, 'minimal');
+      assert.equal(row.waitTime, 'N/A');
+    }
+  });
+
+  it('maps Suez Canal route risk correctly', () => {
+    const routes = [makeRoute({ name: 'Suez Canal', riskLevel: 'high' })];
+    const rows = buildChokepointRows(routes);
+    const suez = rows.find((r) => r.name === 'Suez Canal');
+    assert.ok(suez, 'Suez Canal row should exist');
+    assert.equal(suez!.risk, 'high');
+    assert.equal(suez!.waitTime, '24–48h');
+  });
+
+  it('maps Strait of Hormuz route risk correctly', () => {
+    const routes = [makeRoute({ name: 'Strait of Hormuz', riskLevel: 'critical' })];
+    const rows = buildChokepointRows(routes);
+    const hormuz = rows.find((r) => r.name === 'Strait of Hormuz');
+    assert.ok(hormuz, 'Strait of Hormuz row should exist');
+    assert.equal(hormuz!.risk, 'critical');
+    assert.equal(hormuz!.waitTime, '48h+');
+  });
+
+  it('maps Strait of Malacca route risk correctly', () => {
+    const routes = [makeRoute({ name: 'Strait of Malacca', riskLevel: 'elevated' })];
+    const rows = buildChokepointRows(routes);
+    const malacca = rows.find((r) => r.name === 'Strait of Malacca');
+    assert.ok(malacca, 'Strait of Malacca row should exist');
+    assert.equal(malacca!.risk, 'elevated');
+    assert.equal(malacca!.waitTime, '8–24h');
+  });
+});
+
+// ── deriveSanctionsVessels ───────────────────────────────────────────────────
+
+describe('deriveSanctionsVessels', () => {
+  it('returns empty array for no vessels', () => {
+    assert.deepEqual(deriveSanctionsVessels([]), []);
+  });
+
+  it('detects OFAC SDN match', () => {
+    const vessels = [makeVessel('s1', 'MV Sanctioned', { ofacMatch: true })];
+    const result = deriveSanctionsVessels(vessels);
+    assert.equal(result.length, 1);
+    assert.ok(result[0]!.reasons.includes('OFAC SDN match'));
+  });
+
+  it('detects flag of convenience', () => {
+    const vessels = [makeVessel('s2', 'MV Flag', { flagOfConvenience: true })];
+    const result = deriveSanctionsVessels(vessels);
+    assert.equal(result.length, 1);
+    assert.ok(result[0]!.reasons.includes('flag of convenience'));
+  });
+
+  it('includes both reasons when both flags are present', () => {
+    const vessels = [makeVessel('s3', 'MV Both', { ofacMatch: true, flagOfConvenience: true })];
+    const result = deriveSanctionsVessels(vessels);
+    assert.equal(result.length, 1);
+    assert.ok(result[0]!.reasons.includes('OFAC SDN match'));
+    assert.ok(result[0]!.reasons.includes('flag of convenience'));
+  });
+
+  it('excludes vessels with no sanctions flags', () => {
+    const vessels = [makeVessel('s4', 'MV Clean', {})];
+    assert.deepEqual(deriveSanctionsVessels(vessels), []);
+  });
+});
+
+// ── derivePiracyIncidents ────────────────────────────────────────────────────
+
+describe('derivePiracyIncidents', () => {
+  it('returns empty array for no situations', () => {
+    assert.deepEqual(derivePiracyIncidents([]), []);
+  });
+
+  it('includes maritime situation with piracy tag', () => {
+    const sit = makeSituation({ domain: 'maritime', tags: ['piracy', 'gulf-of-aden'] });
+    const result = derivePiracyIncidents([sit]);
+    assert.equal(result.length, 1);
+  });
+
+  it('includes maritime situation with piracy in title', () => {
+    const sit = makeSituation({ domain: 'maritime', name: 'Piracy incident off Somalia' });
+    const result = derivePiracyIncidents([sit]);
+    assert.equal(result.length, 1);
+    assert.equal(result[0]!.name, 'Piracy incident off Somalia');
+  });
+
+  it('excludes non-maritime situation even with piracy tag', () => {
+    const sit = makeSituation({ domain: 'military', tags: ['piracy'] });
+    const result = derivePiracyIncidents([sit]);
+    assert.deepEqual(result, []);
+  });
+
+  it('excludes maritime situation without piracy tag or title match', () => {
+    const sit = makeSituation({ domain: 'maritime', name: 'Port congestion', tags: ['port'] });
+    const result = derivePiracyIncidents([sit]);
+    assert.deepEqual(result, []);
+  });
+});
+
+// ── derivePortDisruptions ────────────────────────────────────────────────────
+
+describe('derivePortDisruptions', () => {
+  it('returns empty array for no situations', () => {
+    assert.deepEqual(derivePortDisruptions([]), []);
+  });
+
+  it('includes maritime situation with port tag', () => {
+    const sit = makeSituation({ domain: 'maritime', tags: ['port', 'strike'] });
+    const result = derivePortDisruptions([sit]);
+    assert.equal(result.length, 1);
+  });
+
+  it('includes maritime situation with congestion tag', () => {
+    const sit = makeSituation({ domain: 'maritime', tags: ['congestion'] });
+    const result = derivePortDisruptions([sit]);
+    assert.equal(result.length, 1);
+  });
+
+  it('includes maritime situation with port in title', () => {
+    const sit = makeSituation({ domain: 'maritime', name: 'Los Angeles port backlog' });
+    const result = derivePortDisruptions([sit]);
+    assert.equal(result.length, 1);
+    assert.equal(result[0]!.name, 'Los Angeles port backlog');
+  });
+
+  it('excludes situations from non-maritime domains', () => {
+    const sit = makeSituation({ domain: 'economic', tags: ['port'] });
+    const result = derivePortDisruptions([sit]);
+    assert.deepEqual(result, []);
+  });
+});

--- a/tests/components/maritime-superpower-panel.test.mts
+++ b/tests/components/maritime-superpower-panel.test.mts
@@ -168,6 +168,24 @@ describe('buildChokepointRows', () => {
     assert.equal(malacca!.risk, 'elevated');
     assert.equal(malacca!.waitTime, '8–24h');
   });
+
+  it('maps Bab-el-Mandeb Strait (spaced variant) risk correctly', () => {
+    const routes = [makeRoute({ name: 'Bab el Mandeb Strait', riskLevel: 'high' })];
+    const rows = buildChokepointRows(routes);
+    const bab = rows.find((r) => r.name === 'Bab-el-Mandeb');
+    assert.ok(bab, 'Bab-el-Mandeb row should exist');
+    assert.equal(bab!.risk, 'high');
+    assert.equal(bab!.waitTime, '24–48h');
+  });
+
+  it('maps Panama Canal route risk correctly', () => {
+    const routes = [makeRoute({ name: 'Panama Canal', riskLevel: 'critical' })];
+    const rows = buildChokepointRows(routes);
+    const panama = rows.find((r) => r.name === 'Panama Canal');
+    assert.ok(panama, 'Panama Canal row should exist');
+    assert.equal(panama!.risk, 'critical');
+    assert.equal(panama!.waitTime, '48h+');
+  });
 });
 
 // ── deriveSanctionsVessels ───────────────────────────────────────────────────

--- a/tests/panels/panel-smoke-registry.mts
+++ b/tests/panels/panel-smoke-registry.mts
@@ -126,6 +126,7 @@ export const PANEL_SMOKE_REGISTRY: Record<string, SmokeFactory> = {
   'live-webcams': wrap(async () => { const m = await import('@/components/LiveWebcamsPanel'); return new m.LiveWebcamsPanel(); }),
   'local-ids': wrap(async () => { const m = await import('@/components/LocalIDSPanel'); return new m.LocalIDSPanel(); }),
   'macro-signals': wrap(async () => { const m = await import('@/components/MacroSignalsPanel'); return new m.MacroSignalsPanel(); }),
+  'maritime-superpower': wrap(async () => { const m = await import('@/components/MaritimeSuperpowerPanel'); return new m.MaritimeSuperpowerPanel(); }),
   'markets': wrap(async () => { const m = await import('@/components/MarketPanel'); return new m.MarketPanel(); }),
   'heatmap': wrap(async () => { const m = await import('@/components/MarketPanel'); return new m.HeatmapPanel(); }),
   'commodities': wrap(async () => { const m = await import('@/components/MarketPanel'); return new m.CommoditiesPanel(); }),


### PR DESCRIPTION
Adds `MaritimeSuperpowerPanel` (`maritime-superpower`) — a five-section deep-intelligence view for maritime threats, reading live data from the situation engine, entity registry, and trade route risk scorer.

## Five sections

| Section | Data source |
|---|---|
| Vessel Anomaly Tracker | Entity registry ships with `aisGap`, `spoofing`, `sanctionedWaters` meta flags |
| Chokepoint Status | Trade route risk scorer (maritime routes), keyword-matched to 5 chokepoints |
| Piracy & Incident Map | Situations with domain `maritime` + piracy tag/name |
| Sanctions Evasion Watch | Ships with `ofacMatch` or `flagOfConvenience` flags |
| Port Disruption Index | Situations with domain `maritime` + port/congestion tag/name |

## Design notes

- All service calls wrapped in `safe(() => ...)` — any service failure degrades only that section, never crashes the panel.
- Chokepoint matching uses keyword arrays (not string splitting) so variants like `'Bab el Mandeb'`, `'Bab Al-Mandab'`, and `'Bab-el-Mandeb'` all resolve correctly.
- Wait-time labels derived from risk level: minimal → `< 4h`, elevated → `8–24h`, high → `24–48h`, critical → `48h+`.
- Six pure exported helpers (`classifyVesselAnomalies`, `buildChokepointRows`, `waitTimeForRisk`, `derivePiracyIncidents`, `deriveSanctionsVessels`, `derivePortDisruptions`) keep all logic testable without DOM.

## Files changed

- `src/components/MaritimeSuperpowerPanel.ts` — panel + helpers
- `src/config/panels.ts` — `'maritime-superpower'` registration
- `src/app/panel-layout.ts` — instantiation
- `tests/panels/panel-smoke-registry.mts` — smoke factory
- `tests/components/maritime-superpower-panel.test.mts` — 33 tests, all passing

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass