### PR TITLE
fix: dock-badge crash on Apple Silicon — cast variadic objc_msgSend to non-variadic

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1567,13 +1567,27 @@ async fn open_youtube_logout(app: AppHandle) -> Result<(), String> {
 fn set_dock_badge(count: u32) -> Result<(), String> {
  #[cfg(target_os = "macos")]
  {
-  use std::ffi::{c_void, CString};
+  use std::ffi::{c_char, c_void, CString};
   extern "C" {
    fn objc_getClass(name: *const u8) -> *mut c_void;
    fn sel_registerName(name: *const u8) -> *mut c_void;
    fn objc_msgSend(receiver: *mut c_void, sel: *mut c_void, ...) -> *mut c_void;
   }
   unsafe {
+   // Apple Silicon ABI: variadic args are always passed on the stack, but
+   // `objc_msgSend` itself is non-variadic and reads its args from
+   // registers (x2+). Calling the variadic-typed `objc_msgSend` with any
+   // trailing argument therefore reads garbage from x2 — which is what
+   // caused `+[NSString stringWithUTF8String:]` to segfault inside
+   // `strlen` on every launch. Cast to concrete non-variadic signatures
+   // for the two calls that actually pass an argument; the zero-arg
+   // calls (`sharedApplication`, `dockTile`) are safe via the variadic
+   // declaration because no varargs means no ABI mismatch.
+   let msgsend_cstr: unsafe extern "C" fn(*mut c_void, *mut c_void, *const c_char) -> *mut c_void =
+    std::mem::transmute(objc_msgSend as *const ());
+   let msgsend_obj: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> *mut c_void =
+    std::mem::transmute(objc_msgSend as *const ());
+
    let nsapp_cls = objc_getClass(b"NSApplication\0".as_ptr());
    if nsapp_cls.is_null() { return Ok(()); }
    let shared_sel = sel_registerName(b"sharedApplication\0".as_ptr());
@@ -1587,10 +1601,10 @@ fn set_dock_badge(count: u32) -> Result<(), String> {
    let cstr = if count == 0 { CString::new("").unwrap() } else { CString::new(count.to_string()).unwrap() };
    let nsstring_cls = objc_getClass(b"NSString\0".as_ptr());
    let from_utf8_sel = sel_registerName(b"stringWithUTF8String:\0".as_ptr());
-   let label = objc_msgSend(nsstring_cls, from_utf8_sel, cstr.as_ptr());
+   let label = msgsend_cstr(nsstring_cls, from_utf8_sel, cstr.as_ptr());
 
    let set_label_sel = sel_registerName(b"setBadgeLabel:\0".as_ptr());
-   objc_msgSend(tile, set_label_sel, label);
+   msgsend_obj(tile, set_label_sel, label);
   }
  }
  let _ = count;


### PR DESCRIPTION
## Symptom

The desktop app **crashed immediately on every launch** — `SIGSEGV` inside `+[NSString stringWithUTF8String:]` → `_platform_strlen`, on the main thread.

## Diagnosis

Eight crash reports today (`~/Library/Logs/DiagnosticReports/crystalball-2026-05-19-*.ips`) — all identical:

```
libsystem_platform.dylib  _platform_strlen
Foundation                +[NSString stringWithUTF8String:]
crystalball               crystalball::set_dock_badge
crystalball               <Tauri IPC handler>
WebKit                    ScriptMessageHandlerDelegate::didPostMessage
```

Exception subtype: `KERN_INVALID_ADDRESS at 0x29a0129f501450e0 → 0xffff929f501450e0 (possible pointer authentication failure)` — the value `+[NSString stringWithUTF8String:]` read in register `x2` was not a real authenticated pointer.

## Root cause

`set_dock_badge` in `src-tauri/src/main.rs` declared `objc_msgSend` as variadic:

```rust
fn objc_msgSend(receiver: *mut c_void, sel: *mut c_void, ...) -> *mut c_void;
```

…then called it with a trailing pointer arg:

```rust
let label = objc_msgSend(nsstring_cls, from_utf8_sel, cstr.as_ptr());
```

**Apple Silicon's ABI rule:** variadic arguments are *always* passed on the stack, never in registers. But `objc_msgSend` in the system headers is **non-variadic** — it reads its 3rd argument from register `x2`. Result: the Rust caller put `cstr.as_ptr()` on the stack, `objc_msgSend` blindly forwarded `x2` (garbage) to `+[NSString stringWithUTF8String:]`, and `strlen` segfaulted on the first byte.

The bug was masked for the other ObjC FFI in this file because every other call (`alloc`, `init`, `sharedApplication`, `dockTile`, `requestWhenInUseAuthorization`, etc.) passes **zero** trailing args — no varargs = no ABI mismatch. `set_dock_badge` was the only call passing an actual argument through the variadic declaration.

This crash was a regression-magnet: `startDockBadge()` runs at boot to set the initial badge, so every launch hit it. The frontend was working fine (the IPC bridge delivered the call), but the Rust side crashed before returning.

## Fix

Transmute `objc_msgSend` to two concrete non-variadic signatures and use them for the two argument-passing calls:

```rust
let msgsend_cstr: unsafe extern "C" fn(*mut c_void, *mut c_void, *const c_char) -> *mut c_void =
    std::mem::transmute(objc_msgSend as *const ());
let msgsend_obj: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> *mut c_void =
    std::mem::transmute(objc_msgSend as *const ());

let label = msgsend_cstr(nsstring_cls, from_utf8_sel, cstr.as_ptr());
msgsend_obj(tile, set_label_sel, label);
```

The zero-arg calls (`sharedApplication`, `dockTile`) keep using the variadic declaration — safe because they pass nothing varargs.

This mirrors the pattern already used in `get_native_location_impl` for the struct-return `coordinate` call.

## Verification

- `cargo check` passes
- No test additions — this is a cross-FFI ABI bug that no unit test can exercise; the only repro is launching the desktop app on Apple Silicon
- **User verification path:** after merge, run `npm run desktop:build:full` and install. The app should boot past `startDockBadge()` instead of segfaulting; the dock tile should show the unacknowledged alert count

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass
