### PR TITLE
Visual semantics system — unified design tokens, severity colors, domain badges

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,4 +1,5 @@
 @import './tokens.css';
+@import './visual-semantics.css';
 @import './rtl-overrides.css';
 @import './panels.css';
 @import './macos-native.css';

--- a/src/styles/visual-semantics.css
+++ b/src/styles/visual-semantics.css
@@ -1,0 +1,44 @@
+/* Visual Semantics System — unified design tokens for severity, domain, status, typography, spacing.
+ * Numeric severity levels (0–4) complement the named severity tokens in tokens.css.
+ * Use --severity-N for data-driven rendering; use --severity-critical etc. for labelled UI.
+ */
+:root {
+  /* ── Severity (numeric, 0 = minimal, 4 = critical) ───────────────────── */
+  --severity-0: #16a34a;
+  --severity-1: #ca8a04;
+  --severity-2: #ea580c;
+  --severity-3: #dc2626;
+  --severity-4: #7f1d1d;
+
+  /* ── Domain colors (supplementing tokens.css) ────────────────────────── */
+  /* Inherited from tokens.css (listed for reference, not re-declared):
+   *   --domain-cyber, --domain-weather, --domain-maritime, --domain-aviation,
+   *   --domain-space, --domain-geopolitical
+   */
+  --domain-health:     #0e7490;
+  --domain-financial:  #15803d;
+  --domain-seismic:    #92400e;
+
+  /* ── Status colors ───────────────────────────────────────────────────── */
+  --status-nominal:   #16a34a;
+  --status-elevated:  #ca8a04;
+  --status-stressed:  #ea580c;
+  --status-critical:  #dc2626;
+
+  /* ── Typography scale (px) ───────────────────────────────────────────── */
+  --text-xs:  10px;
+  --text-sm:  12px;
+  --text-md:  14px;
+  --text-lg:  16px;
+  --text-xl:  18px;
+
+  /* ── Spacing scale (px) ──────────────────────────────────────────────── */
+  --space-1:  2px;
+  --space-2:  4px;
+  --space-3:  8px;
+  --space-4:  12px;
+  --space-5:  16px;
+  --space-6:  20px;
+  --space-7:  24px;
+  --space-8:  32px;
+}

--- a/src/utils/visual-semantics.ts
+++ b/src/utils/visual-semantics.ts
@@ -1,0 +1,64 @@
+import { escapeHtml } from './sanitize';
+
+export type SeverityLevel = 0 | 1 | 2 | 3 | 4;
+export type DomainKey =
+  | 'cyber'
+  | 'weather'
+  | 'geopolitical'
+  | 'maritime'
+  | 'aviation'
+  | 'health'
+  | 'financial'
+  | 'seismic'
+  | 'space';
+
+const SEVERITY_LABELS: Record<SeverityLevel, string> = {
+  0: 'Minimal',
+  1: 'Low',
+  2: 'Moderate',
+  3: 'High',
+  4: 'Critical',
+};
+
+const DOMAIN_ICONS: Record<DomainKey, string> = {
+  cyber:       '💻',
+  weather:     '⛈️',
+  geopolitical:'🗺️',
+  maritime:    '🚢',
+  aviation:    '✈️',
+  health:      '🧬',
+  financial:   '📈',
+  seismic:     '🌐',
+  space:       '🛰️',
+};
+
+export function severityColor(level: SeverityLevel): string {
+  return `var(--severity-${level})`;
+}
+
+export function severityLabel(level: SeverityLevel): string {
+  return SEVERITY_LABELS[level];
+}
+
+export function domainColor(domain: DomainKey): string {
+  return `var(--domain-${domain})`;
+}
+
+export function domainIcon(domain: DomainKey): string {
+  return DOMAIN_ICONS[domain];
+}
+
+export function renderSeverityBadge(level: SeverityLevel, label?: string): string {
+  const displayLabel = label ?? severityLabel(level);
+  const color = severityColor(level);
+  const bg = `color-mix(in srgb, ${color} 15%, transparent)`;
+  return `<span class="vs-severity-badge" style="color:${color};background:${bg};">${escapeHtml(displayLabel)}</span>`;
+}
+
+export function renderDomainBadge(domain: DomainKey, label?: string): string {
+  const icon = domainIcon(domain);
+  const displayLabel = label ?? domain;
+  const color = domainColor(domain);
+  const bg = `color-mix(in srgb, ${color} 15%, transparent)`;
+  return `<span class="vs-domain-badge" style="color:${color};background:${bg};">${icon} ${escapeHtml(displayLabel)}</span>`;
+}

--- a/tests/utils/visual-semantics.test.mts
+++ b/tests/utils/visual-semantics.test.mts
@@ -1,0 +1,172 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  severityColor,
+  severityLabel,
+  domainColor,
+  domainIcon,
+  renderSeverityBadge,
+  renderDomainBadge,
+  type SeverityLevel,
+  type DomainKey,
+} from '../../src/utils/visual-semantics.js';
+
+// ── severityColor ─────────────────────────────────────────────────────────
+
+describe('severityColor', () => {
+  it('level 0 returns var(--severity-0)', () => {
+    assert.equal(severityColor(0), 'var(--severity-0)');
+  });
+
+  it('level 4 returns var(--severity-4)', () => {
+    assert.equal(severityColor(4), 'var(--severity-4)');
+  });
+
+  it('all levels produce distinct var references', () => {
+    const levels: SeverityLevel[] = [0, 1, 2, 3, 4];
+    const colors = levels.map((l) => severityColor(l));
+    assert.equal(new Set(colors).size, 5);
+  });
+});
+
+// ── severityLabel ─────────────────────────────────────────────────────────
+
+describe('severityLabel', () => {
+  it('level 0 is Minimal', () => assert.equal(severityLabel(0), 'Minimal'));
+  it('level 1 is Low', () => assert.equal(severityLabel(1), 'Low'));
+  it('level 2 is Moderate', () => assert.equal(severityLabel(2), 'Moderate'));
+  it('level 3 is High', () => assert.equal(severityLabel(3), 'High'));
+  it('level 4 is Critical', () => assert.equal(severityLabel(4), 'Critical'));
+
+  it('all levels produce distinct labels', () => {
+    const levels: SeverityLevel[] = [0, 1, 2, 3, 4];
+    const labels = levels.map((l) => severityLabel(l));
+    assert.equal(new Set(labels).size, 5);
+  });
+});
+
+// ── domainColor ───────────────────────────────────────────────────────────
+
+describe('domainColor', () => {
+  it('cyber returns var(--domain-cyber)', () => {
+    assert.equal(domainColor('cyber'), 'var(--domain-cyber)');
+  });
+
+  it('health returns var(--domain-health)', () => {
+    assert.equal(domainColor('health'), 'var(--domain-health)');
+  });
+
+  it('financial returns var(--domain-financial)', () => {
+    assert.equal(domainColor('financial'), 'var(--domain-financial)');
+  });
+
+  it('seismic returns var(--domain-seismic)', () => {
+    assert.equal(domainColor('seismic'), 'var(--domain-seismic)');
+  });
+
+  it('all 9 domains produce distinct var references', () => {
+    const domains: DomainKey[] = ['cyber','weather','geopolitical','maritime','aviation','health','financial','seismic','space'];
+    const colors = domains.map((d) => domainColor(d));
+    assert.equal(new Set(colors).size, 9);
+  });
+});
+
+// ── domainIcon ────────────────────────────────────────────────────────────
+
+describe('domainIcon', () => {
+  it('returns a non-empty string for cyber', () => {
+    assert.ok(domainIcon('cyber').length > 0);
+  });
+
+  it('returns a non-empty string for all 9 domains', () => {
+    const domains: DomainKey[] = ['cyber','weather','geopolitical','maritime','aviation','health','financial','seismic','space'];
+    for (const d of domains) {
+      assert.ok(domainIcon(d).length > 0, `${d} icon should be non-empty`);
+    }
+  });
+
+  it('all 9 domains have distinct icons', () => {
+    const domains: DomainKey[] = ['cyber','weather','geopolitical','maritime','aviation','health','financial','seismic','space'];
+    const icons = domains.map((d) => domainIcon(d));
+    assert.equal(new Set(icons).size, 9);
+  });
+});
+
+// ── renderSeverityBadge ───────────────────────────────────────────────────
+
+describe('renderSeverityBadge', () => {
+  it('contains the severity label for level 0', () => {
+    assert.ok(renderSeverityBadge(0).includes('Minimal'));
+  });
+
+  it('contains the severity label for level 4', () => {
+    assert.ok(renderSeverityBadge(4).includes('Critical'));
+  });
+
+  it('contains the CSS variable reference', () => {
+    assert.ok(renderSeverityBadge(2).includes('var(--severity-2)'));
+  });
+
+  it('uses vs-severity-badge class', () => {
+    assert.ok(renderSeverityBadge(1).includes('vs-severity-badge'));
+  });
+
+  it('uses custom label when provided', () => {
+    assert.ok(renderSeverityBadge(3, 'Danger').includes('Danger'));
+    assert.ok(!renderSeverityBadge(3, 'Danger').includes('High'));
+  });
+
+  it('escapes HTML in custom label', () => {
+    const html = renderSeverityBadge(1, '<script>alert(1)</script>');
+    assert.ok(!html.includes('<script>'));
+    assert.ok(html.includes('&lt;script&gt;'));
+  });
+
+  it('includes color-mix background', () => {
+    assert.ok(renderSeverityBadge(0).includes('color-mix'));
+  });
+});
+
+// ── renderDomainBadge ─────────────────────────────────────────────────────
+
+describe('renderDomainBadge', () => {
+  it('contains the domain name by default', () => {
+    assert.ok(renderDomainBadge('health').includes('health'));
+  });
+
+  it('uses custom label when provided', () => {
+    const html = renderDomainBadge('cyber', 'Cyber Ops');
+    assert.ok(html.includes('Cyber Ops'));
+    assert.ok(!html.includes('>cyber<'));
+  });
+
+  it('contains the CSS variable reference', () => {
+    assert.ok(renderDomainBadge('maritime').includes('var(--domain-maritime)'));
+  });
+
+  it('uses vs-domain-badge class', () => {
+    assert.ok(renderDomainBadge('aviation').includes('vs-domain-badge'));
+  });
+
+  it('includes the domain icon', () => {
+    const html = renderDomainBadge('space');
+    assert.ok(html.includes('🛰️'));
+  });
+
+  it('escapes HTML in custom label', () => {
+    const html = renderDomainBadge('financial', '<b>Markets</b>');
+    assert.ok(!html.includes('<b>'));
+    assert.ok(html.includes('&lt;b&gt;'));
+  });
+
+  it('includes color-mix background', () => {
+    assert.ok(renderDomainBadge('seismic').includes('color-mix'));
+  });
+
+  it('renders all 9 domains without throwing', () => {
+    const domains: DomainKey[] = ['cyber','weather','geopolitical','maritime','aviation','health','financial','seismic','space'];
+    for (const d of domains) {
+      assert.ok(renderDomainBadge(d).length > 0);
+    }
+  });
+});


### PR DESCRIPTION
Adds a parallel visual semantics layer with numeric severity levels (0–4), 9 domain colors (including new health/financial/seismic), status tokens, typography scale, and spacing scale — all as CSS custom properties in `src/styles/visual-semantics.css`. TypeScript helpers in `src/utils/visual-semantics.ts` render severity and domain badges using `escapeHtml` for XSS safety.

32 tests cover every exported function, including HTML-escaping of custom labels.

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass