### PR TITLE
Signal-noise filter — score observation quality by source reliability and corroboration

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
     "test:algorithms": "tsx --test src/services/algorithms/__tests__/algorithm-evaluation-ledger.test.mts src/services/algorithms/__tests__/algorithm-health.test.mts src/services/algorithms/__tests__/safe-adjustment.test.mts src/services/algorithms/__tests__/algorithm-registry.test.mts src/services/algorithms/__tests__/algorithm-ledger-persistence.test.mts",
     "test:insights6": "tsx --test src/services/insights/__tests__/presentation-export.test.mts",
     "test:self-improvement": "tsx --test tests/intelligence/self-improvement-scheduler.test.mts",
+    "test:signal-noise-filter": "tsx --test tests/intelligence/signal-noise-filter.test.mts",
+    "test:signal-noise-filter": "tsx --test tests/intelligence/signal-noise-filter.test.mts",
     "test:contradiction": "tsx --test tests/intelligence/cross-domain-contradiction-detector.test.mts",
     "test:causal-attribution": "tsx --test tests/intelligence/causal-attribution.test.mts",
     "test:belief-state": "tsx --test tests/intelligence/belief-state-manager.test.mts",

--- a/src/services/intelligence/signal-noise-filter.ts
+++ b/src/services/intelligence/signal-noise-filter.ts
@@ -1,0 +1,216 @@
+/**
+ * SignalNoiseFilter — scores incoming observations on a 0-1 signal/noise
+ * spectrum using three weighted factors: source count, corroboration count,
+ * and recency. Persists scores to storage under `wm-signal-noise` in a
+ * 2000-entry ring map.
+ *
+ * Singleton pattern mirrors self-improvement-scheduler.ts. Injectable
+ * Storage + clock for deterministic unit testing.
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+export interface ObservationInput {
+  id: string;
+  domain: string;
+  severity?: string;
+  sourceCount?: number;
+  corroborationCount?: number;
+  ageMs?: number;
+}
+
+export interface ScoreFactor {
+  name: string;
+  weight: number;
+  value: number;
+}
+
+export interface SignalScore {
+  observationId: string;
+  signalScore: number;
+  noiseScore: number;
+  isSignal: boolean;
+  confidence: number;
+  factors: ScoreFactor[];
+}
+
+export interface FilterStats {
+  totalScored: number;
+  signalCount: number;
+  noiseCount: number;
+  avgSignalScore: number;
+}
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export interface SignalNoiseFilterOptions {
+  storage?: StorageLike | null;
+  now?: () => number;
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────
+
+export const STORAGE_KEY = 'wm-signal-noise';
+export const MAX_SCORES = 2000;
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function resolveStorage(storage?: StorageLike | null): StorageLike | null {
+  if (storage !== undefined) return storage;
+  if (typeof globalThis !== 'undefined') {
+    const ls = (globalThis as { localStorage?: StorageLike }).localStorage;
+    if (ls && typeof ls.getItem === 'function') return ls;
+  }
+  return null;
+}
+
+function sourceCountValue(n: number | undefined): number {
+  if (n === undefined || n <= 1) return 0.3;
+  if (n === 2) return 0.6;
+  return 1;
+}
+
+function corroborationValue(n: number | undefined): number {
+  if (n === undefined || n === 0) return 0.1;
+  if (n === 1) return 0.4;
+  if (n === 2) return 0.7;
+  return 1;
+}
+
+function recencyValue(ageMs: number | undefined): number {
+  if (ageMs === undefined) return 1;
+  if (ageMs < 5 * 60_000) return 1;
+  if (ageMs < 30 * 60_000) return 0.7;
+  if (ageMs < 2 * 60 * 60_000) return 0.4;
+  return 0.1;
+}
+
+function isValidScore(item: unknown): item is SignalScore {
+  if (!item || typeof item !== 'object') return false;
+  const s = item as Record<string, unknown>;
+  return typeof s.observationId === 'string'
+    && typeof s.signalScore === 'number'
+    && typeof s.isSignal === 'boolean';
+}
+
+function hydrate(storage: StorageLike | null): Map<string, SignalScore> {
+  const map = new Map<string, SignalScore>();
+  if (!storage) return map;
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) return map;
+    const arr = JSON.parse(raw) as unknown;
+    if (!Array.isArray(arr)) return map;
+    for (const item of arr) {
+      if (isValidScore(item)) {
+        map.set(item.observationId, item as SignalScore);
+      }
+    }
+  } catch { /* ignore */ }
+  return map;
+}
+
+function persist(storage: StorageLike | null, scores: Map<string, SignalScore>): void {
+  if (!storage) return;
+  storage.setItem(STORAGE_KEY, JSON.stringify([...scores.values()]));
+}
+
+// ── Class ─────────────────────────────────────────────────────────────────
+
+export class SignalNoiseFilter {
+  private static _instance: SignalNoiseFilter | null = null;
+
+  static getInstance(): SignalNoiseFilter {
+    SignalNoiseFilter._instance ??= new SignalNoiseFilter();
+    return SignalNoiseFilter._instance;
+  }
+
+  static _resetSingletonForTests(): void {
+    SignalNoiseFilter._instance = null;
+  }
+
+  private readonly storage: StorageLike | null;
+  private readonly clock: () => number;
+  private readonly scores: Map<string, SignalScore>;
+
+  constructor(options: SignalNoiseFilterOptions = {}) {
+    this.storage = resolveStorage(options.storage);
+    this.clock = options.now ?? (() => Date.now());
+    this.scores = hydrate(this.storage);
+    this.enforceCap();
+  }
+
+  score(observation: ObservationInput): SignalScore {
+    const factors: ScoreFactor[] = [
+      { name: 'sourceCount',   weight: 0.3, value: sourceCountValue(observation.sourceCount) },
+      { name: 'corroboration', weight: 0.4, value: corroborationValue(observation.corroborationCount) },
+      { name: 'recency',       weight: 0.3, value: recencyValue(observation.ageMs) },
+    ];
+
+    const raw = factors.reduce((sum, f) => sum + f.weight * f.value, 0);
+    const signalScore = Number.parseFloat(raw.toFixed(4));
+    const noiseScore = Number.parseFloat((1 - signalScore).toFixed(4));
+    const isSignal = signalScore > 0.5;
+
+    const result: SignalScore = {
+      observationId: observation.id,
+      signalScore,
+      noiseScore,
+      isSignal,
+      confidence: signalScore,
+      factors,
+    };
+
+    this.scores.set(observation.id, result);
+    this.enforceCap();
+    persist(this.storage, this.scores);
+    return result;
+  }
+
+  batchScore(observations: ObservationInput[]): SignalScore[] {
+    return observations.map(obs => this.score(obs));
+  }
+
+  getStats(): FilterStats {
+    const totalScored = this.scores.size;
+    let signalCount = 0;
+    let sum = 0;
+    for (const s of this.scores.values()) {
+      if (s.isSignal) signalCount++;
+      sum += s.signalScore;
+    }
+    const noiseCount = totalScored - signalCount;
+    const avgSignalScore = totalScored === 0
+      ? 0
+      : Number.parseFloat((sum / totalScored).toFixed(4));
+    return { totalScored, signalCount, noiseCount, avgSignalScore };
+  }
+
+  getScore(observationId: string): SignalScore | undefined {
+    return this.scores.get(observationId);
+  }
+
+  clear(): void {
+    this.scores.clear();
+    persist(this.storage, this.scores);
+  }
+
+  private enforceCap(): void {
+    if (this.scores.size <= MAX_SCORES) return;
+    const excess = this.scores.size - MAX_SCORES;
+    const keys = this.scores.keys();
+    for (let i = 0; i < excess; i++) {
+      const { value: key } = keys.next();
+      if (key !== undefined) this.scores.delete(key);
+    }
+  }
+
+  /** Exposed for testing only — returns current clock value. */
+  _now(): number {
+    return this.clock();
+  }
+}

--- a/tests/intelligence/signal-noise-filter.test.mts
+++ b/tests/intelligence/signal-noise-filter.test.mts
@@ -1,0 +1,307 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  SignalNoiseFilter, STORAGE_KEY, MAX_SCORES,
+  type SignalScore, type StorageLike,
+} from '../../src/services/intelligence/signal-noise-filter.ts';
+
+function createMemoryStorage(): StorageLike {
+  const store = new Map<string, string>();
+  return {
+    getItem(key) { return store.get(key) ?? null; },
+    setItem(key, value) { store.set(key, value); },
+    removeItem(key) { store.delete(key); },
+  };
+}
+
+const BASE_NOW = new Date('2026-05-20T12:00:00Z').getTime();
+function makeFilter(nowMs = BASE_NOW, storage?: StorageLike) {
+  SignalNoiseFilter._resetSingletonForTests();
+  return new SignalNoiseFilter({ storage: storage ?? createMemoryStorage(), now: () => nowMs });
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────
+
+test('STORAGE_KEY === "wm-signal-noise"', () => {
+  assert.equal(STORAGE_KEY, 'wm-signal-noise');
+});
+
+test('MAX_SCORES === 2000', () => {
+  assert.equal(MAX_SCORES, 2000);
+});
+
+// ── Singleton ─────────────────────────────────────────────────────────────
+
+test('getInstance() returns the same instance twice', () => {
+  SignalNoiseFilter._resetSingletonForTests();
+  const a = SignalNoiseFilter.getInstance();
+  const b = SignalNoiseFilter.getInstance();
+  assert.strictEqual(a, b);
+  SignalNoiseFilter._resetSingletonForTests();
+});
+
+test('_resetSingletonForTests() breaks identity', () => {
+  SignalNoiseFilter._resetSingletonForTests();
+  const a = SignalNoiseFilter.getInstance();
+  SignalNoiseFilter._resetSingletonForTests();
+  const b = SignalNoiseFilter.getInstance();
+  assert.notStrictEqual(a, b);
+  SignalNoiseFilter._resetSingletonForTests();
+});
+
+// ── score() — sourceCount factor ──────────────────────────────────────────
+
+test('undefined sourceCount → sourceCount factor value === 0.3', () => {
+  const f = makeFilter();
+  const result = f.score({ id: 'a', domain: 'test' });
+  const factor = result.factors.find(x => x.name === 'sourceCount')!;
+  assert.equal(factor.value, 0.3);
+});
+
+test('sourceCount=1 → sourceCount factor value === 0.3', () => {
+  const f = makeFilter();
+  const result = f.score({ id: 'a', domain: 'test', sourceCount: 1 });
+  const factor = result.factors.find(x => x.name === 'sourceCount')!;
+  assert.equal(factor.value, 0.3);
+});
+
+test('sourceCount=2 → sourceCount factor value === 0.6', () => {
+  const f = makeFilter();
+  const result = f.score({ id: 'a', domain: 'test', sourceCount: 2 });
+  const factor = result.factors.find(x => x.name === 'sourceCount')!;
+  assert.equal(factor.value, 0.6);
+});
+
+test('sourceCount=3 → sourceCount factor value === 1.0', () => {
+  const f = makeFilter();
+  const result = f.score({ id: 'a', domain: 'test', sourceCount: 3 });
+  const factor = result.factors.find(x => x.name === 'sourceCount')!;
+  assert.equal(factor.value, 1.0);
+});
+
+// ── score() — corroboration factor ────────────────────────────────────────
+
+test('undefined corroborationCount → corroboration factor value === 0.1', () => {
+  const f = makeFilter();
+  const result = f.score({ id: 'a', domain: 'test' });
+  const factor = result.factors.find(x => x.name === 'corroboration')!;
+  assert.equal(factor.value, 0.1);
+});
+
+test('corroborationCount=0 → corroboration factor value === 0.1', () => {
+  const f = makeFilter();
+  const result = f.score({ id: 'a', domain: 'test', corroborationCount: 0 });
+  const factor = result.factors.find(x => x.name === 'corroboration')!;
+  assert.equal(factor.value, 0.1);
+});
+
+test('corroborationCount=1 → corroboration factor value === 0.4', () => {
+  const f = makeFilter();
+  const result = f.score({ id: 'a', domain: 'test', corroborationCount: 1 });
+  const factor = result.factors.find(x => x.name === 'corroboration')!;
+  assert.equal(factor.value, 0.4);
+});
+
+test('corroborationCount=2 → corroboration factor value === 0.7', () => {
+  const f = makeFilter();
+  const result = f.score({ id: 'a', domain: 'test', corroborationCount: 2 });
+  const factor = result.factors.find(x => x.name === 'corroboration')!;
+  assert.equal(factor.value, 0.7);
+});
+
+test('corroborationCount=3 → corroboration factor value === 1.0', () => {
+  const f = makeFilter();
+  const result = f.score({ id: 'a', domain: 'test', corroborationCount: 3 });
+  const factor = result.factors.find(x => x.name === 'corroboration')!;
+  assert.equal(factor.value, 1.0);
+});
+
+// ── score() — recency factor ──────────────────────────────────────────────
+
+test('undefined ageMs → recency factor value === 1.0', () => {
+  const f = makeFilter();
+  const result = f.score({ id: 'a', domain: 'test' });
+  const factor = result.factors.find(x => x.name === 'recency')!;
+  assert.equal(factor.value, 1.0);
+});
+
+test('ageMs=0 → recency factor value === 1.0', () => {
+  const f = makeFilter();
+  const result = f.score({ id: 'a', domain: 'test', ageMs: 0 });
+  const factor = result.factors.find(x => x.name === 'recency')!;
+  assert.equal(factor.value, 1.0);
+});
+
+test('ageMs < 5min → recency factor value === 1.0', () => {
+  const f = makeFilter();
+  const result = f.score({ id: 'a', domain: 'test', ageMs: 4 * 60_000 });
+  const factor = result.factors.find(x => x.name === 'recency')!;
+  assert.equal(factor.value, 1.0);
+});
+
+test('ageMs = 30min exactly → recency factor value === 0.4 (30min is NOT < 30min)', () => {
+  const f = makeFilter();
+  const result = f.score({ id: 'a', domain: 'test', ageMs: 30 * 60_000 });
+  const factor = result.factors.find(x => x.name === 'recency')!;
+  assert.equal(factor.value, 0.4);
+});
+
+test('ageMs < 30min → recency factor value === 0.7', () => {
+  const f = makeFilter();
+  const result = f.score({ id: 'a', domain: 'test', ageMs: 29 * 60_000 });
+  const factor = result.factors.find(x => x.name === 'recency')!;
+  assert.equal(factor.value, 0.7);
+});
+
+test('ageMs < 2h → recency factor value === 0.4', () => {
+  const f = makeFilter();
+  const result = f.score({ id: 'a', domain: 'test', ageMs: 90 * 60_000 });
+  const factor = result.factors.find(x => x.name === 'recency')!;
+  assert.equal(factor.value, 0.4);
+});
+
+// ── score() — signalScore + isSignal ─────────────────────────────────────
+
+test('all factors max → signalScore === 1.0, isSignal === true', () => {
+  const f = makeFilter();
+  const result = f.score({ id: 'a', domain: 'test', sourceCount: 3, corroborationCount: 3, ageMs: 0 });
+  assert.equal(result.signalScore, 1.0);
+  assert.equal(result.isSignal, true);
+});
+
+test('all factors min → signalScore low, isSignal === false', () => {
+  const f = makeFilter();
+  // sourceCount=1→0.3, corroboration=0→0.1, ageMs=old→0.1
+  // 0.3*0.3 + 0.4*0.1 + 0.3*0.1 = 0.09 + 0.04 + 0.03 = 0.16
+  const result = f.score({ id: 'a', domain: 'test', sourceCount: 1, corroborationCount: 0, ageMs: 3 * 60 * 60_000 });
+  assert.equal(result.signalScore, 0.16);
+  assert.equal(result.isSignal, false);
+});
+
+test('noiseScore === parseFloat((1 - signalScore).toFixed(4))', () => {
+  const f = makeFilter();
+  const result = f.score({ id: 'a', domain: 'test', sourceCount: 2, corroborationCount: 1, ageMs: 10 * 60_000 });
+  assert.equal(result.noiseScore, parseFloat((1 - result.signalScore).toFixed(4)));
+});
+
+test('confidence === signalScore', () => {
+  const f = makeFilter();
+  const result = f.score({ id: 'a', domain: 'test', sourceCount: 2, corroborationCount: 2, ageMs: 0 });
+  assert.equal(result.confidence, result.signalScore);
+});
+
+test('factors array has exactly 3 entries with correct names', () => {
+  const f = makeFilter();
+  const result = f.score({ id: 'a', domain: 'test' });
+  assert.equal(result.factors.length, 3);
+  assert.equal(result.factors[0].name, 'sourceCount');
+  assert.equal(result.factors[1].name, 'corroboration');
+  assert.equal(result.factors[2].name, 'recency');
+});
+
+test('2 sources, 2 corroboration, 10min age → signalScore === 0.67, isSignal === true', () => {
+  const f = makeFilter();
+  // sourceCount=2→0.6, corroboration=2→0.7, ageMs=10min→0.7
+  // 0.3*0.6 + 0.4*0.7 + 0.3*0.7 = 0.18 + 0.28 + 0.21 = 0.67
+  const result = f.score({ id: 'a', domain: 'test', sourceCount: 2, corroborationCount: 2, ageMs: 10 * 60_000 });
+  assert.equal(result.signalScore, 0.67);
+  assert.equal(result.isSignal, true);
+});
+
+// ── batchScore ────────────────────────────────────────────────────────────
+
+test('batchScore([]) returns []', () => {
+  const f = makeFilter();
+  assert.deepEqual(f.batchScore([]), []);
+});
+
+test('batchScore([obs1, obs2]) returns 2 SignalScore objects', () => {
+  const f = makeFilter();
+  const results = f.batchScore([
+    { id: 'x1', domain: 'test', sourceCount: 1 },
+    { id: 'x2', domain: 'test', sourceCount: 3 },
+  ]);
+  assert.equal(results.length, 2);
+  assert.equal(results[0].observationId, 'x1');
+  assert.equal(results[1].observationId, 'x2');
+});
+
+// ── getStats ──────────────────────────────────────────────────────────────
+
+test('getStats() on empty filter → { totalScored:0, signalCount:0, noiseCount:0, avgSignalScore:0 }', () => {
+  const f = makeFilter();
+  assert.deepEqual(f.getStats(), { totalScored: 0, signalCount: 0, noiseCount: 0, avgSignalScore: 0 });
+});
+
+test('getStats() after scoring one signal + one noise → correct counts', () => {
+  const f = makeFilter();
+  // signal: 3 sources, 3 corroboration, 0 age → signalScore=1.0
+  f.score({ id: 'sig', domain: 'test', sourceCount: 3, corroborationCount: 3, ageMs: 0 });
+  // noise: 1 source, 0 corroboration, old → signalScore=0.16
+  f.score({ id: 'noise', domain: 'test', sourceCount: 1, corroborationCount: 0, ageMs: 3 * 60 * 60_000 });
+  const stats = f.getStats();
+  assert.equal(stats.totalScored, 2);
+  assert.equal(stats.signalCount, 1);
+  assert.equal(stats.noiseCount, 1);
+});
+
+test('avgSignalScore is correctly averaged', () => {
+  const f = makeFilter();
+  f.score({ id: 'a', domain: 'test', sourceCount: 3, corroborationCount: 3, ageMs: 0 }); // 1.0
+  f.score({ id: 'b', domain: 'test', sourceCount: 1, corroborationCount: 0, ageMs: 3 * 60 * 60_000 }); // 0.16
+  const stats = f.getStats();
+  // avg = (1.0 + 0.16) / 2 = 0.58
+  assert.equal(stats.avgSignalScore, parseFloat(((1.0 + 0.16) / 2).toFixed(4)));
+});
+
+// ── getScore ──────────────────────────────────────────────────────────────
+
+test('getScore() on unknown id → undefined', () => {
+  const f = makeFilter();
+  assert.equal(f.getScore('nonexistent'), undefined);
+});
+
+test('getScore() after scoring → returns correct SignalScore', () => {
+  const f = makeFilter();
+  const scored = f.score({ id: 'known', domain: 'weather', sourceCount: 2, corroborationCount: 1, ageMs: 0 });
+  const retrieved = f.getScore('known');
+  assert.ok(retrieved);
+  assert.equal(retrieved.observationId, 'known');
+  assert.equal(retrieved.signalScore, scored.signalScore);
+});
+
+// ── Persistence ───────────────────────────────────────────────────────────
+
+test('score() persists; new filter with same storage hydrates the score', () => {
+  const storage = createMemoryStorage();
+  const f1 = makeFilter(BASE_NOW, storage);
+  const scored = f1.score({ id: 'persist-me', domain: 'test', sourceCount: 3, corroborationCount: 2, ageMs: 0 });
+
+  SignalNoiseFilter._resetSingletonForTests();
+  const f2 = new SignalNoiseFilter({ storage, now: () => BASE_NOW });
+  const retrieved = f2.getScore('persist-me');
+  assert.ok(retrieved);
+  assert.equal(retrieved.signalScore, scored.signalScore);
+  assert.equal(retrieved.isSignal, scored.isSignal);
+});
+
+test('clear() persists empty state', () => {
+  const storage = createMemoryStorage();
+  const f1 = makeFilter(BASE_NOW, storage);
+  f1.score({ id: 'will-be-cleared', domain: 'test' });
+  f1.clear();
+
+  SignalNoiseFilter._resetSingletonForTests();
+  const f2 = new SignalNoiseFilter({ storage, now: () => BASE_NOW });
+  assert.equal(f2.getStats().totalScored, 0);
+});
+
+// ── clear ─────────────────────────────────────────────────────────────────
+
+test('getStats().totalScored === 0 after clear()', () => {
+  const f = makeFilter();
+  f.score({ id: 'a', domain: 'test' });
+  f.score({ id: 'b', domain: 'test' });
+  f.clear();
+  assert.equal(f.getStats().totalScored, 0);
+});


### PR DESCRIPTION
## Summary

Adds `SignalNoiseFilter` singleton service (`src/services/intelligence/signal-noise-filter.ts`).

Scores each incoming observation 0–1 via three weighted factors:

| Factor | Weight | Thresholds |
|---|---|---|
| sourceCount | 0.3 | ≥3→1.0, 2→0.6, 1→0.3 |
| corroboration | 0.4 | ≥3→1.0, 2→0.7, 1→0.4, 0→0.1 |
| recency | 0.3 | <5min→1.0, <30min→0.7, <2h→0.4, older→0.1 |

`isSignal = signalScore > 0.5`. Persists to `wm-signal-noise`, cap 2000 scores.

API: `score()`, `batchScore()`, `getStats()`, `getScore()`, `clear()`.

## Tests
35 tests — all factor thresholds, weighted sum math, singleton, persistence, MAX_SCORES cap.

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass