### PR TITLE
Backtest gate — validate algorithm changes against historical data before applying

### DIFF
--- a/src/services/intelligence/backtest-gate.ts
+++ b/src/services/intelligence/backtest-gate.ts
@@ -24,11 +24,12 @@ import {
   getBacktestEngine,
   type BacktestEngine,
   type BacktestParameterChanges,
-  type BacktestResult,
+  type BacktestResult as EngineBacktestResult,
   type BacktestScenario,
   type SeverityBand,
   DEFAULT_SEVERITY_BANDS,
 } from './backtest-engine';
+import type { ObservationEvent } from '@/types/intelligence';
 import { getBuiltInScenarios } from './built-in-scenarios';
 import {
   getAlgoEvalLedger,
@@ -75,12 +76,50 @@ export interface ChangeTemplate {
   build(input: { algoId: string; rationale?: string; proposedValue: unknown }): ProposedChange;
 }
 
+// ── Generic proposal API (Phase: backtest-before-apply gate) ──────────
+//
+// A second, simpler API surface exposed on the same gate so callers that
+// don't want to encode their change as an algoId/paramName pair can
+// submit a typed proposal + run a precision/recall backtest against a
+// labeled historical observation set. The new methods share the gate's
+// localStorage envelope so a single hydrate covers both views.
+
+export type BacktestChangeType = 'threshold' | 'weight' | 'rule' | 'config';
+
+export type BacktestProposalStatus = 'pending' | 'running' | 'approved' | 'rejected';
+
+export interface BacktestResult {
+  proposalId: string;
+  historicalPrecision: number;
+  historicalRecall: number;
+  baselinePrecision: number;
+  baselineRecall: number;
+  precisionDelta: number;
+  recallDelta: number;
+  approved: boolean;
+  reason: string;
+}
+
+export interface BacktestProposal {
+  id: string;
+  description: string;
+  changeType: BacktestChangeType;
+  proposedChange: Record<string, unknown>;
+  currentValue: Record<string, unknown>;
+  status: BacktestProposalStatus;
+  createdAt: number;
+  completedAt?: number;
+  result?: BacktestResult;
+}
+
 // ── Constants ─────────────────────────────────────────────────────────
 
 const STORAGE_KEY = 'wm-backtest-gate';
 const MAX_HISTORY = 100;
+const MAX_PROPOSALS = 200;
 const APPROVAL_DELTA_FLOOR = -0.05;
 const APPROVAL_ACCURACY_FLOOR = 0.5;
+const PROPOSAL_DELTA_FLOOR = -0.05;
 const MIN_PREDICTIONS_FOR_HIGH = 30;
 const MIN_PREDICTIONS_FOR_MEDIUM = 10;
 
@@ -147,6 +186,7 @@ export interface BacktestGateOptions {
 interface GateSnapshot {
   pending: ProposedChange[];
   verdicts: GateVerdict[];
+  proposals?: BacktestProposal[];
 }
 
 export class BacktestGate {
@@ -155,6 +195,9 @@ export class BacktestGate {
   /** Insertion order so persistence + getVerdicts() stay deterministic. */
   private verdictOrder: string[] = [];
   private pendingOrder: string[] = [];
+  private proposals = new Map<string, BacktestProposal>();
+  private proposalOrder: string[] = [];
+  private proposalIdSeq = 0;
   private listeners = new Set<GateListener>();
   private idSeq = 0;
   private hydrated = false;
@@ -232,12 +275,159 @@ export class BacktestGate {
     this.verdicts.clear();
     this.pendingOrder = [];
     this.verdictOrder = [];
+    this.proposals.clear();
+    this.proposalOrder = [];
+    this.proposalIdSeq = 0;
     this.listeners.clear();
     this.idSeq = 0;
     this.hydrated = true;
     const store = safeStorage();
     if (store) {
       try { store.removeItem(STORAGE_KEY); } catch { /* ignore */ }
+    }
+  }
+
+  // ── Proposal API (precision/recall against historical observations) ──
+
+  /** Singleton accessor matching the spec's `BacktestGate.getInstance()`
+   *  shape. Equivalent to `getBacktestGate()` — kept as a static so
+   *  callers can reach the gate without an extra import. */
+  static getInstance(): BacktestGate {
+    return getBacktestGate();
+  }
+
+  submitProposal(input: Partial<BacktestProposal> & Pick<BacktestProposal, 'changeType' | 'proposedChange' | 'currentValue'>): BacktestProposal {
+    this.ensureHydrated();
+    const id = typeof input.id === 'string' && input.id.length > 0 ? input.id : this.nextProposalId();
+    const proposal: BacktestProposal = {
+      id,
+      description: typeof input.description === 'string' ? input.description : '',
+      changeType: input.changeType,
+      proposedChange: { ...input.proposedChange },
+      currentValue: { ...input.currentValue },
+      status: input.status ?? 'pending',
+      createdAt: typeof input.createdAt === 'number' ? input.createdAt : this.clock(),
+      completedAt: input.completedAt,
+      result: input.result ? { ...input.result } : undefined,
+    };
+    if (!this.proposals.has(id)) this.proposalOrder.push(id);
+    this.proposals.set(id, proposal);
+    this.enforceProposalCapacity();
+    this.persist();
+    return cloneProposal(proposal);
+  }
+
+  runBacktest(id: string, historicalObservations: readonly ObservationEvent[]): BacktestResult {
+    this.ensureHydrated();
+    const proposal = this.proposals.get(id);
+    if (!proposal) {
+      throw new Error(`BacktestGate.runBacktest: proposal ${id} not found`);
+    }
+    proposal.status = 'running';
+    this.proposals.set(id, proposal);
+    this.persist();
+
+    const proposed = scoreObservations(historicalObservations, proposal.changeType, proposal.proposedChange);
+    const baseline = scoreObservations(historicalObservations, proposal.changeType, proposal.currentValue);
+    const precisionDelta = round4(proposed.precision - baseline.precision);
+    const recallDelta = round4(proposed.recall - baseline.recall);
+    const approved = precisionDelta >= PROPOSAL_DELTA_FLOOR && recallDelta >= PROPOSAL_DELTA_FLOOR;
+    const precisionFailed = precisionDelta < PROPOSAL_DELTA_FLOOR;
+    const recallFailed = recallDelta < PROPOSAL_DELTA_FLOOR;
+    const failedMetrics = [precisionFailed ? 'precision' : null, recallFailed ? 'recall' : null]
+      .filter((m): m is string => m !== null);
+    const reason = approved
+      ? `Approved: precisionΔ=${signedPct(precisionDelta)}, recallΔ=${signedPct(recallDelta)} (both ≥ ${signedPct(PROPOSAL_DELTA_FLOOR)})`
+      : `Rejected: ${failedMetrics.join(' + ')} below floor — precisionΔ=${signedPct(precisionDelta)}, recallΔ=${signedPct(recallDelta)} (floor ${signedPct(PROPOSAL_DELTA_FLOOR)})`;
+
+    const result: BacktestResult = {
+      proposalId: id,
+      historicalPrecision: round4(proposed.precision),
+      historicalRecall: round4(proposed.recall),
+      baselinePrecision: round4(baseline.precision),
+      baselineRecall: round4(baseline.recall),
+      precisionDelta,
+      recallDelta,
+      approved,
+      reason,
+    };
+
+    const completed: BacktestProposal = {
+      ...proposal,
+      status: approved ? 'approved' : 'rejected',
+      completedAt: this.clock(),
+      result,
+    };
+    this.proposals.set(id, completed);
+    this.persist();
+    return { ...result };
+  }
+
+  approve(id: string): BacktestProposal | undefined {
+    this.ensureHydrated();
+    const proposal = this.proposals.get(id);
+    if (!proposal) return undefined;
+    const next: BacktestProposal = {
+      ...proposal,
+      status: 'approved',
+      completedAt: proposal.completedAt ?? this.clock(),
+    };
+    this.proposals.set(id, next);
+    this.persist();
+    return cloneProposal(next);
+  }
+
+  reject(id: string, reason: string): BacktestProposal | undefined {
+    this.ensureHydrated();
+    const proposal = this.proposals.get(id);
+    if (!proposal) return undefined;
+    const result: BacktestResult = proposal.result
+      ? { ...proposal.result, approved: false, reason }
+      : {
+          proposalId: id,
+          historicalPrecision: 0,
+          historicalRecall: 0,
+          baselinePrecision: 0,
+          baselineRecall: 0,
+          precisionDelta: 0,
+          recallDelta: 0,
+          approved: false,
+          reason,
+        };
+    const next: BacktestProposal = {
+      ...proposal,
+      status: 'rejected',
+      completedAt: proposal.completedAt ?? this.clock(),
+      result,
+    };
+    this.proposals.set(id, next);
+    this.persist();
+    return cloneProposal(next);
+  }
+
+  getProposals(): BacktestProposal[] {
+    this.ensureHydrated();
+    return this.proposalOrder
+      .map((id) => this.proposals.get(id))
+      .filter((p): p is BacktestProposal => p !== undefined)
+      .map((p) => cloneProposal(p));
+  }
+
+  getProposal(id: string): BacktestProposal | undefined {
+    this.ensureHydrated();
+    const p = this.proposals.get(id);
+    return p ? cloneProposal(p) : undefined;
+  }
+
+  private nextProposalId(): string {
+    this.proposalIdSeq += 1;
+    return `prop-${this.clock().toString(36)}-${this.proposalIdSeq}`;
+  }
+
+  private enforceProposalCapacity(): void {
+    while (this.proposalOrder.length > MAX_PROPOSALS) {
+      const oldest = this.proposalOrder.shift();
+      if (oldest !== undefined) this.proposals.delete(oldest);
     }
   }
 
@@ -342,6 +532,12 @@ export class BacktestGate {
         this.verdicts.set(v.changeId, normalizeVerdict(v));
         this.verdictOrder.push(v.changeId);
       }
+      for (const p of parsed.proposals ?? []) {
+        const normalized = normalizeProposal(p);
+        if (!normalized) continue;
+        this.proposals.set(normalized.id, normalized);
+        this.proposalOrder.push(normalized.id);
+      }
     } catch {
       // corrupt — leave empty
     }
@@ -357,6 +553,9 @@ export class BacktestGate {
       verdicts: this.verdictOrder
         .map((id) => this.verdicts.get(id))
         .filter((v): v is GateVerdict => v !== undefined),
+      proposals: this.proposalOrder
+        .map((id) => this.proposals.get(id))
+        .filter((p): p is BacktestProposal => p !== undefined),
     };
     try {
       store.setItem(STORAGE_KEY, JSON.stringify(snapshot));
@@ -399,7 +598,7 @@ function shiftSeverityBands(base: readonly SeverityBand[], shift: number): Sever
 function buildVerdict(
   changeId: string,
   change: ProposedChange,
-  result: BacktestResult,
+  result: EngineBacktestResult,
   currentAccuracy: number,
   resolvedCount: number,
   now: number,
@@ -433,7 +632,7 @@ function explainRejection(simulated: number, delta: number, current: number): st
   return `Rejected — accuracy delta ${signedPct(delta)} regresses past the ${signedPct(APPROVAL_DELTA_FLOOR)} floor (current ${pct(current)} → simulated ${pct(simulated)}).`;
 }
 
-function deriveConfidence(resolvedCount: number, result: BacktestResult): GateConfidenceLevel {
+function deriveConfidence(resolvedCount: number, result: EngineBacktestResult): GateConfidenceLevel {
   const scenarioCount = result.scenarioResults.length;
   if (resolvedCount >= MIN_PREDICTIONS_FOR_HIGH && scenarioCount >= 3) return 'high';
   if (resolvedCount >= MIN_PREDICTIONS_FOR_MEDIUM && scenarioCount >= 1) return 'medium';
@@ -457,6 +656,101 @@ function normalizeVerdict(raw: unknown): GateVerdict {
 
 function cloneVerdict(v: GateVerdict): GateVerdict {
   return { ...v };
+}
+
+// ── Proposal-API helpers ─────────────────────────────────────────────
+
+const VALID_CHANGE_TYPES: ReadonlySet<BacktestChangeType> =
+  new Set<BacktestChangeType>(['threshold', 'weight', 'rule', 'config']);
+const VALID_PROPOSAL_STATUSES: ReadonlySet<BacktestProposalStatus> =
+  new Set<BacktestProposalStatus>(['pending', 'running', 'approved', 'rejected']);
+
+function cloneProposal(p: BacktestProposal): BacktestProposal {
+  return {
+    ...p,
+    proposedChange: { ...p.proposedChange },
+    currentValue: { ...p.currentValue },
+    result: p.result ? { ...p.result } : undefined,
+  };
+}
+
+function normalizeProposal(raw: unknown): BacktestProposal | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const p = raw as Partial<BacktestProposal>;
+  if (typeof p.id !== 'string' || !p.id) return null;
+  if (!p.changeType || !VALID_CHANGE_TYPES.has(p.changeType)) return null;
+  if (!p.proposedChange || typeof p.proposedChange !== 'object') return null;
+  if (!p.currentValue || typeof p.currentValue !== 'object') return null;
+  const status: BacktestProposalStatus = p.status && VALID_PROPOSAL_STATUSES.has(p.status)
+    ? p.status : 'pending';
+  return {
+    id: p.id,
+    description: typeof p.description === 'string' ? p.description : '',
+    changeType: p.changeType,
+    proposedChange: { ...(p.proposedChange as Record<string, unknown>) },
+    currentValue: { ...(p.currentValue as Record<string, unknown>) },
+    status,
+    createdAt: typeof p.createdAt === 'number' ? p.createdAt : 0,
+    completedAt: typeof p.completedAt === 'number' ? p.completedAt : undefined,
+    result: p.result && typeof p.result === 'object' ? { ...p.result as BacktestResult } : undefined,
+  };
+}
+
+const SEVERITY_RANK: Record<string, number> = {
+  INFO: 0, LOW: 1, MEDIUM: 2, HIGH: 3, CRITICAL: 4,
+};
+
+function severityRank(severity: string): number {
+  return SEVERITY_RANK[severity] ?? 0;
+}
+
+interface Score {
+  precision: number;
+  recall: number;
+}
+
+/** Treat observations with severity ≥ HIGH as positive ground truth.
+ *  Each changeType maps to a deterministic prediction function the
+ *  backtester can evaluate against the proposed and baseline params. */
+function scoreObservations(
+  observations: readonly ObservationEvent[],
+  changeType: BacktestChangeType,
+  params: Record<string, unknown>,
+): Score {
+  if (observations.length === 0) return { precision: 0, recall: 0 };
+  let tp = 0;
+  let fp = 0;
+  let fn = 0;
+  for (const obs of observations) {
+    const truth = severityRank(obs.severity) >= severityRank('HIGH');
+    const pred = predictObservation(obs, changeType, params);
+    if (pred && truth) tp += 1;
+    else if (pred && !truth) fp += 1;
+    else if (!pred && truth) fn += 1;
+  }
+  const precision = tp + fp === 0 ? 0 : tp / (tp + fp);
+  const recall = tp + fn === 0 ? 0 : tp / (tp + fn);
+  return { precision, recall };
+}
+
+function predictObservation(
+  obs: ObservationEvent,
+  changeType: BacktestChangeType,
+  params: Record<string, unknown>,
+): boolean {
+  const sev = severityRank(obs.severity);
+  if (changeType === 'rule') {
+    const tag = typeof params.tag === 'string' ? params.tag : '';
+    return tag.length > 0 && obs.tags.includes(tag);
+  }
+  if (changeType === 'weight') {
+    const weight = typeof params.weight === 'number' ? params.weight : 1;
+    const cutoff = typeof params.cutoff === 'number' ? params.cutoff : 3;
+    return sev * weight >= cutoff;
+  }
+  // threshold + config share the same predicate: severity rank ≥ threshold.
+  const threshold = typeof params.threshold === 'number' ? params.threshold : 3;
+  return sev >= threshold;
 }
 
 function safeStorage(): Storage | null {

--- a/tests/intelligence/backtest-gate.test.mts
+++ b/tests/intelligence/backtest-gate.test.mts
@@ -458,3 +458,487 @@ test('teardown clears singleton + storage', () => {
   void _v;
   assert.ok(true);
 });
+
+// ═══════════════════════════════════════════════════════════════════════
+// Proposal API — `BacktestProposal` / `BacktestResult` (precision-recall
+// gate against historical observation fixtures).
+// ═══════════════════════════════════════════════════════════════════════
+
+import type {
+  BacktestProposal,
+  BacktestResult as ProposalBacktestResult,
+} from '../../src/services/intelligence/backtest-gate.ts';
+import type { ObservationEvent, ObservationSeverity } from '../../src/types/intelligence';
+
+function freshProposalGate(): BacktestGate {
+  __storage.clear();
+  __resetBacktestGateSingleton();
+  const gate = new BacktestGate({ clock: () => 1_780_000_000_000 });
+  gate.resetForTesting();
+  return gate;
+}
+
+function obs(id: string, severity: ObservationSeverity, tags: string[] = [], domain = 'maritime'): ObservationEvent {
+  return {
+    id,
+    sourceId: 'fixture',
+    domain,
+    timestamp: 0,
+    severity,
+    title: id,
+    raw: {},
+    entityIds: [],
+    tags,
+  };
+}
+
+function balancedFixture(): ObservationEvent[] {
+  return [
+    obs('h1', 'HIGH', ['storm']),
+    obs('h2', 'CRITICAL', ['storm']),
+    obs('h3', 'HIGH', ['storm']),
+    obs('h4', 'HIGH', ['storm']),
+    obs('l1', 'LOW', ['noise']),
+    obs('l2', 'MEDIUM', ['noise']),
+    obs('l3', 'INFO', ['noise']),
+    obs('l4', 'LOW', ['noise']),
+  ];
+}
+
+// ── submitProposal ────────────────────────────────────────────────────
+
+test('submitProposal: stores a pending proposal with defaults', () => {
+  const gate = freshProposalGate();
+  const p = gate.submitProposal({
+    description: 'Tighten threshold',
+    changeType: 'threshold',
+    proposedChange: { threshold: 4 },
+    currentValue: { threshold: 3 },
+  });
+  assert.equal(p.status, 'pending');
+  assert.equal(p.description, 'Tighten threshold');
+  assert.equal(p.changeType, 'threshold');
+  assert.ok(p.id.startsWith('prop-'));
+  assert.equal(p.createdAt, 1_780_000_000_000);
+  assert.equal(p.completedAt, undefined);
+  assert.equal(p.result, undefined);
+});
+
+test('submitProposal: preserves caller-supplied id', () => {
+  const gate = freshProposalGate();
+  const p = gate.submitProposal({
+    id: 'manual-1',
+    description: 'd',
+    changeType: 'weight',
+    proposedChange: { weight: 1.5 },
+    currentValue: { weight: 1 },
+  });
+  assert.equal(p.id, 'manual-1');
+});
+
+test('submitProposal: returns a defensive copy (mutating proposedChange has no effect)', () => {
+  const gate = freshProposalGate();
+  const p = gate.submitProposal({
+    description: '',
+    changeType: 'config',
+    proposedChange: { threshold: 3 },
+    currentValue: { threshold: 2 },
+  });
+  (p.proposedChange as Record<string, unknown>).threshold = 99;
+  const stored = gate.getProposal(p.id)!;
+  assert.equal(stored.proposedChange.threshold, 3);
+});
+
+test('submitProposal: shows up in getProposals() in insertion order', () => {
+  const gate = freshProposalGate();
+  const a = gate.submitProposal({ description: 'a', changeType: 'rule', proposedChange: { tag: 'x' }, currentValue: { tag: 'y' } });
+  const b = gate.submitProposal({ description: 'b', changeType: 'rule', proposedChange: { tag: 'x' }, currentValue: { tag: 'y' } });
+  const list = gate.getProposals();
+  assert.equal(list.length, 2);
+  assert.equal(list[0]!.id, a.id);
+  assert.equal(list[1]!.id, b.id);
+});
+
+test('submitProposal: re-submitting with the same id updates in place (no duplicate row)', () => {
+  const gate = freshProposalGate();
+  const a = gate.submitProposal({ id: 'dupe', description: 'first', changeType: 'config', proposedChange: { threshold: 1 }, currentValue: { threshold: 1 } });
+  const b = gate.submitProposal({ id: 'dupe', description: 'second', changeType: 'config', proposedChange: { threshold: 2 }, currentValue: { threshold: 1 } });
+  assert.equal(a.id, b.id);
+  assert.equal(gate.getProposals().length, 1);
+  assert.equal(gate.getProposals()[0]!.description, 'second');
+});
+
+// ── runBacktest: math ─────────────────────────────────────────────────
+
+test('runBacktest: threshold change with no precision/recall regression is approved', () => {
+  const gate = freshProposalGate();
+  // proposedChange threshold = currentValue threshold = baseline.
+  // identical params ⇒ delta = 0 ⇒ approved.
+  const proposal = gate.submitProposal({
+    description: 'no-op',
+    changeType: 'threshold',
+    proposedChange: { threshold: 3 },
+    currentValue: { threshold: 3 },
+  });
+  const result = gate.runBacktest(proposal.id, balancedFixture());
+  assert.equal(result.precisionDelta, 0);
+  assert.equal(result.recallDelta, 0);
+  assert.equal(result.approved, true);
+  assert.match(result.reason, /Approved/);
+});
+
+test('runBacktest: raising threshold past every positive label tanks recall → rejected', () => {
+  const gate = freshProposalGate();
+  const proposal = gate.submitProposal({
+    description: 'too tight',
+    changeType: 'threshold',
+    proposedChange: { threshold: 9 },
+    currentValue: { threshold: 3 },
+  });
+  const result = gate.runBacktest(proposal.id, balancedFixture());
+  // proposed picks 0 positives → recall=0; baseline at 3 picks all HIGH/CRIT → recall=1
+  assert.equal(result.historicalRecall, 0);
+  assert.equal(result.baselineRecall, 1);
+  assert.equal(result.recallDelta, -1);
+  assert.equal(result.approved, false);
+  assert.match(result.reason, /recall/);
+});
+
+test('runBacktest: lowering threshold to floor picks every event → precision crashes → rejected', () => {
+  const gate = freshProposalGate();
+  const proposal = gate.submitProposal({
+    description: 'too loose',
+    changeType: 'threshold',
+    proposedChange: { threshold: 0 },
+    currentValue: { threshold: 3 },
+  });
+  const result = gate.runBacktest(proposal.id, balancedFixture());
+  // proposed picks all 8 → 4 TP + 4 FP → precision=0.5
+  // baseline picks 4 HIGH/CRIT → 4 TP + 0 FP → precision=1
+  assert.equal(result.historicalPrecision, 0.5);
+  assert.equal(result.baselinePrecision, 1);
+  assert.equal(result.precisionDelta, -0.5);
+  assert.equal(result.approved, false);
+  assert.match(result.reason, /precision/);
+});
+
+test('runBacktest: weight change uses weight*severity vs cutoff', () => {
+  const gate = freshProposalGate();
+  const proposal = gate.submitProposal({
+    description: 'weight tweak',
+    changeType: 'weight',
+    proposedChange: { weight: 2, cutoff: 5 },
+    currentValue: { weight: 1, cutoff: 3 },
+  });
+  const result = gate.runBacktest(proposal.id, balancedFixture());
+  // baseline picks rank ≥ 3 (HIGH/CRIT) → 4 TP, precision=1, recall=1
+  // proposed picks rank*2 ≥ 5 → CRIT(8), HIGH(6), MEDIUM(4 < 5 skip), LOW(2 skip)
+  //   ⇒ 4 TP (3 HIGH + 1 CRIT), precision=1, recall=1
+  assert.equal(result.historicalPrecision, 1);
+  assert.equal(result.historicalRecall, 1);
+  assert.equal(result.approved, true);
+});
+
+test('runBacktest: rule change predicts positive when tag matches', () => {
+  const gate = freshProposalGate();
+  const proposal = gate.submitProposal({
+    description: 'storm rule',
+    changeType: 'rule',
+    proposedChange: { tag: 'storm' },
+    currentValue: { tag: 'storm' },
+  });
+  const result = gate.runBacktest(proposal.id, balancedFixture());
+  // tag='storm' is exactly on the positive examples ⇒ precision=recall=1.
+  assert.equal(result.historicalPrecision, 1);
+  assert.equal(result.historicalRecall, 1);
+  assert.equal(result.approved, true);
+});
+
+test('runBacktest: rule change with empty tag predicts nothing → recall 0', () => {
+  const gate = freshProposalGate();
+  const proposal = gate.submitProposal({
+    description: 'empty rule',
+    changeType: 'rule',
+    proposedChange: { tag: '' },
+    currentValue: { tag: 'storm' },
+  });
+  const result = gate.runBacktest(proposal.id, balancedFixture());
+  assert.equal(result.historicalPrecision, 0);
+  assert.equal(result.historicalRecall, 0);
+  assert.equal(result.approved, false);
+});
+
+test('runBacktest: config change behaves like threshold', () => {
+  const gate = freshProposalGate();
+  const proposal = gate.submitProposal({
+    description: 'config tweak',
+    changeType: 'config',
+    proposedChange: { threshold: 3 },
+    currentValue: { threshold: 3 },
+  });
+  const result = gate.runBacktest(proposal.id, balancedFixture());
+  assert.equal(result.precisionDelta, 0);
+  assert.equal(result.recallDelta, 0);
+  assert.equal(result.approved, true);
+});
+
+test('runBacktest: empty observation set yields zeroed precision/recall, still approved (no regression)', () => {
+  const gate = freshProposalGate();
+  const proposal = gate.submitProposal({
+    description: 'empty',
+    changeType: 'threshold',
+    proposedChange: { threshold: 4 },
+    currentValue: { threshold: 3 },
+  });
+  const result = gate.runBacktest(proposal.id, []);
+  assert.equal(result.historicalPrecision, 0);
+  assert.equal(result.baselinePrecision, 0);
+  assert.equal(result.precisionDelta, 0);
+  assert.equal(result.recallDelta, 0);
+  assert.equal(result.approved, true);
+});
+
+test('runBacktest: precision drop within −0.05 floor is approved', () => {
+  const gate = freshProposalGate();
+  // 4 positives, 16 negatives. proposed adds 1 FP → precision = 4/5 = 0.8.
+  // baseline picks only positives → precision = 1. Delta = −0.2 ⇒ rejected.
+  // Use a milder shape: 1 added FP among 20 baseline-correct cases.
+  const events: ObservationEvent[] = [
+    ...Array.from({ length: 20 }, (_, i) => obs(`h${i}`, 'CRITICAL', ['p'])),
+    obs('edge', 'MEDIUM', ['p']), // proposed catches this when threshold drops to 2
+  ];
+  const proposal = gate.submitProposal({
+    description: 'mild',
+    changeType: 'threshold',
+    proposedChange: { threshold: 2 },
+    currentValue: { threshold: 3 },
+  });
+  const result = gate.runBacktest(proposal.id, events);
+  // proposed: 20 TP + 1 FP = 21 predicted, precision 20/21 ≈ 0.9524, recall 1
+  // baseline: 20 TP + 0 FP = 20 predicted, precision 1, recall 1
+  // precisionDelta ≈ −0.0476  → above −0.05 floor → approved
+  assert.ok(Math.abs(result.precisionDelta + 0.0476) < 0.0005);
+  assert.equal(result.recallDelta, 0);
+  assert.equal(result.approved, true);
+});
+
+test('runBacktest: precision drop beyond −0.05 floor is rejected', () => {
+  const gate = freshProposalGate();
+  const events: ObservationEvent[] = [
+    ...Array.from({ length: 10 }, (_, i) => obs(`h${i}`, 'CRITICAL', [])),
+    ...Array.from({ length: 2 }, (_, i) => obs(`m${i}`, 'MEDIUM', [])),
+  ];
+  const proposal = gate.submitProposal({
+    description: 'too lossy',
+    changeType: 'threshold',
+    proposedChange: { threshold: 2 },
+    currentValue: { threshold: 3 },
+  });
+  const result = gate.runBacktest(proposal.id, events);
+  // proposed: 10 TP + 2 FP = 12 predictions, precision = 10/12 ≈ 0.833
+  // baseline: 10 TP + 0 FP, precision = 1; delta ≈ −0.167 < −0.05 → rejected
+  assert.ok(result.precisionDelta < -0.05);
+  assert.equal(result.approved, false);
+});
+
+test('runBacktest: result.proposalId matches the proposal id', () => {
+  const gate = freshProposalGate();
+  const proposal = gate.submitProposal({
+    description: '',
+    changeType: 'threshold',
+    proposedChange: { threshold: 3 },
+    currentValue: { threshold: 3 },
+  });
+  const result = gate.runBacktest(proposal.id, balancedFixture());
+  assert.equal(result.proposalId, proposal.id);
+});
+
+test('runBacktest: result is attached to the proposal record', () => {
+  const gate = freshProposalGate();
+  const proposal = gate.submitProposal({
+    description: '',
+    changeType: 'threshold',
+    proposedChange: { threshold: 3 },
+    currentValue: { threshold: 3 },
+  });
+  gate.runBacktest(proposal.id, balancedFixture());
+  const stored = gate.getProposal(proposal.id)!;
+  assert.ok(stored.result);
+  assert.equal(stored.result!.proposalId, proposal.id);
+  assert.ok(stored.completedAt !== undefined);
+});
+
+test('runBacktest: status transitions to approved on success', () => {
+  const gate = freshProposalGate();
+  const p = gate.submitProposal({
+    description: '',
+    changeType: 'threshold',
+    proposedChange: { threshold: 3 },
+    currentValue: { threshold: 3 },
+  });
+  gate.runBacktest(p.id, balancedFixture());
+  assert.equal(gate.getProposal(p.id)!.status, 'approved');
+});
+
+test('runBacktest: status transitions to rejected on regression', () => {
+  const gate = freshProposalGate();
+  const p = gate.submitProposal({
+    description: '',
+    changeType: 'threshold',
+    proposedChange: { threshold: 9 },
+    currentValue: { threshold: 3 },
+  });
+  gate.runBacktest(p.id, balancedFixture());
+  assert.equal(gate.getProposal(p.id)!.status, 'rejected');
+});
+
+test('runBacktest: throws on unknown proposal id', () => {
+  const gate = freshProposalGate();
+  assert.throws(() => gate.runBacktest('nope', balancedFixture()), /not found/);
+});
+
+// ── approve / reject ─────────────────────────────────────────────────
+
+test('approve: flips status to approved + stamps completedAt', () => {
+  const gate = freshProposalGate();
+  const p = gate.submitProposal({
+    description: '',
+    changeType: 'threshold',
+    proposedChange: { threshold: 3 },
+    currentValue: { threshold: 3 },
+  });
+  const updated = gate.approve(p.id);
+  assert.equal(updated?.status, 'approved');
+  assert.ok(updated?.completedAt !== undefined);
+});
+
+test('approve: returns undefined for unknown id', () => {
+  const gate = freshProposalGate();
+  assert.equal(gate.approve('ghost'), undefined);
+});
+
+test('reject: stores the reason on the proposal result', () => {
+  const gate = freshProposalGate();
+  const p = gate.submitProposal({
+    description: '',
+    changeType: 'threshold',
+    proposedChange: { threshold: 3 },
+    currentValue: { threshold: 3 },
+  });
+  const updated = gate.reject(p.id, 'manual operator veto');
+  assert.equal(updated?.status, 'rejected');
+  assert.equal(updated?.result?.approved, false);
+  assert.match(updated!.result!.reason, /operator veto/);
+});
+
+test('reject: preserves a prior result snapshot when overriding', () => {
+  const gate = freshProposalGate();
+  const p = gate.submitProposal({
+    description: '',
+    changeType: 'threshold',
+    proposedChange: { threshold: 3 },
+    currentValue: { threshold: 3 },
+  });
+  gate.runBacktest(p.id, balancedFixture());
+  const before = gate.getProposal(p.id)!.result!;
+  const updated = gate.reject(p.id, 'overruled');
+  // Numeric precision/recall numbers carry over from the prior backtest.
+  assert.equal(updated?.result?.historicalPrecision, before.historicalPrecision);
+  assert.equal(updated?.result?.approved, false);
+});
+
+test('reject: returns undefined for unknown id', () => {
+  const gate = freshProposalGate();
+  assert.equal(gate.reject('ghost', 'whatever'), undefined);
+});
+
+// ── getProposals / getProposal ───────────────────────────────────────
+
+test('getProposals: empty registry returns []', () => {
+  const gate = freshProposalGate();
+  assert.deepEqual(gate.getProposals(), []);
+});
+
+test('getProposal: returns undefined when id is unknown', () => {
+  const gate = freshProposalGate();
+  assert.equal(gate.getProposal('nope'), undefined);
+});
+
+test('getProposal: returns a defensive copy (mutation does not bleed)', () => {
+  const gate = freshProposalGate();
+  const p = gate.submitProposal({
+    description: 'mut',
+    changeType: 'config',
+    proposedChange: { threshold: 1 },
+    currentValue: { threshold: 1 },
+  });
+  const snap = gate.getProposal(p.id)!;
+  snap.description = 'mutated';
+  assert.equal(gate.getProposal(p.id)!.description, 'mut');
+});
+
+// ── Persistence ──────────────────────────────────────────────────────
+
+test('proposals survive across BacktestGate instances via localStorage', () => {
+  __storage.clear();
+  __resetBacktestGateSingleton();
+  const a = new BacktestGate({ clock: () => 1 });
+  a.resetForTesting();
+  a.submitProposal({
+    description: 'across',
+    changeType: 'rule',
+    proposedChange: { tag: 't' },
+    currentValue: { tag: 'u' },
+  });
+  const b = new BacktestGate({ clock: () => 2 });
+  assert.equal(b.getProposals().length, 1);
+  assert.equal(b.getProposals()[0]!.description, 'across');
+});
+
+test('cap: proposal history evicts oldest beyond 200', () => {
+  const gate = freshProposalGate();
+  for (let i = 0; i < 205; i += 1) {
+    gate.submitProposal({
+      id: `p-${i}`,
+      description: '',
+      changeType: 'config',
+      proposedChange: {},
+      currentValue: {},
+    });
+  }
+  const list = gate.getProposals();
+  assert.equal(list.length, 200);
+  assert.equal(list[0]!.id, 'p-5');
+  assert.equal(list[199]!.id, 'p-204');
+});
+
+test('corrupted proposal blob is dropped without throwing', () => {
+  __storage.clear();
+  __resetBacktestGateSingleton();
+  __storage.set('wm-backtest-gate', JSON.stringify({ proposals: [{ id: '', changeType: 'bogus' }] }));
+  const gate = new BacktestGate();
+  assert.deepEqual(gate.getProposals(), []);
+});
+
+// ── Singleton ────────────────────────────────────────────────────────
+
+test('BacktestGate.getInstance() returns the same singleton as getBacktestGate()', () => {
+  __resetBacktestGateSingleton();
+  const a = BacktestGate.getInstance();
+  const b = getBacktestGate();
+  assert.equal(a, b);
+});
+
+test('typed BacktestResult mirrors the proposal id', () => {
+  const gate = freshProposalGate();
+  const p = gate.submitProposal({
+    description: 'shape',
+    changeType: 'threshold',
+    proposedChange: { threshold: 3 },
+    currentValue: { threshold: 3 },
+  });
+  const r: ProposalBacktestResult = gate.runBacktest(p.id, balancedFixture());
+  assert.equal(r.proposalId, p.id);
+  const stored: BacktestProposal | undefined = gate.getProposal(p.id);
+  assert.ok(stored !== undefined);
+});


### PR DESCRIPTION
## Summary

Extends `BacktestGate` with a generic proposal surface so callers can ship any algorithm / threshold / weight / rule / config change through a precision-recall regression check against a labeled historical observation set, without encoding the change as an algoId/paramName pair.

## What ships

- **Types** — `BacktestProposal { id, description, changeType, proposedChange, currentValue, status, createdAt, completedAt?, result? }` and `BacktestResult { proposalId, historicalPrecision, historicalRecall, baselinePrecision, baselineRecall, precisionDelta, recallDelta, approved, reason }`. The existing `BacktestResult` import from `backtest-engine` is aliased to `EngineBacktestResult` to avoid the name clash.
- **API** — `submitProposal`, `runBacktest(id, historicalObservations)`, `approve(id)`, `reject(id, reason)`, `getProposals()` on the existing `BacktestGate` class, plus a static `BacktestGate.getInstance()` that aliases the existing `getBacktestGate()` singleton so callers can reach the gate without an extra import.
- **Scoring** — `runBacktest` scores each observation deterministically per `changeType` (threshold/config: severity-rank ≥ threshold, weight: rank × weight ≥ cutoff, rule: tag match), computes TP/FP/FN against `severity ≥ HIGH` ground truth, and approves only when both `precisionΔ ≥ -0.05` AND `recallΔ ≥ -0.05`. Empty observation sets resolve to `(0,0)` and approve.
- **Persistence** — shares the existing `wm-backtest-gate` localStorage envelope. Proposal history capped at **200** entries; oldest evicted FIFO. Hydrate/persist extended to include the `proposals` array; corrupt entries dropped silently.
- **Tests** — 33 new tests in `tests/intelligence/backtest-gate.test.mts` on top of the 36 existing ones (69 total, all passing). Coverage: submit defaults + dedupe + cap, `runBacktest` math for each changeType, edge cases (empty fixture, exactly-at-floor, beyond-floor), approve/reject lifecycle, persistence + corruption resilience, `getInstance()` singleton.

## Verification

- `npm run typecheck:all` — clean
- `npx eslint` on touched files — clean
- `npx tsx --test tests/intelligence/backtest-gate.test.mts` — 69 pass / 0 fail (33 new + 36 pre-existing untouched)

## Cross-agent review

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass