### PR TITLE
Backtest gate — validate alert rules against historical data before applying

### DIFF
--- a/src/services/intelligence/backtest-gate.ts
+++ b/src/services/intelligence/backtest-gate.ts
@@ -75,10 +75,30 @@ export interface ChangeTemplate {
   build(input: { algoId: string; rationale?: string; proposedValue: unknown }): ProposedChange;
 }
 
+// ── BacktestRun — rule-centric historical replay ──────────────────────
+
+export interface BacktestRun {
+  id: string;
+  ruleId: string;
+  ruleSnapshot: object;
+  ranAt: number;
+  windowDays: number;
+  triggeredCount: number;
+  falsePositiveRate: number;
+  precision: number;
+  passed: boolean;
+  failReason?: string;
+}
+
 // ── Constants ─────────────────────────────────────────────────────────
 
 const STORAGE_KEY = 'wm-backtest-gate';
 const MAX_HISTORY = 100;
+const MAX_RUNS = 500;
+const DEFAULT_WINDOW_DAYS = 30;
+const FP_RATE_THRESHOLD = 0.3;
+const PRECISION_THRESHOLD = 0.7;
+const APPROVAL_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 const APPROVAL_DELTA_FLOOR = -0.05;
 const APPROVAL_ACCURACY_FLOOR = 0.5;
 const MIN_PREDICTIONS_FOR_HIGH = 30;
@@ -147,6 +167,7 @@ export interface BacktestGateOptions {
 interface GateSnapshot {
   pending: ProposedChange[];
   verdicts: GateVerdict[];
+  runs?: BacktestRun[];
 }
 
 export class BacktestGate {
@@ -158,6 +179,7 @@ export class BacktestGate {
   private listeners = new Set<GateListener>();
   private idSeq = 0;
   private hydrated = false;
+  private allRuns: BacktestRun[] = [];
   private backtestEngine?: BacktestEngine;
   private evalLedger?: AlgoEvalLedger;
   private scenarios?: readonly BacktestScenario[];
@@ -168,6 +190,10 @@ export class BacktestGate {
     this.evalLedger = options.evalLedger;
     this.scenarios = options.scenarios;
     this.clock = options.clock ?? (() => Date.now());
+  }
+
+  static getInstance(): BacktestGate {
+    return getBacktestGate();
   }
 
   // ── Public API ──────────────────────────────────────────────────
@@ -232,6 +258,7 @@ export class BacktestGate {
     this.verdicts.clear();
     this.pendingOrder = [];
     this.verdictOrder = [];
+    this.allRuns = [];
     this.listeners.clear();
     this.idSeq = 0;
     this.hydrated = true;
@@ -239,6 +266,70 @@ export class BacktestGate {
     if (store) {
       try { store.removeItem(STORAGE_KEY); } catch { /* ignore */ }
     }
+  }
+
+  // ── Rule-centric backtest API ────────────────────────────────────
+
+  runBacktest(
+    ruleId: string,
+    ruleSnapshot: object,
+    historicalEvents: object[],
+    windowDays = DEFAULT_WINDOW_DAYS,
+  ): BacktestRun {
+    this.ensureHydrated();
+    const now = this.clock();
+    const windowMs = windowDays * 24 * 60 * 60 * 1000;
+    const cutoff = now - windowMs;
+
+    const inWindow = historicalEvents.filter((ev) => {
+      const ts = (ev as Record<string, unknown>).timestamp;
+      return typeof ts !== 'number' || ts >= cutoff;
+    });
+
+    const triggered = inWindow.filter((ev) => triggersRule(ev, ruleSnapshot));
+    const triggeredCount = triggered.length;
+    const fpCount = triggered.filter((ev) => isFalsePositive(ev, ruleSnapshot)).length;
+
+    const falsePositiveRate = triggeredCount === 0 ? 0 : round4(fpCount / triggeredCount);
+    const precision = triggeredCount === 0 ? 0 : round4((triggeredCount - fpCount) / triggeredCount);
+
+    const failReason = resolveFailReason(triggeredCount, falsePositiveRate, precision);
+    const run: BacktestRun = {
+      id: this.nextId('btr'),
+      ruleId,
+      ruleSnapshot,
+      ranAt: now,
+      windowDays,
+      triggeredCount,
+      falsePositiveRate,
+      precision,
+      passed: failReason === undefined,
+      failReason,
+    };
+
+    this.storeRun(run);
+    this.persist();
+    return { ...run };
+  }
+
+  getLastRun(ruleId: string): BacktestRun | undefined {
+    this.ensureHydrated();
+    let last: BacktestRun | undefined;
+    for (const r of this.allRuns) {
+      if (r.ruleId === ruleId) last = r;
+    }
+    return last ? { ...last } : undefined;
+  }
+
+  getHistory(ruleId: string): BacktestRun[] {
+    this.ensureHydrated();
+    return this.allRuns.filter((r) => r.ruleId === ruleId).map((r) => ({ ...r }));
+  }
+
+  isApproved(ruleId: string): boolean {
+    const last = this.getLastRun(ruleId);
+    if (last === undefined) return false;
+    return last.passed && (this.clock() - last.ranAt) < APPROVAL_WINDOW_MS;
   }
 
   // ── Verdict construction ────────────────────────────────────────
@@ -284,6 +375,13 @@ export class BacktestGate {
     if (!existing) {
       this.verdictOrder.push(verdict.changeId);
       this.enforceCapacity();
+    }
+  }
+
+  private storeRun(run: BacktestRun): void {
+    this.allRuns.push(run);
+    while (this.allRuns.length > MAX_RUNS) {
+      this.allRuns.shift();
     }
   }
 
@@ -342,6 +440,10 @@ export class BacktestGate {
         this.verdicts.set(v.changeId, normalizeVerdict(v));
         this.verdictOrder.push(v.changeId);
       }
+      for (const r of parsed.runs ?? []) {
+        if (!r || typeof (r as unknown as Record<string, unknown>).ruleId !== 'string') continue;
+        this.allRuns.push(normalizeRun(r));
+      }
     } catch {
       // corrupt — leave empty
     }
@@ -357,6 +459,7 @@ export class BacktestGate {
       verdicts: this.verdictOrder
         .map((id) => this.verdicts.get(id))
         .filter((v): v is GateVerdict => v !== undefined),
+      runs: this.allRuns,
     };
     try {
       store.setItem(STORAGE_KEY, JSON.stringify(snapshot));
@@ -488,6 +591,76 @@ function signedPct(n: number): string {
   return `${sign}${(n * 100).toFixed(1)}%`;
 }
 
+// ── Rule-replay helpers ──────────────────────────────────────────────
+
+const SEVERITY_RANK: Record<string, number> = {
+  INFO: 0, LOW: 1, MEDIUM: 2, HIGH: 3, CRITICAL: 4,
+};
+
+function eventSeverityRank(ev: object): number {
+  const e = ev as Record<string, unknown>;
+  const s = typeof e.severity === 'string' ? e.severity.toUpperCase() : 'INFO';
+  return SEVERITY_RANK[s] ?? 0;
+}
+
+function ruleSeverityThreshold(ruleSnapshot: object): number {
+  const r = ruleSnapshot as Record<string, unknown>;
+  const ts = Array.isArray(r.triggerSeverity) ? (r.triggerSeverity as string[]) : [];
+  if (ts.length === 0) return 0;
+  const ranks = ts.map((s) => SEVERITY_RANK[String(s).toUpperCase()] ?? 0);
+  return Math.min(...ranks);
+}
+
+function triggersRule(ev: object, ruleSnapshot: object): boolean {
+  const e = ev as Record<string, unknown>;
+  const r = ruleSnapshot as Record<string, unknown>;
+  if (typeof r.domain === 'string' && typeof e.domain === 'string' && r.domain !== e.domain) {
+    return false;
+  }
+  const ruleTags = Array.isArray(r.triggerTags) ? (r.triggerTags as string[]) : [];
+  if (ruleTags.length > 0) {
+    const evtTags = Array.isArray(e.tags) ? (e.tags as string[]) : [];
+    const matched = ruleTags.find((t) => evtTags.includes(t));
+    if (matched === undefined) return false;
+  }
+  return true;
+}
+
+function isFalsePositive(ev: object, ruleSnapshot: object): boolean {
+  return eventSeverityRank(ev) < ruleSeverityThreshold(ruleSnapshot);
+}
+
+function resolveFailReason(
+  triggeredCount: number,
+  falsePositiveRate: number,
+  precision: number,
+): string | undefined {
+  if (triggeredCount === 0) return 'no events triggered the rule in the historical window';
+  if (falsePositiveRate >= FP_RATE_THRESHOLD) {
+    return `false-positive rate ${pct(falsePositiveRate)} exceeds ${pct(FP_RATE_THRESHOLD)} threshold`;
+  }
+  if (precision <= PRECISION_THRESHOLD) {
+    return `precision ${pct(precision)} did not clear ${pct(PRECISION_THRESHOLD)} threshold`;
+  }
+  return undefined;
+}
+
+function normalizeRun(raw: unknown): BacktestRun {
+  const r = raw as BacktestRun;
+  return {
+    id: typeof r.id === 'string' ? r.id : '',
+    ruleId: typeof r.ruleId === 'string' ? r.ruleId : '',
+    ruleSnapshot: (typeof r.ruleSnapshot === 'object' && r.ruleSnapshot != null) ? r.ruleSnapshot : {},
+    ranAt: typeof r.ranAt === 'number' ? r.ranAt : 0,
+    windowDays: typeof r.windowDays === 'number' ? r.windowDays : DEFAULT_WINDOW_DAYS,
+    triggeredCount: typeof r.triggeredCount === 'number' ? r.triggeredCount : 0,
+    falsePositiveRate: typeof r.falsePositiveRate === 'number' ? r.falsePositiveRate : 0,
+    precision: typeof r.precision === 'number' ? r.precision : 0,
+    passed: r.passed === true,
+    failReason: typeof r.failReason === 'string' ? r.failReason : undefined,
+  };
+}
+
 // ── Singleton ────────────────────────────────────────────────────────
 
 let _singleton: BacktestGate | null = null;
@@ -508,8 +681,17 @@ export const __internals = {
   MAX_HISTORY,
   MIN_PREDICTIONS_FOR_HIGH,
   MIN_PREDICTIONS_FOR_MEDIUM,
+  MAX_RUNS,
+  DEFAULT_WINDOW_DAYS,
+  FP_RATE_THRESHOLD,
+  PRECISION_THRESHOLD,
+  APPROVAL_WINDOW_MS,
   mapChangeToParameters,
   shiftSeverityBands,
   deriveConfidence,
   buildVerdict,
+  triggersRule,
+  isFalsePositive,
+  resolveFailReason,
+  normalizeRun,
 };

--- a/tests/intelligence/backtest-gate.test.mts
+++ b/tests/intelligence/backtest-gate.test.mts
@@ -27,6 +27,7 @@ import {
   getBacktestGate,
   type GateVerdict,
   type ProposedChange,
+  type BacktestRun,
 } from '../../src/services/intelligence/backtest-gate.ts';
 import type {
   BacktestConfig,
@@ -457,4 +458,399 @@ test('teardown clears singleton + storage', () => {
   const _v: GateVerdict | undefined = undefined;
   void _v;
   assert.ok(true);
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// Rule-centric BacktestRun API
+// ══════════════════════════════════════════════════════════════════════
+
+import { describe, it, beforeEach } from 'node:test';
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function freshRuleGate(clockMs = NOW): BacktestGate {
+  const gate = new BacktestGate({ clock: () => clockMs });
+  gate.resetForTesting();
+  return gate;
+}
+
+function makeEvent(overrides: Record<string, unknown> = {}): object {
+  return {
+    domain: 'weather',
+    severity: 'HIGH',
+    tags: ['tornado'],
+    timestamp: NOW - DAY_MS,
+    ...overrides,
+  };
+}
+
+function passRule(): object {
+  return { domain: 'weather', triggerTags: ['tornado'], triggerSeverity: ['MEDIUM', 'HIGH', 'CRITICAL'] };
+}
+
+function eventsForPass(): object[] {
+  return [
+    makeEvent({ severity: 'HIGH' }),
+    makeEvent({ severity: 'CRITICAL' }),
+    makeEvent({ severity: 'HIGH' }),
+    makeEvent({ severity: 'HIGH' }),
+  ];
+}
+
+// ── getInstance ────────────────────────────────────────────────────────
+
+describe('BacktestGate.getInstance()', () => {
+  it('returns the same singleton as getBacktestGate()', () => {
+    assert.equal(BacktestGate.getInstance(), getBacktestGate());
+  });
+});
+
+// ── runBacktest — basic shape ──────────────────────────────────────────
+
+describe('runBacktest — result shape', () => {
+  it('returns a BacktestRun with the given ruleId', () => {
+    const gate = freshRuleGate();
+    const run = gate.runBacktest('rule-1', passRule(), eventsForPass());
+    assert.equal(run.ruleId, 'rule-1');
+  });
+
+  it('result has a non-empty id', () => {
+    const gate = freshRuleGate();
+    const run = gate.runBacktest('rule-1', passRule(), eventsForPass());
+    assert.ok(run.id.length > 0);
+  });
+
+  it('ranAt equals the gate clock', () => {
+    const gate = freshRuleGate(NOW);
+    const run = gate.runBacktest('rule-1', passRule(), eventsForPass());
+    assert.equal(run.ranAt, NOW);
+  });
+
+  it('windowDays defaults to 30', () => {
+    const gate = freshRuleGate();
+    const run = gate.runBacktest('rule-1', passRule(), eventsForPass());
+    assert.equal(run.windowDays, __internals.DEFAULT_WINDOW_DAYS);
+  });
+
+  it('windowDays accepts an explicit override', () => {
+    const gate = freshRuleGate();
+    const run = gate.runBacktest('rule-1', passRule(), eventsForPass(), 14);
+    assert.equal(run.windowDays, 14);
+  });
+
+  it('ruleSnapshot is preserved in the result', () => {
+    const gate = freshRuleGate();
+    const snap = passRule();
+    const run = gate.runBacktest('rule-1', snap, eventsForPass());
+    assert.deepEqual(run.ruleSnapshot, snap);
+  });
+});
+
+// ── runBacktest — trigger counting ─────────────────────────────────────
+
+describe('runBacktest — triggeredCount', () => {
+  it('triggeredCount is 0 when no events match domain', () => {
+    const gate = freshRuleGate();
+    const events = [makeEvent({ domain: 'cyber' }), makeEvent({ domain: 'aviation' })];
+    const run = gate.runBacktest('rule-1', passRule(), events);
+    assert.equal(run.triggeredCount, 0);
+  });
+
+  it('triggeredCount is 0 when no events match tags', () => {
+    const gate = freshRuleGate();
+    const events = [makeEvent({ tags: ['rain'] }), makeEvent({ tags: ['wind'] })];
+    const run = gate.runBacktest('rule-1', passRule(), events);
+    assert.equal(run.triggeredCount, 0);
+  });
+
+  it('triggeredCount counts matching events', () => {
+    const gate = freshRuleGate();
+    const run = gate.runBacktest('rule-1', passRule(), eventsForPass());
+    assert.equal(run.triggeredCount, 4);
+  });
+
+  it('events outside the window are excluded', () => {
+    const gate = freshRuleGate(NOW);
+    const old = makeEvent({ timestamp: NOW - 31 * DAY_MS });
+    const run = gate.runBacktest('rule-1', passRule(), [old]);
+    assert.equal(run.triggeredCount, 0);
+  });
+
+  it('events without a timestamp are included', () => {
+    const gate = freshRuleGate(NOW);
+    const noTs = { domain: 'weather', severity: 'HIGH', tags: ['tornado'] };
+    const run = gate.runBacktest('rule-1', passRule(), [noTs]);
+    assert.equal(run.triggeredCount, 1);
+  });
+});
+
+// ── runBacktest — false-positive rate ──────────────────────────────────
+
+describe('runBacktest — falsePositiveRate', () => {
+  it('falsePositiveRate is 0 when no triggers', () => {
+    const gate = freshRuleGate();
+    const run = gate.runBacktest('rule-1', passRule(), []);
+    assert.equal(run.falsePositiveRate, 0);
+  });
+
+  it('falsePositiveRate is 0 when all triggers meet severity threshold', () => {
+    const gate = freshRuleGate();
+    const run = gate.runBacktest('rule-1', passRule(), eventsForPass());
+    assert.equal(run.falsePositiveRate, 0);
+  });
+
+  it('falsePositiveRate is 0.5 when half triggers are below threshold', () => {
+    const gate = freshRuleGate();
+    const events = [
+      makeEvent({ severity: 'HIGH' }),
+      makeEvent({ severity: 'LOW' }),   // below MEDIUM threshold
+    ];
+    const run = gate.runBacktest('rule-1', passRule(), events);
+    assert.equal(run.falsePositiveRate, 0.5);
+  });
+
+  it('falsePositiveRate is 1 when all triggers are below threshold', () => {
+    const gate = freshRuleGate();
+    const events = [makeEvent({ severity: 'INFO' }), makeEvent({ severity: 'LOW' })];
+    const run = gate.runBacktest('rule-1', passRule(), events);
+    assert.equal(run.falsePositiveRate, 1);
+  });
+});
+
+// ── runBacktest — precision ────────────────────────────────────────────
+
+describe('runBacktest — precision', () => {
+  it('precision is 0 when no triggers', () => {
+    const gate = freshRuleGate();
+    const run = gate.runBacktest('rule-1', passRule(), []);
+    assert.equal(run.precision, 0);
+  });
+
+  it('precision is 1 when all triggers are true positives', () => {
+    const gate = freshRuleGate();
+    const run = gate.runBacktest('rule-1', passRule(), eventsForPass());
+    assert.equal(run.precision, 1);
+  });
+
+  it('precision is 0.5 when half triggers are true positives', () => {
+    const gate = freshRuleGate();
+    const events = [makeEvent({ severity: 'HIGH' }), makeEvent({ severity: 'LOW' })];
+    const run = gate.runBacktest('rule-1', passRule(), events);
+    assert.equal(run.precision, 0.5);
+  });
+});
+
+// ── runBacktest — pass/fail logic ──────────────────────────────────────
+
+describe('runBacktest — passed + failReason', () => {
+  it('passes when triggeredCount > 0, falsePositiveRate < 0.3, precision > 0.7', () => {
+    const gate = freshRuleGate();
+    const run = gate.runBacktest('rule-1', passRule(), eventsForPass());
+    assert.equal(run.passed, true);
+    assert.equal(run.failReason, undefined);
+  });
+
+  it('fails when triggeredCount is 0', () => {
+    const gate = freshRuleGate();
+    const run = gate.runBacktest('rule-1', passRule(), []);
+    assert.equal(run.passed, false);
+    assert.ok(run.failReason?.includes('no events triggered'));
+  });
+
+  it('fails when falsePositiveRate is exactly 0.3', () => {
+    const gate = freshRuleGate();
+    // 3 triggered, 1 TP (HIGH), 2 FP (LOW) → FPR = 2/3 ≈ 0.6667
+    // Need FPR exactly 0.3: 10 triggered, 3 FP, 7 TP
+    const events: object[] = [
+      ...Array.from({ length: 7 }, () => makeEvent({ severity: 'HIGH' })),
+      ...Array.from({ length: 3 }, () => makeEvent({ severity: 'LOW' })),
+    ];
+    const run = gate.runBacktest('rule-1', passRule(), events);
+    assert.equal(run.passed, false);
+    assert.ok(run.failReason?.includes('false-positive rate'));
+  });
+
+  it('precision field equals 0.7 when 7 TP and 3 FP of 10 triggered', () => {
+    const gate = freshRuleGate();
+    // 10 triggered: 7 TP (HIGH), 3 FP (LOW) → precision = 0.7, FPR = 0.3
+    // Both metrics are at threshold; run fails (FP rate check fires first)
+    const events: object[] = [
+      ...Array.from({ length: 7 }, () => makeEvent({ severity: 'HIGH' })),
+      ...Array.from({ length: 3 }, () => makeEvent({ severity: 'LOW' })),
+    ];
+    const run = gate.runBacktest('rule-1', passRule(), events);
+    assert.equal(run.precision, 0.7);
+    assert.equal(run.passed, false);
+  });
+
+  it('failReason is undefined when passed', () => {
+    const gate = freshRuleGate();
+    const run = gate.runBacktest('rule-1', passRule(), eventsForPass());
+    assert.equal(run.failReason, undefined);
+  });
+});
+
+// ── getLastRun ─────────────────────────────────────────────────────────
+
+describe('getLastRun', () => {
+  it('returns undefined for an unknown ruleId', () => {
+    const gate = freshRuleGate();
+    assert.equal(gate.getLastRun('unknown'), undefined);
+  });
+
+  it('returns the run after one runBacktest call', () => {
+    const gate = freshRuleGate();
+    gate.runBacktest('rule-a', passRule(), eventsForPass());
+    const last = gate.getLastRun('rule-a');
+    assert.ok(last !== undefined);
+    assert.equal(last.ruleId, 'rule-a');
+  });
+
+  it('returns the most recent run when multiple runs exist', () => {
+    const gate = freshRuleGate();
+    gate.runBacktest('rule-a', passRule(), eventsForPass());
+    gate.runBacktest('rule-a', passRule(), []);
+    const last = gate.getLastRun('rule-a');
+    assert.equal(last?.passed, false); // second run had no events
+  });
+
+  it('is independent per ruleId', () => {
+    const gate = freshRuleGate();
+    gate.runBacktest('rule-a', passRule(), eventsForPass());
+    gate.runBacktest('rule-b', passRule(), []);
+    assert.equal(gate.getLastRun('rule-a')?.passed, true);
+    assert.equal(gate.getLastRun('rule-b')?.passed, false);
+  });
+});
+
+// ── getHistory ─────────────────────────────────────────────────────────
+
+describe('getHistory', () => {
+  it('returns empty array for unknown ruleId', () => {
+    const gate = freshRuleGate();
+    assert.deepEqual(gate.getHistory('unknown'), []);
+  });
+
+  it('returns all runs for a ruleId in insertion order', () => {
+    const gate = freshRuleGate();
+    gate.runBacktest('rule-a', passRule(), eventsForPass());
+    gate.runBacktest('rule-a', passRule(), []);
+    const history = gate.getHistory('rule-a');
+    assert.equal(history.length, 2);
+    assert.equal(history[0]?.passed, true);
+    assert.equal(history[1]?.passed, false);
+  });
+
+  it('does not include runs from other ruleIds', () => {
+    const gate = freshRuleGate();
+    gate.runBacktest('rule-a', passRule(), eventsForPass());
+    gate.runBacktest('rule-b', passRule(), eventsForPass());
+    assert.equal(gate.getHistory('rule-a').length, 1);
+    assert.equal(gate.getHistory('rule-b').length, 1);
+  });
+});
+
+// ── isApproved ─────────────────────────────────────────────────────────
+
+describe('isApproved', () => {
+  it('returns false for unknown ruleId', () => {
+    const gate = freshRuleGate();
+    assert.equal(gate.isApproved('unknown'), false);
+  });
+
+  it('returns false when last run failed', () => {
+    const gate = freshRuleGate(NOW);
+    gate.runBacktest('rule-a', passRule(), []);
+    assert.equal(gate.isApproved('rule-a'), false);
+  });
+
+  it('returns true when last run passed and is within 7 days', () => {
+    const gate = freshRuleGate(NOW);
+    gate.runBacktest('rule-a', passRule(), eventsForPass());
+    assert.equal(gate.isApproved('rule-a'), true);
+  });
+
+  it('returns false when last run passed but is older than 7 days', () => {
+    const runAt = NOW - 8 * DAY_MS;
+    const gate1 = new BacktestGate({ clock: () => runAt });
+    gate1.resetForTesting();
+    gate1.runBacktest('rule-a', passRule(), eventsForPass());
+
+    // gate2 clock is 8 days later — run is outside the 7-day approval window
+    const gate2 = new BacktestGate({ clock: () => NOW });
+    assert.equal(gate2.isApproved('rule-a'), false);
+  });
+});
+
+// ── Storage / cap enforcement ──────────────────────────────────────────
+
+describe('BacktestRun storage', () => {
+  beforeEach(() => { __storage.clear(); });
+
+  it('persists runs and rehydrates them', () => {
+    const gate1 = new BacktestGate({ clock: () => NOW });
+    gate1.resetForTesting();
+    gate1.runBacktest('rule-persist', passRule(), eventsForPass());
+
+    const gate2 = new BacktestGate({ clock: () => NOW });
+    const last = gate2.getLastRun('rule-persist');
+    assert.ok(last !== undefined);
+    assert.equal(last.ruleId, 'rule-persist');
+  });
+
+  it('rehydrated run has correct passed flag', () => {
+    const gate1 = new BacktestGate({ clock: () => NOW });
+    gate1.resetForTesting();
+    gate1.runBacktest('rule-p', passRule(), eventsForPass());
+
+    const gate2 = new BacktestGate({ clock: () => NOW });
+    assert.equal(gate2.getLastRun('rule-p')?.passed, true);
+  });
+
+  it('enforces MAX_RUNS cap by evicting oldest', () => {
+    const gate = freshRuleGate();
+    const cap = __internals.MAX_RUNS;
+    for (let i = 0; i < cap + 5; i++) {
+      gate.runBacktest(`rule-${i}`, {}, eventsForPass());
+    }
+    // Total stored runs should not exceed cap
+    let total = 0;
+    for (let i = 0; i < cap + 5; i++) {
+      total += gate.getHistory(`rule-${i}`).length;
+    }
+    assert.ok(total <= cap);
+  });
+
+  it('handles corrupt storage gracefully', () => {
+    __storage.set('wm-backtest-gate', '{corrupt json}}');
+    const gate = new BacktestGate({ clock: () => NOW });
+    assert.equal(gate.getLastRun('any'), undefined);
+    assert.deepEqual(gate.getHistory('any'), []);
+  });
+});
+
+// ── __internals constants ──────────────────────────────────────────────
+
+describe('__internals — rule-backtest constants', () => {
+  it('MAX_RUNS is 500', () => {
+    assert.equal(__internals.MAX_RUNS, 500);
+  });
+
+  it('DEFAULT_WINDOW_DAYS is 30', () => {
+    assert.equal(__internals.DEFAULT_WINDOW_DAYS, 30);
+  });
+
+  it('FP_RATE_THRESHOLD is 0.3', () => {
+    assert.equal(__internals.FP_RATE_THRESHOLD, 0.3);
+  });
+
+  it('PRECISION_THRESHOLD is 0.7', () => {
+    assert.equal(__internals.PRECISION_THRESHOLD, 0.7);
+  });
+
+  it('APPROVAL_WINDOW_MS is 7 days', () => {
+    assert.equal(__internals.APPROVAL_WINDOW_MS, 7 * 24 * 60 * 60 * 1000);
+  });
 });


### PR DESCRIPTION
Extends `BacktestGate` with a rule-centric historical replay API so alert rules can be validated before they go live.

## What's new

- **`BacktestRun`** type — captures replay result: `ruleId`, `ruleSnapshot`, `ranAt`, `windowDays`, `triggeredCount`, `falsePositiveRate`, `precision`, `passed`, `failReason`
- **`runBacktest(ruleId, ruleSnapshot, historicalEvents, windowDays?)`** — replays events against the rule snapshot, scoring trigger/FP/TP counts and writing the run to storage
- **`getLastRun(ruleId)`** — most recent run for a rule (or `undefined`)
- **`getHistory(ruleId)`** — all runs for a rule in insertion order
- **`isApproved(ruleId)`** — `true` if the last run passed within the 7-day approval window
- **`BacktestGate.getInstance()`** — static singleton accessor

## Thresholds

| Threshold | Value |
|-----------|-------|
| False-positive rate max | 0.3 |
| Precision min | 0.7 |
| Default replay window | 30 days |
| Approval TTL | 7 days |
| Max stored runs | 500 (oldest evicted) |

## Tests

80 tests total (36 existing + 44 new), zero type errors.

---

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass