### PR TITLE
Cyber mission bridges — CISA KEV, threat actor campaigns, infrastructure attacks

### DIFF
--- a/src/services/intelligence/mission-bridges/cyber-bridges.ts
+++ b/src/services/intelligence/mission-bridges/cyber-bridges.ts
@@ -141,9 +141,163 @@ export class InfraAttackBridge extends MissionBridgeBase {
   }
 }
 
+// ── Cyber-Attack Mission Bridge ────────────────────────────────────────
+// Active attack-in-progress events (DDoS, intrusion attempt, exploitation).
+// Distinct from InfraAttackBridge: this one focuses on the *stage* of the
+// attack (confirmed impact / in-progress / attempted / probe) rather than
+// the asset class targeted. Used when we have stage telemetry from EDR /
+// SOC tooling but not necessarily an asset taxonomy.
+
+const ATTACK_STAGE_SEVERITY: Record<string, FeedSeverity> = {
+  confirmed_impact:   4,
+  exfiltration:       4,
+  active_exploit:     4,
+  in_progress:        3,
+  intrusion:          3,
+  attempted:          2,
+  probe:              1,
+  reconnaissance:     1,
+};
+
+const KILL_CHAIN_SEVERITY: Record<string, FeedSeverity> = {
+  // Lockheed Martin Cyber Kill Chain stages, mapped to severity.
+  actions_on_objectives: 4,
+  command_and_control:   4,
+  exploitation:          4,
+  installation:          3,
+  delivery:              3,
+  weaponization:         2,
+  reconnaissance:        1,
+};
+
+export class CyberAttackMissionBridge extends MissionBridgeBase {
+  readonly domain = 'cyber';
+  readonly feedId  = 'cyber-attack';
+
+  normalize(raw: Record<string, unknown>): NormalizedFeedEvent | null {
+    const id = str(raw.id);
+    if (id.length === 0) return null;
+
+    const stage = str(raw.stage).toLowerCase().replace(/\s+/g, '_');
+    const killChain = str(raw.killChain).toLowerCase().replace(/\s+/g, '_');
+    const stageSeverity = ATTACK_STAGE_SEVERITY[stage];
+    const chainSeverity = KILL_CHAIN_SEVERITY[killChain];
+    // Take the higher of the two signals when both are present — a
+    // 'reconnaissance' stage label paired with a kill-chain reading of
+    // 'exploitation' should escalate.
+    const severity: FeedSeverity = Math.max(
+      stageSeverity ?? 0,
+      chainSeverity ?? 0,
+    ) as FeedSeverity || 1;
+    const actor = str(raw.actor) || 'unknown actor';
+    const target = str(raw.target) || 'unknown target';
+    const description = str(raw.description)
+      || `${stage || 'attack'} (${actor} → ${target})`;
+    const timestamp = num(raw.timestamp, Date.now());
+    return { id, severity, description, timestamp, raw };
+  }
+}
+
+// ── Data Breach Mission Bridge ─────────────────────────────────────────
+// Disclosed breaches with structured severity by data class + record count.
+// Distinct from BreachIntelBridge (which is HIBP/dark-web focused): this
+// bridge handles official disclosures (regulator, vendor, customer
+// notification) where we have a clean record-count + data-class pair.
+
+const BREACH_DATA_CLASS_SEVERITY: Record<string, FeedSeverity> = {
+  financial:    4,
+  health:       4,
+  credentials:  3,
+  pii:          3,
+  email:        2,
+  metadata:     1,
+};
+
+export class DataBreachMissionBridge extends MissionBridgeBase {
+  readonly domain = 'cyber';
+  readonly feedId  = 'data-breach';
+
+  normalize(raw: Record<string, unknown>): NormalizedFeedEvent | null {
+    const id = str(raw.id);
+    if (id.length === 0) return null;
+
+    const dataClass = str(raw.dataClass).toLowerCase();
+    const recordCount = num(raw.recordCount, 0);
+    const baseSeverity: FeedSeverity = BREACH_DATA_CLASS_SEVERITY[dataClass] ?? 1;
+
+    // Volume escalation, capped at 4. Bucketed coarsely so we never
+    // escalate one notch for a 1-record increment near a boundary.
+    // (< 1M records leaves the baseline class severity untouched.)
+    let volumeBoost = 0;
+    if (recordCount >= 10_000_000) volumeBoost = 2;
+    else if (recordCount >= 1_000_000) volumeBoost = 1;
+
+    const severity: FeedSeverity = Math.min(4, baseSeverity + volumeBoost) as FeedSeverity;
+    const organization = str(raw.organization) || 'undisclosed org';
+    const description = str(raw.description)
+      || `Breach: ${organization} (${dataClass || 'unknown'}, ${recordCount.toLocaleString()} records)`;
+    const timestamp = num(raw.timestamp, Date.now());
+    return { id, severity, description, timestamp, raw };
+  }
+}
+
+// ── Infrastructure-Compromise Mission Bridge ───────────────────────────
+// Confirmed compromise of critical infrastructure (utilities, transit,
+// healthcare, finance). Severity reflects *impact* on the asset, not the
+// attack stage. The InfraAttackBridge focuses on the attack type (ddos /
+// ransomware / etc); this bridge focuses on the post-attack state.
+
+const COMPROMISE_IMPACT_SEVERITY: Record<string, FeedSeverity> = {
+  outage:              4,
+  service_disruption:  3,
+  degraded:            3,
+  data_loss:           3,
+  contained:           2,
+  suspicious_activity: 2,
+  scanning:            1,
+  none:                0,
+};
+
+const SECTOR_CRITICALITY: Record<string, number> = {
+  // Hardening floor: critical sectors never drop below severity 2 once
+  // a confirmed compromise has occurred. The number is the *floor* the
+  // sector imposes on the impact-derived severity.
+  power_grid: 3,
+  utilities:  3,
+  hospital:   3,
+  healthcare: 3,
+  transit:    2,
+  finance:    2,
+  telecom:    2,
+};
+
+export class InfrastructureCompromiseMissionBridge extends MissionBridgeBase {
+  readonly domain = 'cyber';
+  readonly feedId  = 'infra-compromise';
+
+  normalize(raw: Record<string, unknown>): NormalizedFeedEvent | null {
+    const id = str(raw.id);
+    if (id.length === 0) return null;
+
+    const impact = str(raw.impact).toLowerCase().replace(/\s+/g, '_');
+    const sector = str(raw.sector).toLowerCase().replace(/\s+/g, '_');
+    const impactSeverity: FeedSeverity = COMPROMISE_IMPACT_SEVERITY[impact] ?? 1;
+    const sectorFloor = SECTOR_CRITICALITY[sector] ?? 0;
+    const severity: FeedSeverity = Math.max(impactSeverity, sectorFloor) as FeedSeverity;
+    const operator = str(raw.operator) || 'undisclosed operator';
+    const description = str(raw.description)
+      || `${sector || 'infra'} compromise: ${operator} (${impact || 'impact unknown'})`;
+    const timestamp = num(raw.timestamp, Date.now());
+    return { id, severity, description, timestamp, raw };
+  }
+}
+
 // ── Auto-registration ─────────────────────────────────────────────────
 
 getMissionBridgeRegistry().register(new CVEKevBridge());
 getMissionBridgeRegistry().register(new ThreatIntelBridge());
 getMissionBridgeRegistry().register(new BreachIntelBridge());
 getMissionBridgeRegistry().register(new InfraAttackBridge());
+getMissionBridgeRegistry().register(new CyberAttackMissionBridge());
+getMissionBridgeRegistry().register(new DataBreachMissionBridge());
+getMissionBridgeRegistry().register(new InfrastructureCompromiseMissionBridge());

--- a/tests/intelligence/mission-bridges/cyber-attack-bridges.test.mts
+++ b/tests/intelligence/mission-bridges/cyber-attack-bridges.test.mts
@@ -1,0 +1,244 @@
+/**
+ * Tests for the three new cyber mission bridges added on top of the
+ * shipped 4-bridge baseline:
+ *
+ *   • CyberAttackMissionBridge          (cyber:cyber-attack)
+ *   • DataBreachMissionBridge           (cyber:data-breach)
+ *   • InfrastructureCompromiseMissionBridge (cyber:infra-compromise)
+ *
+ * Each bridge extends MissionBridgeBase + self-registers. Tests cover
+ * stage / data-class / sector tier mappings, escalation rules, fallback
+ * behavior, null-id guard, and registry wiring.
+ *
+ * Run: npx tsx --test tests/intelligence/mission-bridges/cyber-attack-bridges.test.mts
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  CyberAttackMissionBridge,
+  DataBreachMissionBridge,
+  InfrastructureCompromiseMissionBridge,
+} from '../../../src/services/intelligence/mission-bridges/cyber-bridges.ts';
+import {
+  getMissionBridgeRegistry,
+} from '../../../src/services/intelligence/mission-bridges/mission-bridge-core.ts';
+
+// ── Registry wiring ───────────────────────────────────────────────────
+
+test('registry: CyberAttackMissionBridge is registered under cyber:cyber-attack', () => {
+  assert.equal(getMissionBridgeRegistry().has('cyber', 'cyber-attack'), true);
+});
+
+test('registry: DataBreachMissionBridge is registered under cyber:data-breach', () => {
+  assert.equal(getMissionBridgeRegistry().has('cyber', 'data-breach'), true);
+});
+
+test('registry: InfrastructureCompromiseMissionBridge is registered under cyber:infra-compromise', () => {
+  assert.equal(getMissionBridgeRegistry().has('cyber', 'infra-compromise'), true);
+});
+
+test('registry: getByDomain("cyber") returns at least 7 bridges (4 legacy + 3 new)', () => {
+  const bridges = getMissionBridgeRegistry().getByDomain('cyber');
+  assert.ok(bridges.length >= 7, `expected ≥7, got ${bridges.length}`);
+});
+
+// ── CyberAttackMissionBridge ──────────────────────────────────────────
+
+const cyberAttack = new CyberAttackMissionBridge();
+
+test('CyberAttack: confirmed_impact stage → severity 4', () => {
+  const ev = cyberAttack.normalize({ id: 'a1', stage: 'confirmed_impact' });
+  assert.equal(ev?.severity, 4);
+});
+
+test('CyberAttack: in_progress stage → severity 3', () => {
+  const ev = cyberAttack.normalize({ id: 'a2', stage: 'in_progress' });
+  assert.equal(ev?.severity, 3);
+});
+
+test('CyberAttack: attempted stage → severity 2', () => {
+  const ev = cyberAttack.normalize({ id: 'a3', stage: 'attempted' });
+  assert.equal(ev?.severity, 2);
+});
+
+test('CyberAttack: probe stage → severity 1', () => {
+  const ev = cyberAttack.normalize({ id: 'a4', stage: 'probe' });
+  assert.equal(ev?.severity, 1);
+});
+
+test('CyberAttack: unknown stage falls through to severity 1', () => {
+  const ev = cyberAttack.normalize({ id: 'a5', stage: 'whatever' });
+  assert.equal(ev?.severity, 1);
+});
+
+test('CyberAttack: kill-chain "exploitation" escalates over "reconnaissance" stage', () => {
+  const ev = cyberAttack.normalize({ id: 'a6', stage: 'reconnaissance', killChain: 'exploitation' });
+  assert.equal(ev?.severity, 4);
+});
+
+test('CyberAttack: kill-chain delivery → severity 3 even when stage is missing', () => {
+  const ev = cyberAttack.normalize({ id: 'a7', killChain: 'delivery' });
+  assert.equal(ev?.severity, 3);
+});
+
+test('CyberAttack: includes actor + target in description fallback', () => {
+  const ev = cyberAttack.normalize({ id: 'a8', stage: 'attempted', actor: 'apt29', target: 'mailserver' });
+  assert.match(ev!.description, /apt29/);
+  assert.match(ev!.description, /mailserver/);
+});
+
+test('CyberAttack: custom description wins over the synthesized one', () => {
+  const ev = cyberAttack.normalize({ id: 'a9', stage: 'probe', description: 'custom blurb' });
+  assert.equal(ev?.description, 'custom blurb');
+});
+
+test('CyberAttack: missing id → null', () => {
+  assert.equal(cyberAttack.normalize({ stage: 'probe' }), null);
+  assert.equal(cyberAttack.normalize({ id: '' }), null);
+});
+
+test('CyberAttack: stage normalization tolerates spaces ("in progress" === "in_progress")', () => {
+  const ev = cyberAttack.normalize({ id: 'a10', stage: 'in progress' });
+  assert.equal(ev?.severity, 3);
+});
+
+// ── DataBreachMissionBridge ───────────────────────────────────────────
+
+const dataBreach = new DataBreachMissionBridge();
+
+test('DataBreach: financial dataClass → severity 4 regardless of record count', () => {
+  const ev = dataBreach.normalize({ id: 'b1', dataClass: 'financial', recordCount: 50 });
+  assert.equal(ev?.severity, 4);
+});
+
+test('DataBreach: health dataClass → severity 4', () => {
+  const ev = dataBreach.normalize({ id: 'b2', dataClass: 'health' });
+  assert.equal(ev?.severity, 4);
+});
+
+test('DataBreach: credentials dataClass at baseline → severity 3', () => {
+  const ev = dataBreach.normalize({ id: 'b3', dataClass: 'credentials', recordCount: 1000 });
+  assert.equal(ev?.severity, 3);
+});
+
+test('DataBreach: pii dataClass → severity 3', () => {
+  const ev = dataBreach.normalize({ id: 'b4', dataClass: 'pii' });
+  assert.equal(ev?.severity, 3);
+});
+
+test('DataBreach: email dataClass at low volume → severity 2', () => {
+  const ev = dataBreach.normalize({ id: 'b5', dataClass: 'email', recordCount: 500 });
+  assert.equal(ev?.severity, 2);
+});
+
+test('DataBreach: unknown dataClass → severity 1', () => {
+  const ev = dataBreach.normalize({ id: 'b6', dataClass: 'sensor_logs' });
+  assert.equal(ev?.severity, 1);
+});
+
+test('DataBreach: 1M-record email breach escalates 2 → 3', () => {
+  const ev = dataBreach.normalize({ id: 'b7', dataClass: 'email', recordCount: 1_000_000 });
+  assert.equal(ev?.severity, 3);
+});
+
+test('DataBreach: 10M-record email breach escalates 2 → 4 (capped)', () => {
+  const ev = dataBreach.normalize({ id: 'b8', dataClass: 'email', recordCount: 10_000_000 });
+  assert.equal(ev?.severity, 4);
+});
+
+test('DataBreach: 10M-record financial breach stays capped at 4 (no over-escalation)', () => {
+  const ev = dataBreach.normalize({ id: 'b9', dataClass: 'financial', recordCount: 50_000_000 });
+  assert.equal(ev?.severity, 4);
+});
+
+test('DataBreach: organization name appears in fallback description', () => {
+  const ev = dataBreach.normalize({ id: 'b10', dataClass: 'pii', organization: 'AcmeCorp', recordCount: 5000 });
+  assert.match(ev!.description, /AcmeCorp/);
+});
+
+test('DataBreach: missing id → null', () => {
+  assert.equal(dataBreach.normalize({ dataClass: 'financial' }), null);
+});
+
+// ── InfrastructureCompromiseMissionBridge ─────────────────────────────
+
+const infraCompromise = new InfrastructureCompromiseMissionBridge();
+
+test('InfraCompromise: outage impact → severity 4', () => {
+  const ev = infraCompromise.normalize({ id: 'c1', impact: 'outage' });
+  assert.equal(ev?.severity, 4);
+});
+
+test('InfraCompromise: service_disruption impact → severity 3', () => {
+  const ev = infraCompromise.normalize({ id: 'c2', impact: 'service_disruption' });
+  assert.equal(ev?.severity, 3);
+});
+
+test('InfraCompromise: degraded impact → severity 3', () => {
+  const ev = infraCompromise.normalize({ id: 'c3', impact: 'degraded' });
+  assert.equal(ev?.severity, 3);
+});
+
+test('InfraCompromise: contained impact → severity 2', () => {
+  const ev = infraCompromise.normalize({ id: 'c4', impact: 'contained' });
+  assert.equal(ev?.severity, 2);
+});
+
+test('InfraCompromise: scanning impact → severity 1', () => {
+  const ev = infraCompromise.normalize({ id: 'c5', impact: 'scanning' });
+  assert.equal(ev?.severity, 1);
+});
+
+test('InfraCompromise: power_grid sector enforces a floor of 3 even on "contained" impact', () => {
+  const ev = infraCompromise.normalize({ id: 'c6', impact: 'contained', sector: 'power_grid' });
+  assert.equal(ev?.severity, 3);
+});
+
+test('InfraCompromise: hospital sector enforces a floor of 3 on a "scanning" impact', () => {
+  const ev = infraCompromise.normalize({ id: 'c7', impact: 'scanning', sector: 'hospital' });
+  assert.equal(ev?.severity, 3);
+});
+
+test('InfraCompromise: transit sector floor is 2 (lower than power)', () => {
+  const ev = infraCompromise.normalize({ id: 'c8', impact: 'scanning', sector: 'transit' });
+  assert.equal(ev?.severity, 2);
+});
+
+test('InfraCompromise: sector floor does not downgrade a higher impact reading', () => {
+  const ev = infraCompromise.normalize({ id: 'c9', impact: 'outage', sector: 'transit' });
+  assert.equal(ev?.severity, 4);
+});
+
+test('InfraCompromise: unknown impact + unknown sector → severity 1', () => {
+  const ev = infraCompromise.normalize({ id: 'c10', impact: 'mystery', sector: 'mystery' });
+  assert.equal(ev?.severity, 1);
+});
+
+test('InfraCompromise: operator name appears in fallback description', () => {
+  const ev = infraCompromise.normalize({ id: 'c11', impact: 'outage', sector: 'power_grid', operator: 'CenturyEnergy' });
+  assert.match(ev!.description, /CenturyEnergy/);
+});
+
+test('InfraCompromise: missing id → null', () => {
+  assert.equal(infraCompromise.normalize({ impact: 'outage' }), null);
+});
+
+test('InfraCompromise: timestamp passes through when provided', () => {
+  const ev = infraCompromise.normalize({ id: 'c12', impact: 'degraded', timestamp: 1_700_000_000_000 });
+  assert.equal(ev?.timestamp, 1_700_000_000_000);
+});
+
+// ── JSON-serializable contract ────────────────────────────────────────
+
+test('All new bridges return JSON-serializable events', () => {
+  const e1 = cyberAttack.normalize({ id: 'x1', stage: 'attempted' });
+  const e2 = dataBreach.normalize({ id: 'x2', dataClass: 'financial' });
+  const e3 = infraCompromise.normalize({ id: 'x3', impact: 'outage', sector: 'utilities' });
+  for (const e of [e1, e2, e3]) {
+    assert.ok(e);
+    const round = JSON.parse(JSON.stringify(e));
+    assert.deepEqual(round, e);
+  }
+});


### PR DESCRIPTION
Cross-agent review: claude reviewed on 2026-05-18; outcome: pass

Adds three new cyber-domain mission bridges on top of the shipped 4-bridge baseline. All three extend `MissionBridgeBase` from `src/services/intelligence/mission-bridges/mission-bridge-core.ts` and self-register with `MissionBridgeRegistry` at module load.

### `CyberAttackMissionBridge` (`cyber:cyber-attack`)

Active attack-in-progress events tagged by stage. Distinct from the existing `InfraAttackBridge` — this one focuses on the *stage* (confirmed impact / in-progress / attempted / probe) rather than the asset taxonomy. Stage and Lockheed kill-chain reading are merged with `Math.max` so a 'reconnaissance' stage paired with an 'exploitation' kill-chain reading escalates to 4.

### `DataBreachMissionBridge` (`cyber:data-breach`)

Disclosed breaches scored by data class + record-count buckets. `financial` / `health` → 4 regardless of volume; `credentials` / `pii` → 3 baseline; `email` → 2; `metadata` / unknown → 1. Record-count escalation adds +1 at 1M and +2 at 10M, capped at 4.

### `InfrastructureCompromiseMissionBridge` (`cyber:infra-compromise`)

Confirmed compromise of critical infrastructure. Severity reflects *impact* on the asset (`outage` → 4, `service_disruption` / `degraded` / `data_loss` → 3, `contained` → 2, `scanning` → 1). Sector criticality imposes a floor: `power_grid` / `utilities` / `hospital` → 3, `transit` / `finance` / `telecom` → 2. Floor never downgrades a higher impact reading.

### Tests

**40 unit tests** in `tests/intelligence/mission-bridges/cyber-attack-bridges.test.mts` cover registry wiring, every severity tier per bridge, stage normalization (whitespace → underscore), volume escalation boundaries (1M / 10M caps), sector-floor interaction with both stronger and weaker impact readings, null-id guard, custom-description precedence, and JSON-serializability.

`tsc` + ESLint clean. The existing 4 cyber bridges (`CVEKevBridge`, `ThreatIntelBridge`, `BreachIntelBridge`, `InfraAttackBridge`) are preserved — the new bridges cover semantically distinct cases.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>