### PR TITLE
Situation timeline panel — chronological event view with severity badges

### DIFF
--- a/src/components/SituationTimelinePanel.ts
+++ b/src/components/SituationTimelinePanel.ts
@@ -1,38 +1,39 @@
-/* eslint-disable sonarjs/no-nested-template-literals */
 /**
  * Situation Timeline Panel — Phase 4 chronological view.
  *
- * Filter bar (domain chips + status toggle + date range) drives a
- * sorted timeline list. Click any row to expand the peak-severity +
- * correlation details. Stats row at top summarises active count,
- * average duration, and the most-active domain.
+ * Filter bar (domain chips + status toggle + quick-range chips + date
+ * pickers) drives a sorted timeline list. Click any row to expand the
+ * peak-severity + correlation details. Stats row at top summarises
+ * active count, average duration, and the most-active domain.
  */
 
 import { Panel } from './Panel';
 import {
   getSituationTimelineService,
   type DomainBreakdownRow,
-  type TimelineEntry,
   type TimelineFilter,
-  type TimelineStats,
 } from '@/services/intelligence/situation-timeline';
-import type { SituationSeverity } from '@/services/intelligence/situation-store-v2';
 import { escapeHtml } from '@/utils/sanitize';
+import {
+  QUICK_RANGES,
+  isQuickRangeActive,
+  parseDate,
+  renderStatsRow,
+  renderTimeline,
+} from './situation-timeline-render';
 
 const REFRESH_MS = 30_000;
 const DOMAIN_CHIP_LIMIT = 8;
 
-const SEVERITY_COLOR: Record<SituationSeverity, string> = {
-  low: '#9e9e9e',
-  medium: '#4a9eff',
-  high: '#ffb74d',
-  critical: '#f44336',
-};
-
-const STATUS_COLOR: Record<TimelineEntry['status'], string> = {
-  active: '#f44336',
-  resolved: '#4caf50',
-};
+// Re-export the pure helpers so call sites + tests can keep importing
+// from the panel module path.
+export {
+  QUICK_RANGES,
+  isQuickRangeActive,
+  parseDate,
+  renderStatsRow,
+  renderTimeline,
+} from './situation-timeline-render';
 
 interface PanelState {
   filter: TimelineFilter;
@@ -54,7 +55,7 @@ export class SituationTimelinePanel extends Panel {
       showCount: true,
       trackActivity: true,
       infoTooltip:
-        'Phase 4 chronological view of all Situations. Filter by domain / status / date / minimum severity; click any row to expand peak-severity and correlation detail. Stats row reflects the full cache, not the filtered slice.',
+        'Phase 4 chronological view of all Situations. Filter by domain / status / quick-range / date / minimum severity; click any row to expand peak-severity and correlation detail. Stats row reflects the full cache, not the filtered slice.',
     });
     this.start();
   }
@@ -107,6 +108,12 @@ export class SituationTimelinePanel extends Panel {
       const border = active ? 'var(--accent,#4a9eff)' : 'var(--border-subtle,#333)';
       return `<button data-timeline-status="${s}" style="font-size:11px;padding:3px 8px;border:1px solid ${border};border-radius:3px;background:${bg};color:inherit;cursor:pointer;">${s}</button>`;
     }).join('');
+    const quickChips = QUICK_RANGES.map((r) => {
+      const active = isQuickRangeActive(this.state.filter, r.windowMs, Date.now());
+      const bg = active ? 'var(--accent,#4a9eff)26' : 'transparent';
+      const border = active ? 'var(--accent,#4a9eff)' : 'var(--border-subtle,#333)';
+      return `<button data-timeline-quick="${r.windowMs}" style="font-size:11px;padding:3px 8px;border:1px solid ${border};border-radius:3px;background:${bg};color:inherit;cursor:pointer;">${r.label}</button>`;
+    }).join('');
     const fromValue = this.state.filter.fromDate ? new Date(this.state.filter.fromDate).toISOString().slice(0, 10) : '';
     const toValue = this.state.filter.toDate ? new Date(this.state.filter.toDate).toISOString().slice(0, 10) : '';
     return `<div style="display:flex;flex-direction:column;gap:8px;">
@@ -118,7 +125,9 @@ export class SituationTimelinePanel extends Panel {
       <div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;">
         <span style="font-size:11px;color:var(--text-secondary,#aaa);text-transform:uppercase;letter-spacing:0.05em;">Status</span>
         ${statusToggles}
-        <span style="font-size:11px;color:var(--text-secondary,#aaa);margin-left:12px;">From</span>
+        <span style="font-size:11px;color:var(--text-secondary,#aaa);margin-left:12px;text-transform:uppercase;letter-spacing:0.05em;">Range</span>
+        ${quickChips}
+        <span style="font-size:11px;color:var(--text-secondary,#aaa);margin-left:8px;">From</span>
         <input id="timelineFromDate" type="date" value="${escapeHtml(fromValue)}" style="font-size:11px;padding:2px 4px;background:var(--surface-2,#1a1a1a);color:inherit;border:1px solid var(--border-subtle,#333);border-radius:3px;">
         <span style="font-size:11px;color:var(--text-secondary,#aaa);">To</span>
         <input id="timelineToDate" type="date" value="${escapeHtml(toValue)}" style="font-size:11px;padding:2px 4px;background:var(--surface-2,#1a1a1a);color:inherit;border:1px solid var(--border-subtle,#333);border-radius:3px;">
@@ -158,6 +167,15 @@ export class SituationTimelinePanel extends Panel {
         this.state.filter = { status: 'all' };
         this.render();
       });
+      root.querySelectorAll<HTMLButtonElement>('[data-timeline-quick]').forEach((el) => {
+        el.addEventListener('click', () => {
+          const windowMs = Number.parseInt(el.dataset.timelineQuick ?? '', 10);
+          if (!Number.isFinite(windowMs) || windowMs <= 0) return;
+          this.state.filter.fromDate = Date.now() - windowMs;
+          this.state.filter.toDate = undefined;
+          this.render();
+        });
+      });
       root.querySelectorAll<HTMLElement>('[data-timeline-row]').forEach((el) => {
         el.addEventListener('click', () => {
           const id = el.dataset.timelineRow;
@@ -168,91 +186,4 @@ export class SituationTimelinePanel extends Panel {
       });
     }, 0);
   }
-}
-
-function parseDate(value: string): number | undefined {
-  if (!value) return undefined;
-  const ts = Date.parse(value);
-  return Number.isFinite(ts) ? ts : undefined;
-}
-
-function renderStatsRow(stats: TimelineStats): string {
-  const longest = stats.longestActiveSituation;
-  const longestText = longest
-    ? `${escapeHtml(longest.title)} (${formatHours(longest.duration ?? 0)})`
-    : '—';
-  return `<div style="display:flex;gap:18px;font-size:12px;font-family:ui-monospace,monospace;flex-wrap:wrap;">
-    <span><strong>${stats.totalSituations}</strong> total</span>
-    <span><strong style="color:#f44336;">${stats.activeCount}</strong> active</span>
-    <span>avg <strong>${stats.avgDurationHours.toFixed(1)} h</strong></span>
-    <span>most active: <strong>${escapeHtml(stats.mostActiveDomain ?? '—')}</strong></span>
-    <span style="color:var(--text-secondary,#aaa);">longest active: ${longestText}</span>
-  </div>`;
-}
-
-function renderTimeline(entries: readonly TimelineEntry[], expandedId: string | null): string {
-  if (entries.length === 0) {
-    return `<div style="font-size:12px;color:var(--text-secondary,#aaa);">No situations match the current filter.</div>`;
-  }
-  const items = entries.map((e) => renderRow(e, e.situationId === expandedId)).join('');
-  return `<ul style="margin:0;padding:0;list-style:none;display:flex;flex-direction:column;gap:6px;">${items}</ul>`;
-}
-
-function renderRow(e: TimelineEntry, expanded: boolean): string {
-  const sevColor = SEVERITY_COLOR[e.currentSeverity];
-  const statusColor = STATUS_COLOR[e.status];
-  const arrow = expanded ? '▾' : '▸';
-  const durText = formatDurationText(e);
-  const startRel = formatAgo(Date.now() - e.startedAt);
-  return `<li data-timeline-row="${escapeHtml(e.situationId)}" style="cursor:pointer;border:1px solid var(--border-subtle,#333);border-left:3px solid ${sevColor};border-radius:3px;background:var(--surface-2,#1a1a1a);padding:6px 10px;display:flex;flex-direction:column;gap:4px;">
-    <div style="display:flex;align-items:center;gap:8px;font-size:12px;">
-      <span style="color:var(--text-secondary,#aaa);width:12px;">${arrow}</span>
-      <span style="font-size:10px;padding:1px 6px;border-radius:3px;background:${statusColor}26;color:${statusColor};text-transform:uppercase;letter-spacing:0.04em;">${e.status}</span>
-      <span style="font-size:10px;padding:1px 6px;border-radius:3px;background:var(--surface-3,#222);color:var(--text-secondary,#aaa);font-family:ui-monospace,monospace;">${escapeHtml(e.domain)}</span>
-      <span style="font-weight:600;flex:1;">${escapeHtml(e.title)}</span>
-      <span style="font-size:10px;padding:1px 6px;border-radius:3px;background:${sevColor}26;color:${sevColor};text-transform:uppercase;">${escapeHtml(e.currentSeverity)}</span>
-      <span style="font-size:11px;color:var(--text-secondary,#aaa);font-family:ui-monospace,monospace;">${escapeHtml(startRel)} · ${escapeHtml(durText)}</span>
-    </div>
-    ${expanded ? renderExpansion(e) : ''}
-  </li>`;
-}
-
-function renderExpansion(e: TimelineEntry): string {
-  const peakColor = SEVERITY_COLOR[e.peakSeverity];
-  const peakLabel = e.peakAt === null
-    ? `${e.peakSeverity} (current)`
-    : `${e.peakSeverity} at ${new Date(e.peakAt).toISOString().slice(0, 16)}Z`;
-  const resolvedText = e.resolvedAt === null
-    ? 'ongoing'
-    : `resolved ${new Date(e.resolvedAt).toISOString().slice(0, 16)}Z`;
-  return `<div style="display:flex;flex-direction:column;gap:4px;padding-top:4px;border-top:1px solid var(--border-subtle,#333);font-size:11px;">
-    <div>peak <span style="color:${peakColor};font-weight:600;">${escapeHtml(peakLabel)}</span></div>
-    <div style="color:var(--text-secondary,#aaa);">started ${new Date(e.startedAt).toISOString().slice(0, 16)}Z · ${escapeHtml(resolvedText)}</div>
-    <div style="color:var(--text-secondary,#aaa);">${e.correlationCount} correlation edge${e.correlationCount === 1 ? '' : 's'}</div>
-  </div>`;
-}
-
-function formatDurationText(e: TimelineEntry): string {
-  if (e.duration === null) return '—';
-  if (e.status === 'active') return `${formatHours(e.duration)} so far`;
-  return formatHours(e.duration);
-}
-
-function formatHours(ms: number): string {
-  const hours = ms / 3_600_000;
-  if (hours < 1) return `${Math.round(ms / 60_000)}m`;
-  if (hours < 24) return `${hours.toFixed(1)}h`;
-  return `${(hours / 24).toFixed(1)}d`;
-}
-
-function formatAgo(ms: number): string {
-  if (ms < 0) return 'just now';
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return `${s}s ago`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ago`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h ago`;
-  const d = Math.floor(h / 24);
-  return `${d}d ago`;
 }

--- a/src/components/situation-timeline-render.ts
+++ b/src/components/situation-timeline-render.ts
@@ -1,0 +1,131 @@
+/**
+ * Pure render helpers + format utilities for SituationTimelinePanel.
+ *
+ * Isolated from the Panel base class so unit tests can exercise the
+ * HTML/string contract without pulling in DOM, i18n, or Vite-only
+ * imports.
+ */
+
+import type { SituationSeverity } from '@/services/intelligence/situation-store-v2';
+import type { TimelineEntry, TimelineFilter, TimelineStats } from '@/services/intelligence/situation-timeline';
+import { escapeHtml } from '@/utils/sanitize';
+
+export const HOUR_MS = 60 * 60 * 1000;
+export const DAY_MS = 24 * HOUR_MS;
+
+export const SEVERITY_COLOR: Record<SituationSeverity, string> = {
+  low: '#9e9e9e',
+  medium: '#4a9eff',
+  high: '#ffb74d',
+  critical: '#f44336',
+};
+
+export const STATUS_COLOR: Record<TimelineEntry['status'], string> = {
+  active: '#f44336',
+  resolved: '#4caf50',
+};
+
+export interface QuickRange {
+  label: string;
+  windowMs: number;
+}
+
+export const QUICK_RANGES: readonly QuickRange[] = [
+  { label: '1h', windowMs: HOUR_MS },
+  { label: '6h', windowMs: 6 * HOUR_MS },
+  { label: '24h', windowMs: DAY_MS },
+  { label: '7d', windowMs: 7 * DAY_MS },
+];
+
+export function isQuickRangeActive(filter: TimelineFilter, windowMs: number, now: number): boolean {
+  if (filter.fromDate === undefined) return false;
+  const expected = now - windowMs;
+  return Math.abs(filter.fromDate - expected) <= 60_000;
+}
+
+export function parseDate(value: string): number | undefined {
+  if (!value) return undefined;
+  const ts = Date.parse(value);
+  return Number.isFinite(ts) ? ts : undefined;
+}
+
+export function renderStatsRow(stats: TimelineStats): string {
+  const longest = stats.longestActiveSituation;
+  const longestText = longest
+    ? `${escapeHtml(longest.title)} (${formatHours(longest.duration ?? 0)})`
+    : '—';
+  return `<div style="display:flex;gap:18px;font-size:12px;font-family:ui-monospace,monospace;flex-wrap:wrap;">
+    <span><strong>${stats.totalSituations}</strong> total</span>
+    <span><strong style="color:#f44336;">${stats.activeCount}</strong> active</span>
+    <span>avg <strong>${stats.avgDurationHours.toFixed(1)} h</strong></span>
+    <span>most active: <strong>${escapeHtml(stats.mostActiveDomain ?? '—')}</strong></span>
+    <span style="color:var(--text-secondary,#aaa);">longest active: ${longestText}</span>
+  </div>`;
+}
+
+export function renderTimeline(entries: readonly TimelineEntry[], expandedId: string | null): string {
+  if (entries.length === 0) {
+    return `<div style="font-size:12px;color:var(--text-secondary,#aaa);">No situations match the current filter.</div>`;
+  }
+  const items = entries.map((e) => renderRow(e, e.situationId === expandedId)).join('');
+  return `<ul style="margin:0;padding:0;list-style:none;display:flex;flex-direction:column;gap:6px;">${items}</ul>`;
+}
+
+export function renderRow(e: TimelineEntry, expanded: boolean): string {
+  const sevColor = SEVERITY_COLOR[e.currentSeverity];
+  const statusColor = STATUS_COLOR[e.status];
+  const arrow = expanded ? '▾' : '▸';
+  const durText = formatDurationText(e);
+  const startRel = formatAgo(Date.now() - e.startedAt);
+  return `<li data-timeline-row="${escapeHtml(e.situationId)}" style="cursor:pointer;border:1px solid var(--border-subtle,#333);border-left:3px solid ${sevColor};border-radius:3px;background:var(--surface-2,#1a1a1a);padding:6px 10px;display:flex;flex-direction:column;gap:4px;">`
+    + `<div style="display:flex;align-items:center;gap:8px;font-size:12px;">`
+    + `<span style="color:var(--text-secondary,#aaa);width:12px;">${arrow}</span>`
+    + `<span style="font-size:10px;padding:1px 6px;border-radius:3px;background:${statusColor}26;color:${statusColor};text-transform:uppercase;letter-spacing:0.04em;">${e.status}</span>`
+    + `<span style="font-size:10px;padding:1px 6px;border-radius:3px;background:var(--surface-3,#222);color:var(--text-secondary,#aaa);font-family:ui-monospace,monospace;">${escapeHtml(e.domain)}</span>`
+    + `<span style="font-weight:600;flex:1;">${escapeHtml(e.title)}</span>`
+    + `<span style="font-size:10px;padding:1px 6px;border-radius:3px;background:${sevColor}26;color:${sevColor};text-transform:uppercase;">${escapeHtml(e.currentSeverity)}</span>`
+    + `<span style="font-size:11px;color:var(--text-secondary,#aaa);font-family:ui-monospace,monospace;">${escapeHtml(startRel)} · ${escapeHtml(durText)}</span>`
+    + `</div>`
+    + `${expanded ? renderExpansion(e) : ''}`
+    + `</li>`;
+}
+
+export function renderExpansion(e: TimelineEntry): string {
+  const peakColor = SEVERITY_COLOR[e.peakSeverity];
+  const peakLabel = e.peakAt === null
+    ? `${e.peakSeverity} (current)`
+    : `${e.peakSeverity} at ${new Date(e.peakAt).toISOString().slice(0, 16)}Z`;
+  const resolvedText = e.resolvedAt === null
+    ? 'ongoing'
+    : `resolved ${new Date(e.resolvedAt).toISOString().slice(0, 16)}Z`;
+  return `<div style="display:flex;flex-direction:column;gap:4px;padding-top:4px;border-top:1px solid var(--border-subtle,#333);font-size:11px;">`
+    + `<div>peak <span style="color:${peakColor};font-weight:600;">${escapeHtml(peakLabel)}</span></div>`
+    + `<div style="color:var(--text-secondary,#aaa);">started ${new Date(e.startedAt).toISOString().slice(0, 16)}Z · ${escapeHtml(resolvedText)}</div>`
+    + `<div style="color:var(--text-secondary,#aaa);">${e.correlationCount} correlation edge${e.correlationCount === 1 ? '' : 's'}</div>`
+    + `</div>`;
+}
+
+export function formatDurationText(e: TimelineEntry): string {
+  if (e.duration === null) return '—';
+  if (e.status === 'active') return `${formatHours(e.duration)} so far`;
+  return formatHours(e.duration);
+}
+
+export function formatHours(ms: number): string {
+  const hours = ms / 3_600_000;
+  if (hours < 1) return `${Math.round(ms / 60_000)}m`;
+  if (hours < 24) return `${hours.toFixed(1)}h`;
+  return `${(hours / 24).toFixed(1)}d`;
+}
+
+export function formatAgo(ms: number): string {
+  if (ms < 0) return 'just now';
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -193,6 +193,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'notification-settings': { name: 'Notification Settings', enabled: true, priority: 1 },
   'personal-relevance': { name: 'Personal Relevance', enabled: true, priority: 1 },
   'situations': { name: 'Situations', enabled: true, priority: 1 },
+  'situation-timeline': { name: 'Situation Timeline', enabled: true, priority: 1 },
   'observation-rules': { name: 'Observation Rules', enabled: true, priority: 1 },
   // Worldview / Palantir / Dragos-inspired panels
   'pattern-of-life': { name: 'Pattern of Life', enabled: true, priority: 2 },

--- a/tests/components/situation-timeline-panel.test.mts
+++ b/tests/components/situation-timeline-panel.test.mts
@@ -1,0 +1,326 @@
+/**
+ * SituationTimelinePanel — pure render-helper unit tests.
+ *
+ * The panel itself wires DOM events and reads from the live
+ * `getSituationTimelineService()` singleton. Tests here exercise the
+ * pure HTML helpers + utility functions exposed through `__internals`
+ * so the rendering contract stays nailed down without needing JSDOM.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  QUICK_RANGES,
+  SEVERITY_COLOR,
+  STATUS_COLOR,
+  HOUR_MS,
+  DAY_MS,
+  parseDate,
+  isQuickRangeActive,
+  renderStatsRow,
+  renderTimeline,
+  renderRow,
+  renderExpansion,
+  formatDurationText,
+  formatHours,
+  formatAgo,
+} from '../../src/components/situation-timeline-render.ts';
+import type { TimelineEntry, TimelineStats, TimelineFilter } from '../../src/services/intelligence/situation-timeline.ts';
+
+const NOW = 1_780_000_000_000;
+
+function makeEntry(over: Partial<TimelineEntry> = {}): TimelineEntry {
+  return {
+    situationId: 'sit-1',
+    title: 'Storm cluster over Midwest',
+    domain: 'weather',
+    startedAt: NOW - 2 * HOUR_MS,
+    peakAt: NOW - HOUR_MS,
+    resolvedAt: null,
+    peakSeverity: 'high',
+    currentSeverity: 'medium',
+    duration: 2 * HOUR_MS,
+    status: 'active',
+    correlationCount: 0,
+    ...over,
+  };
+}
+
+function makeStats(over: Partial<TimelineStats> = {}): TimelineStats {
+  return {
+    totalSituations: 5,
+    activeCount: 2,
+    avgDurationHours: 3.5,
+    longestActiveSituation: null,
+    mostActiveDomain: 'weather',
+    ...over,
+  };
+}
+
+// ── QUICK_RANGES ─────────────────────────────────────────────────────
+
+describe('QUICK_RANGES', () => {
+  it('exposes the four spec presets', () => {
+    assert.equal(QUICK_RANGES.length, 4);
+    assert.deepEqual(
+      QUICK_RANGES.map((r) => r.label),
+      ['1h', '6h', '24h', '7d'],
+    );
+  });
+
+  it('preset windowMs values match their labels', () => {
+    const byLabel = Object.fromEntries(QUICK_RANGES.map((r) => [r.label, r.windowMs]));
+    assert.equal(byLabel['1h'], HOUR_MS);
+    assert.equal(byLabel['6h'], 6 * HOUR_MS);
+    assert.equal(byLabel['24h'], DAY_MS);
+    assert.equal(byLabel['7d'], 7 * DAY_MS);
+  });
+});
+
+// ── isQuickRangeActive ───────────────────────────────────────────────
+
+describe('isQuickRangeActive', () => {
+  it('returns false when filter.fromDate is undefined', () => {
+    const filter: TimelineFilter = {};
+    assert.equal(isQuickRangeActive(filter, HOUR_MS, NOW), false);
+  });
+
+  it('returns true when fromDate matches now - window exactly', () => {
+    const filter: TimelineFilter = { fromDate: NOW - HOUR_MS };
+    assert.equal(isQuickRangeActive(filter, HOUR_MS, NOW), true);
+  });
+
+  it('tolerates up to 60s of clock drift', () => {
+    const filter: TimelineFilter = { fromDate: NOW - HOUR_MS + 30_000 };
+    assert.equal(isQuickRangeActive(filter, HOUR_MS, NOW), true);
+  });
+
+  it('returns false when drift exceeds 60s', () => {
+    const filter: TimelineFilter = { fromDate: NOW - HOUR_MS - 90_000 };
+    assert.equal(isQuickRangeActive(filter, HOUR_MS, NOW), false);
+  });
+
+  it('different windows do not match each other', () => {
+    const filter: TimelineFilter = { fromDate: NOW - HOUR_MS };
+    assert.equal(isQuickRangeActive(filter, DAY_MS, NOW), false);
+  });
+});
+
+// ── parseDate ────────────────────────────────────────────────────────
+
+describe('parseDate', () => {
+  it('returns undefined for empty input', () => {
+    assert.equal(parseDate(''), undefined);
+  });
+
+  it('parses an ISO date string to epoch ms', () => {
+    const ts = parseDate('2024-01-15');
+    assert.equal(typeof ts, 'number');
+    assert.equal(ts, Date.parse('2024-01-15'));
+  });
+
+  it('returns undefined for unparseable input', () => {
+    assert.equal(parseDate('not-a-date'), undefined);
+  });
+});
+
+// ── Severity / status color tables ───────────────────────────────────
+
+describe('SEVERITY_COLOR + STATUS_COLOR', () => {
+  it('covers the four severity levels', () => {
+    assert.ok(SEVERITY_COLOR.low);
+    assert.ok(SEVERITY_COLOR.medium);
+    assert.ok(SEVERITY_COLOR.high);
+    assert.ok(SEVERITY_COLOR.critical);
+  });
+
+  it('critical is the brightest red signal', () => {
+    assert.equal(SEVERITY_COLOR.critical, '#f44336');
+  });
+
+  it('low is gray', () => {
+    assert.equal(SEVERITY_COLOR.low, '#9e9e9e');
+  });
+
+  it('active uses red, resolved uses green', () => {
+    assert.equal(STATUS_COLOR.active, '#f44336');
+    assert.equal(STATUS_COLOR.resolved, '#4caf50');
+  });
+});
+
+// ── Format helpers ───────────────────────────────────────────────────
+
+describe('formatHours', () => {
+  it('renders sub-hour durations in minutes', () => {
+    assert.equal(formatHours(15 * 60 * 1000), '15m');
+  });
+
+  it('renders 1-24h durations with 1 decimal hour', () => {
+    assert.equal(formatHours(2.5 * 60 * 60 * 1000), '2.5h');
+  });
+
+  it('renders multi-day durations in days', () => {
+    assert.equal(formatHours(3 * 24 * 60 * 60 * 1000), '3.0d');
+  });
+});
+
+describe('formatAgo', () => {
+  it('returns "just now" for negative durations', () => {
+    assert.equal(formatAgo(-1000), 'just now');
+  });
+
+  it('renders sub-minute as seconds', () => {
+    assert.equal(formatAgo(30_000), '30s ago');
+  });
+
+  it('renders sub-hour as minutes', () => {
+    assert.equal(formatAgo(5 * 60_000), '5m ago');
+  });
+
+  it('renders sub-day as hours', () => {
+    assert.equal(formatAgo(5 * 60 * 60_000), '5h ago');
+  });
+
+  it('renders multi-day as days', () => {
+    assert.equal(formatAgo(3 * 24 * 60 * 60_000), '3d ago');
+  });
+});
+
+describe('formatDurationText', () => {
+  it('renders em-dash for null duration', () => {
+    assert.equal(formatDurationText(makeEntry({ duration: null })), '—');
+  });
+
+  it('renders "so far" suffix for active entries', () => {
+    const txt = formatDurationText(makeEntry({ status: 'active', duration: 2 * HOUR_MS }));
+    assert.match(txt, /so far$/);
+  });
+
+  it('renders bare duration for resolved entries', () => {
+    const txt = formatDurationText(makeEntry({ status: 'resolved', duration: 2 * HOUR_MS }));
+    assert.equal(txt, '2.0h');
+  });
+});
+
+// ── renderStatsRow ───────────────────────────────────────────────────
+
+describe('renderStatsRow', () => {
+  it('renders the totals + active count + avg duration', () => {
+    const html = renderStatsRow(makeStats({ totalSituations: 12, activeCount: 4, avgDurationHours: 3.5 }));
+    assert.match(html, /12.*total/);
+    assert.match(html, /4.*active/);
+    assert.match(html, /3\.5 h/);
+  });
+
+  it('shows em-dash when no most-active domain is known', () => {
+    const html = renderStatsRow(makeStats({ mostActiveDomain: null }));
+    assert.match(html, /most active:.*—/);
+  });
+
+  it('escapes the most-active-domain name', () => {
+    const html = renderStatsRow(makeStats({ mostActiveDomain: '<script>x</script>' }));
+    assert.ok(!html.includes('<script>x</script>'));
+    assert.match(html, /&lt;script&gt;/);
+  });
+
+  it('shows longest active situation when present', () => {
+    const longest = makeEntry({ title: 'Hurricane Echo', duration: 12 * HOUR_MS });
+    const html = renderStatsRow(makeStats({ longestActiveSituation: longest }));
+    assert.match(html, /Hurricane Echo/);
+    assert.match(html, /12\.0h/);
+  });
+});
+
+// ── renderTimeline ───────────────────────────────────────────────────
+
+describe('renderTimeline empty + populated', () => {
+  it('renders empty-state copy when there are no entries', () => {
+    const html = renderTimeline([], null);
+    assert.match(html, /No situations match the current filter/i);
+  });
+
+  it('renders an entry list with one li per entry', () => {
+    const entries = [makeEntry({ situationId: 'a' }), makeEntry({ situationId: 'b' })];
+    const html = renderTimeline(entries, null);
+    const liCount = (html.match(/<li /g) ?? []).length;
+    assert.equal(liCount, 2);
+  });
+
+  it('marks the matching id as expanded', () => {
+    const entries = [makeEntry({ situationId: 'a' }), makeEntry({ situationId: 'b' })];
+    const html = renderTimeline(entries, 'b');
+    // The expanded row has the down-arrow ▾ and the collapsed has ▸.
+    const downArrowCount = (html.match(/▾/g) ?? []).length;
+    const rightArrowCount = (html.match(/▸/g) ?? []).length;
+    assert.equal(downArrowCount, 1);
+    assert.equal(rightArrowCount, 1);
+  });
+});
+
+// ── renderRow ────────────────────────────────────────────────────────
+
+describe('renderRow', () => {
+  it('renders the data-timeline-row attribute carrying the situation id', () => {
+    const html = renderRow(makeEntry({ situationId: 'sit-42' }), false);
+    assert.match(html, /data-timeline-row="sit-42"/);
+  });
+
+  it('uses the critical color when severity is critical', () => {
+    const html = renderRow(makeEntry({ currentSeverity: 'critical' }), false);
+    assert.ok(html.includes(SEVERITY_COLOR.critical));
+  });
+
+  it('escapes the entry title against XSS', () => {
+    const html = renderRow(makeEntry({ title: '<img src=x onerror=alert(1)>' }), false);
+    assert.ok(!html.includes('<img src=x'));
+    assert.match(html, /&lt;img/);
+  });
+
+  it('shows the right arrow when collapsed', () => {
+    const html = renderRow(makeEntry(), false);
+    assert.match(html, /▸/);
+    assert.ok(!html.includes('▾'));
+  });
+
+  it('shows the down arrow + expansion content when expanded', () => {
+    const html = renderRow(makeEntry({ peakAt: NOW - HOUR_MS, peakSeverity: 'high' }), true);
+    assert.match(html, /▾/);
+    assert.match(html, /peak/);
+  });
+});
+
+// ── renderExpansion ──────────────────────────────────────────────────
+
+describe('renderExpansion', () => {
+  it('renders "(current)" when peakAt is null', () => {
+    const html = renderExpansion(makeEntry({ peakAt: null, peakSeverity: 'medium' }));
+    assert.match(html, /medium \(current\)/);
+  });
+
+  it('renders "ongoing" when resolvedAt is null', () => {
+    const html = renderExpansion(makeEntry({ resolvedAt: null }));
+    assert.match(html, /ongoing/);
+  });
+
+  it('renders "resolved <iso>" when resolved', () => {
+    const html = renderExpansion(makeEntry({ resolvedAt: NOW }));
+    assert.match(html, /resolved \d{4}-\d{2}-\d{2}T\d{2}:\d{2}Z/);
+  });
+
+  it('renders singular "edge" for one correlation', () => {
+    const html = renderExpansion(makeEntry({ correlationCount: 1 }));
+    assert.match(html, /1 correlation edge\b/);
+    assert.ok(!html.includes('edges'));
+  });
+
+  it('renders plural "edges" for many correlations', () => {
+    const html = renderExpansion(makeEntry({ correlationCount: 3 }));
+    assert.match(html, /3 correlation edges/);
+  });
+
+  it('uses peakSeverity color for the peak label', () => {
+    const html = renderExpansion(makeEntry({ peakSeverity: 'critical' }));
+    assert.ok(html.includes(SEVERITY_COLOR.critical));
+  });
+});


### PR DESCRIPTION
## Summary

Wires the missing FULL_PANELS dict entry for the existing `SituationTimelinePanel`, extracts its pure render helpers into a sibling module so they're unit-testable without DOM, adds **1h / 6h / 24h / 7d quick-range chips**, and ships **43 unit tests** at `tests/components/situation-timeline-panel.test.mts`.

## Why the refactor

The panel's render code lived inline alongside the Panel-base lifecycle code, which means importing it from a test runner pulls in the i18n module → which pulls in a Vite-only `?worker` import that node can't resolve. Moving the pure helpers (`renderStatsRow`, `renderTimeline`, `renderRow`, `renderExpansion`, `formatHours`, `formatAgo`, `formatDurationText`, `parseDate`, `isQuickRangeActive`, `QUICK_RANGES`, `SEVERITY_COLOR`, `STATUS_COLOR`) into `src/components/situation-timeline-render.ts` makes them testable in isolation while the panel re-exports them so any existing call site keeps working.

## Quick-range chips

`QUICK_RANGES` defines four presets (`1h`, `6h`, `24h`, `7d`). Clicking a chip sets `filter.fromDate = now - windowMs` and clears `toDate`. `isQuickRangeActive` tolerates up to 60 s of drift between the persisted `fromDate` and `now - windowMs` so the active-state highlight stays stable across repaints.

## Registration gap

`panel-layout.ts:1441` already constructs the panel, but `src/config/panels.ts` was missing the `'situation-timeline': { name: 'Situation Timeline', enabled: true, priority: 1 }` entry — without it the variant-aware enable check filtered the panel out. This PR adds that entry.

## Tests — 43 in `tests/components/situation-timeline-panel.test.mts`

- **QUICK_RANGES**: exposes 4 spec presets; `windowMs` matches labels (1h / 6h / 24h / 7d)
- **isQuickRangeActive**: false when `fromDate` undefined; true on exact match; tolerates 60 s drift; rejects > 60 s drift; different windows don't cross-match
- **parseDate**: empty → undefined; ISO string → epoch ms; unparseable → undefined
- **SEVERITY_COLOR / STATUS_COLOR**: covers all 4 severities; critical = #f44336; low = #9e9e9e; active = red; resolved = green
- **formatHours**: sub-hour → "15m"; sub-day → "2.5h"; multi-day → "3.0d"
- **formatAgo**: negative → "just now"; seconds / minutes / hours / days branches
- **formatDurationText**: null → em-dash; active gets "so far" suffix; resolved is bare
- **renderStatsRow**: total + active + avg; em-dash on null most-active-domain; escapes XSS in most-active-domain; renders longest-active when present
- **renderTimeline**: empty-state copy; one `<li>` per entry; matching id gets ▾ arrow, others get ▸
- **renderRow**: data-timeline-row attr carries id; critical color when severity is critical; escapes title XSS; arrow state per expanded flag; expansion renders when expanded
- **renderExpansion**: "(current)" when `peakAt` is null; "ongoing" when `resolvedAt` is null; "resolved <iso>" when set; singular "edge" vs plural "edges"; peakSeverity color is applied

## Preview verification

**Unavailable** — pre-existing `@luma.gl/engine` / `@deck.gl/geo-layers` Vite optimize-deps error blocks the dev server, same as prior PRs in this stack.

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass