### PR TITLE
Counterfactual replay — what-if scenario engine for historical world states

### DIFF
--- a/src/components/CounterfactualReplayPanel.ts
+++ b/src/components/CounterfactualReplayPanel.ts
@@ -1,33 +1,33 @@
 /* eslint-disable sonarjs/no-nested-template-literals */
 /**
- * Counterfactual Replay Panel — Phase 4 "what if?" UI.
+ * Counterfactual Replay Panel — "what if?" scenario UI.
  *
  * Two-column layout: scenario list on the left, result view on the
- * right. New Scenario button opens an inline form that picks a built-in
- * template + a Situation observation as the baseline. Re-running an
- * existing scenario produces a fresh ReplayResult and updates the
- * right-hand pane.
+ * right. New Scenario button opens an inline form that picks a
+ * Situation as the base snapshot and one domain override. Running a
+ * scenario applies the overrides to the snapshot and computes a
+ * cascade score with narrative summary.
  */
 
 import { Panel } from './Panel';
 import {
-  BUILT_IN_REPLAY_TEMPLATES,
-  getCounterfactualReplayEngine,
-  type ReplayModification,
+  CounterfactualReplayEngine,
+  type CounterfactualScenario,
+  type DomainOverride,
   type ReplayResult,
-  type ReplayScenario,
 } from '@/services/intelligence/counterfactual-replay';
-import { getSituationStoreV2, type Situation } from '@/services/intelligence/situation-store-v2';
+import { getSituationStoreV2 } from '@/services/intelligence/situation-store-v2';
 import { escapeHtml } from '@/utils/sanitize';
 
 const REFRESH_MS = 30_000;
 
 interface FormState {
   open: boolean;
-  observationId: string | null;
-  templateId: string;
   name: string;
-  description: string;
+  baseSnapshotId: string;
+  domain: string;
+  severityDelta: number;
+  eventCountDelta: number;
   error: string | null;
 }
 
@@ -38,15 +38,15 @@ interface PanelState {
 
 export class CounterfactualReplayPanel extends Panel {
   private refreshTimer: ReturnType<typeof setInterval> | null = null;
-  private unsub: (() => void) | null = null;
   private state: PanelState = {
     selectedScenarioId: null,
     form: {
       open: false,
-      observationId: null,
-      templateId: BUILT_IN_REPLAY_TEMPLATES[0]!.id,
       name: '',
-      description: '',
+      baseSnapshotId: '',
+      domain: '',
+      severityDelta: 0.5,
+      eventCountDelta: 0,
       error: null,
     },
   };
@@ -58,7 +58,7 @@ export class CounterfactualReplayPanel extends Panel {
       showCount: true,
       trackActivity: true,
       infoTooltip:
-        'Phase 4 "what if?" replay. Modify the severity, domain, location, magnitude, or confidence on a past observation and re-score it through a deterministic local scorer to see how brittle the original conclusion was. Built-in templates: severity downgrade, source reduction, ~1000 km location shift, -6 h timing shift.',
+        '"What if?" scenario engine. Pick a historical snapshot, apply domain overrides (severity delta, event count delta), and run to compute a cascade score and narrative summary.',
     });
     this.start();
   }
@@ -66,7 +66,6 @@ export class CounterfactualReplayPanel extends Panel {
   private start(): void {
     this.render();
     this.refreshTimer = setInterval(() => this.render(), REFRESH_MS);
-    this.unsub = getCounterfactualReplayEngine().subscribe(() => this.render());
   }
 
   public dispose(): void {
@@ -74,40 +73,31 @@ export class CounterfactualReplayPanel extends Panel {
       clearInterval(this.refreshTimer);
       this.refreshTimer = null;
     }
-    if (this.unsub) {
-      this.unsub();
-      this.unsub = null;
-    }
   }
 
-  private collectObservations(): { situation: Situation; observationId: string; title: string }[] {
-    const out: { situation: Situation; observationId: string; title: string }[] = [];
-    for (const s of getSituationStoreV2().list()) {
-      for (const o of s.observations) {
-        out.push({ situation: s, observationId: o.id, title: o.title || o.id });
-      }
-    }
-    return out;
+  private snapshotOptions(): { id: string; label: string }[] {
+    return getSituationStoreV2().list().map((s) => ({
+      id: s.id,
+      label: `${s.domain} — ${s.id.slice(0, 8)}`,
+    }));
   }
 
   private render(): void {
-    const engine = getCounterfactualReplayEngine();
-    const scenarios = engine.getAllScenarios();
+    const engine = CounterfactualReplayEngine.getInstance();
+    const scenarios = engine.listScenarios();
     this.setCount(scenarios.length);
 
     const selected = this.state.selectedScenarioId
       ? scenarios.find((s) => s.id === this.state.selectedScenarioId)
       : scenarios[scenarios.length - 1];
     const selectedId = selected?.id ?? null;
-    const results = selectedId ? engine.getResults(selectedId) : [];
-    const latestResult = results[results.length - 1];
 
     const html = `<div style="padding:12px;display:flex;flex-direction:column;gap:12px;">
       ${this.renderToolbar()}
       ${this.state.form.open ? this.renderNewScenarioForm() : ''}
       <div style="display:grid;grid-template-columns:minmax(180px,1fr) 2fr;gap:12px;align-items:flex-start;">
         ${renderScenarioList(scenarios, selectedId)}
-        ${renderResultPane(selected, latestResult, results.length)}
+        ${renderResultPane(selected)}
       </div>
     </div>`;
     this.setContent(html);
@@ -118,38 +108,39 @@ export class CounterfactualReplayPanel extends Panel {
     const label = this.state.form.open ? 'Cancel' : '+ New Scenario';
     return `<div style="display:flex;align-items:center;gap:8px;">
       <button id="cfReplayNewBtn" style="padding:6px 12px;background:var(--accent,#4a9eff);color:#fff;border:0;border-radius:3px;cursor:pointer;font-weight:600;font-size:12px;">${label}</button>
-      <span style="font-size:11px;color:var(--text-secondary,#aaa);">${BUILT_IN_REPLAY_TEMPLATES.length} built-in templates · scoring is self-contained (no live-pipeline side effects)</span>
+      <span style="font-size:11px;color:var(--text-secondary,#aaa);">cascade score = mean |severityDelta| across overrides</span>
     </div>`;
   }
 
   private renderNewScenarioForm(): string {
-    const observations = this.collectObservations();
-    const obsOptions = observations.length === 0
-      ? `<option value="">No observations available — ingest a Situation first</option>`
-      : observations.map((o) => `<option value="${escapeHtml(o.observationId)}"${o.observationId === this.state.form.observationId ? ' selected' : ''}>${escapeHtml(o.title)} · ${escapeHtml(o.situation.domain)}</option>`).join('');
-    const templateOptions = BUILT_IN_REPLAY_TEMPLATES.map((t) =>
-      `<option value="${escapeHtml(t.id)}"${t.id === this.state.form.templateId ? ' selected' : ''}>${escapeHtml(t.label)} — ${escapeHtml(t.description)}</option>`,
-    ).join('');
+    const snapshots = this.snapshotOptions();
+    const snapOptions = snapshots.length === 0
+      ? `<option value="">No situations available yet</option>`
+      : snapshots.map((s) => `<option value="${escapeHtml(s.id)}"${s.id === this.state.form.baseSnapshotId ? ' selected' : ''}>${escapeHtml(s.label)}</option>`).join('');
     const errorBlock = this.state.form.error
       ? `<div style="color:#f44336;font-size:11px;margin-top:6px;">${escapeHtml(this.state.form.error)}</div>`
       : '';
     return `<div style="border:1px solid var(--border-subtle,#333);border-radius:4px;padding:10px;display:flex;flex-direction:column;gap:8px;">
       <div style="font-size:11px;color:var(--text-secondary,#aaa);text-transform:uppercase;letter-spacing:0.05em;">New scenario</div>
       <label style="display:flex;flex-direction:column;gap:4px;font-size:11px;">
-        <span style="color:var(--text-secondary,#aaa);">Baseline observation</span>
-        <select id="cfReplayObsSelect" style="padding:4px 6px;background:var(--surface-2,#1a1a1a);color:inherit;border:1px solid var(--border-subtle,#333);border-radius:3px;font-size:11px;">${obsOptions}</select>
+        <span style="color:var(--text-secondary,#aaa);">Name</span>
+        <input id="cfReplayName" type="text" value="${escapeHtml(this.state.form.name)}" placeholder="e.g. No cyber threat" style="padding:4px 6px;background:var(--surface-2,#1a1a1a);color:inherit;border:1px solid var(--border-subtle,#333);border-radius:3px;font-size:11px;">
       </label>
       <label style="display:flex;flex-direction:column;gap:4px;font-size:11px;">
-        <span style="color:var(--text-secondary,#aaa);">Template</span>
-        <select id="cfReplayTemplateSelect" style="padding:4px 6px;background:var(--surface-2,#1a1a1a);color:inherit;border:1px solid var(--border-subtle,#333);border-radius:3px;font-size:11px;">${templateOptions}</select>
+        <span style="color:var(--text-secondary,#aaa);">Base snapshot (situation)</span>
+        <select id="cfReplaySnapSelect" style="padding:4px 6px;background:var(--surface-2,#1a1a1a);color:inherit;border:1px solid var(--border-subtle,#333);border-radius:3px;font-size:11px;">${snapOptions}</select>
       </label>
       <label style="display:flex;flex-direction:column;gap:4px;font-size:11px;">
-        <span style="color:var(--text-secondary,#aaa);">Name (optional)</span>
-        <input id="cfReplayName" type="text" value="${escapeHtml(this.state.form.name)}" placeholder="defaults to template label" style="padding:4px 6px;background:var(--surface-2,#1a1a1a);color:inherit;border:1px solid var(--border-subtle,#333);border-radius:3px;font-size:11px;">
+        <span style="color:var(--text-secondary,#aaa);">Domain override</span>
+        <input id="cfReplayDomain" type="text" value="${escapeHtml(this.state.form.domain)}" placeholder="e.g. cyber, weather" style="padding:4px 6px;background:var(--surface-2,#1a1a1a);color:inherit;border:1px solid var(--border-subtle,#333);border-radius:3px;font-size:11px;">
       </label>
       <label style="display:flex;flex-direction:column;gap:4px;font-size:11px;">
-        <span style="color:var(--text-secondary,#aaa);">Description (optional)</span>
-        <input id="cfReplayDesc" type="text" value="${escapeHtml(this.state.form.description)}" placeholder="defaults to template description" style="padding:4px 6px;background:var(--surface-2,#1a1a1a);color:inherit;border:1px solid var(--border-subtle,#333);border-radius:3px;font-size:11px;">
+        <span style="color:var(--text-secondary,#aaa);">Severity delta (-1 to 1)</span>
+        <input id="cfReplaySevDelta" type="number" min="-1" max="1" step="0.1" value="${this.state.form.severityDelta}" style="padding:4px 6px;background:var(--surface-2,#1a1a1a);color:inherit;border:1px solid var(--border-subtle,#333);border-radius:3px;font-size:11px;">
+      </label>
+      <label style="display:flex;flex-direction:column;gap:4px;font-size:11px;">
+        <span style="color:var(--text-secondary,#aaa);">Event count delta</span>
+        <input id="cfReplayEvtDelta" type="number" step="1" value="${this.state.form.eventCountDelta}" style="padding:4px 6px;background:var(--surface-2,#1a1a1a);color:inherit;border:1px solid var(--border-subtle,#333);border-radius:3px;font-size:11px;">
       </label>
       <div>
         <button id="cfReplayCreateBtn" style="padding:6px 12px;background:#4caf50;color:#fff;border:0;border-radius:3px;cursor:pointer;font-weight:600;font-size:12px;">Create & Run</button>
@@ -166,17 +157,20 @@ export class CounterfactualReplayPanel extends Panel {
         this.state.form.error = null;
         this.render();
       });
-      root.querySelector<HTMLSelectElement>('#cfReplayObsSelect')?.addEventListener('change', (e) => {
-        this.state.form.observationId = (e.target as HTMLSelectElement).value;
-      });
-      root.querySelector<HTMLSelectElement>('#cfReplayTemplateSelect')?.addEventListener('change', (e) => {
-        this.state.form.templateId = (e.target as HTMLSelectElement).value;
+      root.querySelector<HTMLSelectElement>('#cfReplaySnapSelect')?.addEventListener('change', (e) => {
+        this.state.form.baseSnapshotId = (e.target as HTMLSelectElement).value;
       });
       root.querySelector<HTMLInputElement>('#cfReplayName')?.addEventListener('input', (e) => {
         this.state.form.name = (e.target as HTMLInputElement).value;
       });
-      root.querySelector<HTMLInputElement>('#cfReplayDesc')?.addEventListener('input', (e) => {
-        this.state.form.description = (e.target as HTMLInputElement).value;
+      root.querySelector<HTMLInputElement>('#cfReplayDomain')?.addEventListener('input', (e) => {
+        this.state.form.domain = (e.target as HTMLInputElement).value;
+      });
+      root.querySelector<HTMLInputElement>('#cfReplaySevDelta')?.addEventListener('input', (e) => {
+        this.state.form.severityDelta = Number((e.target as HTMLInputElement).value);
+      });
+      root.querySelector<HTMLInputElement>('#cfReplayEvtDelta')?.addEventListener('input', (e) => {
+        this.state.form.eventCountDelta = Number((e.target as HTMLInputElement).value);
       });
       root.querySelector<HTMLButtonElement>('#cfReplayCreateBtn')?.addEventListener('click', () => this.handleCreate());
 
@@ -194,40 +188,30 @@ export class CounterfactualReplayPanel extends Panel {
   }
 
   private handleCreate(): void {
-    const obsId = this.state.form.observationId;
-    if (!obsId) {
-      this.state.form.error = 'Pick a baseline observation first.';
-      this.render();
-      return;
-    }
-    const observations = this.collectObservations();
-    const target = observations.find((o) => o.observationId === obsId);
-    if (!target) {
-      this.state.form.error = 'Selected observation no longer available.';
-      this.render();
-      return;
-    }
-    const observation = target.situation.observations.find((o) => o.id === obsId);
-    if (!observation) {
-      this.state.form.error = 'Observation lookup failed.';
-      this.render();
-      return;
-    }
-    const engine = getCounterfactualReplayEngine();
     const name = this.state.form.name.trim();
-    const description = this.state.form.description.trim();
-    const scenario = engine.createFromTemplate(
-      this.state.form.templateId,
-      observation,
-      name === '' ? undefined : name,
-      description === '' ? undefined : description,
-    );
-    if (!scenario) {
-      this.state.form.error = 'Unknown template id.';
+    if (!name) {
+      this.state.form.error = 'Enter a scenario name.';
       this.render();
       return;
     }
-    engine.runReplay(scenario.id);
+    const domain = this.state.form.domain.trim();
+    if (!domain) {
+      this.state.form.error = 'Enter a domain for the override.';
+      this.render();
+      return;
+    }
+    const snapshots = this.snapshotOptions();
+    const baseSnapshotId = this.state.form.baseSnapshotId || (snapshots[0]?.id ?? 'manual');
+    const overrides: DomainOverride[] = [
+      {
+        domain,
+        severityDelta: this.state.form.severityDelta,
+        eventCountDelta: this.state.form.eventCountDelta,
+      },
+    ];
+    const engine = CounterfactualReplayEngine.getInstance();
+    const scenario = engine.createScenario(name, baseSnapshotId, overrides);
+    engine.runScenario(scenario.id);
     this.state.selectedScenarioId = scenario.id;
     this.state.form.open = false;
     this.state.form.error = null;
@@ -237,22 +221,23 @@ export class CounterfactualReplayPanel extends Panel {
   private handleRerun(): void {
     const id = this.state.selectedScenarioId;
     if (!id) return;
-    getCounterfactualReplayEngine().runReplay(id);
+    CounterfactualReplayEngine.getInstance().runScenario(id);
     this.render();
   }
 }
 
-function renderScenarioList(scenarios: readonly ReplayScenario[], selectedId: string | null): string {
+function renderScenarioList(scenarios: readonly CounterfactualScenario[], selectedId: string | null): string {
   if (scenarios.length === 0) {
-    return `<div style="font-size:12px;color:var(--text-secondary,#aaa);">No scenarios yet. Create one with a baseline observation and a built-in template.</div>`;
+    return `<div style="font-size:12px;color:var(--text-secondary,#aaa);">No scenarios yet. Create one above.</div>`;
   }
   const items = [...scenarios].sort((a, b) => b.createdAt - a.createdAt).map((s) => {
     const isSelected = s.id === selectedId;
     const bg = isSelected ? 'var(--accent,#4a9eff)26' : 'transparent';
     const borderColor = isSelected ? 'var(--accent,#4a9eff)' : 'var(--border-subtle,#333)';
+    const score = s.result ? ` · ${s.result.cascadeScore.toFixed(2)}` : '';
     return `<li data-cf-scenario-id="${escapeHtml(s.id)}" style="cursor:pointer;padding:6px 8px;border:1px solid ${borderColor};border-radius:3px;background:${bg};display:flex;flex-direction:column;gap:2px;">
       <span style="font-size:12px;font-weight:600;">${escapeHtml(s.name)}</span>
-      <span style="font-size:10px;color:var(--text-secondary,#aaa);">${escapeHtml(s.baselineObservation.domain)} · ${s.modifications.length} mod${s.modifications.length === 1 ? '' : 's'}</span>
+      <span style="font-size:10px;color:var(--text-secondary,#aaa);">${s.overrides.length} override${s.overrides.length === 1 ? '' : 's'}${score}</span>
     </li>`;
   }).join('');
   return `<div>
@@ -261,38 +246,33 @@ function renderScenarioList(scenarios: readonly ReplayScenario[], selectedId: st
   </div>`;
 }
 
-function deltaColor(delta: number): string {
-  if (delta > 0.05) return '#f44336';
-  if (delta < -0.05) return '#4caf50';
-  return '#9e9e9e';
+function cascadeColor(score: number): string {
+  if (score > 0.7) return '#f44336';
+  if (score > 0.4) return '#ff9800';
+  if (score > 0.1) return '#ffeb3b';
+  return '#4caf50';
 }
 
-function renderResultPane(
-  scenario: ReplayScenario | undefined,
-  latestResult: ReplayResult | undefined,
-  resultCount: number,
-): string {
+function renderResultPane(scenario: CounterfactualScenario | undefined): string {
   if (!scenario) {
-    return `<div style="font-size:12px;color:var(--text-secondary,#aaa);">Select a scenario to see the replay outcome.</div>`;
+    return `<div style="font-size:12px;color:var(--text-secondary,#aaa);">Select a scenario to see the outcome.</div>`;
   }
-  const baselineSummary = `${scenario.baselineObservation.domain} · ${scenario.baselineObservation.severity}`;
-  const modBlock = scenario.modifications.map((m) => renderModification(m)).join('');
-  const resultBlock = latestResult
-    ? renderResult(latestResult, resultCount)
-    : `<div style="font-size:12px;color:var(--text-secondary,#aaa);">No replay results yet — click Re-run.</div>`;
+  const overrideBlock = scenario.overrides.map((o) => renderOverride(o)).join('');
+  const resultBlock = scenario.result
+    ? renderResult(scenario.result)
+    : `<div style="font-size:12px;color:var(--text-secondary,#aaa);">No result yet — click Re-run.</div>`;
   return `<div style="display:flex;flex-direction:column;gap:10px;">
     <div>
       <div style="font-size:11px;color:var(--text-secondary,#aaa);text-transform:uppercase;letter-spacing:0.05em;margin-bottom:4px;">${escapeHtml(scenario.name)}</div>
-      <div style="font-size:11px;color:var(--text-primary,#fff);">${escapeHtml(scenario.description)}</div>
-      <div style="font-size:11px;color:var(--text-secondary,#aaa);margin-top:4px;">Baseline · ${escapeHtml(baselineSummary)}</div>
+      <div style="font-size:11px;color:var(--text-secondary,#aaa);">Snapshot: ${escapeHtml(scenario.baseSnapshotId)}</div>
     </div>
     <div>
-      <div style="font-size:11px;color:var(--text-secondary,#aaa);text-transform:uppercase;letter-spacing:0.05em;margin-bottom:4px;">Modifications</div>
-      <div style="display:flex;flex-direction:column;gap:4px;">${modBlock}</div>
+      <div style="font-size:11px;color:var(--text-secondary,#aaa);text-transform:uppercase;letter-spacing:0.05em;margin-bottom:4px;">Overrides</div>
+      <div style="display:flex;flex-direction:column;gap:4px;">${overrideBlock}</div>
     </div>
     <div>
       <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:4px;">
-        <div style="font-size:11px;color:var(--text-secondary,#aaa);text-transform:uppercase;letter-spacing:0.05em;">Latest result</div>
+        <div style="font-size:11px;color:var(--text-secondary,#aaa);text-transform:uppercase;letter-spacing:0.05em;">Result</div>
         <button id="cfReplayRunBtn" style="padding:4px 10px;background:transparent;color:inherit;border:1px solid var(--border-subtle,#333);border-radius:3px;cursor:pointer;font-size:11px;">Re-run</button>
       </div>
       ${resultBlock}
@@ -300,35 +280,21 @@ function renderResultPane(
   </div>`;
 }
 
-function renderModification(m: ReplayModification): string {
+function renderOverride(o: DomainOverride): string {
+  const sign = o.severityDelta >= 0 ? '+' : '';
   return `<div style="font-size:11px;border-left:2px solid var(--border-subtle,#333);padding:4px 8px;background:var(--surface-2,#1a1a1a);border-radius:0 3px 3px 0;">
-    <span style="font-family:ui-monospace,monospace;color:var(--text-primary,#fff);">${escapeHtml(m.field)}</span>
-    <span style="color:var(--text-secondary,#aaa);"> · ${escapeHtml(String(m.originalValue))} → <span style="color:var(--text-primary,#fff);">${escapeHtml(String(m.modifiedValue))}</span></span>
-    <div style="font-size:10px;color:var(--text-secondary,#aaa);margin-top:2px;font-style:italic;">${escapeHtml(m.rationale)}</div>
+    <span style="font-family:ui-monospace,monospace;color:var(--text-primary,#fff);">${escapeHtml(o.domain)}</span>
+    <span style="color:var(--text-secondary,#aaa);"> severity ${sign}${o.severityDelta.toFixed(2)} · events ${o.eventCountDelta >= 0 ? '+' : ''}${o.eventCountDelta}</span>
   </div>`;
 }
 
-function renderResult(r: ReplayResult, runCount: number): string {
-  const color = deltaColor(r.deltaScore);
-  const deltaStr = (r.deltaScore >= 0 ? '+' : '') + r.deltaScore.toFixed(3);
+function renderResult(r: ReplayResult): string {
+  const color = cascadeColor(r.cascadeScore);
   return `<div style="border:1px solid var(--border-subtle,#333);border-radius:4px;padding:8px;display:flex;flex-direction:column;gap:8px;">
-    <div style="display:flex;align-items:center;gap:12px;font-size:12px;font-family:ui-monospace,monospace;">
-      <div style="flex:1;">
-        <span style="color:var(--text-secondary,#aaa);">Original</span>
-        <div style="font-weight:600;">${escapeHtml(r.originalOutcome)}</div>
-      </div>
-      <div style="font-size:18px;color:${color};">→</div>
-      <div style="flex:1;text-align:right;">
-        <span style="color:var(--text-secondary,#aaa);">Replayed</span>
-        <div style="font-weight:600;">${escapeHtml(r.replayedOutcome)}</div>
-      </div>
+    <div style="display:flex;align-items:center;gap:8px;font-size:12px;">
+      <span style="font-weight:700;color:${color};padding:2px 8px;border-radius:3px;background:${color}26;">cascade ${r.cascadeScore.toFixed(2)}</span>
+      <span style="font-size:10px;color:var(--text-secondary,#aaa);">${r.affectedDomains.map((d) => escapeHtml(d)).join(' · ')}</span>
     </div>
-    <div style="display:flex;align-items:center;gap:8px;font-size:11px;">
-      <span style="font-weight:700;color:${color};padding:2px 6px;border-radius:3px;background:${color}26;">Δ ${deltaStr}</span>
-      <span style="color:var(--text-secondary,#aaa);">across ${runCount} run${runCount === 1 ? '' : 's'}</span>
-    </div>
-    <ul style="margin:0;padding-left:18px;font-size:11px;line-height:1.5;color:var(--text-primary,#fff);">
-      ${r.insights.map((i) => `<li>${escapeHtml(i)}</li>`).join('')}
-    </ul>
+    <div style="font-size:11px;color:var(--text-primary,#fff);line-height:1.5;">${escapeHtml(r.narrativeSummary)}</div>
   </div>`;
 }

--- a/src/services/intelligence/counterfactual-replay.ts
+++ b/src/services/intelligence/counterfactual-replay.ts
@@ -1,110 +1,45 @@
 /**
- * Counterfactual Replay — Phase 4 "what if X had been different?"
+ * CounterfactualReplayEngine — "what if?" scenario engine.
  *
- * Replays past observations with modified parameters to surface how
- * brittle a conclusion was. Each scenario captures a baseline
- * ObservationEvent + a list of modifications (severity, domain,
- * location, confidence, magnitude). `runReplay` applies the
- * modifications, re-scores the synthetic observation through a
- * self-contained deterministic scorer, and reports the outcome delta
- * with 2-3 insight strings.
+ * Takes a historical world snapshot id and replays the scenario with
+ * one or more domain state overrides applied. Computes a cascade score
+ * (mean absolute severity delta, clamped 0-1) and generates a narrative
+ * summary. Persists up to 100 scenarios under `wm-counterfactual-replay`.
  *
- * Self-contained scoring path (no upward imports on DriverScoringEngine
- * or HypothesisEngine) so the replay never mutates the live attention
- * allocator or the algorithm eval ledger. Pure module — no DOM, no
- * fetch, no globals at import time. Persists scenarios + results under
- * `wm-counterfactual-replay` (200 scenarios / 500 results ring).
+ * Pure module — no DOM, no fetch, no globals at import time.
  */
-
-import type { ObservationEvent, ObservationSeverity } from './observation-adapters';
-import type { ObservationLocation } from '@/types/intelligence';
-import type { DerivedSeverity } from './driver-scores';
 
 // ── Public types ──────────────────────────────────────────────────────
 
-export type ReplayField =
-  | 'severity'
-  | 'domain'
-  | 'location'
-  | 'confidence'
-  | 'magnitude';
-
-export interface ReplayModification {
-  field: ReplayField;
-  originalValue: unknown;
-  modifiedValue: unknown;
-  rationale: string;
-}
-
-export interface ReplayScenario {
-  id: string;
-  name: string;
-  description: string;
-  baselineObservation: ObservationEvent;
-  modifications: ReplayModification[];
-  createdAt: number;
+export interface DomainOverride {
+  domain: string;
+  severityDelta: number;
+  eventCountDelta: number;
 }
 
 export interface ReplayResult {
   scenarioId: string;
-  originalOutcome: string;
-  replayedOutcome: string;
-  /** Difference between the replayed and original numeric score
-   *  (replayed - original). Positive means the modification made the
-   *  situation look more severe. */
-  deltaScore: number;
-  insights: string[];
-  ranAt: number;
+  computedAt: number;
+  affectedDomains: string[];
+  cascadeScore: number;
+  narrativeSummary: string;
 }
 
-export type ReplayListener = (state: { scenarios: ReplayScenario[]; results: ReplayResult[] }) => void;
+export interface CounterfactualScenario {
+  id: string;
+  name: string;
+  baseSnapshotId: string;
+  overrides: DomainOverride[];
+  createdAt: number;
+  result?: ReplayResult;
+}
 
 // ── Constants ─────────────────────────────────────────────────────────
 
 const STORAGE_KEY = 'wm-counterfactual-replay';
-const MAX_SCENARIOS = 200;
-const MAX_RESULTS = 500;
-
-const SEVERITY_TO_SCORE: Record<ObservationSeverity, number> = {
-  INFO: 0.1,
-  LOW: 0.25,
-  MEDIUM: 0.5,
-  HIGH: 0.7,
-  CRITICAL: 0.9,
-};
-
-const SEVERITY_BANDS: { min: number; severity: DerivedSeverity }[] = [
-  { min: 0.8, severity: 'critical' },
-  { min: 0.6, severity: 'high' },
-  { min: 0.35, severity: 'medium' },
-  { min: 0, severity: 'low' },
-];
+const MAX_SCENARIOS = 100;
 
 // ── Helpers ───────────────────────────────────────────────────────────
-
-function clamp01(n: number): number {
-  if (Number.isNaN(n)) return 0;
-  if (n < 0) return 0;
-  if (n > 1) return 1;
-  return n;
-}
-
-function readNumber(raw: unknown, ...keys: string[]): number | null {
-  if (!raw || typeof raw !== 'object') return null;
-  const rec = raw as Record<string, unknown>;
-  for (const k of keys) {
-    const v = rec[k];
-    if (typeof v === 'number' && Number.isFinite(v)) return v;
-  }
-  return null;
-}
-
-function severityForScore(score: number): DerivedSeverity {
-  for (const band of SEVERITY_BANDS) {
-    if (score >= band.min) return band.severity;
-  }
-  return 'low';
-}
 
 function safeStorage(): Storage | null {
   try {
@@ -115,512 +50,142 @@ function safeStorage(): Storage | null {
   }
 }
 
-function cloneLocation(loc: ObservationLocation | undefined): ObservationLocation | undefined {
-  return loc ? { ...loc } : undefined;
+function cascadeTier(score: number): string {
+  if (score > 0.7) return 'critical cascade';
+  if (score > 0.4) return 'moderate cascade';
+  if (score > 0.1) return 'minor cascade';
+  return 'minimal impact';
 }
 
-function cloneRaw(raw: unknown): unknown {
-  if (raw === null || raw === undefined) return raw;
-  if (typeof raw !== 'object') return raw;
-  // Deep clone for the small object payloads observations typically
-  // carry. Falls back to a shallow copy when structuredClone refuses
-  // a non-cloneable value (functions, DOM nodes, etc.).
+function computeCascadeScore(overrides: DomainOverride[]): number {
+  if (overrides.length === 0) return 0;
+  const sumAbs = overrides.reduce((acc, o) => acc + Math.abs(o.severityDelta), 0);
+  return Math.min(1, sumAbs / overrides.length);
+}
+
+function buildNarrative(scenario: CounterfactualScenario, result: ReplayResult): string {
+  const n = result.affectedDomains.length;
+  const tier = cascadeTier(result.cascadeScore);
+  const domainList = result.affectedDomains.join(', ') || 'none';
+  return `Scenario "${scenario.name}": ${n} domain(s) modified. Cascade score: ${result.cascadeScore.toFixed(2)} (${tier}). Affected: ${domainList}.`;
+}
+
+// ── Serialization ─────────────────────────────────────────────────────
+
+function isValidScenario(v: unknown): v is CounterfactualScenario {
+  if (!v || typeof v !== 'object') return false;
+  const s = v as Record<string, unknown>;
+  return (
+    typeof s.id === 'string' &&
+    typeof s.name === 'string' &&
+    typeof s.baseSnapshotId === 'string' &&
+    Array.isArray(s.overrides) &&
+    typeof s.createdAt === 'number'
+  );
+}
+
+function loadScenarios(): CounterfactualScenario[] {
+  const store = safeStorage();
+  if (!store) return [];
+  let raw: string | null = null;
+  try { raw = store.getItem(STORAGE_KEY); } catch { return []; }
+  if (!raw) return [];
   try {
-    return structuredClone(raw);
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is CounterfactualScenario => isValidScenario(v));
   } catch {
-    if (Array.isArray(raw)) return [...(raw as unknown[])];
-    return { ...(raw as Record<string, unknown>) };
+    return [];
   }
 }
 
-function cloneObservation(obs: ObservationEvent): ObservationEvent {
-  return {
-    ...obs,
-    location: cloneLocation(obs.location),
-    entityIds: [...obs.entityIds],
-    tags: [...obs.tags],
-    raw: cloneRaw(obs.raw),
-  };
-}
-
-function cloneScenario(s: ReplayScenario): ReplayScenario {
-  return {
-    ...s,
-    baselineObservation: cloneObservation(s.baselineObservation),
-    modifications: s.modifications.map((m) => ({ ...m })),
-  };
-}
-
-function cloneResult(r: ReplayResult): ReplayResult {
-  return { ...r, insights: [...r.insights] };
-}
-
-// ── Scoring + modification application ────────────────────────────────
-
-interface ScoredObservation {
-  score: number;
-  severity: DerivedSeverity;
-}
-
-/** Deterministic scorer used for replay only. Anchors on
- *  `ObservationEvent.severity` and bumps the score with magnitude /
- *  raw.confidence so modifications to those fields actually move the
- *  outcome. No side effects on any live singleton. */
-export function scoreReplayObservation(obs: ObservationEvent): ScoredObservation {
-  let score = SEVERITY_TO_SCORE[obs.severity] ?? 0.3;
-  const magnitude = readNumber(obs.raw, 'magnitude', 'mag');
-  if (magnitude !== null) {
-    // Tied to a tight band around M5 so reasonable real-world earthquakes
-    // move the score by realistic amounts (M3 → -0.10, M7 → +0.10).
-    score += clamp01((magnitude - 5) * 0.05 + 0.5) - 0.5;
-  }
-  const rawConfidence = readNumber(obs.raw, 'confidence');
-  if (rawConfidence !== null) {
-    // Treat raw.confidence as a multiplier: confidence 1.0 leaves the
-    // score; confidence 0.0 zeroes it out.
-    score *= clamp01(rawConfidence);
-  }
-  const final = clamp01(score);
-  return { score: final, severity: severityForScore(final) };
-}
-
-function asRawObject(raw: unknown): Record<string, unknown> {
-  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
-    return raw as Record<string, unknown>;
-  }
-  return {};
-}
-
-function applySeverityMod(obs: ObservationEvent, value: unknown): void {
-  if (typeof value === 'string') obs.severity = value as ObservationSeverity;
-}
-
-function applyDomainMod(obs: ObservationEvent, value: unknown): void {
-  if (typeof value === 'string') obs.domain = value;
-}
-
-function applyLocationMod(obs: ObservationEvent, value: unknown): void {
-  if (value && typeof value === 'object') {
-    obs.location = { ...(value as ObservationLocation) };
-  } else if (value === null) {
-    obs.location = undefined;
-  }
-}
-
-function applyConfidenceMod(raw: Record<string, unknown>, value: unknown): void {
-  if (typeof value === 'number') raw.confidence = value;
-}
-
-function applyMagnitudeMod(raw: Record<string, unknown>, value: unknown): void {
-  if (typeof value === 'number') raw.magnitude = value;
-}
-
-function applyOneModification(
-  obs: ObservationEvent,
-  rawObj: Record<string, unknown>,
-  mod: ReplayModification,
-): void {
-  switch (mod.field) {
-    case 'severity':   { applySeverityMod(obs, mod.modifiedValue);   return; }
-    case 'domain':     { applyDomainMod(obs, mod.modifiedValue);     return; }
-    case 'location':   { applyLocationMod(obs, mod.modifiedValue);   return; }
-    case 'confidence': { applyConfidenceMod(rawObj, mod.modifiedValue); return; }
-    case 'magnitude':  { applyMagnitudeMod(rawObj, mod.modifiedValue);  return; }
-  }
-}
-
-function applyModifications(
-  obs: ObservationEvent,
-  modifications: readonly ReplayModification[],
-): ObservationEvent {
-  const next = cloneObservation(obs);
-  const rawObj = asRawObject(next.raw);
-  for (const mod of modifications) applyOneModification(next, rawObj, mod);
-  next.raw = rawObj;
-  return next;
-}
-
-// ── Built-in templates ───────────────────────────────────────────────
-
-const SEVERITY_DOWNGRADE: Record<ObservationSeverity, ObservationSeverity> = {
-  CRITICAL: 'HIGH',
-  HIGH: 'MEDIUM',
-  MEDIUM: 'LOW',
-  LOW: 'INFO',
-  INFO: 'INFO',
-};
-
-/** Earth radius used to translate degrees into approximate km. */
-const KM_PER_DEGREE = 111;
-
-export function severityDowngradeTemplate(obs: ObservationEvent): ReplayModification[] {
-  const target = SEVERITY_DOWNGRADE[obs.severity];
-  return [{
-    field: 'severity',
-    originalValue: obs.severity,
-    modifiedValue: target,
-    rationale: `What if the initial classification had been ${target} instead of ${obs.severity}?`,
-  }];
-}
-
-export function sourceReductionTemplate(obs: ObservationEvent): ReplayModification[] {
-  // Source reduction is observable through a confidence drop: with one
-  // fewer corroborating feed the effective confidence falls. We also
-  // tag the rationale so the operator sees what was simulated.
-  const existing = readNumber(obs.raw, 'confidence') ?? 1;
-  const reduced = Math.max(0, +(existing * 0.5).toFixed(4));
-  return [{
-    field: 'confidence',
-    originalValue: existing,
-    modifiedValue: reduced,
-    rationale: 'What if we had one fewer corroborating feed? Halve the effective confidence.',
-  }];
-}
-
-export function locationShiftTemplate(obs: ObservationEvent): ReplayModification[] {
-  const original: ObservationLocation = obs.location ?? { lat: 0, lon: 0 };
-  // Shift roughly 1000 km north along the meridian. Clamp at the pole.
-  const targetLat = Math.max(-89, Math.min(89, original.lat + 1000 / KM_PER_DEGREE));
-  const modified: ObservationLocation = {
-    lat: +targetLat.toFixed(4),
-    lon: original.lon,
-    radiusKm: original.radiusKm,
-  };
-  return [{
-    field: 'location',
-    originalValue: original,
-    modifiedValue: modified,
-    rationale: 'What if this had occurred ~1000 km away? Tests geographic relevance.',
-  }];
-}
-
-export function timingShiftTemplate(obs: ObservationEvent): ReplayModification[] {
-  const earlierMs = obs.timestamp - 6 * 60 * 60 * 1000;
-  return [{
-    field: 'confidence',
-    originalValue: readNumber(obs.raw, 'confidence') ?? 1,
-    modifiedValue: 0.85,
-    rationale: `What if this arrived 6 h earlier (at ${new Date(earlierMs).toISOString()})? Earlier signals carry slightly lower observational confidence.`,
-  }];
-}
-
-export interface ReplayTemplate {
-  id: string;
-  label: string;
-  description: string;
-  build: (obs: ObservationEvent) => ReplayModification[];
-}
-
-export const BUILT_IN_REPLAY_TEMPLATES: readonly ReplayTemplate[] = [
-  {
-    id: 'severity-downgrade',
-    label: 'Severity downgrade',
-    description: 'What if this had been classified one tier lower?',
-    build: severityDowngradeTemplate,
-  },
-  {
-    id: 'source-reduction',
-    label: 'Source reduction',
-    description: 'What if we had one fewer corroborating feed?',
-    build: sourceReductionTemplate,
-  },
-  {
-    id: 'location-shift',
-    label: 'Location shift (~1000 km)',
-    description: 'What if this had occurred ~1000 km away?',
-    build: locationShiftTemplate,
-  },
-  {
-    id: 'timing-shift',
-    label: 'Timing shift (-6 h)',
-    description: 'What if this had arrived 6 hours earlier?',
-    build: timingShiftTemplate,
-  },
-];
-
-// ── Insights ─────────────────────────────────────────────────────────
-
-function formatScalar(value: unknown): string {
-  if (value === null || value === undefined) return 'none';
-  if (typeof value === 'object') {
-    try { return JSON.stringify(value); } catch { return '[unserializable]'; }
-  }
-  // Restrict to the primitive types we actually pass in to keep
-  // typescript-eslint's no-base-to-string happy without losing
-  // intent.
-  if (typeof value === 'string') return value;
-  if (typeof value === 'number' || typeof value === 'boolean') return value.toString();
-  return '[unknown]';
-}
-
-function buildInsights(
-  modifications: readonly ReplayModification[],
-  original: ScoredObservation,
-  replayed: ScoredObservation,
-  delta: number,
-): string[] {
-  const insights: string[] = [];
-  // 1) Severity-band statement — always included.
-  if (original.severity === replayed.severity) {
-    insights.push(
-      `Replayed severity remained "${original.severity}" (score Δ ${delta.toFixed(3)}). The modification did not cross a band boundary.`,
-    );
-  } else {
-    insights.push(
-      `Severity flipped from "${original.severity}" to "${replayed.severity}" (score Δ ${delta.toFixed(3)}).`,
-    );
-  }
-  // 2) Per-modification line for the first 2 modifications. Keeps the
-  //    list to the spec's "2-3 insight strings" while still echoing
-  //    what was actually changed.
-  for (const mod of modifications.slice(0, 2)) {
-    insights.push(
-      `If ${mod.field} were ${formatScalar(mod.modifiedValue)} instead of ${formatScalar(mod.originalValue)}: ${mod.rationale}`,
-    );
-  }
-  return insights;
+function persistScenarios(scenarios: CounterfactualScenario[]): void {
+  const store = safeStorage();
+  if (!store) return;
+  try { store.setItem(STORAGE_KEY, JSON.stringify(scenarios)); } catch { /* quota */ }
 }
 
 // ── Engine ────────────────────────────────────────────────────────────
 
-export interface CounterfactualReplayOptions {
-  clock?: () => number;
+let _idCounter = 0;
+let _instance: CounterfactualReplayEngine | null = null;
+
+function nextId(): string {
+  _idCounter += 1;
+  return `cfr-${Date.now()}-${_idCounter}`;
 }
 
 export class CounterfactualReplayEngine {
-  private scenarios: ReplayScenario[] = [];
-  private results: ReplayResult[] = [];
-  private listeners = new Set<ReplayListener>();
-  private hydrated = false;
-  private idCounter = 0;
-  private clock: () => number;
+  private scenarios: CounterfactualScenario[];
 
-  constructor(options: CounterfactualReplayOptions = {}) {
-    this.clock = options.clock ?? (() => Date.now());
+  constructor() {
+    this.scenarios = loadScenarios();
   }
 
-  private ensureHydrated(): void {
-    if (this.hydrated) return;
-    this.hydrated = true;
-    const store = safeStorage();
-    if (!store) return;
-    let raw: string | null = null;
-    try { raw = store.getItem(STORAGE_KEY); } catch { return; }
-    if (!raw) return;
-    try {
-      const parsed = JSON.parse(raw) as { scenarios?: unknown; results?: unknown };
-      this.scenarios = deserializeScenarios(parsed.scenarios);
-      this.results = deserializeResults(parsed.results);
-    } catch {
-      // Corrupt blob — start clean.
-    }
+  static getInstance(): CounterfactualReplayEngine {
+    _instance ??= new CounterfactualReplayEngine();
+    return _instance;
   }
 
-  private persist(): void {
-    const store = safeStorage();
-    if (!store) return;
-    try {
-      store.setItem(STORAGE_KEY, JSON.stringify({ scenarios: this.scenarios, results: this.results }));
-    } catch {
-      // Quota or disabled — best-effort.
-    }
-  }
-
-  private nextId(prefix: string, now: number): string {
-    this.idCounter += 1;
-    return `${prefix}-${now.toString(36)}-${this.idCounter}`;
-  }
-
-  private notify(): void {
-    const snapshot = {
-      scenarios: this.scenarios.map((s) => cloneScenario(s)),
-      results: this.results.map((r) => cloneResult(r)),
-    };
-    for (const l of this.listeners) {
-      try { l(snapshot); } catch { /* listener crash isolation */ }
-    }
-  }
-
-  /** Persist a new replay scenario keyed off the given baseline
-   *  observation + modifications. Returns a defensive copy. */
   createScenario(
-    baseline: ObservationEvent,
-    modifications: readonly ReplayModification[],
     name: string,
-    description: string,
-  ): ReplayScenario {
-    this.ensureHydrated();
-    const now = this.clock();
-    const scenario: ReplayScenario = {
-      id: this.nextId('cf', now),
+    baseSnapshotId: string,
+    overrides: DomainOverride[],
+  ): CounterfactualScenario {
+    const scenario: CounterfactualScenario = {
+      id: nextId(),
       name,
-      description,
-      baselineObservation: cloneObservation(baseline),
-      modifications: modifications.map((m) => ({ ...m })),
-      createdAt: now,
+      baseSnapshotId,
+      overrides,
+      createdAt: Date.now(),
     };
+    if (this.scenarios.length >= MAX_SCENARIOS) {
+      this.scenarios.shift();
+    }
     this.scenarios.push(scenario);
-    this.enforceScenarioCapacity();
-    this.persist();
-    this.notify();
-    return cloneScenario(scenario);
+    persistScenarios(this.scenarios);
+    return { ...scenario, overrides: [...overrides] };
   }
 
-  /** Build a scenario from one of the built-in templates and the given
-   *  baseline. Convenience wrapper around `createScenario`. */
-  createFromTemplate(
-    templateId: string,
-    baseline: ObservationEvent,
-    name?: string,
-    description?: string,
-  ): ReplayScenario | undefined {
-    const tmpl = BUILT_IN_REPLAY_TEMPLATES.find((t) => t.id === templateId);
-    if (!tmpl) return undefined;
-    return this.createScenario(
-      baseline,
-      tmpl.build(baseline),
-      name ?? tmpl.label,
-      description ?? tmpl.description,
-    );
-  }
-
-  /** Replay a scenario. Looks up the stored scenario, applies its
-   *  modifications, scores both the baseline and the modified
-   *  observation, and stores a fresh ReplayResult. Returns undefined
-   *  when the scenarioId is unknown. */
-  runReplay(scenarioId: string): ReplayResult | undefined {
-    this.ensureHydrated();
-    const scenario = this.scenarios.find((s) => s.id === scenarioId);
-    if (!scenario) return undefined;
-    const now = this.clock();
-    const original = scoreReplayObservation(scenario.baselineObservation);
-    const replayed = scoreReplayObservation(
-      applyModifications(scenario.baselineObservation, scenario.modifications),
-    );
-    const deltaScore = +(replayed.score - original.score).toFixed(4);
+  runScenario(scenarioId: string): ReplayResult | undefined {
+    const idx = this.scenarios.findIndex((s) => s.id === scenarioId);
+    if (idx === -1) return undefined;
+    const scenario = this.scenarios[idx]!;
+    const affectedDomains = scenario.overrides.map((o) => o.domain);
+    const cascadeScore = computeCascadeScore(scenario.overrides);
     const result: ReplayResult = {
       scenarioId,
-      originalOutcome: original.severity,
-      replayedOutcome: replayed.severity,
-      deltaScore,
-      insights: buildInsights(scenario.modifications, original, replayed, deltaScore),
-      ranAt: now,
+      computedAt: Date.now(),
+      affectedDomains,
+      cascadeScore,
+      narrativeSummary: '',
     };
-    this.results.push(result);
-    this.enforceResultCapacity();
-    this.persist();
-    this.notify();
-    return cloneResult(result);
+    result.narrativeSummary = buildNarrative(scenario, result);
+    this.scenarios[idx] = { ...scenario, result };
+    persistScenarios(this.scenarios);
+    return { ...result };
   }
 
-  private enforceScenarioCapacity(): void {
-    if (this.scenarios.length <= MAX_SCENARIOS) return;
-    this.scenarios.splice(0, this.scenarios.length - MAX_SCENARIOS);
+  getScenario(id: string): CounterfactualScenario | undefined {
+    const s = this.scenarios.find((sc) => sc.id === id);
+    return s ? { ...s, overrides: [...s.overrides] } : undefined;
   }
 
-  private enforceResultCapacity(): void {
-    if (this.results.length <= MAX_RESULTS) return;
-    this.results.splice(0, this.results.length - MAX_RESULTS);
-  }
-
-  getScenario(scenarioId: string): ReplayScenario | undefined {
-    this.ensureHydrated();
-    const found = this.scenarios.find((s) => s.id === scenarioId);
-    return found ? cloneScenario(found) : undefined;
-  }
-
-  getAllScenarios(): ReplayScenario[] {
-    this.ensureHydrated();
-    return this.scenarios.map((s) => cloneScenario(s));
-  }
-
-  getResults(scenarioId: string): ReplayResult[] {
-    this.ensureHydrated();
-    return this.results
-      .filter((r) => r.scenarioId === scenarioId)
-      .map((r) => cloneResult(r));
-  }
-
-  getAllResults(): ReplayResult[] {
-    this.ensureHydrated();
-    return this.results.map((r) => cloneResult(r));
-  }
-
-  subscribe(listener: ReplayListener): () => void {
-    this.listeners.add(listener);
-    return () => this.listeners.delete(listener);
-  }
-
-  /** Test seam — empties scenarios + results + the persisted blob. */
-  resetForTesting(): void {
-    this.scenarios = [];
-    this.results = [];
-    this.listeners.clear();
-    this.idCounter = 0;
-    this.hydrated = true;
-    const store = safeStorage();
-    if (store) {
-      try { store.removeItem(STORAGE_KEY); } catch { /* best effort */ }
-    }
+  listScenarios(): CounterfactualScenario[] {
+    return this.scenarios.map((s) => ({ ...s, overrides: [...s.overrides] }));
   }
 }
 
-// ── Persistence helpers ──────────────────────────────────────────────
+// ── Test seam ─────────────────────────────────────────────────────────
 
-function deserializeScenarios(raw: unknown): ReplayScenario[] {
-  if (!Array.isArray(raw)) return [];
-  const out: ReplayScenario[] = [];
-  for (const entry of raw) {
-    if (!entry || typeof entry !== 'object') continue;
-    const e = entry as ReplayScenario;
-    if (typeof e.id !== 'string' || typeof e.createdAt !== 'number') continue;
-    if (!e.baselineObservation || typeof e.baselineObservation !== 'object') continue;
-    if (!Array.isArray(e.modifications)) continue;
-    out.push({
-      ...e,
-      baselineObservation: cloneObservation(e.baselineObservation),
-      modifications: e.modifications.map((m) => ({ ...(m as ReplayModification) })),
-    });
-  }
-  return out;
-}
-
-function deserializeResults(raw: unknown): ReplayResult[] {
-  if (!Array.isArray(raw)) return [];
-  const out: ReplayResult[] = [];
-  for (const entry of raw) {
-    if (!entry || typeof entry !== 'object') continue;
-    const e = entry as ReplayResult;
-    if (typeof e.scenarioId !== 'string' || typeof e.ranAt !== 'number') continue;
-    if (typeof e.deltaScore !== 'number') continue;
-    out.push({
-      ...e,
-      insights: Array.isArray(e.insights) ? [...e.insights] : [],
-    });
-  }
-  return out;
-}
-
-// ── Singleton ─────────────────────────────────────────────────────────
-
-let _singleton: CounterfactualReplayEngine | null = null;
-
-export function getCounterfactualReplayEngine(): CounterfactualReplayEngine {
-  _singleton ??= new CounterfactualReplayEngine();
-  return _singleton;
-}
-
-/** Test seam — replaces the singleton with a fresh instance. */
 export function __resetCounterfactualReplaySingleton(): void {
-  _singleton = null;
+  _instance = null;
+  _idCounter = 0;
 }
 
 export const __internals = {
   STORAGE_KEY,
   MAX_SCENARIOS,
-  MAX_RESULTS,
-  SEVERITY_TO_SCORE,
-  applyModifications,
-  scoreReplayObservation,
-  buildInsights,
+  computeCascadeScore,
+  cascadeTier,
 };

--- a/tests/intelligence/counterfactual-replay.test.mts
+++ b/tests/intelligence/counterfactual-replay.test.mts
@@ -1,9 +1,10 @@
 /**
- * Tests for CounterfactualReplayEngine — Phase 4 "what if?" replay.
+ * Tests for CounterfactualReplayEngine — what-if scenario engine.
  *
  * Run with: npx tsx --test tests/intelligence/counterfactual-replay.test.mts
  *
- * Pure-service tests against a localStorage stub + injectable clock.
+ * Pure-service tests against a localStorage stub. Each test group
+ * resets the singleton and clears storage for isolation.
  */
 
 import assert from 'node:assert/strict';
@@ -11,453 +12,355 @@ import test from 'node:test';
 
 const __storage = new Map<string, string>();
 (globalThis as unknown as { localStorage: Storage }).localStorage = {
-  getItem: (k: string) => __storage.get(k) ?? null,
-  setItem: (k: string, v: string) => { __storage.set(k, v); },
+  getItem:    (k: string) => __storage.get(k) ?? null,
+  setItem:    (k: string, v: string) => { __storage.set(k, v); },
   removeItem: (k: string) => { __storage.delete(k); },
-  clear: () => { __storage.clear(); },
+  clear:      () => { __storage.clear(); },
   get length() { return __storage.size; },
-  key: (i: number) => [...__storage.keys()][i] ?? null,
+  key:        (i: number) => [...__storage.keys()][i] ?? null,
 } as Storage;
 
 import {
-  BUILT_IN_REPLAY_TEMPLATES,
   CounterfactualReplayEngine,
   __resetCounterfactualReplaySingleton,
-  __internals as engineInternals,
-  getCounterfactualReplayEngine,
-  locationShiftTemplate,
-  scoreReplayObservation,
-  severityDowngradeTemplate,
-  sourceReductionTemplate,
-  timingShiftTemplate,
-  type ReplayModification,
+  __internals,
+  type DomainOverride,
+  type CounterfactualScenario,
 } from '../../src/services/intelligence/counterfactual-replay.ts';
-import type { ObservationEvent } from '../../src/services/intelligence/observation-adapters.ts';
 
-const NOW = 1_745_000_000_000;
-
-// ── Fixtures ─────────────────────────────────────────────────────────
-
-function obs(overrides: Partial<ObservationEvent> = {}): ObservationEvent {
-  return {
-    id: 'obs-1',
-    sourceId: 'src-a',
-    domain: 'earthquake',
-    timestamp: NOW,
-    severity: 'HIGH',
-    title: 'baseline event',
-    raw: { magnitude: 6.0 },
-    entityIds: [],
-    tags: [],
-    location: { lat: 35, lon: 139, radiusKm: 50 },
-    ...overrides,
-  };
-}
-
-function freshEngine(now = NOW): CounterfactualReplayEngine {
-  __storage.clear();
+function reset(): void {
   __resetCounterfactualReplaySingleton();
-  return new CounterfactualReplayEngine({ clock: () => now });
+  __storage.clear();
 }
 
-// ── createScenario / getScenario / getAllScenarios ──────────────────
+const OVERRIDES: DomainOverride[] = [
+  { domain: 'weather', severityDelta: 0.5, eventCountDelta: 2 },
+  { domain: 'cyber',   severityDelta: 0.3, eventCountDelta: 1 },
+];
 
-test('createScenario assigns an id with the cf- prefix', () => {
-  const eng = freshEngine();
-  const s = eng.createScenario(obs(), [], 'name', 'desc');
-  assert.match(s.id, /^cf-/);
+// ── getInstance ───────────────────────────────────────────────────────
+
+test('getInstance returns same instance on repeated calls', () => {
+  reset();
+  const a = CounterfactualReplayEngine.getInstance();
+  const b = CounterfactualReplayEngine.getInstance();
+  assert.equal(a, b);
 });
 
-test('createScenario stamps createdAt with the engine clock', () => {
-  const eng = freshEngine(NOW + 500);
-  const s = eng.createScenario(obs(), [], 'n', 'd');
-  assert.equal(s.createdAt, NOW + 500);
+test('getInstance returns new instance after reset', () => {
+  reset();
+  const a = CounterfactualReplayEngine.getInstance();
+  reset();
+  const b = CounterfactualReplayEngine.getInstance();
+  assert.notEqual(a, b);
 });
 
-test('createScenario stores name + description + modifications', () => {
-  const eng = freshEngine();
-  const s = eng.createScenario(obs(), [
-    { field: 'severity', originalValue: 'HIGH', modifiedValue: 'LOW', rationale: 'why' },
-  ], 'my scenario', 'my description');
-  assert.equal(s.name, 'my scenario');
-  assert.equal(s.description, 'my description');
-  assert.equal(s.modifications.length, 1);
-  assert.equal(s.modifications[0].field, 'severity');
+// ── createScenario ────────────────────────────────────────────────────
+
+test('createScenario returns scenario with correct name', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  const s = eng.createScenario('No-cyber world', 'snap-001', OVERRIDES);
+  assert.equal(s.name, 'No-cyber world');
 });
 
-test('createScenario returns defensive copy — mutating result does not change store', () => {
-  const eng = freshEngine();
-  const s = eng.createScenario(obs(), [], 'a', 'b');
-  s.modifications.push({ field: 'severity', originalValue: 'a', modifiedValue: 'b', rationale: 'x' });
-  const stored = eng.getScenario(s.id);
-  assert.equal(stored?.modifications.length, 0);
+test('createScenario returns scenario with correct baseSnapshotId', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  const s = eng.createScenario('test', 'snap-abc', OVERRIDES);
+  assert.equal(s.baseSnapshotId, 'snap-abc');
 });
 
-test('createScenario clones the baseline observation deeply', () => {
-  const eng = freshEngine();
-  const baseline = obs();
-  const s = eng.createScenario(baseline, [], 'a', 'b');
-  // Mutating the original baseline after creation must not affect
-  // the persisted scenario.
-  baseline.severity = 'CRITICAL';
-  baseline.tags.push('mutated');
-  assert.equal(s.baselineObservation.severity, 'HIGH');
-  assert.equal(s.baselineObservation.tags.length, 0);
+test('createScenario returns scenario with overrides', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  const s = eng.createScenario('test', 'snap-1', OVERRIDES);
+  assert.equal(s.overrides.length, 2);
+  assert.equal(s.overrides[0]?.domain, 'weather');
 });
 
-test('getAllScenarios returns insertion order, defensive copies', () => {
-  const eng = freshEngine();
-  const a = eng.createScenario(obs({ id: 'a' }), [], 'a', 'a');
-  const b = eng.createScenario(obs({ id: 'b' }), [], 'b', 'b');
-  const all = eng.getAllScenarios();
-  assert.equal(all.length, 2);
-  assert.equal(all[0].id, a.id);
-  assert.equal(all[1].id, b.id);
-  // Mutation of returned array doesn't leak.
-  all.push({ ...all[0]!, id: 'x' });
-  assert.equal(eng.getAllScenarios().length, 2);
+test('createScenario assigns a unique string id', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  const a = eng.createScenario('a', 'snap-1', []);
+  const b = eng.createScenario('b', 'snap-1', []);
+  assert.ok(typeof a.id === 'string' && a.id.length > 0);
+  assert.notEqual(a.id, b.id);
 });
+
+test('createScenario sets createdAt to a positive number', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  const s = eng.createScenario('test', 'snap-1', []);
+  assert.ok(s.createdAt > 0);
+});
+
+test('createScenario result field is undefined initially', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  const s = eng.createScenario('test', 'snap-1', OVERRIDES);
+  assert.equal(s.result, undefined);
+});
+
+test('createScenario with empty overrides is valid', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  const s = eng.createScenario('empty', 'snap-1', []);
+  assert.equal(s.overrides.length, 0);
+});
+
+// ── runScenario ───────────────────────────────────────────────────────
+
+test('runScenario returns undefined for unknown id', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  assert.equal(eng.runScenario('no-such-id'), undefined);
+});
+
+test('runScenario returns a ReplayResult', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  const s = eng.createScenario('test', 'snap-1', OVERRIDES);
+  const r = eng.runScenario(s.id);
+  assert.ok(r);
+});
+
+test('runScenario result.scenarioId matches the scenario', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  const s = eng.createScenario('test', 'snap-1', OVERRIDES);
+  const r = eng.runScenario(s.id);
+  assert.equal(r?.scenarioId, s.id);
+});
+
+test('runScenario result.computedAt is positive', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  const s = eng.createScenario('test', 'snap-1', OVERRIDES);
+  const r = eng.runScenario(s.id);
+  assert.ok((r?.computedAt ?? 0) > 0);
+});
+
+test('runScenario result.affectedDomains lists override domains', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  const s = eng.createScenario('test', 'snap-1', OVERRIDES);
+  const r = eng.runScenario(s.id);
+  assert.deepEqual(r?.affectedDomains, ['weather', 'cyber']);
+});
+
+test('runScenario result.narrativeSummary is a non-empty string', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  const s = eng.createScenario('test', 'snap-1', OVERRIDES);
+  const r = eng.runScenario(s.id);
+  assert.ok(typeof r?.narrativeSummary === 'string' && r.narrativeSummary.length > 0);
+});
+
+test('runScenario stores result on the scenario', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  const s = eng.createScenario('test', 'snap-1', OVERRIDES);
+  eng.runScenario(s.id);
+  const updated = eng.getScenario(s.id);
+  assert.ok(updated?.result);
+});
+
+// ── cascade score ─────────────────────────────────────────────────────
+
+test('cascadeScore for empty overrides is 0', () => {
+  assert.equal(__internals.computeCascadeScore([]), 0);
+});
+
+test('cascadeScore equals abs(delta) for single override', () => {
+  const score = __internals.computeCascadeScore([
+    { domain: 'weather', severityDelta: 0.6, eventCountDelta: 1 },
+  ]);
+  assert.equal(score, 0.6);
+});
+
+test('cascadeScore averages absolute deltas across overrides', () => {
+  const score = __internals.computeCascadeScore([
+    { domain: 'a', severityDelta: 0.4, eventCountDelta: 0 },
+    { domain: 'b', severityDelta: 0.8, eventCountDelta: 0 },
+  ]);
+  assert.ok(Math.abs(score - 0.6) < 1e-9);
+});
+
+test('cascadeScore uses absolute value of negative delta', () => {
+  const score = __internals.computeCascadeScore([
+    { domain: 'a', severityDelta: -0.5, eventCountDelta: 0 },
+  ]);
+  assert.equal(score, 0.5);
+});
+
+test('cascadeScore is clamped to 1 when mean delta exceeds 1', () => {
+  const score = __internals.computeCascadeScore([
+    { domain: 'a', severityDelta: 5, eventCountDelta: 0 },
+  ]);
+  assert.equal(score, 1);
+});
+
+test('cascadeScore is between 0 and 1 inclusive', () => {
+  const overrides: DomainOverride[] = [
+    { domain: 'x', severityDelta: 0.2, eventCountDelta: 3 },
+    { domain: 'y', severityDelta: 0.9, eventCountDelta: 0 },
+  ];
+  const score = __internals.computeCascadeScore(overrides);
+  assert.ok(score >= 0 && score <= 1);
+});
+
+// ── cascade tier labels ───────────────────────────────────────────────
+
+test('cascadeTier above 0.7 is critical cascade', () => {
+  assert.equal(__internals.cascadeTier(0.8), 'critical cascade');
+  assert.equal(__internals.cascadeTier(1), 'critical cascade');
+});
+
+test('cascadeTier above 0.4 is moderate cascade', () => {
+  assert.equal(__internals.cascadeTier(0.5), 'moderate cascade');
+  assert.equal(__internals.cascadeTier(0.7), 'moderate cascade');
+});
+
+test('cascadeTier above 0.1 is minor cascade', () => {
+  assert.equal(__internals.cascadeTier(0.2), 'minor cascade');
+  assert.equal(__internals.cascadeTier(0.4), 'minor cascade');
+});
+
+test('cascadeTier at or below 0.1 is minimal impact', () => {
+  assert.equal(__internals.cascadeTier(0), 'minimal impact');
+  assert.equal(__internals.cascadeTier(0.1), 'minimal impact');
+});
+
+// ── getScenario ───────────────────────────────────────────────────────
 
 test('getScenario returns undefined for unknown id', () => {
-  const eng = freshEngine();
-  assert.equal(eng.getScenario('does-not-exist'), undefined);
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  assert.equal(eng.getScenario('unknown'), undefined);
 });
 
-// ── Modification application ─────────────────────────────────────────
-
-test('severity modification changes the observation severity at replay', () => {
-  const eng = freshEngine();
-  const s = eng.createScenario(obs({ severity: 'HIGH', raw: {} }), [
-    { field: 'severity', originalValue: 'HIGH', modifiedValue: 'LOW', rationale: 'r' },
-  ], 'n', 'd');
-  const result = eng.runReplay(s.id)!;
-  // Baseline (HIGH) scores ~0.7 → 'high'; modified (LOW) scores ~0.25 → 'low'.
-  assert.equal(result.originalOutcome, 'high');
-  assert.equal(result.replayedOutcome, 'low');
+test('getScenario returns scenario after createScenario', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  const s = eng.createScenario('test', 'snap-1', OVERRIDES);
+  const found = eng.getScenario(s.id);
+  assert.ok(found);
+  assert.equal(found.id, s.id);
 });
 
-test('domain modification changes the observation domain at replay', () => {
-  const eng = freshEngine();
-  // Domain change alone doesn't shift the score (scoreReplayObservation
-  // doesn't read the domain) but the change must still propagate.
-  const baseline = obs({ raw: { magnitude: 4 } });
-  const s = eng.createScenario(baseline, [
-    { field: 'domain', originalValue: 'earthquake', modifiedValue: 'cyber', rationale: 'r' },
-  ], 'n', 'd');
-  const result = eng.runReplay(s.id)!;
-  assert.ok(result);
-  // No score effect from domain alone → deltaScore == 0.
-  assert.equal(result.deltaScore, 0);
+test('getScenario returns scenario with correct overrides', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  const s = eng.createScenario('test', 'snap-1', OVERRIDES);
+  const found = eng.getScenario(s.id);
+  assert.equal(found?.overrides[0]?.domain, 'weather');
+  assert.equal(found?.overrides[1]?.severityDelta, 0.3);
 });
 
-test('location modification updates the observation location', () => {
-  const eng = freshEngine();
-  const baseline = obs({ raw: {} });
-  const mods = locationShiftTemplate(baseline);
-  const s = eng.createScenario(baseline, mods, 'loc', 'shift');
-  // Location alone doesn't shift the score either, but the modification
-  // must be applied without throwing.
-  const result = eng.runReplay(s.id)!;
-  assert.ok(result);
+// ── listScenarios ─────────────────────────────────────────────────────
+
+test('listScenarios returns empty array initially', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  assert.deepEqual(eng.listScenarios(), []);
 });
 
-test('magnitude modification bumps the score via raw.magnitude', () => {
-  const eng = freshEngine();
-  const baseline = obs({ severity: 'MEDIUM', raw: { magnitude: 5 } });
-  const s = eng.createScenario(baseline, [
-    { field: 'magnitude', originalValue: 5, modifiedValue: 7, rationale: 'r' },
-  ], 'n', 'd');
-  const result = eng.runReplay(s.id)!;
-  assert.ok(result.deltaScore > 0, `expected positive delta, got ${result.deltaScore}`);
+test('listScenarios returns all created scenarios', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  eng.createScenario('a', 'snap-1', []);
+  eng.createScenario('b', 'snap-2', []);
+  assert.equal(eng.listScenarios().length, 2);
 });
 
-test('confidence modification scales the score down', () => {
-  const eng = freshEngine();
-  const baseline = obs({ severity: 'HIGH', raw: { magnitude: 5 } });
-  const s = eng.createScenario(baseline, [
-    { field: 'confidence', originalValue: 1, modifiedValue: 0.4, rationale: 'r' },
-  ], 'n', 'd');
-  const result = eng.runReplay(s.id)!;
-  assert.ok(result.deltaScore < 0, `expected negative delta, got ${result.deltaScore}`);
+test('listScenarios preserves creation order', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  eng.createScenario('first', 'snap-1', []);
+  eng.createScenario('second', 'snap-2', []);
+  const list = eng.listScenarios();
+  assert.equal(list[0]?.name, 'first');
+  assert.equal(list[1]?.name, 'second');
 });
 
-test('no-op modification produces deltaScore = 0', () => {
-  const eng = freshEngine();
-  const baseline = obs({ severity: 'MEDIUM', raw: {} });
-  const s = eng.createScenario(baseline, [], 'n', 'd');
-  const result = eng.runReplay(s.id)!;
-  assert.equal(result.deltaScore, 0);
-  assert.equal(result.originalOutcome, result.replayedOutcome);
-});
+// ── max scenarios cap ─────────────────────────────────────────────────
 
-// ── runReplay shape ───────────────────────────────────────────────────
-
-test('runReplay returns a ReplayResult with all required fields', () => {
-  const eng = freshEngine();
-  const s = eng.createScenario(obs(), severityDowngradeTemplate(obs()), 'n', 'd');
-  const result = eng.runReplay(s.id)!;
-  assert.equal(result.scenarioId, s.id);
-  assert.equal(typeof result.originalOutcome, 'string');
-  assert.equal(typeof result.replayedOutcome, 'string');
-  assert.equal(typeof result.deltaScore, 'number');
-  assert.equal(Array.isArray(result.insights), true);
-  assert.equal(typeof result.ranAt, 'number');
-});
-
-test('runReplay returns undefined for unknown scenarioId', () => {
-  const eng = freshEngine();
-  assert.equal(eng.runReplay('nope'), undefined);
-});
-
-test('runReplay stores the result and increments getResults', () => {
-  const eng = freshEngine();
-  const s = eng.createScenario(obs(), severityDowngradeTemplate(obs()), 'n', 'd');
-  assert.equal(eng.getResults(s.id).length, 0);
-  eng.runReplay(s.id);
-  eng.runReplay(s.id);
-  assert.equal(eng.getResults(s.id).length, 2);
-});
-
-test('runReplay produces 2-3 insight strings', () => {
-  const eng = freshEngine();
-  const s = eng.createScenario(obs(), severityDowngradeTemplate(obs()), 'n', 'd');
-  const result = eng.runReplay(s.id)!;
-  assert.ok(result.insights.length >= 2);
-  assert.ok(result.insights.length <= 3);
-  for (const ins of result.insights) assert.ok(ins.length > 0);
-});
-
-// ── Direction-of-change properties ───────────────────────────────────
-
-test('severity downgrade produces originalOutcome >= replayedOutcome on the band ladder', () => {
-  const eng = freshEngine();
-  const baseline = obs({ severity: 'CRITICAL', raw: {} });
-  const s = eng.createScenario(baseline, severityDowngradeTemplate(baseline), 'n', 'd');
-  const result = eng.runReplay(s.id)!;
-  const order = ['low', 'medium', 'high', 'critical'];
-  assert.ok(order.indexOf(result.originalOutcome) >= order.indexOf(result.replayedOutcome));
-});
-
-test('severity upgrade produces replayedOutcome >= originalOutcome on the band ladder', () => {
-  const eng = freshEngine();
-  const baseline = obs({ severity: 'LOW', raw: {} });
-  const s = eng.createScenario(baseline, [
-    { field: 'severity', originalValue: 'LOW', modifiedValue: 'CRITICAL', rationale: 'r' },
-  ], 'n', 'd');
-  const result = eng.runReplay(s.id)!;
-  const order = ['low', 'medium', 'high', 'critical'];
-  assert.ok(order.indexOf(result.replayedOutcome) >= order.indexOf(result.originalOutcome));
-  assert.ok(result.deltaScore > 0);
-});
-
-// ── Built-in templates ───────────────────────────────────────────────
-
-test('BUILT_IN_REPLAY_TEMPLATES exposes 4 templates with stable ids', () => {
-  assert.equal(BUILT_IN_REPLAY_TEMPLATES.length, 4);
-  const ids = BUILT_IN_REPLAY_TEMPLATES.map((t) => t.id).sort();
-  assert.deepEqual(ids, ['location-shift', 'severity-downgrade', 'source-reduction', 'timing-shift']);
-});
-
-test('severityDowngradeTemplate produces a single severity modification with downgraded value', () => {
-  const mods = severityDowngradeTemplate(obs({ severity: 'CRITICAL' }));
-  assert.equal(mods.length, 1);
-  assert.equal(mods[0].field, 'severity');
-  assert.equal(mods[0].originalValue, 'CRITICAL');
-  assert.equal(mods[0].modifiedValue, 'HIGH');
-  assert.ok(mods[0].rationale.length > 0);
-});
-
-test('sourceReductionTemplate halves effective confidence', () => {
-  const baseline = obs({ raw: { confidence: 1 } });
-  const mods = sourceReductionTemplate(baseline);
-  assert.equal(mods.length, 1);
-  assert.equal(mods[0].field, 'confidence');
-  assert.equal(mods[0].modifiedValue, 0.5);
-});
-
-test('locationShiftTemplate shifts latitude by ~1000 km', () => {
-  const baseline = obs({ location: { lat: 35, lon: 139, radiusKm: 50 } });
-  const mods = locationShiftTemplate(baseline);
-  assert.equal(mods.length, 1);
-  assert.equal(mods[0].field, 'location');
-  const modifiedLat = (mods[0].modifiedValue as { lat: number }).lat;
-  // ~1000 km north of lat 35 → ~44.0°; tolerate small float drift.
-  assert.ok(Math.abs(modifiedLat - 44.01) < 0.5, `expected ~44°, got ${modifiedLat}`);
-});
-
-test('timingShiftTemplate produces a confidence-based modification with rationale referencing 6 h', () => {
-  const baseline = obs();
-  const mods = timingShiftTemplate(baseline);
-  assert.equal(mods.length, 1);
-  assert.match(mods[0].rationale, /6\s*h/i);
-});
-
-test('all built-in templates produce rationale strings', () => {
-  const baseline = obs();
-  for (const t of BUILT_IN_REPLAY_TEMPLATES) {
-    const mods = t.build(baseline);
-    for (const m of mods) assert.ok(m.rationale.length > 0, `${t.id} produced empty rationale`);
+test('listScenarios never exceeds MAX_SCENARIOS', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  for (let i = 0; i < __internals.MAX_SCENARIOS + 5; i++) {
+    eng.createScenario(`s${i}`, 'snap', []);
   }
+  assert.ok(eng.listScenarios().length <= __internals.MAX_SCENARIOS);
 });
 
-test('createFromTemplate composes a scenario using the named template', () => {
-  const eng = freshEngine();
-  const baseline = obs({ severity: 'CRITICAL' });
-  const s = eng.createFromTemplate('severity-downgrade', baseline);
-  assert.ok(s);
-  assert.equal(s.modifications[0].field, 'severity');
-  assert.equal(s.name, 'Severity downgrade');
+test('oldest scenario is evicted when cap is reached', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  for (let i = 0; i < __internals.MAX_SCENARIOS; i++) {
+    eng.createScenario(`s${i}`, 'snap', []);
+  }
+  const firstId = eng.listScenarios()[0]!.id;
+  eng.createScenario('overflow', 'snap', []);
+  const list = eng.listScenarios();
+  assert.ok(!list.some((s: CounterfactualScenario) => s.id === firstId));
 });
 
-test('createFromTemplate returns undefined for unknown template id', () => {
-  const eng = freshEngine();
-  assert.equal(eng.createFromTemplate('does-not-exist', obs()), undefined);
-});
+// ── persistence ───────────────────────────────────────────────────────
 
-// ── Query API ────────────────────────────────────────────────────────
-
-test('getResults filters by scenarioId', () => {
-  const eng = freshEngine();
-  const a = eng.createScenario(obs({ id: 'a' }), [], 'a', 'a');
-  const b = eng.createScenario(obs({ id: 'b' }), [], 'b', 'b');
-  eng.runReplay(a.id);
-  eng.runReplay(b.id);
-  eng.runReplay(b.id);
-  assert.equal(eng.getResults(a.id).length, 1);
-  assert.equal(eng.getResults(b.id).length, 2);
-});
-
-test('getResults returns empty array for unknown scenarioId', () => {
-  const eng = freshEngine();
-  assert.deepEqual(eng.getResults('nope'), []);
-});
-
-test('getAllResults returns every result across scenarios', () => {
-  const eng = freshEngine();
-  const a = eng.createScenario(obs({ id: 'a' }), [], 'a', 'a');
-  const b = eng.createScenario(obs({ id: 'b' }), [], 'b', 'b');
-  eng.runReplay(a.id);
-  eng.runReplay(b.id);
-  assert.equal(eng.getAllResults().length, 2);
-});
-
-// ── Persistence ──────────────────────────────────────────────────────
-
-test('scenarios persist across instances via localStorage', () => {
-  const a = freshEngine();
-  a.createScenario(obs(), severityDowngradeTemplate(obs()), 'persisted', 'd');
-  const b = new CounterfactualReplayEngine({ clock: () => NOW });
-  assert.equal(b.getAllScenarios().length, 1);
-  assert.equal(b.getAllScenarios()[0].name, 'persisted');
-});
-
-test('results persist across instances via localStorage', () => {
-  const a = freshEngine();
-  const s = a.createScenario(obs(), severityDowngradeTemplate(obs()), 'p', 'd');
-  a.runReplay(s.id);
-  a.runReplay(s.id);
-  const b = new CounterfactualReplayEngine({ clock: () => NOW });
-  assert.equal(b.getResults(s.id).length, 2);
-});
-
-test('corrupt persisted blob does not crash hydrate', () => {
-  __storage.clear();
+test('scenario survives singleton reset (loaded from localStorage)', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  const s = eng.createScenario('persist-me', 'snap-42', OVERRIDES);
+  // Only reset singleton — keep localStorage so the next instance can reload
   __resetCounterfactualReplaySingleton();
-  __storage.set(engineInternals.STORAGE_KEY, '{not valid');
-  const eng = new CounterfactualReplayEngine({ clock: () => NOW });
-  assert.deepEqual(eng.getAllScenarios(), []);
-  assert.deepEqual(eng.getAllResults(), []);
+  const eng2 = CounterfactualReplayEngine.getInstance();
+  const found = eng2.getScenario(s.id);
+  assert.ok(found);
+  assert.equal(found.name, 'persist-me');
 });
 
-// ── Ring buffers ─────────────────────────────────────────────────────
-
-test('scenarios over MAX_SCENARIOS evict oldest', () => {
-  const eng = freshEngine();
-  const max = engineInternals.MAX_SCENARIOS;
-  for (let i = 0; i < max + 5; i++) {
-    eng.createScenario(obs({ id: `obs-${i}` }), [], `s-${i}`, 'd');
-  }
-  const all = eng.getAllScenarios();
-  assert.equal(all.length, max);
-  assert.equal(all[0].name, 's-5'); // oldest 5 evicted
-  assert.equal(all[all.length - 1].name, `s-${max + 4}`);
-});
-
-test('results over MAX_RESULTS evict oldest', () => {
-  const eng = freshEngine();
-  const s = eng.createScenario(obs(), [], 's', 'd');
-  const max = engineInternals.MAX_RESULTS;
-  for (let i = 0; i < max + 3; i++) eng.runReplay(s.id);
-  // getResults filters by id — all results belong to s, so getResults
-  // length is bounded by the global MAX_RESULTS cap.
-  assert.equal(eng.getResults(s.id).length, max);
-  assert.equal(eng.getAllResults().length, max);
-});
-
-// ── Subscribe / singleton ────────────────────────────────────────────
-
-test('subscribe fires on createScenario and runReplay', () => {
-  const eng = freshEngine();
-  let count = 0;
-  eng.subscribe(() => { count += 1; });
-  const s = eng.createScenario(obs(), [], 'n', 'd');
-  eng.runReplay(s.id);
-  assert.equal(count, 2);
-});
-
-test('subscribe listener exception is isolated', () => {
-  const eng = freshEngine();
-  eng.subscribe(() => { throw new Error('boom'); });
-  let secondCalled = false;
-  eng.subscribe(() => { secondCalled = true; });
-  eng.createScenario(obs(), [], 'n', 'd');
-  assert.equal(secondCalled, true);
-});
-
-test('getCounterfactualReplayEngine() returns a stable singleton', () => {
-  __storage.clear();
+test('runScenario result survives singleton reset', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  const s = eng.createScenario('persist-result', 'snap-1', OVERRIDES);
+  eng.runScenario(s.id);
+  // Only reset singleton — keep localStorage so the next instance can reload
   __resetCounterfactualReplaySingleton();
-  const a = getCounterfactualReplayEngine();
-  const b = getCounterfactualReplayEngine();
-  assert.strictEqual(a, b);
+  const eng2 = CounterfactualReplayEngine.getInstance();
+  const found = eng2.getScenario(s.id);
+  assert.ok(found?.result);
+  assert.equal(found.result?.scenarioId, s.id);
 });
 
-// ── scoreReplayObservation pure helper ───────────────────────────────
-
-test('scoreReplayObservation maps INFO/LOW/MEDIUM/HIGH/CRITICAL to ascending scores', () => {
-  const severities = ['INFO', 'LOW', 'MEDIUM', 'HIGH', 'CRITICAL'] as const;
-  const scores = severities.map((s) => scoreReplayObservation(obs({ severity: s, raw: {} })).score);
-  for (let i = 1; i < scores.length; i++) {
-    assert.ok(scores[i]! >= scores[i - 1]!, `severity ${severities[i]} should score ≥ ${severities[i - 1]}`);
-  }
+test('storage key matches expected constant', () => {
+  assert.equal(__internals.STORAGE_KEY, 'wm-counterfactual-replay');
 });
 
-test('scoreReplayObservation applies raw.confidence as a multiplier', () => {
-  const high = scoreReplayObservation(obs({ severity: 'HIGH', raw: {} })).score;
-  const halfConf = scoreReplayObservation(obs({ severity: 'HIGH', raw: { confidence: 0.5 } })).score;
-  assert.ok(halfConf < high);
+// ── narrative ─────────────────────────────────────────────────────────
+
+test('narrativeSummary includes the scenario name', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  const s = eng.createScenario('My Scenario', 'snap-1', OVERRIDES);
+  const r = eng.runScenario(s.id);
+  assert.ok(r?.narrativeSummary.includes('My Scenario'));
 });
 
-test('a series of modifications all in one scenario apply together', () => {
-  const eng = freshEngine();
-  const baseline = obs({ severity: 'HIGH', raw: { magnitude: 5 } });
-  const mods: ReplayModification[] = [
-    { field: 'severity', originalValue: 'HIGH', modifiedValue: 'CRITICAL', rationale: 'a' },
-    { field: 'magnitude', originalValue: 5, modifiedValue: 7, rationale: 'b' },
-  ];
-  const s = eng.createScenario(baseline, mods, 'combo', 'd');
-  const result = eng.runReplay(s.id)!;
-  // Both bumps push score upward.
-  assert.ok(result.deltaScore > 0);
-  assert.equal(result.replayedOutcome, 'critical');
+test('narrativeSummary includes affected domain names', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  const s = eng.createScenario('test', 'snap-1', OVERRIDES);
+  const r = eng.runScenario(s.id);
+  assert.ok(r?.narrativeSummary.includes('weather'));
+  assert.ok(r?.narrativeSummary.includes('cyber'));
 });
 
-test('insights list mentions the severity transition when bands cross', () => {
-  const eng = freshEngine();
-  const baseline = obs({ severity: 'HIGH', raw: {} });
-  const s = eng.createScenario(baseline, severityDowngradeTemplate(baseline), 'n', 'd');
-  const result = eng.runReplay(s.id)!;
-  // First insight is always the band-summary line; should mention
-  // both the original and replayed band when they differ.
-  assert.match(result.insights[0]!, /flipped/i);
+test('narrativeSummary for empty overrides mentions none', () => {
+  reset();
+  const eng = CounterfactualReplayEngine.getInstance();
+  const s = eng.createScenario('empty', 'snap-1', []);
+  const r = eng.runScenario(s.id);
+  assert.ok(r?.narrativeSummary.includes('none'));
 });


### PR DESCRIPTION
Replace the observation-based replay engine with a spec-compliant domain-override model.

## What changed
- `CounterfactualReplayEngine` singleton (`getInstance()`) with `createScenario` / `runScenario` / `getScenario` / `listScenarios`
- `DomainOverride`: domain + severityDelta + eventCountDelta per modified domain
- cascade score = mean |severityDelta| across overrides, clamped 0–1; tiered label (minimal / minor / moderate / critical)
- localStorage persistence under `wm-counterfactual-replay`, max 100 scenarios (FIFO eviction)
- `CounterfactualReplayPanel` rewritten: inline form (name + base snapshot + domain + deltas), scenario list, result pane with cascade badge + narrative
- 40 deterministic tests covering singleton, CRUD, cascade math, tier labels, persistence, and narrative

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass