### PR TITLE
Mode system visual states — Normal/Elevated/Crisis/Blackout CSS tokens + ModeManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "test:osint": "tsx --test src/services/osint/__tests__/reddit-service.test.mts",
     "test:notifications": "tsx --test src/services/notifications/__tests__/eew-tiers.test.mts src/services/notifications/__tests__/notification-ledger.test.mts src/services/notifications/__tests__/push-notifier.test.mts src/services/notifications/__tests__/imessage-bridge-extended.test.mts src/services/notifications/__tests__/voice-alerter.test.mts src/services/notifications/__tests__/event-bridge.test.mts src-tauri/sidecar/__tests__/notification-integration.test.mts src/components/__tests__/notification-panels.test.mts tests/notifications/all-producers.integration.test.mts tests/notifications/notification-ladder.test.mts",
     "test:panels:fixtures": "tsx --import ./tests/panels/register-hook.mjs --test tests/panels/panel-fixtures.test.mts",
+    "test:mode-manager": "tsx --test tests/utils/mode-manager.test.mts",
     "test:component-lib": "tsx --test tests/components/lib/panel-components.test.mts",
     "test:space-superpower": "tsx --import ./tests/panels/register-hook.mjs --test tests/components/space-superpower-panel.test.mts",
     "test:aviation-superpower": "tsx --import ./tests/panels/register-hook.mjs --test tests/components/aviation-superpower-panel.test.mts",

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,4 +1,5 @@
 @import './tokens.css';
+@import './mode-states.css';
 @import './visual-semantics.css';
 @import './rtl-overrides.css';
 @import './panels.css';

--- a/src/styles/mode-states.css
+++ b/src/styles/mode-states.css
@@ -1,0 +1,68 @@
+/**
+ * Mode system visual states.
+ * Keyed off html[data-mode="normal|elevated|crisis|blackout"].
+ * Set by ModeManager (src/utils/mode-manager.ts) via
+ * document.documentElement.dataset.mode.
+ */
+
+/* ── Default (normal) vars — always present on :root ─────────────────── */
+:root {
+  --mode-bg:           #0f172a;
+  --mode-border:       rgba(59, 130, 246, 0.2);
+  --mode-text-primary: #e2e8f0;
+  --mode-accent:       #3b82f6;
+  --mode-pulse-color:  rgba(59, 130, 246, 0.4);
+}
+
+/* ── Normal — calm operational, blue/gray tones ───────────────────────── */
+[data-mode="normal"] {
+  --mode-bg:           #0f172a;
+  --mode-border:       rgba(59, 130, 246, 0.2);
+  --mode-text-primary: #e2e8f0;
+  --mode-accent:       #3b82f6;
+  --mode-pulse-color:  rgba(59, 130, 246, 0.4);
+}
+
+/* ── Elevated — heightened awareness, amber tones ─────────────────────── */
+[data-mode="elevated"] {
+  --mode-bg:           #1c1407;
+  --mode-border:       rgba(245, 158, 11, 0.3);
+  --mode-text-primary: #fef3c7;
+  --mode-accent:       #f59e0b;
+  --mode-pulse-color:  rgba(245, 158, 11, 0.45);
+}
+
+/* ── Crisis — active emergency, red tones with pulse animation ────────── */
+[data-mode="crisis"] {
+  --mode-bg:           #1a0505;
+  --mode-border:       rgba(239, 68, 68, 0.5);
+  --mode-text-primary: #fee2e2;
+  --mode-accent:       #ef4444;
+  --mode-pulse-color:  rgba(239, 68, 68, 0.65);
+}
+
+/* Elements that carry the pulsing border glow in crisis mode */
+[data-mode="crisis"] .mode-pulse-target {
+  animation: mode-pulse 2s ease-in-out infinite;
+}
+
+/* ── Blackout — operational silence, near-black, minimal color ────────── */
+[data-mode="blackout"] {
+  --mode-bg:           #050505;
+  --mode-border:       rgba(255, 255, 255, 0.06);
+  --mode-text-primary: #9ca3af;
+  --mode-accent:       #374151;
+  --mode-pulse-color:  rgba(255, 255, 255, 0.05);
+}
+
+/* ── Keyframes ────────────────────────────────────────────────────────── */
+@keyframes mode-pulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 var(--mode-pulse-color);
+    border-color: var(--mode-border);
+  }
+  50% {
+    box-shadow: 0 0 12px 3px var(--mode-pulse-color);
+    border-color: var(--mode-accent);
+  }
+}

--- a/src/utils/mode-manager.ts
+++ b/src/utils/mode-manager.ts
@@ -1,0 +1,69 @@
+export type AppMode = 'normal' | 'elevated' | 'crisis' | 'blackout';
+
+export const STORAGE_KEY = 'wm-app-mode';
+const DEFAULT_MODE: AppMode = 'normal';
+const VALID_MODES = new Set<string>(['normal', 'elevated', 'crisis', 'blackout']);
+
+export type ModeChangeCallback = (mode: AppMode, prev: AppMode) => void;
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function isValidMode(value: string | null): value is AppMode {
+  return value !== null && VALID_MODES.has(value);
+}
+
+function applyToDataset(mode: AppMode): void {
+  if (typeof document !== 'undefined') {
+    document.documentElement.dataset.mode = mode;
+  }
+}
+
+export class ModeManager {
+  private static instance: ModeManager | undefined;
+
+  private current: AppMode;
+  private readonly listeners = new Set<ModeChangeCallback>();
+  private readonly storage: StorageLike;
+
+  private constructor(storage: StorageLike) {
+    this.storage = storage;
+    const stored = storage.getItem(STORAGE_KEY);
+    this.current = isValidMode(stored) ? stored : DEFAULT_MODE;
+    applyToDataset(this.current);
+  }
+
+  static getInstance(storage: StorageLike = localStorage): ModeManager {
+    ModeManager.instance ??= new ModeManager(storage);
+    return ModeManager.instance;
+  }
+
+  static resetForTests(): void {
+    ModeManager.instance = undefined;
+  }
+
+  getMode(): AppMode {
+    return this.current;
+  }
+
+  setMode(mode: AppMode): void {
+    const prev = this.current;
+    this.current = mode;
+    this.storage.setItem(STORAGE_KEY, mode);
+    applyToDataset(mode);
+    const snapshot = [...this.listeners];
+    for (const cb of snapshot) {
+      cb(mode, prev);
+    }
+  }
+
+  onModeChange(cb: ModeChangeCallback): void {
+    this.listeners.add(cb);
+  }
+
+  offModeChange(cb: ModeChangeCallback): void {
+    this.listeners.delete(cb);
+  }
+}

--- a/tests/utils/mode-manager.test.mts
+++ b/tests/utils/mode-manager.test.mts
@@ -1,0 +1,252 @@
+import { strict as assert } from 'node:assert';
+import { describe, it, beforeEach } from 'node:test';
+import {
+  ModeManager,
+  STORAGE_KEY,
+  type AppMode,
+  type ModeChangeCallback,
+  type StorageLike,
+} from '../../src/utils/mode-manager.ts';
+
+class MockStorage implements StorageLike {
+  readonly store = new Map<string, string>();
+  getItem(key: string): string | null { return this.store.get(key) ?? null; }
+  setItem(key: string, value: string): void { this.store.set(key, value); }
+}
+
+function makeManager(storage = new MockStorage()): ModeManager {
+  ModeManager.resetForTests();
+  return ModeManager.getInstance(storage);
+}
+
+// ── Singleton ─────────────────────────────────────────────────────────────
+
+describe('ModeManager singleton', () => {
+  beforeEach(() => { ModeManager.resetForTests(); });
+
+  it('returns the same instance on repeated calls', () => {
+    const s = new MockStorage();
+    const a = ModeManager.getInstance(s);
+    const b = ModeManager.getInstance(s);
+    assert.equal(a, b);
+  });
+
+  it('resetForTests clears the instance so next call gets a fresh one', () => {
+    const a = ModeManager.getInstance(new MockStorage());
+    ModeManager.resetForTests();
+    const b = ModeManager.getInstance(new MockStorage());
+    assert.notEqual(a, b);
+  });
+});
+
+// ── Default mode ──────────────────────────────────────────────────────────
+
+describe('ModeManager defaults', () => {
+  it('starts in normal mode when storage is empty', () => {
+    const m = makeManager();
+    assert.equal(m.getMode(), 'normal');
+  });
+
+  it('restores persisted mode from storage on construction', () => {
+    const s = new MockStorage();
+    s.setItem(STORAGE_KEY, 'crisis');
+    const m = makeManager(s);
+    assert.equal(m.getMode(), 'crisis');
+  });
+
+  it('falls back to normal when storage holds an unrecognised value', () => {
+    const s = new MockStorage();
+    s.setItem(STORAGE_KEY, 'turbo-mode');
+    const m = makeManager(s);
+    assert.equal(m.getMode(), 'normal');
+  });
+
+  it('falls back to normal when storage holds an empty string', () => {
+    const s = new MockStorage();
+    s.setItem(STORAGE_KEY, '');
+    const m = makeManager(s);
+    assert.equal(m.getMode(), 'normal');
+  });
+});
+
+// ── setMode ───────────────────────────────────────────────────────────────
+
+describe('ModeManager.setMode', () => {
+  it('updates getMode()', () => {
+    const m = makeManager();
+    m.setMode('elevated');
+    assert.equal(m.getMode(), 'elevated');
+  });
+
+  it('persists to storage', () => {
+    const s = new MockStorage();
+    const m = makeManager(s);
+    m.setMode('blackout');
+    assert.equal(s.getItem(STORAGE_KEY), 'blackout');
+  });
+
+  it('sets all four modes without error', () => {
+    const m = makeManager();
+    const modes: AppMode[] = ['normal', 'elevated', 'crisis', 'blackout'];
+    for (const mode of modes) {
+      m.setMode(mode);
+      assert.equal(m.getMode(), mode);
+    }
+  });
+
+  it('persists each mode correctly', () => {
+    const s = new MockStorage();
+    const m = makeManager(s);
+    const modes: AppMode[] = ['elevated', 'crisis', 'blackout', 'normal'];
+    for (const mode of modes) {
+      m.setMode(mode);
+      assert.equal(s.getItem(STORAGE_KEY), mode);
+    }
+  });
+
+  it('setting same mode twice does not throw', () => {
+    const m = makeManager();
+    assert.doesNotThrow(() => {
+      m.setMode('crisis');
+      m.setMode('crisis');
+    });
+  });
+});
+
+// ── onModeChange / offModeChange ──────────────────────────────────────────
+
+describe('ModeManager listeners', () => {
+  it('fires callback with new mode and previous mode', () => {
+    const m = makeManager();
+    let received: [AppMode, AppMode] | undefined;
+    const cb: ModeChangeCallback = (mode, prev) => { received = [mode, prev]; };
+    m.onModeChange(cb);
+    m.setMode('crisis');
+    assert.deepEqual(received, ['crisis', 'normal']);
+  });
+
+  it('fires callback for each mode transition', () => {
+    const m = makeManager();
+    const calls: [AppMode, AppMode][] = [];
+    m.onModeChange((mode, prev) => { calls.push([mode, prev]); });
+    m.setMode('elevated');
+    m.setMode('crisis');
+    assert.deepEqual(calls, [
+      ['elevated', 'normal'],
+      ['crisis', 'elevated'],
+    ]);
+  });
+
+  it('offModeChange stops delivery', () => {
+    const m = makeManager();
+    let count = 0;
+    const cb: ModeChangeCallback = () => { count++; };
+    m.onModeChange(cb);
+    m.setMode('elevated');
+    m.offModeChange(cb);
+    m.setMode('crisis');
+    assert.equal(count, 1);
+  });
+
+  it('adding same callback twice fires it only once per change', () => {
+    const m = makeManager();
+    let count = 0;
+    const cb: ModeChangeCallback = () => { count++; };
+    m.onModeChange(cb);
+    m.onModeChange(cb);
+    m.setMode('blackout');
+    assert.equal(count, 1);
+  });
+
+  it('multiple distinct callbacks all fire', () => {
+    const m = makeManager();
+    let a = 0;
+    let b = 0;
+    m.onModeChange(() => { a++; });
+    m.onModeChange(() => { b++; });
+    m.setMode('elevated');
+    assert.equal(a, 1);
+    assert.equal(b, 1);
+  });
+
+  it('removing a listener that was never added does not throw', () => {
+    const m = makeManager();
+    const cb: ModeChangeCallback = () => { /* no-op */ };
+    assert.doesNotThrow(() => { m.offModeChange(cb); });
+  });
+
+  it('callback removed during iteration does not affect delivery to others', () => {
+    const m = makeManager();
+    let secondFired = false;
+    const second: ModeChangeCallback = () => { secondFired = true; };
+    const first: ModeChangeCallback = () => { m.offModeChange(second); };
+    m.onModeChange(first);
+    m.onModeChange(second);
+    m.setMode('crisis');
+    assert.equal(secondFired, true, 'snapshot-copy means second still fires this round');
+  });
+});
+
+// ── Storage persistence ───────────────────────────────────────────────────
+
+describe('ModeManager storage integration', () => {
+  it('a fresh instance reads the mode written by a previous instance', () => {
+    const s = new MockStorage();
+    const first = makeManager(s);
+    first.setMode('blackout');
+    ModeManager.resetForTests();
+    const second = ModeManager.getInstance(s);
+    assert.equal(second.getMode(), 'blackout');
+  });
+
+  it('writes only to wm-app-mode key, not other keys', () => {
+    const s = new MockStorage();
+    const m = makeManager(s);
+    m.setMode('elevated');
+    const keys = [...s.store.keys()];
+    assert.deepEqual(keys, [STORAGE_KEY]);
+  });
+
+  it('STORAGE_KEY is the expected string', () => {
+    assert.equal(STORAGE_KEY, 'wm-app-mode');
+  });
+});
+
+// ── getMode consistency ───────────────────────────────────────────────────
+
+describe('ModeManager getMode consistency', () => {
+  it('getMode reflects the last setMode call in a chain', () => {
+    const m = makeManager();
+    m.setMode('elevated');
+    m.setMode('blackout');
+    m.setMode('normal');
+    assert.equal(m.getMode(), 'normal');
+  });
+
+  it('callback prev matches getMode() from before the transition', () => {
+    const m = makeManager();
+    m.setMode('elevated');
+    let prevAtCallTime: AppMode | undefined;
+    m.onModeChange((_mode, prev) => { prevAtCallTime = prev; });
+    m.setMode('crisis');
+    assert.equal(prevAtCallTime, 'elevated');
+  });
+});
+
+// ── DOM guard (no document in Node test environment) ─────────────────────
+
+describe('ModeManager DOM guard', () => {
+  it('setMode does not throw even though document is undefined in Node', () => {
+    const m = makeManager();
+    assert.doesNotThrow(() => {
+      m.setMode('crisis');
+      m.setMode('normal');
+    });
+  });
+
+  it('getMode still returns correct value without a DOM', () => {
+    const m = makeManager();
+    m.setMode('blackout');
+    assert.equal(m.getMode(), 'blackout');
+  });
+});


### PR DESCRIPTION
CSS custom properties and TypeScript singleton for the app-wide mode system.

## CSS (`src/styles/mode-states.css`)
- Custom properties on `[data-mode="..."]` (applied to `<html>`): `--mode-bg`, `--mode-border`, `--mode-text-primary`, `--mode-accent`, `--mode-pulse-color`
- **Normal**: blue/gray calm operational palette
- **Elevated**: amber heightened-awareness tones
- **Crisis**: red emergency palette + `@keyframes mode-pulse` glow animation on `.mode-pulse-target` elements
- **Blackout**: near-black, minimal color, operational silence
- Imported in `src/styles/main.css` after tokens

## TypeScript (`src/utils/mode-manager.ts`)
- `ModeManager` singleton with `getInstance(storage?)` / `resetForTests()`
- `setMode()` persists to `localStorage` key `wm-app-mode`, applies to `document.documentElement.dataset.mode` (DOM write guarded for Node test safety), fires listeners
- `onModeChange()` / `offModeChange()` with snapshot-copy iteration so removing a listener during a callback doesn't skip siblings
- `StorageLike` interface for injectable test storage

## Tests
25 tests — singleton identity, default/restore/invalid storage, all four modes, listener add/remove/dedup/mid-loop removal, storage key isolation, DOM guard in Node.

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass