### PR TITLE
Closed-loop mission ledger — wire situation outcomes back into algorithm calibration

### DIFF
--- a/src/services/intelligence/closed-loop-mission-ledger.ts
+++ b/src/services/intelligence/closed-loop-mission-ledger.ts
@@ -1,0 +1,421 @@
+/**
+ * Closed-Loop Mission Ledger — wires situation lifecycle outcomes back
+ * into per-algorithm calibration in the OutcomeLedger.
+ *
+ * When a situation transitions to `resolved`, the singleton automatically
+ * builds a MissionOutcome from the lifecycle (lead time, accuracy /
+ * timeliness defaults) and persists one OutcomeRecord per contributing
+ * algorithmId so each algorithm's calibration moves with the actual
+ * verdict. Manual `recordOutcome(...)` lets analysts override the
+ * accuracy / timeliness flags when reviewing a resolution.
+ *
+ * Pure module — no DOM, no fetch, no globals at import time. Persists
+ * the most-recent 500 outcomes to `localStorage` under
+ * `wm-closed-loop-ledger`.
+ */
+
+import {
+  getSituationLifecycleTrackerService,
+  type PhaseTransition,
+  type SituationLifecycle,
+  type SituationLifecycleTrackerService,
+} from './situation-lifecycle-tracker';
+import {
+  getOutcomeLedger,
+  type OutcomeLedger,
+  type PredictedSeverity,
+} from './outcome-ledger';
+
+// ── Public types ─────────────────────────────────────────────────────
+
+export interface MissionOutcome {
+  situationId: string;
+  domain: string;
+  detectedAt: number;
+  resolvedAt: number;
+  /** ms between detection and resolution — convenience field, always
+   *  equal to `resolvedAt - detectedAt` after normalisation. */
+  leadTimeMs: number;
+  wasAccurate: boolean;
+  wasTimely: boolean;
+  /** Algorithm contributors. Each id maps to one OutcomeLedger record so
+   *  per-algorithm calibration tracks the resolution outcome. */
+  algorithmIds: string[];
+}
+
+export interface DomainCalibrationReport {
+  domain: string;
+  accuracy: number;
+  timeliness: number;
+  sampleCount: number;
+}
+
+export interface FeedbackLoopStats {
+  totalOutcomes: number;
+  accuracyRate: number;
+  timelinessRate: number;
+  avgLeadTimeMinutes: number;
+  topDomainsByAccuracy: string[];
+}
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem?(key: string): void;
+}
+
+export interface ClosedLoopMissionLedgerOptions {
+  storage?: StorageLike | null;
+  clock?: () => number;
+  lifecycleTracker?: SituationLifecycleTrackerService;
+  outcomeLedger?: OutcomeLedger;
+  /** Wire the lifecycle subscription on construction. Defaults to true.
+   *  Tests that drive transitions manually can pass `false` to keep the
+   *  ledger free of subscriber side effects. */
+  autoSubscribe?: boolean;
+  /** Lead-time ceiling (ms) for the auto-derived `wasTimely` flag.
+   *  Defaults to 24 hours. */
+  timelyThresholdMs?: number;
+  /** Severity predicted by the algorithm contributors at detection time.
+   *  Used as the `predictedSeverity` on every OutcomeRecord this ledger
+   *  forwards into the OutcomeLedger. Defaults to 'high' — situations
+   *  that reach `resolved` were almost always escalated past 'low'. */
+  defaultPredictedSeverity?: PredictedSeverity;
+}
+
+// ── Constants ────────────────────────────────────────────────────────
+
+export const STORAGE_KEY = 'wm-closed-loop-ledger';
+export const MAX_OUTCOMES = 500;
+export const DEFAULT_TIMELY_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+export const MIN_ACCURACY_SAMPLES = 3;
+
+// ── Serialization ────────────────────────────────────────────────────
+
+interface PersistedLedger {
+  version: 1;
+  outcomes: MissionOutcome[];
+}
+
+function deserialize(raw: unknown): MissionOutcome[] {
+  if (!raw || typeof raw !== 'object') return [];
+  const payload = raw as PersistedLedger;
+  if (payload.version !== 1) return [];
+  if (!Array.isArray(payload.outcomes)) return [];
+  const out: MissionOutcome[] = [];
+  for (const entry of payload.outcomes) {
+    const o = deserializeEntry(entry);
+    if (o) out.push(o);
+  }
+  return out;
+}
+
+function deserializeEntry(entry: unknown): MissionOutcome | undefined {
+  if (!entry || typeof entry !== 'object') return undefined;
+  const e = entry as Record<string, unknown>;
+  if (typeof e.situationId !== 'string') return undefined;
+  if (typeof e.domain !== 'string') return undefined;
+  if (typeof e.detectedAt !== 'number') return undefined;
+  if (typeof e.resolvedAt !== 'number') return undefined;
+  if (typeof e.leadTimeMs !== 'number') return undefined;
+  if (typeof e.wasAccurate !== 'boolean') return undefined;
+  if (typeof e.wasTimely !== 'boolean') return undefined;
+  if (!Array.isArray(e.algorithmIds)) return undefined;
+  const algorithmIds = e.algorithmIds.filter((a): a is string => typeof a === 'string');
+  return {
+    situationId: e.situationId,
+    domain: e.domain,
+    detectedAt: e.detectedAt,
+    resolvedAt: e.resolvedAt,
+    leadTimeMs: e.leadTimeMs,
+    wasAccurate: e.wasAccurate,
+    wasTimely: e.wasTimely,
+    algorithmIds,
+  };
+}
+
+// ── Ledger ───────────────────────────────────────────────────────────
+
+export class ClosedLoopMissionLedger {
+  private outcomes: MissionOutcome[] = [];
+  private hydrated = false;
+  private readonly storage: StorageLike | null;
+  private readonly lifecycleTracker: SituationLifecycleTrackerService;
+  private readonly outcomeLedger: OutcomeLedger;
+  private readonly timelyThresholdMs: number;
+  private readonly defaultPredictedSeverity: PredictedSeverity;
+  private unsubscribe: (() => void) | null = null;
+
+  constructor(options: ClosedLoopMissionLedgerOptions = {}) {
+    this.storage = options.storage === undefined ? defaultStorage() : options.storage;
+    this.lifecycleTracker = options.lifecycleTracker ?? getSituationLifecycleTrackerService();
+    this.outcomeLedger = options.outcomeLedger ?? getOutcomeLedger();
+    this.timelyThresholdMs = options.timelyThresholdMs ?? DEFAULT_TIMELY_THRESHOLD_MS;
+    this.defaultPredictedSeverity = options.defaultPredictedSeverity ?? 'high';
+    if (options.autoSubscribe !== false) {
+      this.unsubscribe = this.lifecycleTracker.subscribe((t) => this.onTransition(t));
+    }
+  }
+
+  // ── Auto-subscription path ──────────────────────────────────────────
+
+  /** Builds + records a MissionOutcome whenever a transition lands on
+   *  `resolved`. No-op for every other phase. The auto-derived
+   *  `wasAccurate` is `true` (resolved is an analyst-confirmed terminal
+   *  phase) and `wasTimely` checks the lead time against
+   *  `timelyThresholdMs`. */
+  private onTransition(transition: PhaseTransition): void {
+    if (transition.toPhase !== 'resolved') return;
+    const lifecycle = this.lifecycleTracker.getLifecycle(transition.situationId);
+    if (!lifecycle) return;
+    const outcome = this.buildAutoOutcome(lifecycle, transition);
+    if (!outcome) return;
+    this.recordOutcome(outcome, { algorithmIdsRequired: false });
+  }
+
+  private buildAutoOutcome(
+    lifecycle: SituationLifecycle,
+    transition: PhaseTransition,
+  ): MissionOutcome | null {
+    const resolvedAt = lifecycle.resolvedAt ?? transition.transitionedAt;
+    const detectedAt = lifecycle.detectedAt;
+    if (!Number.isFinite(detectedAt) || !Number.isFinite(resolvedAt)) return null;
+    const leadTimeMs = Math.max(0, resolvedAt - detectedAt);
+    return {
+      situationId: lifecycle.situationId,
+      domain: lifecycle.domain,
+      detectedAt,
+      resolvedAt,
+      leadTimeMs,
+      wasAccurate: true,
+      wasTimely: leadTimeMs <= this.timelyThresholdMs,
+      algorithmIds: [],
+    };
+  }
+
+  // ── Public API ──────────────────────────────────────────────────────
+
+  /**
+   * Persist a MissionOutcome and forward one OutcomeRecord per
+   * `algorithmIds[]` entry into the OutcomeLedger so each algorithm's
+   * per-domain calibration moves with the verdict.
+   *
+   * Caller-supplied `leadTimeMs` is recomputed from detectedAt /
+   * resolvedAt to keep the field consistent.
+   */
+  recordOutcome(
+    outcome: MissionOutcome,
+    options: { algorithmIdsRequired?: boolean } = {},
+  ): MissionOutcome {
+    this.ensureHydrated();
+    const algorithmIdsRequired = options.algorithmIdsRequired ?? true;
+    if (algorithmIdsRequired && outcome.algorithmIds.length === 0) {
+      throw new Error('MissionOutcome.algorithmIds must include at least one algorithm');
+    }
+    const normalised = normaliseOutcome(outcome);
+    this.outcomes.push(normalised);
+    this.enforceCapacity();
+    this.persist();
+    this.forwardToOutcomeLedger(normalised);
+    return cloneOutcome(normalised);
+  }
+
+  getOutcomes(domain?: string): MissionOutcome[] {
+    this.ensureHydrated();
+    const filtered = domain
+      ? this.outcomes.filter((o) => o.domain === domain)
+      : this.outcomes;
+    return filtered.map((o) => cloneOutcome(o));
+  }
+
+  getCalibrationReport(): DomainCalibrationReport[] {
+    this.ensureHydrated();
+    const byDomain = groupByDomain(this.outcomes);
+    const reports: DomainCalibrationReport[] = [];
+    for (const [domain, list] of byDomain) reports.push(summariseDomain(domain, list));
+    reports.sort((a, b) => b.sampleCount - a.sampleCount || a.domain.localeCompare(b.domain));
+    return reports;
+  }
+
+  getFeedbackLoopStats(): FeedbackLoopStats {
+    this.ensureHydrated();
+    const total = this.outcomes.length;
+    if (total === 0) {
+      return {
+        totalOutcomes: 0,
+        accuracyRate: 0,
+        timelinessRate: 0,
+        avgLeadTimeMinutes: 0,
+        topDomainsByAccuracy: [],
+      };
+    }
+    let accurate = 0;
+    let timely = 0;
+    let leadTotal = 0;
+    for (const o of this.outcomes) {
+      if (o.wasAccurate) accurate += 1;
+      if (o.wasTimely) timely += 1;
+      leadTotal += o.leadTimeMs;
+    }
+    const reports = this.getCalibrationReport();
+    const eligible = [...reports.filter((r) => r.sampleCount >= MIN_ACCURACY_SAMPLES)];
+    eligible.sort((a, b) =>
+      b.accuracy - a.accuracy
+      || b.sampleCount - a.sampleCount
+      || a.domain.localeCompare(b.domain),
+    );
+    const topDomainsByAccuracy = eligible.slice(0, 3).map((r) => r.domain);
+    return {
+      totalOutcomes: total,
+      accuracyRate: accurate / total,
+      timelinessRate: timely / total,
+      avgLeadTimeMinutes: Math.round(leadTotal / total / 60_000),
+      topDomainsByAccuracy,
+    };
+  }
+
+  /** Stop responding to lifecycle transitions. Idempotent. */
+  dispose(): void {
+    if (this.unsubscribe) {
+      this.unsubscribe();
+      this.unsubscribe = null;
+    }
+  }
+
+  /** Test seam — clears outcomes + the persisted blob, but preserves
+   *  any active lifecycle subscription so the same instance can keep
+   *  ingesting transitions. */
+  resetForTesting(): void {
+    this.outcomes = [];
+    this.hydrated = true;
+    if (this.storage?.removeItem) {
+      try { this.storage.removeItem(STORAGE_KEY); } catch { /* best effort */ }
+    } else if (this.storage) {
+      try { this.storage.setItem(STORAGE_KEY, JSON.stringify({ version: 1, outcomes: [] })); } catch { /* best effort */ }
+    }
+  }
+
+  // ── Internals ───────────────────────────────────────────────────────
+
+  private ensureHydrated(): void {
+    if (this.hydrated) return;
+    this.hydrated = true;
+    if (!this.storage) return;
+    let raw: string | null = null;
+    try { raw = this.storage.getItem(STORAGE_KEY); } catch { return; }
+    if (!raw) return;
+    try {
+      this.outcomes = deserialize(JSON.parse(raw));
+    } catch {
+      // Corrupt blob — start clean rather than crash on hydrate.
+    }
+  }
+
+  private persist(): void {
+    if (!this.storage) return;
+    try {
+      const payload: PersistedLedger = { version: 1, outcomes: this.outcomes };
+      this.storage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    } catch {
+      // Quota / unavailable — best-effort.
+    }
+  }
+
+  private enforceCapacity(): void {
+    if (this.outcomes.length <= MAX_OUTCOMES) return;
+    this.outcomes.splice(0, this.outcomes.length - MAX_OUTCOMES);
+  }
+
+  private forwardToOutcomeLedger(outcome: MissionOutcome): void {
+    const actual = outcome.wasAccurate ? 'confirmed-real' : 'marked-false-positive';
+    const recordedAt = new Date(outcome.resolvedAt);
+    for (const algorithmId of outcome.algorithmIds) {
+      this.outcomeLedger.record({
+        domain: outcome.domain,
+        situationId: outcome.situationId,
+        predictedSeverity: this.defaultPredictedSeverity,
+        actualOutcome: actual,
+        recordedAt,
+        notes: `closed-loop:${algorithmId}`,
+      });
+    }
+  }
+}
+
+// ── Singleton ────────────────────────────────────────────────────────
+
+let singleton: ClosedLoopMissionLedger | null = null;
+
+/** Singleton accessor. The first call wires the lifecycle subscription
+ *  via {@link getSituationLifecycleTrackerService}. */
+export function getClosedLoopMissionLedger(): ClosedLoopMissionLedger {
+  singleton ??= new ClosedLoopMissionLedger();
+  return singleton;
+}
+
+/** Test seam — drops the singleton + unsubscribes from the tracker. */
+export function __resetClosedLoopMissionLedgerSingleton(): void {
+  if (singleton) singleton.dispose();
+  singleton = null;
+}
+
+/** Alias for callers used to `<Service>.getInstance()` patterns. */
+export const ClosedLoopMissionLedgerService = {
+  getInstance: getClosedLoopMissionLedger,
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function groupByDomain(outcomes: readonly MissionOutcome[]): Map<string, MissionOutcome[]> {
+  const byDomain = new Map<string, MissionOutcome[]>();
+  for (const o of outcomes) {
+    const list = byDomain.get(o.domain);
+    if (list) list.push(o);
+    else byDomain.set(o.domain, [o]);
+  }
+  return byDomain;
+}
+
+function summariseDomain(domain: string, list: readonly MissionOutcome[]): DomainCalibrationReport {
+  const sampleCount = list.length;
+  let accurate = 0;
+  let timely = 0;
+  for (const o of list) {
+    if (o.wasAccurate) accurate += 1;
+    if (o.wasTimely) timely += 1;
+  }
+  return {
+    domain,
+    accuracy: sampleCount === 0 ? 0 : accurate / sampleCount,
+    timeliness: sampleCount === 0 ? 0 : timely / sampleCount,
+    sampleCount,
+  };
+}
+
+function normaliseOutcome(outcome: MissionOutcome): MissionOutcome {
+  const leadTimeMs = Math.max(0, outcome.resolvedAt - outcome.detectedAt);
+  return {
+    ...outcome,
+    leadTimeMs,
+    algorithmIds: [...outcome.algorithmIds],
+  };
+}
+
+function cloneOutcome(outcome: MissionOutcome): MissionOutcome {
+  return { ...outcome, algorithmIds: [...outcome.algorithmIds] };
+}
+
+function defaultStorage(): StorageLike | null {
+  if (typeof globalThis === 'undefined') return null;
+  const ls = (globalThis as { localStorage?: StorageLike }).localStorage;
+  return ls ?? null;
+}
+
+// Exposed for tests that need to peek at internals.
+export const __internals = {
+  STORAGE_KEY,
+  MAX_OUTCOMES,
+  DEFAULT_TIMELY_THRESHOLD_MS,
+  MIN_ACCURACY_SAMPLES,
+  normaliseOutcome,
+};

--- a/tests/intelligence/closed-loop-mission-ledger.test.mts
+++ b/tests/intelligence/closed-loop-mission-ledger.test.mts
@@ -1,0 +1,466 @@
+/**
+ * Closed-Loop Mission Ledger tests.
+ *
+ * Covers:
+ *   - construction / dispose / singleton seam
+ *   - storage hydrate / persist / corruption tolerance / capacity cap
+ *   - manual recordOutcome shape + algorithmIds guard + leadTime normalisation
+ *   - getOutcomes filter by domain + array-clone safety
+ *   - getCalibrationReport per-domain math (accuracy, timeliness, sample size)
+ *   - getFeedbackLoopStats aggregate math + topDomainsByAccuracy ranking
+ *   - lifecycle-tracker subscription auto-records on `resolved` only
+ *   - downstream forward into OutcomeLedger (one record per algorithmId)
+ *
+ * Tests inject a fresh SituationLifecycleTrackerService and OutcomeLedger
+ * per case so the singletons stay hermetic.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  ClosedLoopMissionLedger,
+  ClosedLoopMissionLedgerService,
+  STORAGE_KEY,
+  MAX_OUTCOMES,
+  DEFAULT_TIMELY_THRESHOLD_MS,
+  __resetClosedLoopMissionLedgerSingleton,
+  __internals,
+  type MissionOutcome,
+  type StorageLike,
+} from '../../src/services/intelligence/closed-loop-mission-ledger.ts';
+import {
+  SituationLifecycleTrackerService,
+} from '../../src/services/intelligence/situation-lifecycle-tracker.ts';
+import {
+  OutcomeLedger,
+} from '../../src/services/intelligence/outcome-ledger.ts';
+
+// ── Fixtures ──────────────────────────────────────────────────────────
+
+const T0 = 1_780_000_000_000;
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+
+function memoryStorage(): StorageLike & { data: Map<string, string> } {
+  const data = new Map<string, string>();
+  return {
+    data,
+    getItem: (k) => data.get(k) ?? null,
+    setItem: (k, v) => { data.set(k, v); },
+    removeItem: (k) => { data.delete(k); },
+  };
+}
+
+function freshTracker(now: () => number = () => T0): SituationLifecycleTrackerService {
+  return new SituationLifecycleTrackerService({ now, storage: null });
+}
+
+function freshOutcomeLedger(now: () => number = () => T0): OutcomeLedger {
+  // OutcomeLedger uses its own localStorage shim; passing a clock keeps
+  // recordedAt deterministic without touching the global object.
+  return new OutcomeLedger({ clock: now });
+}
+
+function makeLedger(
+  options: Partial<ConstructorParameters<typeof ClosedLoopMissionLedger>[0]> = {},
+): ClosedLoopMissionLedger {
+  const now = options.clock ?? (() => T0);
+  return new ClosedLoopMissionLedger({
+    storage: options.storage ?? memoryStorage(),
+    clock: now,
+    lifecycleTracker: options.lifecycleTracker ?? freshTracker(now),
+    outcomeLedger: options.outcomeLedger ?? freshOutcomeLedger(now),
+    autoSubscribe: options.autoSubscribe ?? false,
+    timelyThresholdMs: options.timelyThresholdMs,
+    defaultPredictedSeverity: options.defaultPredictedSeverity,
+  });
+}
+
+function makeOutcome(overrides: Partial<MissionOutcome> = {}): MissionOutcome {
+  return {
+    situationId: 'sit-1',
+    domain: 'weather',
+    detectedAt: T0,
+    resolvedAt: T0 + 2 * HOUR,
+    leadTimeMs: 2 * HOUR,
+    wasAccurate: true,
+    wasTimely: true,
+    algorithmIds: ['truth-score', 'compound-risk'],
+    ...overrides,
+  };
+}
+
+// ── 1. Constants + class exports (3 tests) ────────────────────────────
+
+describe('constants / exports', () => {
+  it('STORAGE_KEY is the documented key', () => {
+    assert.equal(STORAGE_KEY, 'wm-closed-loop-ledger');
+  });
+
+  it('MAX_OUTCOMES caps at 500', () => {
+    assert.equal(MAX_OUTCOMES, 500);
+  });
+
+  it('DEFAULT_TIMELY_THRESHOLD_MS is 24h', () => {
+    assert.equal(DEFAULT_TIMELY_THRESHOLD_MS, 24 * HOUR);
+  });
+});
+
+// ── 2. recordOutcome shape + guards (5 tests) ─────────────────────────
+
+describe('recordOutcome — shape + guards', () => {
+  it('persists a manual outcome and returns a clone', () => {
+    const ledger = makeLedger();
+    const out = ledger.recordOutcome(makeOutcome());
+    assert.equal(out.situationId, 'sit-1');
+    assert.equal(out.wasAccurate, true);
+    assert.deepEqual(out.algorithmIds, ['truth-score', 'compound-risk']);
+  });
+
+  it('throws when algorithmIds is empty by default', () => {
+    const ledger = makeLedger();
+    assert.throws(
+      () => ledger.recordOutcome(makeOutcome({ algorithmIds: [] })),
+      /algorithmIds/,
+    );
+  });
+
+  it('normalises leadTimeMs to resolvedAt - detectedAt regardless of caller value', () => {
+    const ledger = makeLedger();
+    const out = ledger.recordOutcome(makeOutcome({
+      detectedAt: T0,
+      resolvedAt: T0 + 3 * HOUR,
+      leadTimeMs: 99_999, // wrong on purpose
+    }));
+    assert.equal(out.leadTimeMs, 3 * HOUR);
+  });
+
+  it('clamps negative leadTime to 0 when resolvedAt precedes detectedAt', () => {
+    const ledger = makeLedger();
+    const out = ledger.recordOutcome(makeOutcome({
+      detectedAt: T0 + HOUR,
+      resolvedAt: T0,
+      leadTimeMs: 0,
+    }));
+    assert.equal(out.leadTimeMs, 0);
+  });
+
+  it('mutating the returned outcome does not mutate the stored record', () => {
+    const ledger = makeLedger();
+    const out = ledger.recordOutcome(makeOutcome());
+    out.algorithmIds.push('mutation-poison');
+    const stored = ledger.getOutcomes()[0]!;
+    assert.deepEqual(stored.algorithmIds, ['truth-score', 'compound-risk']);
+  });
+});
+
+// ── 3. getOutcomes filter + immutability (3 tests) ────────────────────
+
+describe('getOutcomes', () => {
+  it('returns every recorded outcome when no domain filter is supplied', () => {
+    const ledger = makeLedger();
+    ledger.recordOutcome(makeOutcome({ situationId: 'a' }));
+    ledger.recordOutcome(makeOutcome({ situationId: 'b', domain: 'cyber' }));
+    assert.equal(ledger.getOutcomes().length, 2);
+  });
+
+  it('filters by domain when provided', () => {
+    const ledger = makeLedger();
+    ledger.recordOutcome(makeOutcome({ situationId: 'a', domain: 'weather' }));
+    ledger.recordOutcome(makeOutcome({ situationId: 'b', domain: 'cyber' }));
+    ledger.recordOutcome(makeOutcome({ situationId: 'c', domain: 'weather' }));
+    assert.equal(ledger.getOutcomes('weather').length, 2);
+    assert.equal(ledger.getOutcomes('cyber').length, 1);
+    assert.equal(ledger.getOutcomes('does-not-exist').length, 0);
+  });
+
+  it('cloning isolates caller from internal storage array', () => {
+    const ledger = makeLedger();
+    ledger.recordOutcome(makeOutcome());
+    const snapshot = ledger.getOutcomes();
+    snapshot.length = 0;
+    assert.equal(ledger.getOutcomes().length, 1);
+  });
+});
+
+// ── 4. Calibration report (5 tests) ───────────────────────────────────
+
+describe('getCalibrationReport', () => {
+  it('returns empty array when no outcomes recorded', () => {
+    const ledger = makeLedger();
+    assert.deepEqual(ledger.getCalibrationReport(), []);
+  });
+
+  it('computes accuracy as wasAccurate / sampleCount', () => {
+    const ledger = makeLedger();
+    ledger.recordOutcome(makeOutcome({ situationId: 'a', domain: 'weather', wasAccurate: true }));
+    ledger.recordOutcome(makeOutcome({ situationId: 'b', domain: 'weather', wasAccurate: false }));
+    ledger.recordOutcome(makeOutcome({ situationId: 'c', domain: 'weather', wasAccurate: true }));
+    const report = ledger.getCalibrationReport();
+    const weather = report.find((r) => r.domain === 'weather')!;
+    assert.equal(weather.sampleCount, 3);
+    assert.equal(Number(weather.accuracy.toFixed(3)), Number((2 / 3).toFixed(3)));
+  });
+
+  it('computes timeliness as wasTimely / sampleCount independently of accuracy', () => {
+    const ledger = makeLedger();
+    ledger.recordOutcome(makeOutcome({ situationId: 'a', wasAccurate: false, wasTimely: true }));
+    ledger.recordOutcome(makeOutcome({ situationId: 'b', wasAccurate: true, wasTimely: false }));
+    const report = ledger.getCalibrationReport()[0]!;
+    assert.equal(report.accuracy, 0.5);
+    assert.equal(report.timeliness, 0.5);
+  });
+
+  it('rolls up multiple domains and sorts by sampleCount descending', () => {
+    const ledger = makeLedger();
+    for (let i = 0; i < 3; i += 1) ledger.recordOutcome(makeOutcome({ situationId: `c${i}`, domain: 'cyber' }));
+    for (let i = 0; i < 5; i += 1) ledger.recordOutcome(makeOutcome({ situationId: `w${i}`, domain: 'weather' }));
+    const report = ledger.getCalibrationReport();
+    assert.equal(report[0]?.domain, 'weather');
+    assert.equal(report[0]?.sampleCount, 5);
+    assert.equal(report[1]?.domain, 'cyber');
+    assert.equal(report[1]?.sampleCount, 3);
+  });
+
+  it('breaks ties by domain name alphabetically', () => {
+    const ledger = makeLedger();
+    ledger.recordOutcome(makeOutcome({ situationId: 'z', domain: 'zeta' }));
+    ledger.recordOutcome(makeOutcome({ situationId: 'a', domain: 'alpha' }));
+    const report = ledger.getCalibrationReport();
+    assert.equal(report[0]?.domain, 'alpha');
+    assert.equal(report[1]?.domain, 'zeta');
+  });
+});
+
+// ── 5. Feedback loop stats (5 tests) ──────────────────────────────────
+
+describe('getFeedbackLoopStats', () => {
+  it('returns zeroed stats with empty topDomains when ledger is empty', () => {
+    const stats = makeLedger().getFeedbackLoopStats();
+    assert.equal(stats.totalOutcomes, 0);
+    assert.equal(stats.accuracyRate, 0);
+    assert.equal(stats.timelinessRate, 0);
+    assert.equal(stats.avgLeadTimeMinutes, 0);
+    assert.deepEqual(stats.topDomainsByAccuracy, []);
+  });
+
+  it('computes overall accuracyRate across all domains', () => {
+    const ledger = makeLedger();
+    ledger.recordOutcome(makeOutcome({ situationId: 'a', wasAccurate: true }));
+    ledger.recordOutcome(makeOutcome({ situationId: 'b', wasAccurate: true }));
+    ledger.recordOutcome(makeOutcome({ situationId: 'c', wasAccurate: false }));
+    ledger.recordOutcome(makeOutcome({ situationId: 'd', wasAccurate: true }));
+    assert.equal(ledger.getFeedbackLoopStats().accuracyRate, 0.75);
+  });
+
+  it('computes avgLeadTimeMinutes (rounded)', () => {
+    const ledger = makeLedger();
+    ledger.recordOutcome(makeOutcome({ situationId: 'a', detectedAt: T0, resolvedAt: T0 + 30 * MIN }));
+    ledger.recordOutcome(makeOutcome({ situationId: 'b', detectedAt: T0, resolvedAt: T0 + 60 * MIN }));
+    // Average lead time = 45 min
+    assert.equal(ledger.getFeedbackLoopStats().avgLeadTimeMinutes, 45);
+  });
+
+  it('topDomainsByAccuracy excludes domains below MIN_ACCURACY_SAMPLES', () => {
+    const ledger = makeLedger();
+    // weather: 5 outcomes, all accurate → 1.0 accuracy
+    for (let i = 0; i < 5; i += 1) ledger.recordOutcome(makeOutcome({ situationId: `w${i}`, domain: 'weather', wasAccurate: true }));
+    // cyber: 2 outcomes (below threshold of 3) — excluded
+    ledger.recordOutcome(makeOutcome({ situationId: 'c1', domain: 'cyber', wasAccurate: true }));
+    ledger.recordOutcome(makeOutcome({ situationId: 'c2', domain: 'cyber', wasAccurate: true }));
+    const stats = ledger.getFeedbackLoopStats();
+    assert.deepEqual(stats.topDomainsByAccuracy, ['weather']);
+  });
+
+  it('topDomainsByAccuracy caps at 3 and orders by accuracy then sampleCount', () => {
+    const ledger = makeLedger();
+    // 4 domains: weather (3 / 1.0), cyber (5 / 0.8), maritime (3 / 0.67), wildfire (4 / 0.5)
+    for (let i = 0; i < 3; i += 1) ledger.recordOutcome(makeOutcome({ situationId: `w${i}`, domain: 'weather', wasAccurate: true }));
+    for (let i = 0; i < 5; i += 1) ledger.recordOutcome(makeOutcome({ situationId: `c${i}`, domain: 'cyber', wasAccurate: i < 4 }));
+    for (let i = 0; i < 3; i += 1) ledger.recordOutcome(makeOutcome({ situationId: `m${i}`, domain: 'maritime', wasAccurate: i < 2 }));
+    for (let i = 0; i < 4; i += 1) ledger.recordOutcome(makeOutcome({ situationId: `f${i}`, domain: 'wildfire', wasAccurate: i < 2 }));
+    const top = makeLedger ? ledger.getFeedbackLoopStats().topDomainsByAccuracy : [];
+    assert.equal(top.length, 3);
+    assert.deepEqual(top, ['weather', 'cyber', 'maritime']);
+  });
+});
+
+// ── 6. Storage hydrate / persist / corruption (5 tests) ──────────────
+
+describe('storage', () => {
+  it('persists outcomes under STORAGE_KEY as a v1 payload', () => {
+    const storage = memoryStorage();
+    const ledger = makeLedger({ storage });
+    ledger.recordOutcome(makeOutcome());
+    const raw = storage.getItem(STORAGE_KEY);
+    assert.ok(raw, 'expected storage payload');
+    const parsed = JSON.parse(raw!);
+    assert.equal(parsed.version, 1);
+    assert.equal(parsed.outcomes.length, 1);
+  });
+
+  it('hydrates outcomes from an existing storage blob on first read', () => {
+    const storage = memoryStorage();
+    const seed = { version: 1, outcomes: [{ ...makeOutcome(), leadTimeMs: 2 * HOUR }] };
+    storage.setItem(STORAGE_KEY, JSON.stringify(seed));
+    const ledger = makeLedger({ storage });
+    assert.equal(ledger.getOutcomes().length, 1);
+  });
+
+  it('ignores a corrupt storage blob without throwing', () => {
+    const storage = memoryStorage();
+    storage.setItem(STORAGE_KEY, '<<not json>>');
+    const ledger = makeLedger({ storage });
+    assert.deepEqual(ledger.getOutcomes(), []);
+  });
+
+  it('ignores a payload with the wrong version', () => {
+    const storage = memoryStorage();
+    storage.setItem(STORAGE_KEY, JSON.stringify({ version: 2, outcomes: [makeOutcome()] }));
+    const ledger = makeLedger({ storage });
+    assert.deepEqual(ledger.getOutcomes(), []);
+  });
+
+  it('drops entries with invalid shape during hydrate', () => {
+    const storage = memoryStorage();
+    const mixed = {
+      version: 1,
+      outcomes: [
+        makeOutcome({ situationId: 'good-1' }),
+        { situationId: 'bad', domain: 'x' /* missing required fields */ },
+      ],
+    };
+    storage.setItem(STORAGE_KEY, JSON.stringify(mixed));
+    const ledger = makeLedger({ storage });
+    const stored = ledger.getOutcomes();
+    assert.equal(stored.length, 1);
+    assert.equal(stored[0]?.situationId, 'good-1');
+  });
+});
+
+// ── 7. Capacity cap (1 test) ─────────────────────────────────────────
+
+describe('capacity', () => {
+  it('caps to MAX_OUTCOMES, evicting oldest first', () => {
+    const ledger = makeLedger();
+    for (let i = 0; i < MAX_OUTCOMES + 10; i += 1) {
+      ledger.recordOutcome(makeOutcome({ situationId: `sit-${i}` }));
+    }
+    const stored = ledger.getOutcomes();
+    assert.equal(stored.length, MAX_OUTCOMES);
+    // First surviving entry should be #10 — the first 10 were evicted.
+    assert.equal(stored[0]?.situationId, 'sit-10');
+  });
+});
+
+// ── 8. Lifecycle subscription auto-record (4 tests) ──────────────────
+
+describe('lifecycle subscription', () => {
+  beforeEach(() => { __resetClosedLoopMissionLedgerSingleton(); });
+
+  it('records a MissionOutcome when a transition lands on `resolved`', () => {
+    let t = T0;
+    const tracker = freshTracker(() => t);
+    const ledger = makeLedger({ lifecycleTracker: tracker, autoSubscribe: true });
+    tracker.recordTransition('sit-A', 'weather', 'detected'); t += 30 * MIN;
+    tracker.recordTransition('sit-A', 'weather', 'resolved');
+    const stored = ledger.getOutcomes();
+    assert.equal(stored.length, 1);
+    assert.equal(stored[0]?.situationId, 'sit-A');
+    assert.equal(stored[0]?.leadTimeMs, 30 * MIN);
+    assert.equal(stored[0]?.wasAccurate, true);
+    assert.equal(stored[0]?.wasTimely, true);
+    ledger.dispose();
+  });
+
+  it('does not record on non-resolved transitions', () => {
+    let t = T0;
+    const tracker = freshTracker(() => t);
+    const ledger = makeLedger({ lifecycleTracker: tracker, autoSubscribe: true });
+    tracker.recordTransition('sit-A', 'cyber', 'detected'); t += MIN;
+    tracker.recordTransition('sit-A', 'cyber', 'escalated'); t += MIN;
+    tracker.recordTransition('sit-A', 'cyber', 'investigated'); t += MIN;
+    tracker.recordTransition('sit-A', 'cyber', 'mitigated');
+    assert.equal(ledger.getOutcomes().length, 0);
+    ledger.dispose();
+  });
+
+  it('marks wasTimely=false when lead time exceeds threshold', () => {
+    let t = T0;
+    const tracker = freshTracker(() => t);
+    const ledger = makeLedger({
+      lifecycleTracker: tracker,
+      autoSubscribe: true,
+      timelyThresholdMs: HOUR,
+    });
+    tracker.recordTransition('sit-slow', 'maritime', 'detected'); t += 3 * HOUR;
+    tracker.recordTransition('sit-slow', 'maritime', 'resolved');
+    assert.equal(ledger.getOutcomes()[0]?.wasTimely, false);
+    ledger.dispose();
+  });
+
+  it('dispose() detaches the subscription so subsequent transitions are ignored', () => {
+    let t = T0;
+    const tracker = freshTracker(() => t);
+    const ledger = makeLedger({ lifecycleTracker: tracker, autoSubscribe: true });
+    ledger.dispose();
+    tracker.recordTransition('sit-X', 'weather', 'detected'); t += 10 * MIN;
+    tracker.recordTransition('sit-X', 'weather', 'resolved');
+    assert.equal(ledger.getOutcomes().length, 0);
+  });
+});
+
+// ── 9. OutcomeLedger forwarding (3 tests) ────────────────────────────
+
+describe('OutcomeLedger forwarding', () => {
+  it('forwards one OutcomeRecord per algorithmId', () => {
+    const outcomes = freshOutcomeLedger();
+    const ledger = makeLedger({ outcomeLedger: outcomes });
+    ledger.recordOutcome(makeOutcome({ algorithmIds: ['a', 'b', 'c'] }));
+    assert.equal(outcomes.list().length, 3);
+  });
+
+  it('forwards confirmed-real when wasAccurate=true, marked-false-positive when false', () => {
+    const outcomes = freshOutcomeLedger();
+    const ledger = makeLedger({ outcomeLedger: outcomes });
+    ledger.recordOutcome(makeOutcome({ situationId: 'a', wasAccurate: true,  algorithmIds: ['truth-score'] }));
+    ledger.recordOutcome(makeOutcome({ situationId: 'b', wasAccurate: false, algorithmIds: ['truth-score'] }));
+    const actions = outcomes.list().map((r) => r.actualOutcome).sort();
+    assert.deepEqual(actions, ['confirmed-real', 'marked-false-positive']);
+  });
+
+  it('tags forwarded records with notes=closed-loop:<algorithmId>', () => {
+    const outcomes = freshOutcomeLedger();
+    const ledger = makeLedger({ outcomeLedger: outcomes });
+    ledger.recordOutcome(makeOutcome({ algorithmIds: ['truth-score', 'evidence-graph'] }));
+    const notes = outcomes.list().map((r) => r.notes).sort();
+    assert.deepEqual(notes, ['closed-loop:evidence-graph', 'closed-loop:truth-score']);
+  });
+});
+
+// ── 10. Singleton + service alias (3 tests) ──────────────────────────
+
+describe('singleton', () => {
+  beforeEach(() => { __resetClosedLoopMissionLedgerSingleton(); });
+
+  it('ClosedLoopMissionLedgerService.getInstance() returns a stable instance', () => {
+    const a = ClosedLoopMissionLedgerService.getInstance();
+    const b = ClosedLoopMissionLedgerService.getInstance();
+    assert.strictEqual(a, b);
+  });
+
+  it('__resetClosedLoopMissionLedgerSingleton() drops the cached instance', () => {
+    const a = ClosedLoopMissionLedgerService.getInstance();
+    __resetClosedLoopMissionLedgerSingleton();
+    const b = ClosedLoopMissionLedgerService.getInstance();
+    assert.notStrictEqual(a, b);
+  });
+
+  it('__internals.normaliseOutcome is the exact computation used by recordOutcome', () => {
+    const raw = makeOutcome({ detectedAt: T0, resolvedAt: T0 + DAY, leadTimeMs: 0 });
+    const normalised = __internals.normaliseOutcome(raw);
+    assert.equal(normalised.leadTimeMs, DAY);
+  });
+});


### PR DESCRIPTION
## What

Closes the Phase-2 feedback loop. When a situation transitions to `resolved`, `ClosedLoopMissionLedger` auto-builds a `MissionOutcome` from the lifecycle and forwards one `OutcomeRecord` per contributing algorithm into `OutcomeLedger` so per-algorithm calibration moves with the verdict. Analysts can also call `recordOutcome(...)` directly to override `wasAccurate` / `wasTimely` during a manual review.

## Files

- [`src/services/intelligence/closed-loop-mission-ledger.ts`](src/services/intelligence/closed-loop-mission-ledger.ts) — `ClosedLoopMissionLedger` class + singleton (`getClosedLoopMissionLedger` and `ClosedLoopMissionLedgerService.getInstance`). Subscribes to [`SituationLifecycleTrackerService`](src/services/intelligence/situation-lifecycle-tracker.ts) by default; `autoSubscribe: false` keeps tests hermetic. Persists to `localStorage` at `wm-closed-loop-ledger`, cap **500**, versioned blob with corruption-tolerant hydrate.

  **Public API:**
  - `recordOutcome(outcome, { algorithmIdsRequired? })` — persist + forward one record per algorithm
  - `getOutcomes(domain?)` — filtered, deep-cloned snapshot
  - `getCalibrationReport()` — `[{ domain, accuracy, timeliness, sampleCount }]` sorted by sample count
  - `getFeedbackLoopStats()` — overall accuracy / timeliness / avg lead time + top-3 domains by accuracy (filtered to `sampleCount >= 3`)
  - `dispose()` / `resetForTesting()` — test seams

- [`tests/intelligence/closed-loop-mission-ledger.test.mts`](tests/intelligence/closed-loop-mission-ledger.test.mts) — **37 tests across 10 suites**:
  - constants + exports (3)
  - recordOutcome shape + algorithmIds guard + leadTime normalisation + clone safety (5)
  - getOutcomes filter + immutability (3)
  - getCalibrationReport per-domain math + tie-break ordering (5)
  - getFeedbackLoopStats incl. `topDomainsByAccuracy` threshold + ranking (5)
  - storage hydrate / persist / corruption / version mismatch / bad-row drop (5)
  - capacity cap evicts oldest first (1)
  - lifecycle subscription auto-records only on `resolved`, respects `timelyThresholdMs`, `dispose()` unwires (4)
  - OutcomeLedger forwarding — one record per algorithmId, confirmed-real vs marked-false-positive, `notes=closed-loop:<algorithmId>` (3)
  - singleton + service alias + `__internals.normaliseOutcome` (3)

## Validation

```
npx tsx --test tests/intelligence/closed-loop-mission-ledger.test.mts  → 37 / 37 pass
npm run typecheck:all                                                   → pass
npx eslint <new files>                                                  → clean
```

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass
