### PR TITLE
sec: tighten relay CORS to owner-anchored patterns + surface bypass flag (R2-SEC-006/007)

### DIFF
--- a/scripts/ais-relay-cors.test.cjs
+++ b/scripts/ais-relay-cors.test.cjs
@@ -24,12 +24,18 @@ const ALLOWED_ORIGINS = [
   'tauri://localhost',
 ];
 
-// Matches the pattern in ais-relay.cjs getCorsOrigin
-const VERCEL_PREVIEW_RE = /^https:\/\/[a-z0-9-]+-bradleybond512\.vercel\.app$/;
+// Owner-anchored patterns — kept in sync with ais-relay.cjs ALLOWED_PREVIEW_PATTERNS.
+// Requires crystalball-/crystal-ball- prefix AND a known owner slug.
+const ALLOWED_PREVIEW_PATTERNS = [
+  /^https:\/\/crystalball-[a-z0-9-]+-bradleybond512\.vercel\.app$/,
+  /^https:\/\/crystal-ball-[a-z0-9-]+-bradleybond512\.vercel\.app$/,
+  /^https:\/\/crystalball-[a-z0-9-]+-elie-[a-z0-9]+\.vercel\.app$/,
+  /^https:\/\/crystal-ball-[a-z0-9-]+-elie-[a-z0-9]+\.vercel\.app$/,
+];
 
 function getCorsOrigin(origin, allowVercelPreview) {
   if (ALLOWED_ORIGINS.includes(origin)) return origin;
-  if (allowVercelPreview && VERCEL_PREVIEW_RE.test(origin)) return origin;
+  if (allowVercelPreview && ALLOWED_PREVIEW_PATTERNS.some(p => p.test(origin))) return origin;
   return '';
 }
 
@@ -49,26 +55,37 @@ test('relay CORS: rejects unknown origin when preview flag off', () => {
   assert.equal(getCorsOrigin('https://evil.example.com', false), '');
 });
 
-test('relay CORS: accepts owner-anchored preview origin when flag enabled', () => {
-  assert.equal(
-    getCorsOrigin('https://abc123-bradleybond512.vercel.app', true),
-    'https://abc123-bradleybond512.vercel.app',
-  );
-  assert.equal(
-    getCorsOrigin('https://deploy-hash-abc123-bradleybond512.vercel.app', true),
-    'https://deploy-hash-abc123-bradleybond512.vercel.app',
-  );
+test('relay CORS: accepts owner-anchored preview origins when flag enabled', () => {
+  const valid = [
+    'https://crystalball-my-branch-bradleybond512.vercel.app',
+    'https://crystal-ball-fix-123-bradleybond512.vercel.app',
+    'https://crystalball-pr-42-elie-abc123.vercel.app',
+    'https://crystal-ball-feature-elie-xyz.vercel.app',
+  ];
+  for (const origin of valid) {
+    assert.equal(getCorsOrigin(origin, true), origin, `should accept ${origin}`);
+  }
 });
 
 test('relay CORS: rejects lookalike vercel origins even when flag enabled (R2-SEC-006)', () => {
-  // Any .vercel.app that is NOT pinned to bradleybond512 must be rejected
-  assert.equal(getCorsOrigin('https://crystalball-attacker.vercel.app', true), '');
-  assert.equal(getCorsOrigin('https://abc123-otherperson.vercel.app', true), '');
-  assert.equal(getCorsOrigin('https://evil.vercel.app', true), '');
-  // Must not allow bradleybond512-suffix trickery from another account
-  assert.equal(getCorsOrigin('https://attack-bradleybond512x.vercel.app', true), '');
-  // Must require https:
-  assert.equal(getCorsOrigin('http://abc-bradleybond512.vercel.app', true), '');
+  const invalid = [
+    // Missing crystalball-/crystal-ball- prefix
+    'https://abc123-bradleybond512.vercel.app',
+    'https://deploy-hash-bradleybond512.vercel.app',
+    // Wrong owner slug
+    'https://crystalball-my-branch-otherperson.vercel.app',
+    'https://crystalball-evilorg.vercel.app',
+    'https://evil.vercel.app',
+    // Protocol tricks
+    'http://crystalball-branch-bradleybond512.vercel.app',
+    // Suffix forgery
+    'https://crystalball-attack-bradleybond512x.vercel.app',
+    // Lookalike domain
+    'https://crystalball-bradleybond512.evil.com',
+  ];
+  for (const origin of invalid) {
+    assert.equal(getCorsOrigin(origin, true), '', `should reject ${origin}`);
+  }
 });
 
 test('relay CORS: rejects empty or missing origin', () => {

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -88,6 +88,10 @@ if (IS_PRODUCTION_RELAY && !RELAY_SHARED_SECRET && !ALLOW_UNAUTHENTICATED_RELAY)
   console.error('[Relay] To bypass temporarily, set ALLOW_UNAUTHENTICATED_RELAY=true (non-production only)');
   process.exit(1);
 }
+if (ALLOW_UNAUTHENTICATED_RELAY) {
+  console.warn('[Relay] WARNING: ALLOW_UNAUTHENTICATED_RELAY is enabled — all auth checks are bypassed');
+  console.warn('[Relay] This flag is blocked in production (IS_PRODUCTION_RELAY=false required)');
+}
 
 let upstreamSocket = null;
 let upstreamPaused = false;
@@ -2647,13 +2651,20 @@ const ALLOWED_ORIGINS = [
   'tauri://localhost', // Tauri iOS/macOS
 ];
 
+// Owner-anchored preview patterns — mirrors api/_api-key.js and api/youtube/embed.js.
+// Requires the crystalball-/crystal-ball- project prefix AND a known owner slug so
+// unrelated third-party Vercel projects sharing the "crystalball" name cannot match.
+const ALLOWED_PREVIEW_PATTERNS = [
+  /^https:\/\/crystalball-[a-z0-9-]+-bradleybond512\.vercel\.app$/,
+  /^https:\/\/crystal-ball-[a-z0-9-]+-bradleybond512\.vercel\.app$/,
+  /^https:\/\/crystalball-[a-z0-9-]+-elie-[a-z0-9]+\.vercel\.app$/,
+  /^https:\/\/crystal-ball-[a-z0-9-]+-elie-[a-z0-9]+\.vercel\.app$/,
+];
+
 function getCorsOrigin(req) {
   const origin = req.headers.origin || '';
   if (ALLOWED_ORIGINS.includes(origin)) return origin;
-  // Optional: allow Crystal Ball's own Vercel preview deployments when explicitly enabled.
-  // Pinned to the bradleybond512 team slug so lookalike third-party projects cannot
-  // match. Vercel preview URL format: {deployment-hash}-{team-slug}.vercel.app
-  if (ALLOW_VERCEL_PREVIEW_ORIGINS && /^https:\/\/[a-z0-9-]+-bradleybond512\.vercel\.app$/.test(origin)) return origin;
+  if (ALLOW_VERCEL_PREVIEW_ORIGINS && ALLOWED_PREVIEW_PATTERNS.some(p => p.test(origin))) return origin;
   return '';
 }
 
@@ -2741,6 +2752,7 @@ const server = http.createServer(async (req, res) => {
  auth: {
  sharedSecretEnabled: !!RELAY_SHARED_SECRET,
  authHeader: RELAY_AUTH_HEADER,
+ allowUnauthenticated: ALLOW_UNAUTHENTICATED_RELAY,
  allowVercelPreviewOrigins: ALLOW_VERCEL_PREVIEW_ORIGINS,
  },
  rateLimit: {


### PR DESCRIPTION
## Summary

Closes out R2-SEC-006 and R2-SEC-007 from the security scan round 2.

**R2-SEC-006 — Relay CORS origin hardening**
- Replaced the broad single regex `/^https:\/\/[a-z0-9-]+-bradleybond512\.vercel\.app$/` with the same 4-pattern owner-anchored set used in `api/_api-key.js` and `api/youtube/embed.js`
- Now requires the `crystalball-` or `crystal-ball-` project prefix AND a known owner slug (`bradleybond512` or `elie-*`), blocking any unrelated Vercel project that only shares the owner

**R2-SEC-007 — Unauthenticated bypass visibility**
- `ALLOW_UNAUTHENTICATED_RELAY` was already blocked in production via `&& !IS_PRODUCTION_RELAY` — no change needed there
- Added startup `console.warn` when flag is active so it shows in logs
- Exposed `allowUnauthenticated` in the `/health` auth block for monitoring

**R2-SEC-011 — download-node.sh** *(no change needed)*
- Script already implements SHA-256 verification against `SHASUMS256.txt`, TLS-only URLs, and fail-closed behavior — fully compliant

## Test Plan
- [ ] `node --test scripts/ais-relay-cors.test.cjs` — 6/6 pass
- [ ] `npm run typecheck:all` — zero errors