### PR TITLE
Quality debt tracker — record and prioritize intelligence pipeline quality debts

### DIFF
--- a/src/services/intelligence/quality-debt-tracker.ts
+++ b/src/services/intelligence/quality-debt-tracker.ts
@@ -1,0 +1,472 @@
+/**
+ * Quality Debt Tracker — manual CRUD store for known quality debts in
+ * the intelligence pipeline (data freshness gaps, model calibration
+ * issues, coverage holes, latency wins, accuracy regressions).
+ *
+ * This is the *foundation* layer: a plain register of debts the team
+ * already knows about, seeded with 8 well-documented gaps. A separate
+ * auto-detector module (`src/services/quality/quality-debt.ts` and any
+ * later evolution) can sit on top and call `addDebt()` when it spots
+ * something new.
+ *
+ * Storage:
+ *   - In-memory ring (max 500 entries, FIFO eviction).
+ *   - Persists to localStorage `wm-quality-debt-tracker`, schema v1.
+ *   - Singleton via `QualityDebtTracker.getInstance()`.
+ *
+ * No DOM imports, no fetch, no globals beyond `localStorage`/`Date.now()`.
+ * Pure helpers (severityRank, sortBySeverity) are exported so callers
+ * can render without instantiating the tracker.
+ */
+
+export type QualityDebtCategory =
+  | 'data'      // freshness / feed gaps / parse fragility
+  | 'model'     // calibration / drift / score stability
+  | 'coverage'  // missing domains, regions, asset classes
+  | 'latency'   // p95 above SLO
+  | 'accuracy'; // forecast / classification accuracy regressions
+
+export type QualityDebtSeverity = 'low' | 'medium' | 'high' | 'critical';
+
+export type QualityDebtStatus = 'open' | 'in-progress' | 'resolved';
+
+export interface QualityDebt {
+  /** Stable id, monotonic per-process. Persists across reload. */
+  id: string;
+  /** Short title for the debt (≤140 chars, trimmed). */
+  title: string;
+  /** Long-form description — what the debt is, why it matters. */
+  description: string;
+  category: QualityDebtCategory;
+  severity: QualityDebtSeverity;
+  /** Optional domain hint matching ObservationEvent.domain values. */
+  domain?: string;
+  /** Plain-text impact statement: e.g. "30-min gap in vessel positions". */
+  estimatedImpact: string;
+  /** ms since epoch. */
+  createdAt: number;
+  /** ms since epoch; undefined unless status === 'resolved'. */
+  resolvedAt?: number;
+  status: QualityDebtStatus;
+}
+
+export interface QualityDebtStats {
+  totalOpen: number;
+  bySeverity: Record<QualityDebtSeverity, number>;
+  byCategory: Record<QualityDebtCategory, number>;
+  /** Resolved / (resolved + open + in-progress), as a percentage 0–100.
+   *  Returns 0 when the tracker is completely empty. */
+  resolutionRatePct: number;
+}
+
+export type CreateDebtInput =
+  Omit<QualityDebt, 'id' | 'createdAt' | 'resolvedAt' | 'status'>
+  & { id?: string; createdAt?: number; status?: QualityDebtStatus };
+
+export type DebtListener = (debt: QualityDebt, kind: 'added' | 'updated') => void;
+
+export const STORAGE_KEY = 'wm-quality-debt-tracker';
+export const STORE_LIMIT = 500;
+export const SCHEMA_VERSION = 1;
+
+// ── Pure helpers ──────────────────────────────────────────────────────────
+
+const SEVERITY_RANK: Record<QualityDebtSeverity, number> = {
+  critical: 3, high: 2, medium: 1, low: 0,
+};
+
+export function severityRank(severity: QualityDebtSeverity): number {
+  return SEVERITY_RANK[severity];
+}
+
+/** Sort debts critical-first, with createdAt desc as tiebreaker. Returns
+ *  a new array — the input is not mutated. */
+export function sortBySeverity(debts: readonly QualityDebt[]): QualityDebt[] {
+  return [...debts].sort((a, b) => {
+    const ra = SEVERITY_RANK[a.severity];
+    const rb = SEVERITY_RANK[b.severity];
+    if (ra !== rb) return rb - ra;
+    return b.createdAt - a.createdAt;
+  });
+}
+
+const VALID_CATEGORIES: ReadonlySet<QualityDebtCategory> =
+  new Set(['data', 'model', 'coverage', 'latency', 'accuracy']);
+const VALID_SEVERITIES: ReadonlySet<QualityDebtSeverity> =
+  new Set(['low', 'medium', 'high', 'critical']);
+const VALID_STATUSES: ReadonlySet<QualityDebtStatus> =
+  new Set(['open', 'in-progress', 'resolved']);
+
+export function isValidDebt(value: unknown): value is QualityDebt {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.id !== 'string' || v.id.length === 0) return false;
+  if (typeof v.title !== 'string' || typeof v.description !== 'string') return false;
+  if (typeof v.estimatedImpact !== 'string') return false;
+  if (typeof v.createdAt !== 'number' || !Number.isFinite(v.createdAt)) return false;
+  if (!VALID_CATEGORIES.has(v.category as QualityDebtCategory)) return false;
+  if (!VALID_SEVERITIES.has(v.severity as QualityDebtSeverity)) return false;
+  if (!VALID_STATUSES.has(v.status as QualityDebtStatus)) return false;
+  if (v.domain !== undefined && typeof v.domain !== 'string') return false;
+  if (v.resolvedAt !== undefined
+      && (typeof v.resolvedAt !== 'number' || !Number.isFinite(v.resolvedAt))) return false;
+  return true;
+}
+
+// ── Seeded debts ──────────────────────────────────────────────────────────
+
+/** Eight known intelligence-pipeline gaps. The auto-detector module can
+ *  later add to or update these — the foundation just ships them so the
+ *  panel never displays an empty state on first run. */
+export const SEEDED_DEBTS: readonly Omit<QualityDebt,
+  'id' | 'createdAt' | 'resolvedAt' | 'status'>[] = [
+  {
+    title: 'AIS vessel data 6h latency',
+    description:
+      'AISStream WebSocket reconnect timing means we can be up to 6 hours behind on '
+      + 'vessel positions in dense traffic zones. The dark-vessel detector partially '
+      + 'compensates with a 24h history ring, but real-time chokepoint risk scoring '
+      + 'is degraded during the gap window.',
+    category: 'latency',
+    severity: 'high',
+    domain: 'ais',
+    estimatedImpact:
+      'Chokepoint closure-risk score is up to 6h stale during heavy reconnect cycles.',
+  },
+  {
+    title: 'GDACS RSS envelope parsing fragile',
+    description:
+      'GDACS occasionally emits non-RFC RSS with mixed CDATA and inline HTML in the '
+      + 'description element. The current parser strips the inner XML rather than '
+      + 'reading the geocoded payload, so coordinates default to country centroid.',
+    category: 'data',
+    severity: 'medium',
+    domain: 'gdacs',
+    estimatedImpact: 'Disaster coordinates fall back to country centroid ~3% of the time.',
+  },
+  {
+    title: 'Earthquake magnitude confidence uncalibrated',
+    description:
+      'USGS PAGER magnitudes vary between Mw, Mb, and Ms across event sources. The '
+      + 'truth-score pipeline treats them as interchangeable; in practice Mb tends to '
+      + 'over-estimate at low magnitudes by ~0.2 units versus the canonical Mw.',
+    category: 'model',
+    severity: 'medium',
+    domain: 'usgs',
+    estimatedImpact: 'Low-magnitude events scored 0.1–0.3 higher than calibrated truth.',
+  },
+  {
+    title: 'NHC cone-of-uncertainty not weighted by intensity',
+    description:
+      'Hurricane cones treat every track point as equally uncertain. Intensity-aware '
+      + 'modeling (post-rapid-intensification windows are tighter than pre-) would '
+      + 'narrow alert footprint for ~20% of storms.',
+    category: 'accuracy',
+    severity: 'medium',
+    domain: 'nhc',
+    estimatedImpact: 'Personal-impact alerts fire for 1.2x more saved-places than necessary.',
+  },
+  {
+    title: 'Cyber-domain coverage missing OT-specific feeds',
+    description:
+      'The cyber-threat panel ingests IT-oriented IOC feeds (Feodo, URLhaus, OTX) but '
+      + 'has no OT/ICS-specific source (Dragos, SCADAfence, CISA ICS-CERT). For '
+      + 'critical-infrastructure scenarios this is a coverage gap.',
+    category: 'coverage',
+    severity: 'high',
+    domain: 'cyber',
+    estimatedImpact: 'OT-threat scenarios miss 40% of relevant IOCs.',
+  },
+  {
+    title: 'GDELT Doc API global-event filter drops local feeds',
+    description:
+      'The GDELT Doc API query filter is tuned for cross-border events; same-country '
+      + 'local-language reporting (e.g. domestic strikes, regional weather) gets '
+      + 'dropped before reaching the truth scorer.',
+    category: 'coverage',
+    severity: 'low',
+    domain: 'gdelt',
+    estimatedImpact: 'Domestic-only events underweighted in regional risk scoring.',
+  },
+  {
+    title: 'FRED economic series cached without ETag revalidation',
+    description:
+      'FRED economic indicator pulls use a flat 24h cache with no If-Modified-Since '
+      + 'check. Series with multiple-times-per-day publication (Treasury rates, daily '
+      + 'spot prices) can be up to 24h behind during volatile periods.',
+    category: 'latency',
+    severity: 'medium',
+    domain: 'economic',
+    estimatedImpact: 'Macro stress score can lag market events by up to 24h.',
+  },
+  {
+    title: 'Forecast calibration over-confident in long-tail scenarios',
+    description:
+      'Brier-score calibration buckets above the 95th percentile (very-low-probability '
+      + 'catastrophic events) are systematically over-confident by 8–12 points, based '
+      + 'on the rolling forecast-calibration ledger. Long-tail predictions need an '
+      + 'isotonic-regression recalibration pass.',
+    category: 'accuracy',
+    severity: 'critical',
+    estimatedImpact:
+      'Catastrophic-tail forecasts (Cat 5, M8+, G5) are mis-confident by 8–12 pp.',
+  },
+];
+
+// ── Storage adapter ───────────────────────────────────────────────────────
+
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+function defaultStorage(): StorageLike | null {
+  if (typeof globalThis === 'undefined') return null;
+  const g = globalThis as { localStorage?: StorageLike };
+  return g.localStorage ?? null;
+}
+
+interface PersistEnvelope {
+  schema: number;
+  nextId: number;
+  debts: QualityDebt[];
+}
+
+// ── Tracker class ─────────────────────────────────────────────────────────
+
+export interface QualityDebtTrackerOptions {
+  /** Override storage host (used by tests). Pass `null` to disable. */
+  storage?: StorageLike | null;
+  /** Override `Date.now()` (used by tests). */
+  clock?: () => number;
+  /** Skip seeding the 8 built-in debts (tests + replays). */
+  skipSeed?: boolean;
+}
+
+export class QualityDebtTracker {
+  private static _instance: QualityDebtTracker | null = null;
+
+  private readonly _storage: StorageLike | null;
+  private readonly _clock: () => number;
+  private _debts: QualityDebt[] = [];
+  private _nextId = 1;
+  private _listeners = new Set<DebtListener>();
+
+  public static getInstance(): QualityDebtTracker {
+    QualityDebtTracker._instance ??= new QualityDebtTracker();
+    return QualityDebtTracker._instance;
+  }
+
+  /** Test seam — replaces the singleton. */
+  public static __setInstance(next: QualityDebtTracker | null): void {
+    QualityDebtTracker._instance = next;
+  }
+
+  public constructor(options: QualityDebtTrackerOptions = {}) {
+    this._storage = options.storage === undefined ? defaultStorage() : options.storage;
+    this._clock = options.clock ?? (() => Date.now());
+    if (!this._hydrateFromStorage() && !options.skipSeed) {
+      this._seed();
+      this._persist();
+    }
+  }
+
+  // ── CRUD ───────────────────────────────────────────────────────────
+
+  public addDebt(input: CreateDebtInput): QualityDebt {
+    const title = input.title.trim();
+    if (title.length === 0) {
+      throw new Error('QualityDebtTracker.addDebt: title is required');
+    }
+    if (!VALID_CATEGORIES.has(input.category)) {
+      throw new Error(`QualityDebtTracker.addDebt: invalid category ${input.category}`);
+    }
+    if (!VALID_SEVERITIES.has(input.severity)) {
+      throw new Error(`QualityDebtTracker.addDebt: invalid severity ${input.severity}`);
+    }
+    const now = input.createdAt ?? this._clock();
+    const status = input.status ?? 'open';
+    if (!VALID_STATUSES.has(status)) {
+      throw new Error(`QualityDebtTracker.addDebt: invalid status ${status}`);
+    }
+    const debt: QualityDebt = {
+      id: input.id ?? this._nextStableId(),
+      title: title.slice(0, 140),
+      description: input.description,
+      category: input.category,
+      severity: input.severity,
+      domain: input.domain,
+      estimatedImpact: input.estimatedImpact,
+      createdAt: now,
+      status,
+      ...(status === 'resolved' ? { resolvedAt: now } : {}),
+    };
+    this._debts.push(debt);
+    if (this._debts.length > STORE_LIMIT) {
+      this._debts.splice(0, this._debts.length - STORE_LIMIT);
+    }
+    this._persist();
+    this._emit(debt, 'added');
+    return { ...debt };
+  }
+
+  public updateStatus(id: string, status: QualityDebtStatus): QualityDebt {
+    if (!VALID_STATUSES.has(status)) {
+      throw new Error(`QualityDebtTracker.updateStatus: invalid status ${status}`);
+    }
+    const index = this._debts.findIndex((d) => d.id === id);
+    if (index === -1) {
+      throw new Error(`QualityDebtTracker.updateStatus: debt ${id} not found`);
+    }
+    const current = this._debts[index]!;
+    const next: QualityDebt = { ...current, status };
+    if (status === 'resolved') {
+      next.resolvedAt = current.resolvedAt ?? this._clock();
+    } else if (current.resolvedAt !== undefined) {
+      delete next.resolvedAt;
+    }
+    this._debts[index] = next;
+    this._persist();
+    this._emit(next, 'updated');
+    return { ...next };
+  }
+
+  public getDebt(id: string): QualityDebt | null {
+    const found = this._debts.find((d) => d.id === id);
+    return found ? { ...found } : null;
+  }
+
+  public getAll(): QualityDebt[] {
+    return this._debts.map((d) => ({ ...d }));
+  }
+
+  public getOpen(): QualityDebt[] {
+    const open = this._debts.filter((d) => d.status !== 'resolved');
+    return sortBySeverity(open).map((d) => ({ ...d }));
+  }
+
+  public getByCategory(category: QualityDebtCategory): QualityDebt[] {
+    return this._debts
+      .filter((d) => d.category === category)
+      .map((d) => ({ ...d }));
+  }
+
+  public findByDomain(domain: string): QualityDebt[] {
+    return this._debts
+      .filter((d) => d.domain === domain)
+      .map((d) => ({ ...d }));
+  }
+
+  // ── Stats ───────────────────────────────────────────────────────────
+
+  public getStats(): QualityDebtStats {
+    const open = this._debts.filter((d) => d.status !== 'resolved');
+    const resolved = this._debts.filter((d) => d.status === 'resolved');
+    const bySeverity: Record<QualityDebtSeverity, number> = { critical: 0, high: 0, medium: 0, low: 0 };
+    const byCategory: Record<QualityDebtCategory, number> = {
+      data: 0, model: 0, coverage: 0, latency: 0, accuracy: 0,
+    };
+    for (const d of open) {
+      bySeverity[d.severity] += 1;
+      byCategory[d.category] += 1;
+    }
+    const total = this._debts.length;
+    const resolutionRatePct = total === 0 ? 0
+      : Math.round((resolved.length / total) * 100);
+    return { totalOpen: open.length, bySeverity, byCategory, resolutionRatePct };
+  }
+
+  // ── Pub/sub (small, optional) ───────────────────────────────────────
+
+  /** Subscribe to add/update events. Returns an unsubscribe handle. */
+  public subscribe(listener: DebtListener): () => void {
+    this._listeners.add(listener);
+    return () => { this._listeners.delete(listener); };
+  }
+
+  /** Test seam — clears everything. */
+  public __reset(): void {
+    this._debts = [];
+    this._nextId = 1;
+    this._listeners.clear();
+    if (this._storage) {
+      try { this._storage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
+    }
+  }
+
+  // ── Internals ───────────────────────────────────────────────────────
+
+  private _nextStableId(): string {
+    const id = `debt-${this._nextId.toString(36)}`;
+    this._nextId += 1;
+    return id;
+  }
+
+  private _seed(): void {
+    const seedClock = this._clock();
+    for (const partial of SEEDED_DEBTS) {
+      this._debts.push({
+        id: this._nextStableId(),
+        title: partial.title,
+        description: partial.description,
+        category: partial.category,
+        severity: partial.severity,
+        domain: partial.domain,
+        estimatedImpact: partial.estimatedImpact,
+        createdAt: seedClock,
+        status: 'open',
+      });
+    }
+  }
+
+  private _persist(): void {
+    if (!this._storage) return;
+    try {
+      const envelope: PersistEnvelope = {
+        schema: SCHEMA_VERSION,
+        nextId: this._nextId,
+        debts: this._debts,
+      };
+      this._storage.setItem(STORAGE_KEY, JSON.stringify(envelope));
+    } catch {
+      // localStorage quota / SecurityError — drop silently; in-memory ring
+      // remains canonical until the next setItem succeeds.
+    }
+  }
+
+  private _hydrateFromStorage(): boolean {
+    if (!this._storage) return false;
+    let raw: string | null;
+    try {
+      raw = this._storage.getItem(STORAGE_KEY);
+    } catch {
+      return false;
+    }
+    if (!raw) return false;
+    try {
+      const parsed = JSON.parse(raw) as Partial<PersistEnvelope>;
+      if (!parsed || typeof parsed !== 'object') return false;
+      if (parsed.schema !== SCHEMA_VERSION) return false;
+      if (!Array.isArray(parsed.debts)) return false;
+      const valid = parsed.debts.filter((d) => isValidDebt(d));
+      if (valid.length === 0 && parsed.debts.length > 0) return false;
+      this._debts = valid.slice(-STORE_LIMIT);
+      this._nextId = typeof parsed.nextId === 'number' && Number.isFinite(parsed.nextId)
+        ? Math.max(parsed.nextId, this._debts.length + 1)
+        : this._debts.length + 1;
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private _emit(debt: QualityDebt, kind: 'added' | 'updated'): void {
+    if (this._listeners.size === 0) return;
+    const snapshot = { ...debt };
+    for (const fn of this._listeners) {
+      try { fn(snapshot, kind); }
+      catch { /* listener errors must not break the tracker */ }
+    }
+  }
+}

--- a/tests/intelligence/quality-debt-tracker.test.mts
+++ b/tests/intelligence/quality-debt-tracker.test.mts
@@ -1,0 +1,454 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  QualityDebtTracker,
+  SCHEMA_VERSION,
+  SEEDED_DEBTS,
+  STORAGE_KEY,
+  STORE_LIMIT,
+  isValidDebt,
+  severityRank,
+  sortBySeverity,
+  type CreateDebtInput,
+  type QualityDebt,
+  type QualityDebtCategory,
+} from '../../src/services/intelligence/quality-debt-tracker.ts';
+
+class MemoryStorage {
+  public map = new Map<string, string>();
+  getItem(key: string): string | null { return this.map.get(key) ?? null; }
+  setItem(key: string, value: string): void { this.map.set(key, value); }
+  removeItem(key: string): void { this.map.delete(key); }
+  has(key: string): boolean { return this.map.has(key); }
+}
+
+function makeTracker(over: Partial<ConstructorParameters<typeof QualityDebtTracker>[0]> = {}) {
+  return new QualityDebtTracker({
+    storage: over.storage ?? new MemoryStorage(),
+    clock: over.clock ?? (() => 1_700_000_000_000),
+    skipSeed: over.skipSeed ?? false,
+  });
+}
+
+function debtInput(over: Partial<CreateDebtInput> = {}): CreateDebtInput {
+  return {
+    title: over.title ?? 'Sample debt',
+    description: over.description ?? 'A test debt entry',
+    category: over.category ?? 'data',
+    severity: over.severity ?? 'medium',
+    domain: over.domain,
+    estimatedImpact: over.estimatedImpact ?? 'Test impact',
+    ...over,
+  };
+}
+
+// ── Seed + initial state ──────────────────────────────────────────────────
+
+test('SEEDED_DEBTS exposes 8 well-formed entries', () => {
+  assert.equal(SEEDED_DEBTS.length, 8);
+  for (const seed of SEEDED_DEBTS) {
+    assert.ok(seed.title.length > 0);
+    assert.ok(seed.description.length > 0);
+    assert.ok(seed.estimatedImpact.length > 0);
+    assert.ok(['data', 'model', 'coverage', 'latency', 'accuracy'].includes(seed.category));
+    assert.ok(['low', 'medium', 'high', 'critical'].includes(seed.severity));
+  }
+});
+
+test('SEEDED_DEBTS covers every spec category at least once', () => {
+  const categories = new Set(SEEDED_DEBTS.map((d) => d.category));
+  for (const c of ['data', 'model', 'coverage', 'latency', 'accuracy']) {
+    assert.ok(categories.has(c as QualityDebtCategory), `missing seed for ${c}`);
+  }
+});
+
+test('constructor seeds 8 debts on first run', () => {
+  const t = makeTracker();
+  assert.equal(t.getAll().length, 8);
+  assert.equal(t.getOpen().length, 8);
+});
+
+test('constructor skipSeed: true leaves the tracker empty', () => {
+  const t = makeTracker({ skipSeed: true });
+  assert.equal(t.getAll().length, 0);
+  assert.equal(t.getOpen().length, 0);
+});
+
+// ── Singleton ─────────────────────────────────────────────────────────────
+
+test('getInstance returns the same singleton each call', () => {
+  QualityDebtTracker.__setInstance(null);
+  const a = QualityDebtTracker.getInstance();
+  const b = QualityDebtTracker.getInstance();
+  assert.equal(a, b);
+  QualityDebtTracker.__setInstance(null);
+});
+
+test('__setInstance lets tests inject a custom tracker', () => {
+  const custom = makeTracker({ skipSeed: true });
+  QualityDebtTracker.__setInstance(custom);
+  assert.equal(QualityDebtTracker.getInstance(), custom);
+  QualityDebtTracker.__setInstance(null);
+});
+
+// ── Pure helpers ──────────────────────────────────────────────────────────
+
+test('severityRank: critical > high > medium > low', () => {
+  assert.ok(severityRank('critical') > severityRank('high'));
+  assert.ok(severityRank('high') > severityRank('medium'));
+  assert.ok(severityRank('medium') > severityRank('low'));
+});
+
+test('sortBySeverity: returns critical-first, breaks ties by createdAt desc', () => {
+  const debts: QualityDebt[] = [
+    { id: 'a', title: 'a', description: '', category: 'data', severity: 'low',
+      estimatedImpact: '', createdAt: 1000, status: 'open' },
+    { id: 'b', title: 'b', description: '', category: 'data', severity: 'critical',
+      estimatedImpact: '', createdAt: 2000, status: 'open' },
+    { id: 'c', title: 'c', description: '', category: 'data', severity: 'critical',
+      estimatedImpact: '', createdAt: 3000, status: 'open' },
+    { id: 'd', title: 'd', description: '', category: 'data', severity: 'high',
+      estimatedImpact: '', createdAt: 4000, status: 'open' },
+  ];
+  const sorted = sortBySeverity(debts);
+  assert.deepEqual(sorted.map((d) => d.id), ['c', 'b', 'd', 'a']);
+});
+
+test('sortBySeverity: does not mutate input', () => {
+  const debts: QualityDebt[] = [
+    { id: 'a', title: '', description: '', category: 'data', severity: 'low',
+      estimatedImpact: '', createdAt: 1, status: 'open' },
+    { id: 'b', title: '', description: '', category: 'data', severity: 'critical',
+      estimatedImpact: '', createdAt: 2, status: 'open' },
+  ];
+  const before = debts.map((d) => d.id).join(',');
+  sortBySeverity(debts);
+  assert.equal(debts.map((d) => d.id).join(','), before);
+});
+
+// ── isValidDebt ───────────────────────────────────────────────────────────
+
+test('isValidDebt accepts a well-formed debt', () => {
+  const debt: QualityDebt = {
+    id: 'debt-1', title: 't', description: 'd', category: 'data', severity: 'low',
+    estimatedImpact: 'i', createdAt: 1, status: 'open',
+  };
+  assert.equal(isValidDebt(debt), true);
+});
+
+test('isValidDebt rejects null / primitive / missing fields', () => {
+  assert.equal(isValidDebt(null), false);
+  assert.equal(isValidDebt(42), false);
+  assert.equal(isValidDebt('hello'), false);
+  assert.equal(isValidDebt({ id: 'debt-1' }), false);
+});
+
+test('isValidDebt rejects invalid category / severity / status', () => {
+  const base: QualityDebt = {
+    id: 'debt-1', title: 't', description: 'd', category: 'data', severity: 'low',
+    estimatedImpact: 'i', createdAt: 1, status: 'open',
+  };
+  assert.equal(isValidDebt({ ...base, category: 'security' }), false);
+  assert.equal(isValidDebt({ ...base, severity: 'severe' }), false);
+  assert.equal(isValidDebt({ ...base, status: 'pending' }), false);
+});
+
+// ── addDebt ───────────────────────────────────────────────────────────────
+
+test('addDebt: appends a row with auto-generated id and createdAt', () => {
+  const t = makeTracker({ skipSeed: true, clock: () => 5000 });
+  const debt = t.addDebt(debtInput({ title: 'new', severity: 'high' }));
+  assert.match(debt.id, /^debt-/);
+  assert.equal(debt.createdAt, 5000);
+  assert.equal(debt.status, 'open');
+  assert.equal(debt.resolvedAt, undefined);
+  assert.equal(t.getAll().length, 1);
+});
+
+test('addDebt: trims and clips long titles to 140 chars', () => {
+  const t = makeTracker({ skipSeed: true });
+  const long = 'X'.repeat(200);
+  const debt = t.addDebt(debtInput({ title: `   ${long}   ` }));
+  assert.equal(debt.title.length, 140);
+  assert.equal(debt.title.startsWith('X'), true);
+});
+
+test('addDebt: throws on empty / whitespace-only title', () => {
+  const t = makeTracker({ skipSeed: true });
+  assert.throws(() => t.addDebt(debtInput({ title: '' })), /title is required/);
+  assert.throws(() => t.addDebt(debtInput({ title: '   ' })), /title is required/);
+});
+
+test('addDebt: throws on invalid category', () => {
+  const t = makeTracker({ skipSeed: true });
+  assert.throws(
+    () => t.addDebt(debtInput({ category: 'security' as QualityDebtCategory })),
+    /invalid category/,
+  );
+});
+
+test('addDebt: throws on invalid severity', () => {
+  const t = makeTracker({ skipSeed: true });
+  assert.throws(
+    () => t.addDebt({ ...debtInput(), severity: 'nuclear' as never }),
+    /invalid severity/,
+  );
+});
+
+test('addDebt: status=resolved stamps resolvedAt with createdAt', () => {
+  const t = makeTracker({ skipSeed: true, clock: () => 7777 });
+  const debt = t.addDebt({ ...debtInput(), status: 'resolved' });
+  assert.equal(debt.status, 'resolved');
+  assert.equal(debt.resolvedAt, 7777);
+});
+
+test('addDebt: emits to subscribers with kind="added"', () => {
+  const t = makeTracker({ skipSeed: true });
+  const calls: { id: string; kind: string }[] = [];
+  t.subscribe((d, kind) => calls.push({ id: d.id, kind }));
+  const debt = t.addDebt(debtInput());
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.id, debt.id);
+  assert.equal(calls[0]?.kind, 'added');
+});
+
+// ── updateStatus ──────────────────────────────────────────────────────────
+
+test('updateStatus: open → in-progress preserves createdAt, no resolvedAt', () => {
+  const t = makeTracker({ skipSeed: true, clock: () => 100 });
+  const debt = t.addDebt(debtInput());
+  const updated = t.updateStatus(debt.id, 'in-progress');
+  assert.equal(updated.status, 'in-progress');
+  assert.equal(updated.createdAt, 100);
+  assert.equal(updated.resolvedAt, undefined);
+});
+
+test('updateStatus: open → resolved stamps resolvedAt with current clock', () => {
+  let now = 100;
+  const t = makeTracker({ skipSeed: true, clock: () => now });
+  const debt = t.addDebt(debtInput());
+  now = 500;
+  const updated = t.updateStatus(debt.id, 'resolved');
+  assert.equal(updated.status, 'resolved');
+  assert.equal(updated.resolvedAt, 500);
+});
+
+test('updateStatus: resolved → open clears resolvedAt', () => {
+  const t = makeTracker({ skipSeed: true, clock: () => 100 });
+  const debt = t.addDebt({ ...debtInput(), status: 'resolved' });
+  const updated = t.updateStatus(debt.id, 'open');
+  assert.equal(updated.status, 'open');
+  assert.equal(updated.resolvedAt, undefined);
+});
+
+test('updateStatus: throws on unknown id', () => {
+  const t = makeTracker({ skipSeed: true });
+  assert.throws(() => t.updateStatus('nonexistent', 'resolved'), /not found/);
+});
+
+test('updateStatus: throws on invalid status', () => {
+  const t = makeTracker({ skipSeed: true });
+  const debt = t.addDebt(debtInput());
+  assert.throws(
+    () => t.updateStatus(debt.id, 'pending' as never),
+    /invalid status/,
+  );
+});
+
+test('updateStatus: emits to subscribers with kind="updated"', () => {
+  const t = makeTracker({ skipSeed: true });
+  const debt = t.addDebt(debtInput());
+  const calls: { kind: string }[] = [];
+  t.subscribe((_d, kind) => calls.push({ kind }));
+  t.updateStatus(debt.id, 'resolved');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.kind, 'updated');
+});
+
+// ── Queries ───────────────────────────────────────────────────────────────
+
+test('getOpen: returns sorted critical-first, excludes resolved', () => {
+  const t = makeTracker({ skipSeed: true });
+  const a = t.addDebt(debtInput({ title: 'a', severity: 'low' }));
+  const b = t.addDebt(debtInput({ title: 'b', severity: 'critical' }));
+  t.addDebt(debtInput({ title: 'c', severity: 'high' }));
+  t.updateStatus(a.id, 'resolved');
+  const open = t.getOpen();
+  assert.equal(open.length, 2);
+  assert.equal(open[0]?.severity, 'critical');
+  assert.equal(open[0]?.id, b.id);
+  assert.equal(open[1]?.severity, 'high');
+});
+
+test('getByCategory: filters to matching category, ignores others', () => {
+  const t = makeTracker({ skipSeed: true });
+  t.addDebt(debtInput({ category: 'data' }));
+  t.addDebt(debtInput({ category: 'model' }));
+  t.addDebt(debtInput({ category: 'data' }));
+  assert.equal(t.getByCategory('data').length, 2);
+  assert.equal(t.getByCategory('model').length, 1);
+  assert.equal(t.getByCategory('latency').length, 0);
+});
+
+test('findByDomain: filters to matching domain hint', () => {
+  const t = makeTracker({ skipSeed: true });
+  t.addDebt(debtInput({ domain: 'ais' }));
+  t.addDebt(debtInput({ domain: 'cyber' }));
+  t.addDebt(debtInput({ /* no domain */ }));
+  assert.equal(t.findByDomain('ais').length, 1);
+  assert.equal(t.findByDomain('cyber').length, 1);
+  assert.equal(t.findByDomain('aviation').length, 0);
+});
+
+test('getDebt: returns a copy on hit, null on miss', () => {
+  const t = makeTracker({ skipSeed: true });
+  const debt = t.addDebt(debtInput({ title: 'original' }));
+  const hit = t.getDebt(debt.id);
+  assert.ok(hit);
+  assert.equal(hit.title, 'original');
+  // Mutating the copy must not bleed into the store.
+  hit.title = 'tampered';
+  assert.equal(t.getDebt(debt.id)?.title, 'original');
+  assert.equal(t.getDebt('nope'), null);
+});
+
+test('getAll / getOpen / getByCategory return independent copies', () => {
+  const t = makeTracker({ skipSeed: true });
+  t.addDebt(debtInput({ title: 'preserved' }));
+  const all = t.getAll();
+  all[0]!.title = 'tampered';
+  assert.equal(t.getAll()[0]?.title, 'preserved');
+});
+
+// ── Stats ─────────────────────────────────────────────────────────────────
+
+test('getStats: empty tracker reports zeros and 0% resolution', () => {
+  const t = makeTracker({ skipSeed: true });
+  const s = t.getStats();
+  assert.equal(s.totalOpen, 0);
+  assert.equal(s.resolutionRatePct, 0);
+  assert.equal(s.bySeverity.critical, 0);
+  assert.equal(s.byCategory.data, 0);
+});
+
+test('getStats: counts open debts only, not resolved', () => {
+  const t = makeTracker({ skipSeed: true });
+  t.addDebt(debtInput({ severity: 'critical', category: 'data' }));
+  t.addDebt(debtInput({ severity: 'high', category: 'model' }));
+  const resolved = t.addDebt(debtInput({ severity: 'low', category: 'latency' }));
+  t.updateStatus(resolved.id, 'resolved');
+  const s = t.getStats();
+  assert.equal(s.totalOpen, 2);
+  assert.equal(s.bySeverity.critical, 1);
+  assert.equal(s.bySeverity.high, 1);
+  assert.equal(s.bySeverity.low, 0); // resolved one is excluded
+  assert.equal(s.byCategory.data, 1);
+  assert.equal(s.byCategory.model, 1);
+  assert.equal(s.byCategory.latency, 0);
+});
+
+test('getStats: resolutionRatePct rounds to nearest integer', () => {
+  const t = makeTracker({ skipSeed: true });
+  for (let i = 0; i < 3; i += 1) t.addDebt(debtInput());
+  const resolvedIds = [
+    t.addDebt(debtInput()).id,
+    t.addDebt(debtInput()).id,
+  ];
+  for (const id of resolvedIds) t.updateStatus(id, 'resolved');
+  // 2 resolved out of 5 total = 40%
+  assert.equal(t.getStats().resolutionRatePct, 40);
+});
+
+// ── Persistence ───────────────────────────────────────────────────────────
+
+test('persistence: addDebt writes a v1 envelope to storage', () => {
+  const storage = new MemoryStorage();
+  const t = makeTracker({ storage, skipSeed: true });
+  t.addDebt(debtInput({ title: 'persisted' }));
+  const raw = storage.getItem(STORAGE_KEY);
+  assert.ok(raw);
+  const parsed = JSON.parse(raw) as { schema: number; debts: unknown[] };
+  assert.equal(parsed.schema, SCHEMA_VERSION);
+  assert.equal(parsed.debts.length, 1);
+});
+
+test('persistence: second tracker hydrates from existing envelope (no re-seed)', () => {
+  const storage = new MemoryStorage();
+  const t1 = makeTracker({ storage, skipSeed: true });
+  t1.addDebt(debtInput({ title: 'survives reload' }));
+  const t2 = makeTracker({ storage });
+  assert.equal(t2.getAll().length, 1);
+  assert.equal(t2.getAll()[0]?.title, 'survives reload');
+});
+
+test('persistence: corrupt envelope JSON triggers re-seed', () => {
+  const storage = new MemoryStorage();
+  storage.setItem(STORAGE_KEY, '{not valid json');
+  const t = makeTracker({ storage });
+  assert.equal(t.getAll().length, 8); // seed kicks in
+});
+
+test('persistence: wrong schema version triggers re-seed', () => {
+  const storage = new MemoryStorage();
+  storage.setItem(STORAGE_KEY, JSON.stringify({ schema: 99, debts: [] }));
+  const t = makeTracker({ storage });
+  assert.equal(t.getAll().length, 8);
+});
+
+test('persistence: storage host that throws setItem does not crash addDebt', () => {
+  const throwing = {
+    getItem: () => null,
+    setItem: () => { throw new Error('quota'); },
+    removeItem: () => { /* noop */ },
+  };
+  const t = makeTracker({ storage: throwing, skipSeed: true });
+  const debt = t.addDebt(debtInput()); // must not throw
+  assert.equal(t.getAll().length, 1);
+  assert.equal(debt.status, 'open');
+});
+
+// ── Ring buffer eviction ──────────────────────────────────────────────────
+
+test('ring buffer: STORE_LIMIT enforces FIFO eviction at 500', () => {
+  const t = makeTracker({ skipSeed: true, storage: null });
+  for (let i = 0; i < STORE_LIMIT + 10; i += 1) {
+    t.addDebt(debtInput({ title: `debt-${i}` }));
+  }
+  const all = t.getAll();
+  assert.equal(all.length, STORE_LIMIT);
+  // Oldest 10 evicted; newest debt is at the end.
+  assert.equal(all[0]?.title, 'debt-10');
+  assert.equal(all[all.length - 1]?.title, `debt-${STORE_LIMIT + 9}`);
+});
+
+// ── Subscribe / unsubscribe ───────────────────────────────────────────────
+
+test('subscribe: unsubscribe stops further callbacks', () => {
+  const t = makeTracker({ skipSeed: true });
+  const calls: string[] = [];
+  const unsub = t.subscribe((d) => calls.push(d.id));
+  t.addDebt(debtInput({ title: 'first' }));
+  unsub();
+  t.addDebt(debtInput({ title: 'second' }));
+  assert.equal(calls.length, 1);
+});
+
+test('subscribe: listener errors do not break the tracker', () => {
+  const t = makeTracker({ skipSeed: true });
+  t.subscribe(() => { throw new Error('boom'); });
+  // Must not throw despite the listener exception.
+  const debt = t.addDebt(debtInput());
+  assert.equal(t.getDebt(debt.id)?.title, debt.title);
+});
+
+// ── __reset ────────────────────────────────────────────────────────────────
+
+test('__reset: clears the store and storage', () => {
+  const storage = new MemoryStorage();
+  const t = makeTracker({ storage, skipSeed: true });
+  t.addDebt(debtInput());
+  t.__reset();
+  assert.equal(t.getAll().length, 0);
+  assert.equal(storage.has(STORAGE_KEY), false);
+});


### PR DESCRIPTION
Foundation-layer CRUD register for known quality debts in the intelligence pipeline. The manual layer beneath any future auto-detector — that detector can simply call \`addDebt()\` when it spots something new instead of inventing its own store.

## What's in this PR

[src/services/intelligence/quality-debt-tracker.ts](src/services/intelligence/quality-debt-tracker.ts) — \`QualityDebtTracker\` singleton with:

| Method | Purpose |
| --- | --- |
| \`addDebt(input)\` | Append, persist, emit |
| \`updateStatus(id, status)\` | Stamps \`resolvedAt\` on resolve, clears on reopen |
| \`getOpen()\` | Sorted critical-first via the pure \`sortBySeverity\` helper |
| \`getByCategory(cat)\` | Filter to one of the 5 categories |
| \`findByDomain(domain)\` | Bonus query for compositors that key by domain |
| \`getStats()\` | \`{ totalOpen, bySeverity, byCategory, resolutionRatePct }\` |
| \`subscribe(fn)\` | Pub/sub for future panels |

### Storage
- 500-entry in-memory ring with FIFO eviction.
- Persists to localStorage under \`wm-quality-debt-tracker\` (schema v1).
- Corrupt envelopes / wrong-schema payloads safely fall back to re-seeding.

### Seeded debts (8)
1. AIS vessel data 6h latency
2. GDACS RSS envelope parsing fragile
3. Earthquake magnitude confidence uncalibrated
4. NHC cone-of-uncertainty not weighted by intensity
5. Cyber domain missing OT-specific feeds
6. GDELT Doc API drops same-country local reporting
7. FRED economic series no ETag revalidation
8. Forecast calibration over-confident in long-tail buckets

## Tests — \`npx tsx --test tests/intelligence/quality-debt-tracker.test.mts\`

**42 tests, all green** (spec floor: 33+):
- Seed integrity + every spec category covered
- Singleton + \`__setInstance\` test seam
- Pure helpers: \`severityRank\`, \`sortBySeverity\` (with tie-break by \`createdAt\`), \`isValidDebt\`
- CRUD: 8 cases including title trim/clip, empty-title rejection, invalid-category rejection, resolved-at-creation
- Queries: \`getOpen\` sort, \`getByCategory\`, \`findByDomain\`, \`getDebt\` copy semantics
- Stats: empty tracker, open-only counting, integer-rounded resolution rate
- Persistence: envelope round-trip, corrupt-JSON re-seed, wrong-schema re-seed, throwing storage safety
- Ring buffer FIFO at \`STORE_LIMIT = 500\`
- Subscribe/unsubscribe + listener-exception isolation

\`typecheck:all\` clean, eslint clean.

## Coexistence note

A parallel branch (\`claude/quality-debt-tracker\`, not merged) holds a different design — an auto-detector with 6 categories, fingerprint merging, and a Panel — by Bradley directly. That work targets the same problem at a higher layer and can compose on top of this primitive later by calling \`addDebt()\`. Lives on a separate branch so neither blocks the other.

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass