### PR TITLE
Operational playbooks — human-facing SOP library for domain crisis response

### DIFF
--- a/src/services/intelligence/operational-playbooks.ts
+++ b/src/services/intelligence/operational-playbooks.ts
@@ -1,0 +1,480 @@
+/**
+ * OperationalPlaybookLibrary — human-facing SOP library.
+ *
+ * Distinct from:
+ *   • src/services/intelligence/playbook-engine.ts (PR #417) — automated
+ *     response rules triggered by event signatures.
+ *   • src/services/intelligence/operational-playbook.ts — Situation-driven
+ *     automated checklist engine with TriggerCondition matching.
+ *
+ * This library exposes a static catalog of operator-facing step-by-step
+ * procedures (one per crisis domain) plus a lightweight execution
+ * lifecycle so an operator can walk through a playbook, tick off steps,
+ * and either complete or abort the run.
+ *
+ * Pure deterministic; no DOM, no fetch. Storage is injected via a
+ * StorageLike port so tests can pin behaviour without touching
+ * localStorage.
+ */
+
+// ── Public types ─────────────────────────────────────────────────────
+
+export type PlaybookSeverity = 'low' | 'medium' | 'high' | 'critical';
+export type ExecutionStatus = 'active' | 'completed' | 'aborted';
+
+export interface PlaybookStep {
+  order: number;
+  action: string;
+  responsible: string;
+  timeoutMinutes: number;
+  notes?: string;
+}
+
+export interface OperationalPlaybook {
+  id: string;
+  domain: string;
+  triggerCondition: string;
+  title: string;
+  severity: PlaybookSeverity;
+  steps: PlaybookStep[];
+  estimatedMinutes: number;
+  lastUpdated: number;
+}
+
+export interface PlaybookExecution {
+  id: string;
+  playbookId: string;
+  startedAt: number;
+  completedSteps: number[];
+  status: ExecutionStatus;
+}
+
+// ── Storage port ─────────────────────────────────────────────────────
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+// ── Constants ────────────────────────────────────────────────────────
+
+export const STORAGE_KEY = 'wm-operational-playbooks';
+export const MAX_TOTAL_PLAYBOOKS = 100;
+
+// ── Built-in playbooks ───────────────────────────────────────────────
+//
+// Eight seeded crisis-domain SOPs. Step counts and timeouts are tuned
+// to be useful in the first hour of response rather than exhaustive —
+// the library is a starting checklist, not a substitute for trained
+// incident command. `lastUpdated` is a static epoch (2026-05-01) so
+// the catalog is stable across rebuilds and tests can assert equality.
+
+const SEEDED_AT = Date.parse('2026-05-01T00:00:00Z');
+
+const BUILT_IN_PLAYBOOKS: readonly OperationalPlaybook[] = [
+  {
+    id: 'earthquake-response',
+    domain: 'natural_disaster',
+    triggerCondition: 'M >= 5.5 within 200km of populated area OR USGS PAGER yellow+',
+    title: 'Earthquake response',
+    severity: 'high',
+    estimatedMinutes: 90,
+    lastUpdated: SEEDED_AT,
+    steps: [
+      { order: 1, action: 'Confirm magnitude, depth, epicenter from USGS + EMSC',          responsible: 'analyst',  timeoutMinutes: 5 },
+      { order: 2, action: 'Check ShakeMap MMI overlay against saved-places watchlist',     responsible: 'analyst',  timeoutMinutes: 5 },
+      { order: 3, action: 'Pull PAGER fatality + economic loss estimates',                  responsible: 'analyst',  timeoutMinutes: 5 },
+      { order: 4, action: 'Cross-check tsunami warning bulletins (PTWC, JMA)',             responsible: 'analyst',  timeoutMinutes: 10 },
+      { order: 5, action: 'Notify on-call lead if PAGER yellow+ or saved-place inside MMI VII', responsible: 'analyst',  timeoutMinutes: 5 },
+      { order: 6, action: 'Stand up situation room channel + pin initial brief',           responsible: 'analyst',  timeoutMinutes: 10 },
+      { order: 7, action: 'Schedule 30-minute aftershock + damage recheck cadence',        responsible: 'system',   timeoutMinutes: 5 },
+    ],
+  },
+  {
+    id: 'cyber-incident',
+    domain: 'cyber',
+    triggerCondition: 'CISA KEV exploit observed against owned ASN or CVSS >= 9.0 on prod surface',
+    title: 'Cyber incident response',
+    severity: 'critical',
+    estimatedMinutes: 120,
+    lastUpdated: SEEDED_AT,
+    steps: [
+      { order: 1, action: 'Triage alert — confirm true-positive vs. tuning artefact',                 responsible: 'analyst',  timeoutMinutes: 10 },
+      { order: 2, action: 'Open IR ticket; assign severity SEV-1/2/3 per runbook',                    responsible: 'analyst',  timeoutMinutes: 5 },
+      { order: 3, action: 'Snapshot affected hosts + capture volatile memory before containment',     responsible: 'analyst',  timeoutMinutes: 15 },
+      { order: 4, action: 'Isolate affected hosts at network layer (do not power off)',               responsible: 'system',   timeoutMinutes: 10 },
+      { order: 5, action: 'Rotate credentials with blast radius to affected segment',                 responsible: 'analyst',  timeoutMinutes: 20 },
+      { order: 6, action: 'Notify legal + comms if PII / regulated data may be exposed',              responsible: 'external', timeoutMinutes: 15 },
+      { order: 7, action: 'File initial incident timeline; assign forensics owner',                    responsible: 'analyst',  timeoutMinutes: 15 },
+      { order: 8, action: 'Stand up daily standup until eradication confirmed',                        responsible: 'analyst',  timeoutMinutes: 30, notes: 'Skip if scope contained within 4 hours.' },
+    ],
+  },
+  {
+    id: 'pandemic-escalation',
+    domain: 'biosurveillance',
+    triggerCondition: 'WHO PHEIC OR ProMED unverified cluster + wastewater RNA z-score > 2',
+    title: 'Pandemic escalation',
+    severity: 'critical',
+    estimatedMinutes: 180,
+    lastUpdated: SEEDED_AT,
+    steps: [
+      { order: 1, action: 'Confirm signal across ≥2 independent sources (WHO, ProMED, GISAID, wastewater)', responsible: 'analyst',  timeoutMinutes: 15 },
+      { order: 2, action: 'Classify by ProMED outbreak phase + R0 estimate if available',                    responsible: 'analyst',  timeoutMinutes: 20 },
+      { order: 3, action: 'Identify geographic spread + travel-link risk to home region',                    responsible: 'analyst',  timeoutMinutes: 20 },
+      { order: 4, action: 'Audit PPE + test inventory; flag depletion timelines',                            responsible: 'external', timeoutMinutes: 30 },
+      { order: 5, action: 'Brief leadership; recommend escalation tier (monitor / prepare / activate)',      responsible: 'analyst',  timeoutMinutes: 20 },
+      { order: 6, action: 'Open daily sitrep cadence with HHS / state health authority',                     responsible: 'external', timeoutMinutes: 30 },
+      { order: 7, action: 'Schedule 12-hour signal recheck + sequence-data pull',                            responsible: 'system',   timeoutMinutes: 15 },
+      { order: 8, action: 'Pre-stage public communications draft for tier upgrade',                          responsible: 'analyst',  timeoutMinutes: 30 },
+    ],
+  },
+  {
+    id: 'severe-weather',
+    domain: 'weather',
+    triggerCondition: 'NWS Warning (Tornado / Severe Thunderstorm / Flash Flood) intersects saved-place polygon',
+    title: 'Severe weather response',
+    severity: 'high',
+    estimatedMinutes: 60,
+    lastUpdated: SEEDED_AT,
+    steps: [
+      { order: 1, action: 'Confirm polygon intersect + UGC zone match for each saved place',  responsible: 'analyst', timeoutMinutes: 5 },
+      { order: 2, action: 'Cross-check radar reflectivity + storm-relative velocity',          responsible: 'analyst', timeoutMinutes: 5 },
+      { order: 3, action: 'Fire Storm Mode payload to push notifier (deduped per warning ID)', responsible: 'system',  timeoutMinutes: 2 },
+      { order: 4, action: 'Verify shelter / drive-route guidance is current for affected place', responsible: 'analyst', timeoutMinutes: 10 },
+      { order: 5, action: 'Monitor for warning extensions + new polygons',                       responsible: 'analyst', timeoutMinutes: 30 },
+      { order: 6, action: 'Issue all-clear when expiration passes + radar quiets',               responsible: 'analyst', timeoutMinutes: 5 },
+    ],
+  },
+  {
+    id: 'maritime-incident',
+    domain: 'maritime',
+    triggerCondition: 'AIS gap > 6h in chokepoint OR vessel collision/grounding reported',
+    title: 'Maritime incident response',
+    severity: 'medium',
+    estimatedMinutes: 75,
+    lastUpdated: SEEDED_AT,
+    steps: [
+      { order: 1, action: 'Confirm vessel identity from AISStream + MarineTraffic crosscheck',     responsible: 'analyst',  timeoutMinutes: 10 },
+      { order: 2, action: 'Pull last-known position + heading + draft from cached AIS history',   responsible: 'analyst',  timeoutMinutes: 5 },
+      { order: 3, action: 'Check chokepoint freight-stress score and queue-length deltas',         responsible: 'analyst',  timeoutMinutes: 10 },
+      { order: 4, action: 'Estimate cargo type + downstream commodity-supply impact',              responsible: 'analyst',  timeoutMinutes: 15 },
+      { order: 5, action: 'Notify maritime-domain watch officer if Hormuz/Suez/Bosphorus involved', responsible: 'external', timeoutMinutes: 10 },
+      { order: 6, action: 'Open delta-watch with hourly position polls until resolved',            responsible: 'system',   timeoutMinutes: 25 },
+    ],
+  },
+  {
+    id: 'civil-unrest',
+    domain: 'conflict',
+    triggerCondition: 'ACLED political-violence cluster within 50km of saved-place OR State Dept advisory ≥ 3',
+    title: 'Civil unrest response',
+    severity: 'high',
+    estimatedMinutes: 90,
+    lastUpdated: SEEDED_AT,
+    steps: [
+      { order: 1, action: 'Confirm event count, fatality count, actor list from ACLED',              responsible: 'analyst',  timeoutMinutes: 10 },
+      { order: 2, action: 'Cross-check UCDP + GDELT for corroboration',                              responsible: 'analyst',  timeoutMinutes: 10 },
+      { order: 3, action: 'Map geographic spread vs. saved-place radius',                            responsible: 'analyst',  timeoutMinutes: 10 },
+      { order: 4, action: 'Pull current State Dept / FCDO travel advisories',                        responsible: 'analyst',  timeoutMinutes: 5 },
+      { order: 5, action: 'Identify any in-region personnel + last-known contact',                   responsible: 'external', timeoutMinutes: 20 },
+      { order: 6, action: 'Recommend movement-restriction or evacuation posture to leadership',      responsible: 'analyst',  timeoutMinutes: 20 },
+      { order: 7, action: 'Schedule 6-hour recheck cadence until cluster intensity drops',           responsible: 'system',   timeoutMinutes: 15 },
+    ],
+  },
+  {
+    id: 'infrastructure-failure',
+    domain: 'infrastructure',
+    triggerCondition: 'PowerOutage.us > 50k customers OR BGP hijack on critical prefix OR ISP outage > 30 min',
+    title: 'Infrastructure failure response',
+    severity: 'high',
+    estimatedMinutes: 60,
+    lastUpdated: SEEDED_AT,
+    steps: [
+      { order: 1, action: 'Confirm scope from primary feed + at-least-one independent source',       responsible: 'analyst',  timeoutMinutes: 10 },
+      { order: 2, action: 'Identify dependent services + saved-place utility exposure',              responsible: 'analyst',  timeoutMinutes: 10 },
+      { order: 3, action: 'Estimate restoration ETA from utility / NOC postings',                    responsible: 'analyst',  timeoutMinutes: 15 },
+      { order: 4, action: 'Trigger fallback runbooks for cascading dependencies (DNS, CDN, payments)', responsible: 'system',   timeoutMinutes: 10 },
+      { order: 5, action: 'Push notify affected operators with ETA + workaround guidance',            responsible: 'system',   timeoutMinutes: 5 },
+      { order: 6, action: 'Capture post-incident artefacts for the weekly review',                    responsible: 'analyst',  timeoutMinutes: 10 },
+    ],
+  },
+  {
+    id: 'financial-contagion',
+    domain: 'finance',
+    triggerCondition: 'VIX > 35 sustained 2h OR major bank CDS spike > 200bps OR sovereign yield blow-out',
+    title: 'Financial contagion response',
+    severity: 'critical',
+    estimatedMinutes: 150,
+    lastUpdated: SEEDED_AT,
+    steps: [
+      { order: 1, action: 'Confirm VIX / CDS / credit-spread reading from ≥2 venues',                responsible: 'analyst',  timeoutMinutes: 10 },
+      { order: 2, action: 'Identify originating instrument + counterparty exposure map',             responsible: 'analyst',  timeoutMinutes: 20 },
+      { order: 3, action: 'Pull funding-stress signals (SOFR-IOER, FX swap basis, GC repo)',         responsible: 'analyst',  timeoutMinutes: 20 },
+      { order: 4, action: 'Cross-check Fed / ECB / BoE liquidity-operations posture',                responsible: 'analyst',  timeoutMinutes: 15 },
+      { order: 5, action: 'Brief portfolio leads on tier (watch / de-risk / hedge) recommendation',  responsible: 'external', timeoutMinutes: 25 },
+      { order: 6, action: 'Open hourly recheck cadence until volatility decays',                     responsible: 'system',   timeoutMinutes: 30 },
+      { order: 7, action: 'Pre-stage client communication draft for tier upgrade',                   responsible: 'analyst',  timeoutMinutes: 30 },
+    ],
+  },
+];
+
+// ── Service ──────────────────────────────────────────────────────────
+
+export class OperationalPlaybookLibrary {
+  private static _singleton: OperationalPlaybookLibrary | null = null;
+
+  private custom: OperationalPlaybook[] = [];
+  private executions = new Map<string, PlaybookExecution>();
+  private storage: StorageLike;
+  private hydrated = false;
+  private executionCounter = 0;
+
+  private constructor(
+    storage: StorageLike = (globalThis as { localStorage?: StorageLike }).localStorage ?? nullStorage(),
+  ) {
+    this.storage = storage;
+  }
+
+  static getInstance(): OperationalPlaybookLibrary {
+    OperationalPlaybookLibrary._singleton ??= new OperationalPlaybookLibrary();
+    return OperationalPlaybookLibrary._singleton;
+  }
+
+  /** Build an isolated instance with a caller-supplied storage port — used by tests. */
+  static createForTesting(storage: StorageLike): OperationalPlaybookLibrary {
+    return new OperationalPlaybookLibrary(storage);
+  }
+
+  /** Drop the module-level singleton so subsequent getInstance() calls rebuild it. Tests only. */
+  static _resetForTests(): void {
+    OperationalPlaybookLibrary._singleton = null;
+  }
+
+  // ── Catalog ────────────────────────────────────────────────────────
+
+  /** Return all known playbooks (built-ins first, custom last). When `domain` is supplied
+   *  the result is filtered to playbooks whose `domain` matches exactly. */
+  getPlaybooks(domain?: string): OperationalPlaybook[] {
+    this.ensureHydrated();
+    const all = [...BUILT_IN_PLAYBOOKS, ...this.custom];
+    const matching = domain === undefined ? all : all.filter((p) => p.domain === domain);
+    return matching.map((p) => clonePlaybook(p));
+  }
+
+  /** Return a single playbook by id (or null). Defensive copy — callers cannot mutate the catalog. */
+  getPlaybook(id: string): OperationalPlaybook | null {
+    this.ensureHydrated();
+    const found = this.findPlaybook(id);
+    return found ? clonePlaybook(found) : null;
+  }
+
+  /** Add a custom playbook to the library. Throws on id collision with a built-in or another custom entry. */
+  addPlaybook(playbook: OperationalPlaybook): void {
+    this.ensureHydrated();
+    if (!isValidPlaybook(playbook)) {
+      throw new Error('OperationalPlaybookLibrary: playbook fails shape validation');
+    }
+    if (this.findPlaybook(playbook.id)) {
+      throw new Error(`OperationalPlaybookLibrary: playbook id "${playbook.id}" already exists`);
+    }
+    this.custom.push(clonePlaybook(playbook));
+    this.enforceMaxCap();
+    this.persist();
+  }
+
+  // ── Execution lifecycle ────────────────────────────────────────────
+
+  /** Start a new execution for the given playbook. Throws if the playbook id is unknown. */
+  startExecution(playbookId: string): PlaybookExecution {
+    this.ensureHydrated();
+    const playbook = this.findPlaybook(playbookId);
+    if (!playbook) {
+      throw new Error(`OperationalPlaybookLibrary: unknown playbookId "${playbookId}"`);
+    }
+    this.executionCounter += 1;
+    const execution: PlaybookExecution = {
+      id: `exec-${Date.now()}-${this.executionCounter}`,
+      playbookId,
+      startedAt: Date.now(),
+      completedSteps: [],
+      status: 'active',
+    };
+    this.executions.set(execution.id, execution);
+    return cloneExecution(execution);
+  }
+
+  /** Mark a step as completed. Idempotent — completing the same step twice is a no-op.
+   *  Throws on unknown execution, unknown step order, or non-active execution. Auto-transitions
+   *  to `completed` when every step of the playbook has been ticked off. */
+  completeStep(executionId: string, stepOrder: number): PlaybookExecution {
+    const execution = this.executions.get(executionId);
+    if (!execution) {
+      throw new Error(`OperationalPlaybookLibrary: unknown executionId "${executionId}"`);
+    }
+    if (execution.status !== 'active') {
+      throw new Error(`OperationalPlaybookLibrary: execution "${executionId}" is ${execution.status}; cannot complete steps`);
+    }
+    const playbook = this.findPlaybook(execution.playbookId);
+    if (!playbook) {
+      throw new Error(`OperationalPlaybookLibrary: execution refers to unknown playbookId "${execution.playbookId}"`);
+    }
+    const stepExists = playbook.steps.some((s) => s.order === stepOrder);
+    if (!stepExists) {
+      throw new Error(`OperationalPlaybookLibrary: step order ${stepOrder} not in playbook "${playbook.id}"`);
+    }
+    if (!execution.completedSteps.includes(stepOrder)) {
+      execution.completedSteps.push(stepOrder);
+      execution.completedSteps.sort((a, b) => a - b);
+    }
+    if (execution.completedSteps.length === playbook.steps.length) {
+      execution.status = 'completed';
+    }
+    return cloneExecution(execution);
+  }
+
+  /** Mark an execution as aborted. Idempotent on already-aborted executions; throws if the execution
+   *  is unknown or already completed (completed runs are terminal). */
+  abortExecution(executionId: string): PlaybookExecution {
+    const execution = this.executions.get(executionId);
+    if (!execution) {
+      throw new Error(`OperationalPlaybookLibrary: unknown executionId "${executionId}"`);
+    }
+    if (execution.status === 'completed') {
+      throw new Error(`OperationalPlaybookLibrary: execution "${executionId}" already completed; cannot abort`);
+    }
+    execution.status = 'aborted';
+    return cloneExecution(execution);
+  }
+
+  /** Look up a single execution. */
+  getExecution(executionId: string): PlaybookExecution | null {
+    const e = this.executions.get(executionId);
+    return e ? cloneExecution(e) : null;
+  }
+
+  /** Snapshot of every execution currently tracked by this instance. */
+  listExecutions(): PlaybookExecution[] {
+    return [...this.executions.values()].map((e) => cloneExecution(e));
+  }
+
+  // ── Internal helpers ───────────────────────────────────────────────
+
+  private findPlaybook(id: string): OperationalPlaybook | undefined {
+    const builtin = BUILT_IN_PLAYBOOKS.find((p) => p.id === id);
+    if (builtin) return builtin;
+    return this.custom.find((p) => p.id === id);
+  }
+
+  private enforceMaxCap(): void {
+    const maxCustom = MAX_TOTAL_PLAYBOOKS - BUILT_IN_PLAYBOOKS.length;
+    while (this.custom.length > maxCustom) {
+      this.custom.shift();
+    }
+  }
+
+  private persist(): void {
+    try {
+      this.storage.setItem(STORAGE_KEY, JSON.stringify(this.custom));
+    } catch {
+      // storage unavailable — continue without persistence
+    }
+  }
+
+  private ensureHydrated(): void {
+    if (this.hydrated) return;
+    this.hydrated = true;
+    let raw: string | null = null;
+    try {
+      raw = this.storage.getItem(STORAGE_KEY);
+    } catch {
+      return;
+    }
+    if (!raw) return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    if (!Array.isArray(parsed)) return;
+    for (const entry of parsed) {
+      if (isValidPlaybook(entry)) {
+        // Skip persisted entries that collide with a built-in id — built-ins win.
+        if (BUILT_IN_PLAYBOOKS.some((b) => b.id === entry.id)) continue;
+        this.custom.push(entry);
+      }
+    }
+  }
+}
+
+// ── Shape validation ─────────────────────────────────────────────────
+
+const SEVERITIES: ReadonlySet<PlaybookSeverity> = new Set(['low', 'medium', 'high', 'critical']);
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isNonNegativeFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+function isValidStep(raw: unknown, seenOrders: Set<number>): boolean {
+  if (!raw || typeof raw !== 'object') return false;
+  const s = raw as Record<string, unknown>;
+  if (typeof s.order !== 'number' || !Number.isInteger(s.order) || s.order < 1) return false;
+  if (seenOrders.has(s.order)) return false;
+  seenOrders.add(s.order);
+  if (!isNonEmptyString(s.action)) return false;
+  if (!isNonEmptyString(s.responsible)) return false;
+  if (!isNonNegativeFiniteNumber(s.timeoutMinutes)) return false;
+  if (s.notes !== undefined && typeof s.notes !== 'string') return false;
+  return true;
+}
+
+function hasValidPlaybookHeader(p: Record<string, unknown>): boolean {
+  if (!isNonEmptyString(p.id)) return false;
+  if (!isNonEmptyString(p.domain)) return false;
+  if (typeof p.triggerCondition !== 'string') return false;
+  if (!isNonEmptyString(p.title)) return false;
+  if (typeof p.severity !== 'string' || !SEVERITIES.has(p.severity as PlaybookSeverity)) return false;
+  if (!isNonNegativeFiniteNumber(p.estimatedMinutes)) return false;
+  if (typeof p.lastUpdated !== 'number' || !Number.isFinite(p.lastUpdated)) return false;
+  return true;
+}
+
+function isValidPlaybook(value: unknown): value is OperationalPlaybook {
+  if (!value || typeof value !== 'object') return false;
+  const p = value as Record<string, unknown>;
+  if (!hasValidPlaybookHeader(p)) return false;
+  if (!Array.isArray(p.steps) || p.steps.length === 0) return false;
+  const orders = new Set<number>();
+  for (const raw of p.steps) {
+    if (!isValidStep(raw, orders)) return false;
+  }
+  return true;
+}
+
+// ── Defensive copy helpers ───────────────────────────────────────────
+
+function clonePlaybook(p: OperationalPlaybook): OperationalPlaybook {
+  return {
+    ...p,
+    steps: p.steps.map((s) => ({ ...s })),
+  };
+}
+
+function cloneExecution(e: PlaybookExecution): PlaybookExecution {
+  return {
+    ...e,
+    completedSteps: [...e.completedSteps],
+  };
+}
+
+// ── Null storage fallback ────────────────────────────────────────────
+
+function nullStorage(): StorageLike {
+  return {
+    getItem: () => null,
+    setItem: () => undefined,
+  };
+}

--- a/tests/intelligence/operational-playbooks.test.mts
+++ b/tests/intelligence/operational-playbooks.test.mts
@@ -1,0 +1,477 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  OperationalPlaybookLibrary,
+  STORAGE_KEY,
+  MAX_TOTAL_PLAYBOOKS,
+  type OperationalPlaybook,
+  type StorageLike,
+} from '../../src/services/intelligence/operational-playbooks.js';
+
+// ── Test helpers ─────────────────────────────────────────────────────
+
+interface MockStorage extends StorageLike {
+  store: Map<string, string>;
+}
+
+function makeStorage(): MockStorage {
+  const store = new Map<string, string>();
+  return {
+    store,
+    getItem: (k) => store.get(k) ?? null,
+    setItem: (k, v) => {
+      store.set(k, v);
+    },
+  };
+}
+
+function makePlaybook(id: string, domain = 'custom'): OperationalPlaybook {
+  return {
+    id,
+    domain,
+    triggerCondition: `trigger for ${id}`,
+    title: `Playbook ${id}`,
+    severity: 'medium',
+    estimatedMinutes: 30,
+    lastUpdated: Date.parse('2026-05-01T00:00:00Z'),
+    steps: [
+      { order: 1, action: 'Do thing 1', responsible: 'analyst', timeoutMinutes: 5 },
+      { order: 2, action: 'Do thing 2', responsible: 'system',  timeoutMinutes: 10 },
+    ],
+  };
+}
+
+const BUILT_IN_IDS = [
+  'earthquake-response',
+  'cyber-incident',
+  'pandemic-escalation',
+  'severe-weather',
+  'maritime-incident',
+  'civil-unrest',
+  'infrastructure-failure',
+  'financial-contagion',
+];
+
+// ── Catalog: built-ins ───────────────────────────────────────────────
+
+describe('OperationalPlaybookLibrary — seeded catalog', () => {
+  it('seeds exactly 8 built-in playbooks', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    assert.equal(lib.getPlaybooks().length, 8);
+  });
+
+  it('ships all expected built-in domain ids', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const ids = lib.getPlaybooks().map((p) => p.id).sort();
+    assert.deepEqual(ids, [...BUILT_IN_IDS].sort());
+  });
+
+  it('every built-in playbook has at least 1 step', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    for (const p of lib.getPlaybooks()) {
+      assert.ok(p.steps.length >= 1, `${p.id} should have ≥1 step`);
+    }
+  });
+
+  it('built-in steps have strictly-increasing order numbers starting at 1', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    for (const p of lib.getPlaybooks()) {
+      const orders = p.steps.map((s) => s.order);
+      assert.equal(orders[0], 1, `${p.id} first step.order should be 1`);
+      for (let i = 1; i < orders.length; i++) {
+        assert.ok(orders[i]! > orders[i - 1]!, `${p.id} step order must strictly increase`);
+      }
+    }
+  });
+
+  it('every built-in playbook has a non-empty title and triggerCondition', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    for (const p of lib.getPlaybooks()) {
+      assert.ok(p.title.length > 0, `${p.id} title`);
+      assert.ok(p.triggerCondition.length > 0, `${p.id} triggerCondition`);
+    }
+  });
+
+  it('every built-in step has positive timeoutMinutes', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    for (const p of lib.getPlaybooks()) {
+      for (const s of p.steps) {
+        assert.ok(s.timeoutMinutes > 0, `${p.id} step ${s.order} should have timeoutMinutes > 0`);
+      }
+    }
+  });
+
+  it('severity is one of the 4 allowed values', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const allowed = new Set(['low', 'medium', 'high', 'critical']);
+    for (const p of lib.getPlaybooks()) {
+      assert.ok(allowed.has(p.severity));
+    }
+  });
+});
+
+// ── Catalog: filtering + lookup ──────────────────────────────────────
+
+describe('OperationalPlaybookLibrary — getPlaybooks(domain) filter', () => {
+  it('returns only playbooks for the requested domain', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const weather = lib.getPlaybooks('weather');
+    assert.equal(weather.length, 1);
+    assert.equal(weather[0]!.id, 'severe-weather');
+  });
+
+  it('returns an empty array for an unknown domain', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    assert.deepEqual(lib.getPlaybooks('does-not-exist'), []);
+  });
+
+  it('returns custom playbooks alongside built-ins when domain matches', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    lib.addPlaybook(makePlaybook('custom-weather', 'weather'));
+    const weather = lib.getPlaybooks('weather');
+    assert.equal(weather.length, 2);
+    assert.ok(weather.some((p) => p.id === 'severe-weather'));
+    assert.ok(weather.some((p) => p.id === 'custom-weather'));
+  });
+
+  it('returns deep copies — caller mutation does not leak into the catalog', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const list1 = lib.getPlaybooks();
+    list1[0]!.title = 'mutated';
+    list1[0]!.steps[0]!.action = 'mutated';
+    const list2 = lib.getPlaybooks();
+    assert.notEqual(list2[0]!.title, 'mutated');
+    assert.notEqual(list2[0]!.steps[0]!.action, 'mutated');
+  });
+});
+
+describe('OperationalPlaybookLibrary — getPlaybook(id)', () => {
+  it('returns the requested built-in', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const p = lib.getPlaybook('cyber-incident');
+    assert.ok(p);
+    assert.equal(p!.domain, 'cyber');
+  });
+
+  it('returns null for an unknown id', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    assert.equal(lib.getPlaybook('nope'), null);
+  });
+
+  it('returns a defensive copy', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const p = lib.getPlaybook('cyber-incident')!;
+    p.title = 'mutated';
+    assert.notEqual(lib.getPlaybook('cyber-incident')!.title, 'mutated');
+  });
+});
+
+// ── Custom playbooks ─────────────────────────────────────────────────
+
+describe('OperationalPlaybookLibrary — addPlaybook', () => {
+  it('appends a valid custom playbook to the catalog', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    lib.addPlaybook(makePlaybook('custom-1'));
+    assert.equal(lib.getPlaybooks().length, 9);
+    assert.ok(lib.getPlaybook('custom-1'));
+  });
+
+  it('throws on id collision with a built-in', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    assert.throws(
+      () => lib.addPlaybook(makePlaybook('earthquake-response')),
+      /already exists/,
+    );
+  });
+
+  it('throws on id collision with another custom entry', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    lib.addPlaybook(makePlaybook('dup'));
+    assert.throws(() => lib.addPlaybook(makePlaybook('dup')), /already exists/);
+  });
+
+  it('throws on shape-invalid input (missing title)', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const bad = makePlaybook('bad-1');
+    (bad as Partial<OperationalPlaybook>).title = '';
+    assert.throws(() => lib.addPlaybook(bad), /shape validation/);
+  });
+
+  it('throws on shape-invalid input (no steps)', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const bad = makePlaybook('bad-2');
+    bad.steps = [];
+    assert.throws(() => lib.addPlaybook(bad), /shape validation/);
+  });
+
+  it('throws on shape-invalid input (duplicate step order)', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const bad = makePlaybook('bad-3');
+    bad.steps[1]!.order = 1;
+    assert.throws(() => lib.addPlaybook(bad), /shape validation/);
+  });
+
+  it('throws on shape-invalid severity', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const bad = makePlaybook('bad-4');
+    (bad as { severity: string }).severity = 'catastrophic';
+    assert.throws(() => lib.addPlaybook(bad), /shape validation/);
+  });
+});
+
+// ── Persistence ──────────────────────────────────────────────────────
+
+describe('OperationalPlaybookLibrary — persistence', () => {
+  it('writes custom playbooks to storage on add', () => {
+    const storage = makeStorage();
+    const lib = OperationalPlaybookLibrary.createForTesting(storage);
+    lib.addPlaybook(makePlaybook('persist-1'));
+    const raw = storage.store.get(STORAGE_KEY);
+    assert.ok(raw, 'storage should contain the custom playbook payload');
+    const parsed = JSON.parse(raw!) as OperationalPlaybook[];
+    assert.equal(parsed.length, 1);
+    assert.equal(parsed[0]!.id, 'persist-1');
+  });
+
+  it('rehydrates custom playbooks from storage on next instance', () => {
+    const storage = makeStorage();
+    const first = OperationalPlaybookLibrary.createForTesting(storage);
+    first.addPlaybook(makePlaybook('persist-2'));
+    const second = OperationalPlaybookLibrary.createForTesting(storage);
+    assert.ok(second.getPlaybook('persist-2'));
+    assert.equal(second.getPlaybooks().length, 9);
+  });
+
+  it('does not throw when storage.getItem returns malformed JSON', () => {
+    const storage = makeStorage();
+    storage.store.set(STORAGE_KEY, '{not valid json');
+    const lib = OperationalPlaybookLibrary.createForTesting(storage);
+    assert.equal(lib.getPlaybooks().length, 8);
+  });
+
+  it('ignores persisted entries that fail shape validation', () => {
+    const storage = makeStorage();
+    storage.store.set(STORAGE_KEY, JSON.stringify([{ id: 'bad' }, makePlaybook('good')]));
+    const lib = OperationalPlaybookLibrary.createForTesting(storage);
+    assert.equal(lib.getPlaybooks().length, 9);
+    assert.ok(lib.getPlaybook('good'));
+    assert.equal(lib.getPlaybook('bad'), null);
+  });
+
+  it('drops persisted entries that collide with a built-in id (built-in wins)', () => {
+    const storage = makeStorage();
+    storage.store.set(STORAGE_KEY, JSON.stringify([
+      { ...makePlaybook('earthquake-response'), title: 'IMPOSTOR' },
+    ]));
+    const lib = OperationalPlaybookLibrary.createForTesting(storage);
+    assert.notEqual(lib.getPlaybook('earthquake-response')!.title, 'IMPOSTOR');
+  });
+
+  it('does not throw when storage.setItem fails', () => {
+    const storage: StorageLike = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error('quota exceeded');
+      },
+    };
+    const lib = OperationalPlaybookLibrary.createForTesting(storage);
+    assert.doesNotThrow(() => lib.addPlaybook(makePlaybook('safe-on-error')));
+    assert.ok(lib.getPlaybook('safe-on-error'));
+  });
+});
+
+// ── Cap enforcement ──────────────────────────────────────────────────
+
+describe('OperationalPlaybookLibrary — cap enforcement', () => {
+  it('enforces MAX_TOTAL_PLAYBOOKS by dropping oldest custom entries (FIFO)', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const maxCustom = MAX_TOTAL_PLAYBOOKS - 8; // 8 built-ins
+    for (let i = 0; i < maxCustom + 3; i++) {
+      lib.addPlaybook(makePlaybook(`cap-${i}`));
+    }
+    assert.equal(lib.getPlaybooks().length, MAX_TOTAL_PLAYBOOKS);
+    assert.equal(lib.getPlaybook('cap-0'), null);
+    assert.equal(lib.getPlaybook('cap-1'), null);
+    assert.equal(lib.getPlaybook('cap-2'), null);
+    assert.ok(lib.getPlaybook(`cap-${maxCustom + 2}`));
+  });
+});
+
+// ── startExecution ───────────────────────────────────────────────────
+
+describe('OperationalPlaybookLibrary — startExecution', () => {
+  it('creates an active execution for a known playbook', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const exec = lib.startExecution('cyber-incident');
+    assert.equal(exec.playbookId, 'cyber-incident');
+    assert.equal(exec.status, 'active');
+    assert.deepEqual(exec.completedSteps, []);
+    assert.ok(exec.startedAt > 0);
+    assert.ok(exec.id.startsWith('exec-'));
+  });
+
+  it('throws on unknown playbook id', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    assert.throws(() => lib.startExecution('nope'), /unknown playbookId/);
+  });
+
+  it('gives each execution a unique id', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const a = lib.startExecution('cyber-incident');
+    const b = lib.startExecution('cyber-incident');
+    assert.notEqual(a.id, b.id);
+  });
+});
+
+// ── completeStep ─────────────────────────────────────────────────────
+
+describe('OperationalPlaybookLibrary — completeStep', () => {
+  it('records a completed step on the execution', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const exec = lib.startExecution('severe-weather');
+    const updated = lib.completeStep(exec.id, 1);
+    assert.deepEqual(updated.completedSteps, [1]);
+    assert.equal(updated.status, 'active');
+  });
+
+  it('keeps completedSteps sorted regardless of completion order', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const exec = lib.startExecution('severe-weather');
+    lib.completeStep(exec.id, 3);
+    lib.completeStep(exec.id, 1);
+    const updated = lib.completeStep(exec.id, 2);
+    assert.deepEqual(updated.completedSteps, [1, 2, 3]);
+  });
+
+  it('is idempotent — completing the same step twice is a no-op', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const exec = lib.startExecution('severe-weather');
+    lib.completeStep(exec.id, 1);
+    const second = lib.completeStep(exec.id, 1);
+    assert.deepEqual(second.completedSteps, [1]);
+  });
+
+  it('auto-transitions execution to completed once all steps are ticked off', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const exec = lib.startExecution('severe-weather');
+    const pb = lib.getPlaybook('severe-weather')!;
+    let last = exec;
+    for (const step of pb.steps) {
+      last = lib.completeStep(exec.id, step.order);
+    }
+    assert.equal(last.status, 'completed');
+    assert.equal(last.completedSteps.length, pb.steps.length);
+  });
+
+  it('throws when given an unknown executionId', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    assert.throws(() => lib.completeStep('nope', 1), /unknown executionId/);
+  });
+
+  it('throws when given an unknown step order', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const exec = lib.startExecution('severe-weather');
+    assert.throws(() => lib.completeStep(exec.id, 999), /step order 999/);
+  });
+
+  it('throws when the execution is not active (already aborted)', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const exec = lib.startExecution('severe-weather');
+    lib.abortExecution(exec.id);
+    assert.throws(() => lib.completeStep(exec.id, 1), /is aborted/);
+  });
+
+  it('throws when the execution is not active (already completed)', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const exec = lib.startExecution('severe-weather');
+    const pb = lib.getPlaybook('severe-weather')!;
+    for (const step of pb.steps) lib.completeStep(exec.id, step.order);
+    assert.throws(() => lib.completeStep(exec.id, 1), /is completed/);
+  });
+});
+
+// ── abortExecution ───────────────────────────────────────────────────
+
+describe('OperationalPlaybookLibrary — abortExecution', () => {
+  it('transitions an active execution to aborted', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const exec = lib.startExecution('cyber-incident');
+    const result = lib.abortExecution(exec.id);
+    assert.equal(result.status, 'aborted');
+  });
+
+  it('throws when aborting a completed execution', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const exec = lib.startExecution('severe-weather');
+    const pb = lib.getPlaybook('severe-weather')!;
+    for (const step of pb.steps) lib.completeStep(exec.id, step.order);
+    assert.throws(() => lib.abortExecution(exec.id), /already completed/);
+  });
+
+  it('is idempotent on an already-aborted execution', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const exec = lib.startExecution('cyber-incident');
+    lib.abortExecution(exec.id);
+    const second = lib.abortExecution(exec.id);
+    assert.equal(second.status, 'aborted');
+  });
+
+  it('throws on unknown executionId', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    assert.throws(() => lib.abortExecution('nope'), /unknown executionId/);
+  });
+});
+
+// ── Execution lookup ─────────────────────────────────────────────────
+
+describe('OperationalPlaybookLibrary — getExecution / listExecutions', () => {
+  it('getExecution returns the live state of a started execution', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const exec = lib.startExecution('cyber-incident');
+    lib.completeStep(exec.id, 1);
+    const fetched = lib.getExecution(exec.id)!;
+    assert.deepEqual(fetched.completedSteps, [1]);
+  });
+
+  it('getExecution returns null for unknown ids', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    assert.equal(lib.getExecution('nope'), null);
+  });
+
+  it('getExecution returns a defensive copy', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    const exec = lib.startExecution('cyber-incident');
+    const fetched = lib.getExecution(exec.id)!;
+    fetched.completedSteps.push(999);
+    assert.deepEqual(lib.getExecution(exec.id)!.completedSteps, []);
+  });
+
+  it('listExecutions returns every tracked execution', () => {
+    const lib = OperationalPlaybookLibrary.createForTesting(makeStorage());
+    lib.startExecution('cyber-incident');
+    lib.startExecution('severe-weather');
+    assert.equal(lib.listExecutions().length, 2);
+  });
+});
+
+// ── Singleton plumbing ───────────────────────────────────────────────
+
+describe('OperationalPlaybookLibrary — getInstance / _resetForTests', () => {
+  it('getInstance returns the same instance across calls', () => {
+    OperationalPlaybookLibrary._resetForTests();
+    const a = OperationalPlaybookLibrary.getInstance();
+    const b = OperationalPlaybookLibrary.getInstance();
+    assert.equal(a, b);
+    OperationalPlaybookLibrary._resetForTests();
+  });
+
+  it('_resetForTests forces getInstance to rebuild', () => {
+    OperationalPlaybookLibrary._resetForTests();
+    const a = OperationalPlaybookLibrary.getInstance();
+    OperationalPlaybookLibrary._resetForTests();
+    const b = OperationalPlaybookLibrary.getInstance();
+    assert.notEqual(a, b);
+    OperationalPlaybookLibrary._resetForTests();
+  });
+});


### PR DESCRIPTION
## Summary

Adds `OperationalPlaybookLibrary` — an operator-facing static catalog of crisis-domain SOPs distinct from the two existing automated engines:

- `src/services/intelligence/playbook-engine.ts` (PR #417) is rule-based automated response.
- `src/services/intelligence/operational-playbook.ts` is the Situation-triggered checklist engine with `TriggerCondition` matching.

This new module is the manual, human-driven catalog: 8 seeded crisis playbooks plus a lightweight execution lifecycle so an on-call operator can walk through a checklist, tick steps off, and either complete or abort the run.

## Seeded playbooks (8)

| Id | Domain | Severity | Steps |
| --- | --- | --- | --- |
| `earthquake-response` | natural_disaster | high | 7 |
| `cyber-incident` | cyber | critical | 8 |
| `pandemic-escalation` | biosurveillance | critical | 8 |
| `severe-weather` | weather | high | 6 |
| `maritime-incident` | maritime | medium | 6 |
| `civil-unrest` | conflict | high | 7 |
| `infrastructure-failure` | infrastructure | high | 6 |
| `financial-contagion` | finance | critical | 7 |

Each step carries an `order`, `action`, `responsible` (`analyst` / `system` / `external`), and `timeoutMinutes`.

## Public surface

```ts
class OperationalPlaybookLibrary {
  static getInstance(): OperationalPlaybookLibrary;
  static createForTesting(storage: StorageLike): OperationalPlaybookLibrary;

  getPlaybooks(domain?: string): OperationalPlaybook[];   // defensive copies
  getPlaybook(id: string): OperationalPlaybook | null;
  addPlaybook(playbook: OperationalPlaybook): void;       // shape-validated, throws on id collision

  startExecution(playbookId: string): PlaybookExecution;
  completeStep(executionId: string, stepOrder: number): PlaybookExecution;  // idempotent; auto-completes run
  abortExecution(executionId: string): PlaybookExecution;                    // terminal; rejects on completed
  getExecution(executionId: string): PlaybookExecution | null;
  listExecutions(): PlaybookExecution[];
}
```

## Storage + cap

- Persists custom playbooks at `wm-operational-playbooks` via the injected `StorageLike` port.
- FIFO cap at `MAX_TOTAL_PLAYBOOKS = 100` total entries (built-ins are always retained).
- Persisted entries that collide with a built-in id are dropped — **built-ins always win**.
- Malformed JSON or shape-invalid persisted entries are silently skipped, never thrown.

## Tests — 49

`tests/intelligence/operational-playbooks.test.mts` covers:

- Catalog: exactly 8 built-ins, expected ids, ≥1 step, strictly-increasing step order, non-empty title/triggerCondition, positive timeouts, valid severity (7).
- Filtering + lookup: domain filter, empty unknown-domain result, custom + built-in coexistence, defensive copies, single-id lookup, null on missing, defensive copy on lookup (7).
- `addPlaybook`: append, collision with built-in, collision with custom, shape rejection on empty title / no steps / duplicate step order / bad severity (7).
- Persistence: storage write, rehydrate on new instance, malformed JSON tolerance, shape-invalid entry skip, built-in collision drop, `setItem` throw tolerance (6).
- Cap enforcement: FIFO drop of oldest custom entries (1).
- `startExecution`: active execution shape, unknown id rejection, unique ids (3).
- `completeStep`: record, sorted, idempotent, auto-complete, unknown exec / unknown step / aborted / completed rejections (8).
- `abortExecution`: active→aborted, completed-run rejection, idempotent on aborted, unknown id rejection (4).
- `getExecution` / `listExecutions`: live state, null on missing, defensive copy, list all (4).
- Singleton plumbing: `getInstance` reuse, `_resetForTests` rebuild (2).

## Verification

- `npx tsx --test tests/intelligence/operational-playbooks.test.mts` — **49/49 pass**
- `npx eslint src/services/intelligence/operational-playbooks.ts tests/intelligence/operational-playbooks.test.mts` — clean (exit 0)
- `npm run typecheck:all` — clean (exit 0)
- Pre-commit (lint-staged, secret scan, conflict markers, typecheck) — all green

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass