### PR TITLE
Mission bridge core — standardized adapter infrastructure for all domain feeds

### DIFF
--- a/src/services/intelligence/mission-bridge-core.ts
+++ b/src/services/intelligence/mission-bridge-core.ts
@@ -1,0 +1,417 @@
+/**
+ * MissionBridgeCore — standardized adapter infrastructure for connecting
+ * raw domain feeds to the intelligence pipeline's ObservationEvent
+ * schema.
+ *
+ * Every domain feed lives behind a `MissionBridgeBase` subclass that
+ * implements two operations: `fetchRaw()` returning untyped provider
+ * payloads, and `normalize(raw)` mapping one payload to one
+ * `ObservationEvent` (or null to skip). The base orchestrates the
+ * fetch-normalize-cap cycle, tracks per-bridge stats, and persists
+ * stats to local storage.
+ *
+ * `MissionBridgeRegistry` is the process-wide singleton that owns the
+ * set of registered bridges. The host registers a bridge once at boot
+ * and calls `registry.runAll()` on a refresh tick to drain every
+ * domain.
+ *
+ * Pure / deterministic given a fetch oracle. Injectable Storage + clock
+ * so unit tests can pin behavior without DOM/fetch.
+ */
+
+import type { ObservationEvent, ObservationSeverity } from '@/types/intelligence';
+
+// ── Public types ─────────────────────────────────────────────────────────
+
+export interface MissionBridgeConfig {
+  domain: string;
+  feedId: string;
+  refreshIntervalMs: number;
+  maxObservationsPerCycle: number;
+  enabled: boolean;
+}
+
+export interface MissionBridgeStats {
+  /** Number of times processCycle() has been invoked end-to-end. */
+  cyclesRun: number;
+  /** Total ObservationEvents produced across the lifetime of the bridge. */
+  totalObservations: number;
+  /** Count of normalize() returning null (i.e. skipped / unparseable). */
+  nullSkipped: number;
+  /** Unix epoch ms of the most recent processCycle() completion; 0 if never. */
+  lastCycleAt: number;
+  /** Count of recordError() invocations. */
+  errorCount: number;
+  /** Most recent error message (kept short for the dashboard). */
+  lastError: string | null;
+}
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem?(key: string): void;
+}
+
+export interface MissionBridgeOptions {
+  storage?: StorageLike | null;
+  now?: () => number;
+}
+
+// ── Constants ────────────────────────────────────────────────────────────
+
+export const STORAGE_KEY = 'wm-mission-bridge-stats';
+export const MAX_PERSISTED_BRIDGES = 200;
+const MAX_ERROR_MSG_LEN = 280;
+
+// ── Base ─────────────────────────────────────────────────────────────────
+
+/**
+ * Subclasses must implement `fetchRaw()` and `normalize()`. Construction
+ * is gated behind `super(config, options)`; the base initialises stats,
+ * hydrates from storage, and exposes the standardized lifecycle.
+ */
+export abstract class MissionBridgeBase {
+  protected readonly config: MissionBridgeConfig;
+  protected readonly storage: StorageLike;
+  protected readonly now: () => number;
+  protected stats: MissionBridgeStats;
+
+  protected constructor(config: MissionBridgeConfig, options: MissionBridgeOptions = {}) {
+    if (!config.domain) throw new Error('MissionBridgeBase: domain is required');
+    if (!config.feedId) throw new Error('MissionBridgeBase: feedId is required');
+    if (config.maxObservationsPerCycle <= 0) {
+      throw new Error('MissionBridgeBase: maxObservationsPerCycle must be > 0');
+    }
+    if (config.refreshIntervalMs <= 0) {
+      throw new Error('MissionBridgeBase: refreshIntervalMs must be > 0');
+    }
+    this.config = { ...config };
+    this.storage = options.storage ?? defaultStorage();
+    this.now = options.now ?? (() => Date.now());
+    this.stats = freshStats();
+    this.hydrateStats();
+  }
+
+  /** Implemented by subclass — fetch the raw provider payloads. */
+  abstract fetchRaw(): Promise<unknown[]>;
+
+  /** Implemented by subclass — map one raw item to ObservationEvent (or null to skip). */
+  abstract normalize(raw: unknown): ObservationEvent | null;
+
+  /**
+   * One refresh cycle: fetchRaw → normalize → cap at
+   * maxObservationsPerCycle → return. Skipped items (normalize → null)
+   * contribute to `nullSkipped` rather than the result list. Errors
+   * raised by fetchRaw bubble up; the bridge records the error first so
+   * the dashboard can show it.
+   */
+  async processCycle(): Promise<ObservationEvent[]> {
+    if (!this.config.enabled) return [];
+    let raw: unknown[];
+    try {
+      raw = await this.fetchRaw();
+    } catch (error) {
+      this.recordError(error instanceof Error ? error.message : String(error));
+      throw error;
+    }
+
+    const out: ObservationEvent[] = [];
+    let skipped = 0;
+    for (const item of raw) {
+      if (out.length >= this.config.maxObservationsPerCycle) break;
+      const normalized = this.normalize(item);
+      if (normalized === null) {
+        skipped += 1;
+        continue;
+      }
+      out.push(normalized);
+    }
+
+    this.stats = {
+      ...this.stats,
+      cyclesRun: this.stats.cyclesRun + 1,
+      totalObservations: this.stats.totalObservations + out.length,
+      nullSkipped: this.stats.nullSkipped + skipped,
+      lastCycleAt: this.now(),
+    };
+    this.persistStats();
+    return out;
+  }
+
+  getConfig(): MissionBridgeConfig {
+    return { ...this.config };
+  }
+
+  getStats(): MissionBridgeStats {
+    return { ...this.stats };
+  }
+
+  recordError(message: string): void {
+    const truncated = message.length > MAX_ERROR_MSG_LEN
+      ? `${message.slice(0, MAX_ERROR_MSG_LEN - 1)}…`
+      : message;
+    this.stats = {
+      ...this.stats,
+      errorCount: this.stats.errorCount + 1,
+      lastError: truncated,
+    };
+    this.persistStats();
+  }
+
+  /** Reset stats only — config is preserved. Tests-only. */
+  resetStatsForTesting(): void {
+    this.stats = freshStats();
+    this.persistStats();
+  }
+
+  // ── Persistence ───────────────────────────────────────────────────────
+
+  private hydrateStats(): void {
+    let raw: string | null = null;
+    try {
+      raw = this.storage.getItem(STORAGE_KEY);
+    } catch {
+      raw = null;
+    }
+    if (!raw) return;
+    try {
+      const parsed = JSON.parse(raw) as Record<string, MissionBridgeStats>;
+      const mine = parsed[this.config.feedId];
+      if (mine && isStats(mine)) this.stats = { ...freshStats(), ...mine };
+    } catch {
+      // Corrupt blob — keep fresh stats.
+    }
+  }
+
+  private persistStats(): void {
+    let store: Record<string, MissionBridgeStats> = {};
+    try {
+      const raw = this.storage.getItem(STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as unknown;
+        if (parsed && typeof parsed === 'object') {
+          store = parsed as Record<string, MissionBridgeStats>;
+        }
+      }
+    } catch {
+      store = {};
+    }
+    store[this.config.feedId] = this.stats;
+
+    // Cap persisted bridges by dropping the least-recently-used ones if
+    // the registry grows unbounded.
+    const keys = Object.keys(store);
+    if (keys.length > MAX_PERSISTED_BRIDGES) {
+      const sorted = keys
+        .map((k) => ({ k, t: store[k]?.lastCycleAt ?? 0 }))
+        .sort((a, b) => a.t - b.t);
+      const drop = sorted.slice(0, keys.length - MAX_PERSISTED_BRIDGES);
+      for (const { k } of drop) delete store[k];
+    }
+
+    try {
+      this.storage.setItem(STORAGE_KEY, JSON.stringify(store));
+    } catch {
+      // Best-effort.
+    }
+  }
+}
+
+// ── Registry ─────────────────────────────────────────────────────────────
+
+export class MissionBridgeRegistry {
+  private static instance: MissionBridgeRegistry | undefined;
+
+  private readonly bridges = new Map<string, MissionBridgeBase>();
+
+  static getInstance(): MissionBridgeRegistry {
+    MissionBridgeRegistry.instance ??= new MissionBridgeRegistry();
+    return MissionBridgeRegistry.instance;
+  }
+
+  static resetForTesting(): MissionBridgeRegistry {
+    MissionBridgeRegistry.instance = new MissionBridgeRegistry();
+    return MissionBridgeRegistry.instance;
+  }
+
+  register(bridge: MissionBridgeBase): void {
+    const { feedId } = bridge.getConfig();
+    this.bridges.set(feedId, bridge);
+  }
+
+  unregister(feedId: string): boolean {
+    return this.bridges.delete(feedId);
+  }
+
+  getAll(): MissionBridgeBase[] {
+    return [...this.bridges.values()];
+  }
+
+  getByDomain(domain: string): MissionBridgeBase[] {
+    return this.getAll().filter((b) => b.getConfig().domain === domain);
+  }
+
+  getByFeedId(feedId: string): MissionBridgeBase | undefined {
+    return this.bridges.get(feedId);
+  }
+
+  /**
+   * Run every enabled bridge once and concatenate the produced
+   * ObservationEvents. Errors from any individual bridge are recorded
+   * on that bridge but do not abort the rest of the run.
+   */
+  async runAll(): Promise<ObservationEvent[]> {
+    const out: ObservationEvent[] = [];
+    for (const bridge of this.getAll()) {
+      try {
+        const cycle = await bridge.processCycle();
+        out.push(...cycle);
+      } catch {
+        // recordError already captured the message inside processCycle.
+      }
+    }
+    return out;
+  }
+}
+
+// ── Built-in: Earthquake ─────────────────────────────────────────────────
+
+/**
+ * Raw USGS earthquake payload shape used by the built-in bridge. The
+ * production fetcher comes from the host; tests supply a fake.
+ */
+export interface RawEarthquake {
+  id: string;
+  /** Magnitude on the Richter / moment-magnitude scale. */
+  mag: number | null;
+  /** Unix epoch ms when the quake occurred. */
+  time: number;
+  place: string;
+  /** [lon, lat, depthKm] per the GeoJSON convention USGS uses. */
+  coordinates: [number, number, number];
+}
+
+export interface EarthquakeMissionBridgeOptions extends MissionBridgeOptions {
+  fetcher?: () => Promise<RawEarthquake[]>;
+  config?: Partial<MissionBridgeConfig>;
+}
+
+const EARTHQUAKE_DEFAULT_CONFIG: MissionBridgeConfig = {
+  domain: 'seismic',
+  feedId: 'usgs-earthquake',
+  refreshIntervalMs: 60_000,
+  maxObservationsPerCycle: 100,
+  enabled: true,
+};
+
+export class EarthquakeMissionBridge extends MissionBridgeBase {
+  private readonly fetcher: () => Promise<RawEarthquake[]>;
+
+  constructor(options: EarthquakeMissionBridgeOptions = {}) {
+    super({ ...EARTHQUAKE_DEFAULT_CONFIG, ...options.config }, options);
+    this.fetcher = options.fetcher ?? defaultEmptyFetcher;
+  }
+
+  override fetchRaw(): Promise<unknown[]> {
+    return this.fetcher() as Promise<unknown[]>;
+  }
+
+  override normalize(raw: unknown): ObservationEvent | null {
+    if (!isRawEarthquake(raw)) return null;
+    const mag = raw.mag;
+    if (mag === null || !Number.isFinite(mag)) return null;
+    const severity = magnitudeToSeverity(mag);
+    const [lon, lat] = raw.coordinates;
+    return {
+      id: `usgs-earthquake:${raw.id}`,
+      sourceId: this.config.feedId,
+      domain: this.config.domain,
+      timestamp: raw.time,
+      location: { lat, lon, radiusKm: estimateRadiusKm(mag) },
+      severity,
+      title: `M${mag.toFixed(1)} earthquake near ${raw.place}`,
+      raw,
+      entityIds: [],
+      tags: ['earthquake', `severity-${severity.toLowerCase()}`],
+    };
+  }
+}
+
+/**
+ * Magnitude → ObservationSeverity per spec:
+ *   <3   → INFO     (0)
+ *   <4   → LOW      (1)
+ *   <5   → MEDIUM   (2)
+ *   <6   → HIGH     (3)
+ *   >=6  → CRITICAL (4)
+ */
+export function magnitudeToSeverity(magnitude: number): ObservationSeverity {
+  if (!Number.isFinite(magnitude)) return 'INFO';
+  if (magnitude < 3) return 'INFO';
+  if (magnitude < 4) return 'LOW';
+  if (magnitude < 5) return 'MEDIUM';
+  if (magnitude < 6) return 'HIGH';
+  return 'CRITICAL';
+}
+
+// Empirical: rupture length doubles roughly per magnitude unit.
+function estimateRadiusKm(magnitude: number): number {
+  if (!Number.isFinite(magnitude) || magnitude < 0) return 0;
+  return Math.round(Math.max(1, 2 ** (magnitude - 2)));
+}
+
+function isRawEarthquake(value: unknown): value is RawEarthquake {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.id !== 'string') return false;
+  if (typeof v.time !== 'number' || !Number.isFinite(v.time)) return false;
+  if (typeof v.place !== 'string') return false;
+  if (!Array.isArray(v.coordinates) || v.coordinates.length < 2) return false;
+  const coords = v.coordinates as unknown[];
+  const lon = coords[0];
+  const lat = coords[1];
+  if (typeof lon !== 'number' || typeof lat !== 'number') return false;
+  if (!(v.mag === null || typeof v.mag === 'number')) return false;
+  return true;
+}
+
+function defaultEmptyFetcher(): Promise<RawEarthquake[]> {
+  return Promise.resolve([]);
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function defaultStorage(): StorageLike {
+  if (typeof globalThis !== 'undefined') {
+    const g = globalThis as { localStorage?: StorageLike };
+    if (g.localStorage) return g.localStorage;
+  }
+  return {
+    getItem: () => null,
+    setItem: () => undefined,
+  };
+}
+
+function freshStats(): MissionBridgeStats {
+  return {
+    cyclesRun: 0,
+    totalObservations: 0,
+    nullSkipped: 0,
+    lastCycleAt: 0,
+    errorCount: 0,
+    lastError: null,
+  };
+}
+
+function isStats(value: unknown): value is MissionBridgeStats {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.cyclesRun === 'number' &&
+    typeof v.totalObservations === 'number' &&
+    typeof v.nullSkipped === 'number' &&
+    typeof v.lastCycleAt === 'number' &&
+    typeof v.errorCount === 'number' &&
+    (v.lastError === null || typeof v.lastError === 'string')
+  );
+}

--- a/tests/intelligence/mission-bridge-core.test.mts
+++ b/tests/intelligence/mission-bridge-core.test.mts
@@ -1,0 +1,464 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  EarthquakeMissionBridge,
+  MAX_PERSISTED_BRIDGES,
+  MissionBridgeBase,
+  MissionBridgeRegistry,
+  STORAGE_KEY,
+  magnitudeToSeverity,
+  type MissionBridgeConfig,
+  type MissionBridgeOptions,
+  type RawEarthquake,
+  type StorageLike,
+} from '../../src/services/intelligence/mission-bridge-core.ts';
+import type { ObservationEvent } from '../../src/types/intelligence.ts';
+
+const NOW = 1_700_000_000_000;
+
+function memoryStorage(): StorageLike & { dump(): string | null } {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (k) => store[k] ?? null,
+    setItem: (k, v) => { store[k] = v; },
+    removeItem: (k) => { delete store[k]; },
+    dump: () => store[STORAGE_KEY] ?? null,
+  };
+}
+
+class FakeBridge extends MissionBridgeBase {
+  public raws: unknown[] = [];
+  public skipPredicate: (raw: unknown) => boolean = () => false;
+  public fetchError: Error | null = null;
+
+  constructor(
+    config: Partial<MissionBridgeConfig> = {},
+    options: MissionBridgeOptions = {},
+  ) {
+    super(
+      {
+        domain: 'test',
+        feedId: 'fake-feed',
+        refreshIntervalMs: 1000,
+        maxObservationsPerCycle: 10,
+        enabled: true,
+        ...config,
+      },
+      options,
+    );
+  }
+
+  override fetchRaw(): Promise<unknown[]> {
+    if (this.fetchError) return Promise.reject(this.fetchError);
+    return Promise.resolve(this.raws);
+  }
+
+  override normalize(raw: unknown): ObservationEvent | null {
+    if (this.skipPredicate(raw)) return null;
+    if (typeof raw !== 'object' || !raw) return null;
+    const r = raw as { id?: string; timestamp?: number };
+    if (typeof r.id !== 'string' || typeof r.timestamp !== 'number') return null;
+    return {
+      id: r.id,
+      sourceId: 'fake-feed',
+      domain: 'test',
+      timestamp: r.timestamp,
+      severity: 'INFO',
+      title: `synthetic ${r.id}`,
+      raw,
+      entityIds: [],
+      tags: [],
+    };
+  }
+}
+
+function makeRawQuake(overrides: Partial<RawEarthquake> = {}): RawEarthquake {
+  return {
+    id: 'usgs-' + Math.random().toString(36).slice(2, 8),
+    mag: 4.2,
+    time: NOW,
+    place: '50 km W of Test City',
+    coordinates: [-122.4, 37.7, 10],
+    ...overrides,
+  };
+}
+
+// ── Config validation ────────────────────────────────────────────────────
+
+describe('MissionBridgeBase — construction', () => {
+  it('rejects missing domain', () => {
+    assert.throws(() => new FakeBridge({ domain: '' }, { storage: memoryStorage() }));
+  });
+
+  it('rejects missing feedId', () => {
+    assert.throws(() => new FakeBridge({ feedId: '' }, { storage: memoryStorage() }));
+  });
+
+  it('rejects non-positive maxObservationsPerCycle', () => {
+    assert.throws(() => new FakeBridge({ maxObservationsPerCycle: 0 }, { storage: memoryStorage() }));
+    assert.throws(() => new FakeBridge({ maxObservationsPerCycle: -3 }, { storage: memoryStorage() }));
+  });
+
+  it('rejects non-positive refreshIntervalMs', () => {
+    assert.throws(() => new FakeBridge({ refreshIntervalMs: 0 }, { storage: memoryStorage() }));
+    assert.throws(() => new FakeBridge({ refreshIntervalMs: -5 }, { storage: memoryStorage() }));
+  });
+
+  it('getConfig returns a defensive clone', () => {
+    const b = new FakeBridge({}, { storage: memoryStorage() });
+    const c = b.getConfig();
+    c.domain = 'mutated';
+    assert.equal(b.getConfig().domain, 'test');
+  });
+});
+
+// ── getStats / processCycle accounting ───────────────────────────────────
+
+describe('MissionBridgeBase — processCycle', () => {
+  it('initial stats are zeroed', () => {
+    const b = new FakeBridge({}, { storage: memoryStorage() });
+    const s = b.getStats();
+    assert.equal(s.cyclesRun, 0);
+    assert.equal(s.totalObservations, 0);
+    assert.equal(s.nullSkipped, 0);
+    assert.equal(s.lastCycleAt, 0);
+    assert.equal(s.errorCount, 0);
+    assert.equal(s.lastError, null);
+  });
+
+  it('returns [] and does not bump cycles when disabled', async () => {
+    const b = new FakeBridge({ enabled: false }, { storage: memoryStorage() });
+    b.raws = [{ id: 'a', timestamp: NOW }];
+    const out = await b.processCycle();
+    assert.deepEqual(out, []);
+    assert.equal(b.getStats().cyclesRun, 0);
+  });
+
+  it('normalizes every raw → observation pass-through', async () => {
+    const b = new FakeBridge({}, { storage: memoryStorage() });
+    b.raws = [
+      { id: 'a', timestamp: NOW },
+      { id: 'b', timestamp: NOW + 1 },
+    ];
+    const out = await b.processCycle();
+    assert.equal(out.length, 2);
+    const stats = b.getStats();
+    assert.equal(stats.totalObservations, 2);
+    assert.equal(stats.nullSkipped, 0);
+    assert.equal(stats.cyclesRun, 1);
+  });
+
+  it('counts skipped (normalize → null) into nullSkipped, not the result', async () => {
+    const b = new FakeBridge({}, { storage: memoryStorage() });
+    b.raws = [{ id: 'a', timestamp: NOW }, { skip: true }, { id: 'c', timestamp: NOW }];
+    b.skipPredicate = (r) => typeof r === 'object' && r !== null && 'skip' in r;
+    const out = await b.processCycle();
+    assert.equal(out.length, 2);
+    assert.equal(b.getStats().nullSkipped, 1);
+  });
+
+  it('caps observations at maxObservationsPerCycle', async () => {
+    const b = new FakeBridge({ maxObservationsPerCycle: 3 }, { storage: memoryStorage() });
+    b.raws = Array.from({ length: 10 }, (_, i) => ({ id: `r-${i}`, timestamp: NOW + i }));
+    const out = await b.processCycle();
+    assert.equal(out.length, 3);
+    assert.equal(b.getStats().totalObservations, 3);
+  });
+
+  it('records lastCycleAt from the injected clock', async () => {
+    const b = new FakeBridge({}, { storage: memoryStorage(), now: () => NOW + 999 });
+    b.raws = [{ id: 'a', timestamp: NOW }];
+    await b.processCycle();
+    assert.equal(b.getStats().lastCycleAt, NOW + 999);
+  });
+
+  it('accumulates cyclesRun + totalObservations across multiple runs', async () => {
+    const b = new FakeBridge({}, { storage: memoryStorage() });
+    b.raws = [{ id: 'a', timestamp: NOW }];
+    await b.processCycle();
+    b.raws = [{ id: 'b', timestamp: NOW + 1 }, { id: 'c', timestamp: NOW + 2 }];
+    await b.processCycle();
+    const s = b.getStats();
+    assert.equal(s.cyclesRun, 2);
+    assert.equal(s.totalObservations, 3);
+  });
+
+  it('bubbles fetchRaw error and records it', async () => {
+    const b = new FakeBridge({}, { storage: memoryStorage() });
+    b.fetchError = new Error('upstream down');
+    await assert.rejects(() => b.processCycle(), /upstream down/);
+    const s = b.getStats();
+    assert.equal(s.errorCount, 1);
+    assert.equal(s.lastError, 'upstream down');
+    assert.equal(s.cyclesRun, 0);
+  });
+});
+
+// ── recordError ──────────────────────────────────────────────────────────
+
+describe('MissionBridgeBase — recordError', () => {
+  it('increments errorCount each call', () => {
+    const b = new FakeBridge({}, { storage: memoryStorage() });
+    b.recordError('boom 1');
+    b.recordError('boom 2');
+    assert.equal(b.getStats().errorCount, 2);
+    assert.equal(b.getStats().lastError, 'boom 2');
+  });
+
+  it('truncates very long error messages with an ellipsis', () => {
+    const b = new FakeBridge({}, { storage: memoryStorage() });
+    const long = 'x'.repeat(500);
+    b.recordError(long);
+    const msg = b.getStats().lastError!;
+    assert.ok(msg.length <= 280, `message too long: ${msg.length}`);
+    assert.ok(msg.endsWith('…'));
+  });
+});
+
+// ── Persistence ──────────────────────────────────────────────────────────
+
+describe('MissionBridgeBase — persistence', () => {
+  it('persists stats under STORAGE_KEY keyed by feedId', async () => {
+    const storage = memoryStorage();
+    const b = new FakeBridge({}, { storage, now: () => NOW });
+    b.raws = [{ id: 'a', timestamp: NOW }];
+    await b.processCycle();
+    const dump = storage.dump();
+    assert.ok(dump, 'expected stats payload');
+    const parsed = JSON.parse(dump!);
+    assert.equal(parsed['fake-feed'].cyclesRun, 1);
+    assert.equal(parsed['fake-feed'].totalObservations, 1);
+  });
+
+  it('rehydrates stats on construction', async () => {
+    const storage = memoryStorage();
+    const b1 = new FakeBridge({}, { storage, now: () => NOW });
+    b1.raws = [{ id: 'a', timestamp: NOW }];
+    await b1.processCycle();
+    const b2 = new FakeBridge({}, { storage, now: () => NOW });
+    assert.equal(b2.getStats().cyclesRun, 1);
+    assert.equal(b2.getStats().totalObservations, 1);
+  });
+
+  it('keeps per-bridge stats isolated when many bridges share storage', async () => {
+    const storage = memoryStorage();
+    const a = new FakeBridge({ feedId: 'a' }, { storage });
+    const b = new FakeBridge({ feedId: 'b' }, { storage });
+    a.raws = [{ id: 'x', timestamp: NOW }];
+    b.raws = [{ id: 'y', timestamp: NOW }, { id: 'z', timestamp: NOW + 1 }];
+    await a.processCycle();
+    await b.processCycle();
+    const parsed = JSON.parse(storage.dump()!);
+    assert.equal(parsed.a.totalObservations, 1);
+    assert.equal(parsed.b.totalObservations, 2);
+  });
+
+  it('survives a corrupt persisted payload', async () => {
+    const storage: StorageLike = {
+      getItem: () => '{not-json',
+      setItem: () => undefined,
+    };
+    const b = new FakeBridge({}, { storage });
+    b.raws = [{ id: 'a', timestamp: NOW }];
+    await assert.doesNotReject(() => b.processCycle());
+    assert.equal(b.getStats().cyclesRun, 1);
+  });
+
+  it('caps persisted entries at MAX_PERSISTED_BRIDGES (drops least-recent)', async () => {
+    const storage = memoryStorage();
+    // Pre-seed with MAX_PERSISTED_BRIDGES bridges, all with lastCycleAt = 0.
+    const blob: Record<string, unknown> = {};
+    for (let i = 0; i < MAX_PERSISTED_BRIDGES; i += 1) {
+      blob[`old-${i}`] = {
+        cyclesRun: 1, totalObservations: 1, nullSkipped: 0,
+        lastCycleAt: 0, errorCount: 0, lastError: null,
+      };
+    }
+    storage.setItem(STORAGE_KEY, JSON.stringify(blob));
+
+    const b = new FakeBridge({ feedId: 'new-feed' }, { storage, now: () => NOW });
+    b.raws = [{ id: 'a', timestamp: NOW }];
+    await b.processCycle();
+    const parsed = JSON.parse(storage.dump()!);
+    assert.equal(Object.keys(parsed).length, MAX_PERSISTED_BRIDGES);
+    assert.ok('new-feed' in parsed);
+  });
+
+  it('resetStatsForTesting wipes stats and persists the reset', async () => {
+    const storage = memoryStorage();
+    const b = new FakeBridge({}, { storage });
+    b.raws = [{ id: 'a', timestamp: NOW }];
+    await b.processCycle();
+    assert.equal(b.getStats().cyclesRun, 1);
+    b.resetStatsForTesting();
+    assert.equal(b.getStats().cyclesRun, 0);
+    const parsed = JSON.parse(storage.dump()!);
+    assert.equal(parsed['fake-feed'].cyclesRun, 0);
+  });
+});
+
+// ── Registry ─────────────────────────────────────────────────────────────
+
+describe('MissionBridgeRegistry', () => {
+  beforeEach(() => {
+    MissionBridgeRegistry.resetForTesting();
+  });
+
+  it('getInstance returns the same singleton', () => {
+    const a = MissionBridgeRegistry.getInstance();
+    const b = MissionBridgeRegistry.getInstance();
+    assert.equal(a, b);
+  });
+
+  it('register + getAll round-trips', () => {
+    const reg = MissionBridgeRegistry.getInstance();
+    const bridge = new FakeBridge({ feedId: 'r1' }, { storage: memoryStorage() });
+    reg.register(bridge);
+    assert.equal(reg.getAll().length, 1);
+    assert.equal(reg.getByFeedId('r1'), bridge);
+  });
+
+  it('register is idempotent on feedId (last write wins)', () => {
+    const reg = MissionBridgeRegistry.getInstance();
+    const a = new FakeBridge({ feedId: 'same' }, { storage: memoryStorage() });
+    const b = new FakeBridge({ feedId: 'same' }, { storage: memoryStorage() });
+    reg.register(a);
+    reg.register(b);
+    assert.equal(reg.getAll().length, 1);
+    assert.equal(reg.getByFeedId('same'), b);
+  });
+
+  it('unregister removes the bridge and returns true', () => {
+    const reg = MissionBridgeRegistry.getInstance();
+    reg.register(new FakeBridge({ feedId: 'gone' }, { storage: memoryStorage() }));
+    assert.equal(reg.unregister('gone'), true);
+    assert.equal(reg.getByFeedId('gone'), undefined);
+    assert.equal(reg.unregister('gone'), false);
+  });
+
+  it('getByDomain filters to bridges in that domain', () => {
+    const reg = MissionBridgeRegistry.getInstance();
+    reg.register(new FakeBridge({ feedId: 'd-1', domain: 'alpha' }, { storage: memoryStorage() }));
+    reg.register(new FakeBridge({ feedId: 'd-2', domain: 'alpha' }, { storage: memoryStorage() }));
+    reg.register(new FakeBridge({ feedId: 'd-3', domain: 'beta' }, { storage: memoryStorage() }));
+    assert.equal(reg.getByDomain('alpha').length, 2);
+    assert.equal(reg.getByDomain('beta').length, 1);
+    assert.equal(reg.getByDomain('unknown').length, 0);
+  });
+
+  it('runAll concatenates observations from every registered bridge', async () => {
+    const reg = MissionBridgeRegistry.getInstance();
+    const a = new FakeBridge({ feedId: 'fa' }, { storage: memoryStorage() });
+    a.raws = [{ id: 'a1', timestamp: NOW }];
+    const b = new FakeBridge({ feedId: 'fb' }, { storage: memoryStorage() });
+    b.raws = [{ id: 'b1', timestamp: NOW }, { id: 'b2', timestamp: NOW + 1 }];
+    reg.register(a);
+    reg.register(b);
+    const out = await reg.runAll();
+    assert.equal(out.length, 3);
+  });
+
+  it('runAll: a bridge that throws does not abort the others', async () => {
+    const reg = MissionBridgeRegistry.getInstance();
+    const ok = new FakeBridge({ feedId: 'ok' }, { storage: memoryStorage() });
+    ok.raws = [{ id: 'good', timestamp: NOW }];
+    const bad = new FakeBridge({ feedId: 'bad' }, { storage: memoryStorage() });
+    bad.fetchError = new Error('upstream gone');
+    reg.register(bad);
+    reg.register(ok);
+    const out = await reg.runAll();
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.id, 'good');
+    assert.equal(bad.getStats().errorCount, 1);
+  });
+
+  it('runAll skips disabled bridges silently', async () => {
+    const reg = MissionBridgeRegistry.getInstance();
+    const off = new FakeBridge({ feedId: 'off', enabled: false }, { storage: memoryStorage() });
+    off.raws = [{ id: 'no', timestamp: NOW }];
+    reg.register(off);
+    const out = await reg.runAll();
+    assert.equal(out.length, 0);
+    assert.equal(off.getStats().cyclesRun, 0);
+  });
+});
+
+// ── Built-in Earthquake bridge ───────────────────────────────────────────
+
+describe('magnitudeToSeverity', () => {
+  it('M<3 → INFO', () => assert.equal(magnitudeToSeverity(2.9), 'INFO'));
+  it('M<4 → LOW', () => assert.equal(magnitudeToSeverity(3.5), 'LOW'));
+  it('M<5 → MEDIUM', () => assert.equal(magnitudeToSeverity(4.7), 'MEDIUM'));
+  it('M<6 → HIGH', () => assert.equal(magnitudeToSeverity(5.9), 'HIGH'));
+  it('M>=6 → CRITICAL', () => assert.equal(magnitudeToSeverity(6.0), 'CRITICAL'));
+  it('non-finite → INFO', () => assert.equal(magnitudeToSeverity(Number.NaN), 'INFO'));
+});
+
+describe('EarthquakeMissionBridge', () => {
+  it('uses the seismic / usgs-earthquake defaults', () => {
+    const b = new EarthquakeMissionBridge({ storage: memoryStorage() });
+    assert.equal(b.getConfig().domain, 'seismic');
+    assert.equal(b.getConfig().feedId, 'usgs-earthquake');
+  });
+
+  it('normalize skips items missing magnitude', () => {
+    const b = new EarthquakeMissionBridge({ storage: memoryStorage() });
+    assert.equal(b.normalize(makeRawQuake({ mag: null })), null);
+  });
+
+  it('normalize emits a valid ObservationEvent with severity from magnitude', () => {
+    const b = new EarthquakeMissionBridge({ storage: memoryStorage() });
+    const ev = b.normalize(makeRawQuake({ mag: 5.5, id: 'q-1', place: 'X' }));
+    assert.ok(ev);
+    assert.equal(ev!.severity, 'HIGH');
+    assert.equal(ev!.sourceId, 'usgs-earthquake');
+    assert.equal(ev!.domain, 'seismic');
+    assert.equal(ev!.location?.lat, 37.7);
+    assert.equal(ev!.location?.lon, -122.4);
+    assert.match(ev!.title, /M5\.5/);
+    assert.match(ev!.title, /X/);
+  });
+
+  it('normalize stamps tags with severity classification', () => {
+    const b = new EarthquakeMissionBridge({ storage: memoryStorage() });
+    const ev = b.normalize(makeRawQuake({ mag: 6.4 }));
+    assert.ok(ev?.tags.includes('earthquake'));
+    assert.ok(ev?.tags.includes('severity-critical'));
+  });
+
+  it('normalize rejects malformed raw payloads', () => {
+    const b = new EarthquakeMissionBridge({ storage: memoryStorage() });
+    assert.equal(b.normalize(null), null);
+    assert.equal(b.normalize({}), null);
+    assert.equal(b.normalize({ id: 'x', time: 0, place: 'P', coordinates: [] }), null);
+  });
+
+  it('processCycle integrates fetcher + normalize end-to-end', async () => {
+    const quakes: RawEarthquake[] = [
+      makeRawQuake({ id: 'a', mag: 2.0 }),
+      makeRawQuake({ id: 'b', mag: 5.5 }),
+      makeRawQuake({ id: 'c', mag: null }),  // skipped
+    ];
+    const b = new EarthquakeMissionBridge({
+      storage: memoryStorage(),
+      fetcher: () => Promise.resolve(quakes),
+    });
+    const out = await b.processCycle();
+    assert.equal(out.length, 2);
+    assert.equal(b.getStats().nullSkipped, 1);
+    assert.equal(out[0]!.severity, 'INFO');
+    assert.equal(out[1]!.severity, 'HIGH');
+  });
+
+  it('config overrides merge with defaults', () => {
+    const b = new EarthquakeMissionBridge({
+      storage: memoryStorage(),
+      config: { maxObservationsPerCycle: 5, refreshIntervalMs: 30_000 },
+    });
+    assert.equal(b.getConfig().domain, 'seismic');
+    assert.equal(b.getConfig().feedId, 'usgs-earthquake');
+    assert.equal(b.getConfig().maxObservationsPerCycle, 5);
+    assert.equal(b.getConfig().refreshIntervalMs, 30_000);
+  });
+});


### PR DESCRIPTION
Adds `MissionBridgeCore` — the base infrastructure every domain feed extends to connect raw provider payloads to the intelligence pipeline's `ObservationEvent` schema.

### What's in the box
- `src/services/intelligence/mission-bridge-core.ts`:
  - **`MissionBridgeBase`** (abstract): subclasses implement `fetchRaw()` + `normalize()`; the base orchestrates the cycle (fetch → normalize → cap → return), tracks stats (`cyclesRun` / `totalObservations` / `nullSkipped` / `lastCycleAt` / `errorCount` / `lastError`), persists them to local storage, and enforces `maxObservationsPerCycle`
  - **`MissionBridgeRegistry`** (singleton): `register` / `unregister` / `getAll` / `getByDomain` / `getByFeedId`; `runAll()` fans out across every registered bridge and a single bridge failure does not abort the others
  - **`EarthquakeMissionBridge`** (built-in concrete): `seismic` / `usgs-earthquake`; `magnitudeToSeverity` maps `<3 INFO`, `<4 LOW`, `<5 MEDIUM`, `<6 HIGH`, `>=6 CRITICAL`; stamps tags and an estimated radiusKm
  - Stats persist under `wm-mission-bridge-stats`, capped at `MAX_PERSISTED_BRIDGES` (200) with LRU eviction by `lastCycleAt`; survives corrupt payloads
  - Pure deterministic; injectable `StorageLike` + clock + fetcher; nothing in the core reaches for DOM/fetch directly
- `tests/intelligence/mission-bridge-core.test.mts` — **42 unit tests** (35+ target exceeded) across:
  - Config validation (domain / feedId required, positive cycle caps + interval)
  - `processCycle` accounting (cycles, totals, null-skipped, disabled, cap, clock)
  - `recordError` (incrementing + truncation at 280 chars)
  - Persistence (per-bridge isolation, rehydration, corrupt-blob recovery, LRU cap at `MAX_PERSISTED_BRIDGES`)
  - Registry (idempotent register, unregister, getByDomain filter, runAll concat, isolated failure, disabled-skip)
  - Built-in earthquake bridge (severity classification, malformed-raw rejection, end-to-end integration, config overrides)

### Validation
- `npx tsx --test tests/intelligence/mission-bridge-core.test.mts` → **42/42 pass**
- Husky pre-commit hook ran clean (`typecheck:all` + lint-staged ESLint)

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass