### PR TITLE
Mission bridges: weather domain (NWS/NHC/NIFC)

### DIFF
--- a/src/services/intelligence/mission-bridges/weather-bridges.ts
+++ b/src/services/intelligence/mission-bridges/weather-bridges.ts
@@ -1,0 +1,96 @@
+import {
+  MissionBridgeBase,
+  getMissionBridgeRegistry,
+  type FeedSeverity,
+  type NormalizedFeedEvent,
+} from './mission-bridge-core';
+
+export class NWSAlertsBridge extends MissionBridgeBase {
+  readonly domain = 'weather';
+  readonly feedId = 'nws-alerts';
+
+  normalize(raw: Record<string, unknown>): NormalizedFeedEvent | null {
+    const type = typeof raw['type'] === 'string' ? raw['type'].toLowerCase() : '';
+    let severity: FeedSeverity;
+    if (type.includes('tornado warning')) {
+      severity = 4;
+    } else if (type.includes('severe thunderstorm warning')) {
+      severity = 3;
+    } else if (type.includes('winter storm warning')) {
+      severity = 2;
+    } else if (type.includes('advisory')) {
+      severity = 1;
+    } else {
+      severity = 0;
+    }
+    return {
+      id: typeof raw['id'] === 'string' ? raw['id'] : String(raw['id'] ?? ''),
+      severity,
+      description: typeof raw['type'] === 'string' ? raw['type'] : '',
+      timestamp: Date.now(),
+      raw,
+    };
+  }
+}
+
+export class NHCHurricaneBridge extends MissionBridgeBase {
+  readonly domain = 'weather';
+  readonly feedId = 'nhc-hurricane';
+
+  normalize(raw: Record<string, unknown>): NormalizedFeedEvent | null {
+    const cat = typeof raw['category'] === 'number'
+      ? raw['category']
+      : Number(raw['category'] ?? 0);
+    let severity: FeedSeverity;
+    if (cat >= 5) {
+      severity = 4;
+    } else if (cat === 4) {
+      severity = 3;
+    } else if (cat === 3) {
+      severity = 2;
+    } else if (cat === 1 || cat === 2) {
+      severity = 1;
+    } else {
+      severity = 0;
+    }
+    return {
+      id: typeof raw['id'] === 'string' ? raw['id'] : String(raw['id'] ?? ''),
+      severity,
+      description: `Category ${isNaN(cat) ? 0 : cat} hurricane`,
+      timestamp: Date.now(),
+      raw,
+    };
+  }
+}
+
+export class NIFCWildfireBridge extends MissionBridgeBase {
+  readonly domain = 'weather';
+  readonly feedId = 'nifc-wildfire';
+
+  normalize(raw: Record<string, unknown>): NormalizedFeedEvent | null {
+    const pct = typeof raw['containmentPct'] === 'number' ? raw['containmentPct'] : 100;
+    let severity: FeedSeverity;
+    if (pct === 0) {
+      severity = 4;
+    } else if (pct < 25) {
+      severity = 3;
+    } else if (pct < 75) {
+      severity = 2;
+    } else if (pct < 100) {
+      severity = 1;
+    } else {
+      severity = 0;
+    }
+    return {
+      id: typeof raw['id'] === 'string' ? raw['id'] : String(raw['id'] ?? ''),
+      severity,
+      description: `Wildfire ${pct}% contained`,
+      timestamp: Date.now(),
+      raw,
+    };
+  }
+}
+
+getMissionBridgeRegistry().register(new NWSAlertsBridge());
+getMissionBridgeRegistry().register(new NHCHurricaneBridge());
+getMissionBridgeRegistry().register(new NIFCWildfireBridge());

--- a/tests/intelligence/mission-bridges/weather-bridges.test.mts
+++ b/tests/intelligence/mission-bridges/weather-bridges.test.mts
@@ -1,0 +1,251 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+
+import {
+  NWSAlertsBridge,
+  NHCHurricaneBridge,
+  NIFCWildfireBridge,
+} from '../../../src/services/intelligence/mission-bridges/weather-bridges.ts';
+import {
+  getMissionBridgeRegistry,
+  __resetMissionBridgeRegistry,
+} from '../../../src/services/intelligence/mission-bridges/mission-bridge-core.ts';
+
+// ── NWSAlertsBridge ──────────────────────────────────────────────────
+
+describe('NWSAlertsBridge', () => {
+  const bridge = new NWSAlertsBridge();
+
+  it('has domain weather', () => {
+    assert.equal(bridge.domain, 'weather');
+  });
+
+  it('has feedId nws-alerts', () => {
+    assert.equal(bridge.feedId, 'nws-alerts');
+  });
+
+  it('Tornado Warning → severity 4', () => {
+    assert.equal(bridge.normalize({ id: 'e1', type: 'Tornado Warning' })?.severity, 4);
+  });
+
+  it('TORNADO WARNING (uppercase) → severity 4', () => {
+    assert.equal(bridge.normalize({ id: 'e2', type: 'TORNADO WARNING' })?.severity, 4);
+  });
+
+  it('Severe Thunderstorm Warning → severity 3', () => {
+    assert.equal(bridge.normalize({ id: 'e3', type: 'Severe Thunderstorm Warning' })?.severity, 3);
+  });
+
+  it('Winter Storm Warning → severity 2', () => {
+    assert.equal(bridge.normalize({ id: 'e4', type: 'Winter Storm Warning' })?.severity, 2);
+  });
+
+  it('Frost Advisory → severity 1', () => {
+    assert.equal(bridge.normalize({ id: 'e5', type: 'Frost Advisory' })?.severity, 1);
+  });
+
+  it('Special Weather Statement Advisory → severity 1', () => {
+    assert.equal(bridge.normalize({ id: 'e6', type: 'Special Weather Statement Advisory' })?.severity, 1);
+  });
+
+  it('Special Weather Statement (no keyword) → severity 0', () => {
+    assert.equal(bridge.normalize({ id: 'e7', type: 'Special Weather Statement' })?.severity, 0);
+  });
+
+  it('empty type string → severity 0', () => {
+    assert.equal(bridge.normalize({ id: 'e8', type: '' })?.severity, 0);
+  });
+
+  it('raw preserved on output', () => {
+    const raw = { id: 'e9', type: 'Tornado Warning', extra: 42 };
+    assert.deepEqual(bridge.normalize(raw)?.raw, raw);
+  });
+
+  it('id on output matches input id', () => {
+    assert.equal(bridge.normalize({ id: 'my-alert-123', type: 'Tornado Warning' })?.id, 'my-alert-123');
+  });
+
+  it('timestamp is a recent number', () => {
+    const before = Date.now();
+    const result = bridge.normalize({ id: 'e10', type: 'Tornado Warning' });
+    assert.ok(result?.timestamp !== undefined && result.timestamp >= before);
+  });
+
+  it('tornado warning priority beats advisory substring', () => {
+    assert.equal(bridge.normalize({ id: 'e11', type: 'Tornado Warning Advisory Bulletin' })?.severity, 4);
+  });
+});
+
+// ── NHCHurricaneBridge ───────────────────────────────────────────────
+
+describe('NHCHurricaneBridge', () => {
+  const bridge = new NHCHurricaneBridge();
+
+  it('has domain weather', () => {
+    assert.equal(bridge.domain, 'weather');
+  });
+
+  it('has feedId nhc-hurricane', () => {
+    assert.equal(bridge.feedId, 'nhc-hurricane');
+  });
+
+  it('category 5 → severity 4', () => {
+    assert.equal(bridge.normalize({ id: 'h1', category: 5 })?.severity, 4);
+  });
+
+  it('category 4 → severity 3', () => {
+    assert.equal(bridge.normalize({ id: 'h2', category: 4 })?.severity, 3);
+  });
+
+  it('category 3 → severity 2', () => {
+    assert.equal(bridge.normalize({ id: 'h3', category: 3 })?.severity, 2);
+  });
+
+  it('category 2 → severity 1', () => {
+    assert.equal(bridge.normalize({ id: 'h4', category: 2 })?.severity, 1);
+  });
+
+  it('category 1 → severity 1', () => {
+    assert.equal(bridge.normalize({ id: 'h5', category: 1 })?.severity, 1);
+  });
+
+  it('category 0 → severity 0', () => {
+    assert.equal(bridge.normalize({ id: 'h6', category: 0 })?.severity, 0);
+  });
+
+  it('string "5" → severity 4 (numeric coercion)', () => {
+    assert.equal(bridge.normalize({ id: 'h7', category: '5' })?.severity, 4);
+  });
+
+  it('string "3" → severity 2 (numeric coercion)', () => {
+    assert.equal(bridge.normalize({ id: 'h8', category: '3' })?.severity, 2);
+  });
+
+  it('undefined category → severity 0', () => {
+    assert.equal(bridge.normalize({ id: 'h9' })?.severity, 0);
+  });
+
+  it('NaN string "TS" → severity 0', () => {
+    assert.equal(bridge.normalize({ id: 'h10', category: 'TS' })?.severity, 0);
+  });
+
+  it('raw preserved on output', () => {
+    const raw = { id: 'h11', category: 5 };
+    assert.deepEqual(bridge.normalize(raw)?.raw, raw);
+  });
+
+  it('id on output matches input', () => {
+    assert.equal(bridge.normalize({ id: 'hurricane-99', category: 4 })?.id, 'hurricane-99');
+  });
+
+  it('category >= 6 → severity 4', () => {
+    assert.equal(bridge.normalize({ id: 'h12', category: 6 })?.severity, 4);
+  });
+});
+
+// ── NIFCWildfireBridge ────────────────────────────────────────────────
+
+describe('NIFCWildfireBridge', () => {
+  const bridge = new NIFCWildfireBridge();
+
+  it('has domain weather', () => {
+    assert.equal(bridge.domain, 'weather');
+  });
+
+  it('has feedId nifc-wildfire', () => {
+    assert.equal(bridge.feedId, 'nifc-wildfire');
+  });
+
+  it('containmentPct 0 → severity 4', () => {
+    assert.equal(bridge.normalize({ id: 'w1', containmentPct: 0 })?.severity, 4);
+  });
+
+  it('containmentPct 10 → severity 3', () => {
+    assert.equal(bridge.normalize({ id: 'w2', containmentPct: 10 })?.severity, 3);
+  });
+
+  it('containmentPct 24 → severity 3 (boundary < 25)', () => {
+    assert.equal(bridge.normalize({ id: 'w3', containmentPct: 24 })?.severity, 3);
+  });
+
+  it('containmentPct 25 → severity 2', () => {
+    assert.equal(bridge.normalize({ id: 'w4', containmentPct: 25 })?.severity, 2);
+  });
+
+  it('containmentPct 50 → severity 2', () => {
+    assert.equal(bridge.normalize({ id: 'w5', containmentPct: 50 })?.severity, 2);
+  });
+
+  it('containmentPct 74 → severity 2 (boundary < 75)', () => {
+    assert.equal(bridge.normalize({ id: 'w6', containmentPct: 74 })?.severity, 2);
+  });
+
+  it('containmentPct 75 → severity 1', () => {
+    assert.equal(bridge.normalize({ id: 'w7', containmentPct: 75 })?.severity, 1);
+  });
+
+  it('containmentPct 99 → severity 1 (boundary < 100)', () => {
+    assert.equal(bridge.normalize({ id: 'w8', containmentPct: 99 })?.severity, 1);
+  });
+
+  it('containmentPct 100 → severity 0', () => {
+    assert.equal(bridge.normalize({ id: 'w9', containmentPct: 100 })?.severity, 0);
+  });
+
+  it('missing containmentPct → severity 0 (fallback to 100)', () => {
+    assert.equal(bridge.normalize({ id: 'w10' })?.severity, 0);
+  });
+
+  it('raw preserved on output', () => {
+    const raw = { id: 'w11', containmentPct: 50 };
+    assert.deepEqual(bridge.normalize(raw)?.raw, raw);
+  });
+
+  it('id on output matches input', () => {
+    assert.equal(bridge.normalize({ id: 'fire-001', containmentPct: 0 })?.id, 'fire-001');
+  });
+});
+
+// ── MissionBridgeRegistry ─────────────────────────────────────────────
+
+describe('MissionBridgeRegistry (weather bridges)', () => {
+  before(() => {
+    // Own the registry state — reset then re-register so these tests
+    // are order-independent and don't rely on import-time side effects.
+    __resetMissionBridgeRegistry();
+    const reg = getMissionBridgeRegistry();
+    reg.register(new NWSAlertsBridge());
+    reg.register(new NHCHurricaneBridge());
+    reg.register(new NIFCWildfireBridge());
+  });
+
+  it('has weather:nws-alerts after registration', () => {
+    assert.ok(getMissionBridgeRegistry().has('weather', 'nws-alerts'));
+  });
+
+  it('has weather:nhc-hurricane after registration', () => {
+    assert.ok(getMissionBridgeRegistry().has('weather', 'nhc-hurricane'));
+  });
+
+  it('has weather:nifc-wildfire after registration', () => {
+    assert.ok(getMissionBridgeRegistry().has('weather', 'nifc-wildfire'));
+  });
+
+  it('all() returns at least 3 bridges', () => {
+    assert.ok(getMissionBridgeRegistry().all().length >= 3);
+  });
+
+  it('get returns NWSAlertsBridge instance', () => {
+    const bridge = getMissionBridgeRegistry().get('weather', 'nws-alerts');
+    assert.ok(bridge instanceof NWSAlertsBridge);
+  });
+
+  it('getByDomain returns all weather bridges', () => {
+    assert.ok(getMissionBridgeRegistry().getByDomain('weather').length >= 3);
+  });
+
+  it('reset clears registry', () => {
+    __resetMissionBridgeRegistry();
+    assert.equal(getMissionBridgeRegistry().all().length, 0);
+  });
+});


### PR DESCRIPTION
Adds three concrete `MissionBridgeBase` implementations for the weather domain, self-registering in `MissionBridgeRegistry` at module load.

## Bridges

| Class | feedId | Severity source |
|---|---|---|
| `NWSAlertsBridge` | `nws-alerts` | `event.type` substring (Tornado Warning→4, Severe Thunderstorm Warning→3, Winter Storm Warning→2, advisory→1, else→0) |
| `NHCHurricaneBridge` | `nhc-hurricane` | `event.category` as number (Cat5→4, Cat4→3, Cat3→2, Cat1-2→1, TD/TS/0→0); numeric coercion handles string inputs |
| `NIFCWildfireBridge` | `nifc-wildfire` | `event.containmentPct` (0%→4, <25%→3, <75%→2, <100%→1, 100%→0) |

## Files

- `src/services/intelligence/mission-bridges/weather-bridges.ts` — three bridge classes + module-level registration
- `tests/intelligence/mission-bridges/weather-bridges.test.mts` — 50 tests, all passing

## Notes

- Uses the existing `MissionBridgeRegistry` instance API (`getMissionBridgeRegistry()`, compound `domain:feedId` keys) that shipped on main.
- Registry tests use a `before()` hook to own their state — no dependency on import-time side effects.
- NWS priority ordering: most-specific type checked first so `'Tornado Warning Advisory'` correctly maps to severity 4 (not 1).

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass