### PR TITLE
Seismic mission bridges — USGS earthquakes, tsunami alerts, ShakeAlert EEW

### DIFF
--- a/src/services/intelligence/mission-bridges/seismic-mission-bridges.ts
+++ b/src/services/intelligence/mission-bridges/seismic-mission-bridges.ts
@@ -1,0 +1,390 @@
+/**
+ * Seismic mission bridges (ObservationEvent flavour).
+ *
+ * Adapters that normalize raw seismic feeds into `ObservationEvent`
+ * records via the abstract `MissionBridgeBase` contract in
+ * `src/services/intelligence/mission-bridge-core.ts`.
+ *
+ * Three bridges:
+ *   - SeismicMissionBridge  — USGS earthquakes, M5+ only
+ *                             (feedId 'usgs-earthquake')
+ *   - TsunamiMissionBridge  — PTWC / NWS tsunami alerts
+ *                             (feedId 'tsunami-alert')
+ *   - AfterShockMissionBridge — ShakeAlert EEW intensities
+ *                             (feedId 'shakealert-eew')
+ *
+ * Separate file from the legacy `./seismic-bridges.ts` (which targets
+ * the older `NormalizedFeedEvent` core and stays the source of truth
+ * for that contract). Both designs coexist — pick by import path.
+ *
+ * Pure normalize() logic. Fetchers are injected so tests can pin
+ * behavior without DOM/network.
+ */
+
+import type { ObservationEvent, ObservationSeverity } from '@/types/intelligence';
+import {
+  MissionBridgeBase,
+  type MissionBridgeConfig,
+  type MissionBridgeOptions,
+} from '../mission-bridge-core';
+
+// ── Shared severity scale ────────────────────────────────────────────────
+
+/** 1 = LOW, 2 = MEDIUM, 3 = HIGH, 4 = CRITICAL. */
+export type SeismicSeverityRank = 1 | 2 | 3 | 4;
+
+export function rankToSeverity(rank: SeismicSeverityRank): ObservationSeverity {
+  switch (rank) {
+    case 4: { return 'CRITICAL'; }
+    case 3: { return 'HIGH'; }
+    case 2: { return 'MEDIUM'; }
+    case 1: { return 'LOW'; }
+  }
+}
+
+// ── Pure helpers (exported for tests) ────────────────────────────────────
+
+/**
+ * USGS earthquake rank ladder.
+ *   M ≥ 7    → 4 (CRITICAL)
+ *   M ≥ 6    → 3 (HIGH)
+ *   M ≥ 5    → 2 (MEDIUM)
+ *   else     → 1 (LOW)
+ */
+export function magnitudeRank(magnitude: number): SeismicSeverityRank {
+  if (!Number.isFinite(magnitude)) return 1;
+  if (magnitude >= 7) return 4;
+  if (magnitude >= 6) return 3;
+  if (magnitude >= 5) return 2;
+  return 1;
+}
+
+/**
+ * PTWC/NWS tsunami-alert rank ladder. Inputs are matched case-insensitively
+ * and tolerant of leading/trailing whitespace.
+ *   warning → 4 (CRITICAL)
+ *   watch   → 3 (HIGH)
+ *   advisory → 2 (MEDIUM)
+ *   information → 1 (LOW)
+ *   other / empty → 1 (LOW, defensive)
+ */
+export function tsunamiLevelRank(level: string | null | undefined): SeismicSeverityRank {
+  if (typeof level !== 'string') return 1;
+  const normalised = level.trim().toLowerCase();
+  if (normalised === 'warning') return 4;
+  if (normalised === 'watch') return 3;
+  if (normalised === 'advisory') return 2;
+  if (normalised === 'information') return 1;
+  return 1;
+}
+
+/**
+ * ShakeAlert Modified-Mercalli intensity rank.
+ *   MMI VII+   → 4 (CRITICAL)
+ *   MMI V–VI   → 3 (HIGH)
+ *   MMI III–IV → 2 (MEDIUM)
+ *   else       → 1 (LOW)
+ *
+ * Accepts Roman-numeral strings ('III', 'IX') OR plain integers (3, 9).
+ */
+export function mmiRank(mmi: number | string | null | undefined): SeismicSeverityRank {
+  const value = mmiToInteger(mmi);
+  if (value === null) return 1;
+  if (value >= 7) return 4;
+  if (value >= 5) return 3;
+  if (value >= 3) return 2;
+  return 1;
+}
+
+const ROMAN_MMI: Record<string, number> = {
+  I: 1, II: 2, III: 3, IV: 4, V: 5, VI: 6, VII: 7, VIII: 8, IX: 9, X: 10,
+  XI: 11, XII: 12,
+};
+
+export function mmiToInteger(mmi: number | string | null | undefined): number | null {
+  if (typeof mmi === 'number') {
+    return Number.isFinite(mmi) ? Math.floor(mmi) : null;
+  }
+  if (typeof mmi !== 'string') return null;
+  const trimmed = mmi.trim().toUpperCase();
+  if (trimmed.length === 0) return null;
+  if (ROMAN_MMI[trimmed] !== undefined) return ROMAN_MMI[trimmed];
+  // Allow numeric-string fallback like "5" or "7.2".
+  const n = Number.parseFloat(trimmed);
+  return Number.isFinite(n) ? Math.floor(n) : null;
+}
+
+// ── Raw payload shapes ───────────────────────────────────────────────────
+
+export interface RawUsgsQuake {
+  id: string;
+  magnitude: number;
+  place: string;
+  /** Unix epoch ms. */
+  timestamp: number;
+  lat: number;
+  lon: number;
+  /** Optional depth in km. */
+  depthKm?: number;
+}
+
+/** Official PTWC/NTWC level strings. Stored as plain `string` on the
+ *  raw payload so unknown / future values flow through normalize and
+ *  fall back to LOW; see `tsunamiLevelRank`. */
+export type TsunamiLevel = 'Warning' | 'Watch' | 'Advisory' | 'Information';
+
+export interface RawTsunamiAlert {
+  id: string;
+  /** Stored as plain `string` so unknown levels flow through and fall
+   *  back to LOW via `tsunamiLevelRank`. Construct against `TsunamiLevel`
+   *  for the canonical PTWC/NTWC vocabulary. */
+  level: string;
+  /** Human-readable headline / region name. */
+  region: string;
+  /** Unix epoch ms when the alert was issued. */
+  issuedAt: number;
+  lat?: number;
+  lon?: number;
+  /** Optional reference earthquake / source-event id. */
+  sourceEventId?: string;
+}
+
+export interface RawShakeAlertEEW {
+  id: string;
+  /** Predicted peak MMI as a Roman-numeral string or integer. */
+  mmi: number | string;
+  /** Unix epoch ms when the alert was issued. */
+  issuedAt: number;
+  /** Estimated magnitude of the trigger event. */
+  magnitude?: number;
+  lat: number;
+  lon: number;
+  /** Seconds of warning before S-wave arrival at the user's location. */
+  warningSeconds?: number;
+}
+
+// ── Bridge configs ───────────────────────────────────────────────────────
+
+const SEISMIC_DEFAULT_CONFIG: MissionBridgeConfig = {
+  domain: 'seismic',
+  feedId: 'usgs-earthquake',
+  refreshIntervalMs: 60_000,
+  maxObservationsPerCycle: 100,
+  enabled: true,
+};
+
+const TSUNAMI_DEFAULT_CONFIG: MissionBridgeConfig = {
+  domain: 'seismic',
+  feedId: 'tsunami-alert',
+  refreshIntervalMs: 120_000,
+  maxObservationsPerCycle: 50,
+  enabled: true,
+};
+
+const SHAKEALERT_DEFAULT_CONFIG: MissionBridgeConfig = {
+  domain: 'seismic',
+  feedId: 'shakealert-eew',
+  refreshIntervalMs: 5000,
+  maxObservationsPerCycle: 50,
+  enabled: true,
+};
+
+// ── Bridge options ───────────────────────────────────────────────────────
+
+export interface SeismicMissionBridgeOptions extends MissionBridgeOptions {
+  fetcher?: () => Promise<RawUsgsQuake[]>;
+  config?: Partial<MissionBridgeConfig>;
+}
+
+export interface TsunamiMissionBridgeOptions extends MissionBridgeOptions {
+  fetcher?: () => Promise<RawTsunamiAlert[]>;
+  config?: Partial<MissionBridgeConfig>;
+}
+
+export interface AfterShockMissionBridgeOptions extends MissionBridgeOptions {
+  fetcher?: () => Promise<RawShakeAlertEEW[]>;
+  config?: Partial<MissionBridgeConfig>;
+}
+
+function emptyFetcher<T>(): Promise<T[]> {
+  return Promise.resolve([]);
+}
+
+// ── SeismicMissionBridge — USGS earthquakes ──────────────────────────────
+
+/**
+ * USGS earthquake bridge. Filters to M5+ events; sub-M5 events are
+ * dropped (normalize returns null) so the truth-score pipeline isn't
+ * spammed with micro events the spec considers below-floor.
+ */
+export class SeismicMissionBridge extends MissionBridgeBase {
+  private readonly fetcher: () => Promise<RawUsgsQuake[]>;
+
+  constructor(options: SeismicMissionBridgeOptions = {}) {
+    super({ ...SEISMIC_DEFAULT_CONFIG, ...options.config }, options);
+    this.fetcher = options.fetcher ?? emptyFetcher;
+  }
+
+  override fetchRaw(): Promise<unknown[]> {
+    return this.fetcher() as Promise<unknown[]>;
+  }
+
+  override normalize(raw: unknown): ObservationEvent | null {
+    if (!isRawUsgsQuake(raw)) return null;
+    if (raw.magnitude < 5) return null; // M5+ only per spec
+    const rank = magnitudeRank(raw.magnitude);
+    const severity = rankToSeverity(rank);
+    const depthTag = typeof raw.depthKm === 'number' && Number.isFinite(raw.depthKm)
+      ? `depth-${Math.round(raw.depthKm)}km` : 'depth-unknown';
+    return {
+      id: `usgs-earthquake:${raw.id}`,
+      sourceId: this.config.feedId,
+      domain: this.config.domain,
+      timestamp: raw.timestamp,
+      location: { lat: raw.lat, lon: raw.lon, radiusKm: ruptureRadiusKm(raw.magnitude) },
+      severity,
+      title: `M${raw.magnitude.toFixed(1)} earthquake near ${raw.place}`,
+      raw,
+      entityIds: [],
+      tags: ['earthquake', `rank-${rank}`, `severity-${severity.toLowerCase()}`, depthTag],
+    };
+  }
+}
+
+// ── TsunamiMissionBridge — PTWC / NWS alerts ─────────────────────────────
+
+export class TsunamiMissionBridge extends MissionBridgeBase {
+  private readonly fetcher: () => Promise<RawTsunamiAlert[]>;
+
+  constructor(options: TsunamiMissionBridgeOptions = {}) {
+    super({ ...TSUNAMI_DEFAULT_CONFIG, ...options.config }, options);
+    this.fetcher = options.fetcher ?? emptyFetcher;
+  }
+
+  override fetchRaw(): Promise<unknown[]> {
+    return this.fetcher() as Promise<unknown[]>;
+  }
+
+  override normalize(raw: unknown): ObservationEvent | null {
+    if (!isRawTsunamiAlert(raw)) return null;
+    const rank = tsunamiLevelRank(raw.level);
+    const severity = rankToSeverity(rank);
+    const levelTag = `level-${(raw.level || 'unknown').toLowerCase()}`;
+    const location = typeof raw.lat === 'number' && typeof raw.lon === 'number'
+      && Number.isFinite(raw.lat) && Number.isFinite(raw.lon)
+      ? { lat: raw.lat, lon: raw.lon, radiusKm: 250 }
+      : undefined;
+    return {
+      id: `tsunami-alert:${raw.id}`,
+      sourceId: this.config.feedId,
+      domain: this.config.domain,
+      timestamp: raw.issuedAt,
+      location,
+      severity,
+      title: `Tsunami ${raw.level} — ${raw.region}`,
+      raw,
+      entityIds: typeof raw.sourceEventId === 'string' && raw.sourceEventId.length > 0
+        ? [raw.sourceEventId] : [],
+      tags: ['tsunami', levelTag, `rank-${rank}`, `severity-${severity.toLowerCase()}`],
+    };
+  }
+}
+
+// ── AfterShockMissionBridge — ShakeAlert EEW ─────────────────────────────
+
+/**
+ * ShakeAlert Early-Earthquake-Warning bridge. The name "AfterShock" is
+ * the host-mandated identifier; the underlying feed is the USGS /
+ * UC Berkeley ShakeAlert system, which estimates a peak MMI ahead of
+ * S-wave arrival. We rank by that predicted intensity, not the
+ * underlying source magnitude.
+ */
+export class AfterShockMissionBridge extends MissionBridgeBase {
+  private readonly fetcher: () => Promise<RawShakeAlertEEW[]>;
+
+  constructor(options: AfterShockMissionBridgeOptions = {}) {
+    super({ ...SHAKEALERT_DEFAULT_CONFIG, ...options.config }, options);
+    this.fetcher = options.fetcher ?? emptyFetcher;
+  }
+
+  override fetchRaw(): Promise<unknown[]> {
+    return this.fetcher() as Promise<unknown[]>;
+  }
+
+  override normalize(raw: unknown): ObservationEvent | null {
+    if (!isRawShakeAlertEEW(raw)) return null;
+    const rank = mmiRank(raw.mmi);
+    const severity = rankToSeverity(rank);
+    const mmiInt = mmiToInteger(raw.mmi) ?? 0;
+    const magnitudeText = typeof raw.magnitude === 'number' && Number.isFinite(raw.magnitude)
+      ? `M${raw.magnitude.toFixed(1)} ` : '';
+    const warningTag = typeof raw.warningSeconds === 'number' && raw.warningSeconds > 0
+      ? `warning-${Math.round(raw.warningSeconds)}s` : 'warning-immediate';
+    return {
+      id: `shakealert-eew:${raw.id}`,
+      sourceId: this.config.feedId,
+      domain: this.config.domain,
+      timestamp: raw.issuedAt,
+      location: { lat: raw.lat, lon: raw.lon, radiusKm: 50 },
+      severity,
+      title: `${magnitudeText}ShakeAlert — predicted MMI ${integerToRoman(mmiInt)}`,
+      raw,
+      entityIds: [],
+      tags: ['eew', 'shakealert', `mmi-${mmiInt}`, `rank-${rank}`,
+        `severity-${severity.toLowerCase()}`, warningTag],
+    };
+  }
+}
+
+// ── Type guards ──────────────────────────────────────────────────────────
+
+function isRawUsgsQuake(value: unknown): value is RawUsgsQuake {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.id === 'string' && v.id.length > 0
+    && typeof v.magnitude === 'number' && Number.isFinite(v.magnitude)
+    && typeof v.place === 'string'
+    && typeof v.timestamp === 'number' && Number.isFinite(v.timestamp)
+    && typeof v.lat === 'number' && Number.isFinite(v.lat)
+    && typeof v.lon === 'number' && Number.isFinite(v.lon);
+}
+
+function isRawTsunamiAlert(value: unknown): value is RawTsunamiAlert {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.id === 'string' && v.id.length > 0
+    && typeof v.level === 'string'
+    && typeof v.region === 'string'
+    && typeof v.issuedAt === 'number' && Number.isFinite(v.issuedAt);
+}
+
+function isRawShakeAlertEEW(value: unknown): value is RawShakeAlertEEW {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.id !== 'string' || v.id.length === 0) return false;
+  if (typeof v.issuedAt !== 'number' || !Number.isFinite(v.issuedAt)) return false;
+  if (typeof v.lat !== 'number' || !Number.isFinite(v.lat)) return false;
+  if (typeof v.lon !== 'number' || !Number.isFinite(v.lon)) return false;
+  // mmi may be string or number
+  if (v.mmi === undefined || v.mmi === null) return false;
+  if (typeof v.mmi !== 'string' && typeof v.mmi !== 'number') return false;
+  return true;
+}
+
+// ── Small numeric / display helpers ──────────────────────────────────────
+
+const INT_TO_ROMAN: Record<number, string> = {
+  0: '-', 1: 'I', 2: 'II', 3: 'III', 4: 'IV', 5: 'V', 6: 'VI', 7: 'VII', 8: 'VIII',
+  9: 'IX', 10: 'X', 11: 'XI', 12: 'XII',
+};
+
+export function integerToRoman(n: number): string {
+  if (!Number.isFinite(n) || n < 0) return '-';
+  return INT_TO_ROMAN[Math.min(12, Math.floor(n))] ?? String(n);
+}
+
+/** Rough rupture-radius estimate in km. Doubles per magnitude unit. */
+export function ruptureRadiusKm(magnitude: number): number {
+  if (!Number.isFinite(magnitude) || magnitude < 0) return 0;
+  return Math.round(Math.max(1, 2 ** (magnitude - 2)));
+}

--- a/tests/intelligence/mission-bridges/seismic-mission-bridges.test.mts
+++ b/tests/intelligence/mission-bridges/seismic-mission-bridges.test.mts
@@ -1,0 +1,433 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  AfterShockMissionBridge,
+  SeismicMissionBridge,
+  TsunamiMissionBridge,
+  integerToRoman,
+  magnitudeRank,
+  mmiRank,
+  mmiToInteger,
+  rankToSeverity,
+  ruptureRadiusKm,
+  tsunamiLevelRank,
+  type RawShakeAlertEEW,
+  type RawTsunamiAlert,
+  type RawUsgsQuake,
+} from '../../../src/services/intelligence/mission-bridges/seismic-mission-bridges.ts';
+import type { MissionBridgeOptions } from '../../../src/services/intelligence/mission-bridge-core.ts';
+import type { ObservationEvent } from '../../../src/types/intelligence.ts';
+
+// ── Test infra ────────────────────────────────────────────────────────────
+
+class MemoryStorage {
+  private map = new Map<string, string>();
+  getItem(k: string): string | null { return this.map.get(k) ?? null; }
+  setItem(k: string, v: string): void { this.map.set(k, v); }
+  removeItem(k: string): void { this.map.delete(k); }
+}
+
+function noopStorage(): MissionBridgeOptions {
+  return { storage: new MemoryStorage(), now: () => 1_700_000_000_000 };
+}
+
+function quake(over: Partial<RawUsgsQuake> = {}): RawUsgsQuake {
+  return {
+    id: over.id ?? 'us7000abcd',
+    magnitude: over.magnitude ?? 6.2,
+    place: over.place ?? 'offshore Honshu, Japan',
+    timestamp: over.timestamp ?? 1_700_000_000_000,
+    lat: over.lat ?? 38.3,
+    lon: over.lon ?? 142.4,
+    ...(over.depthKm !== undefined ? { depthKm: over.depthKm } : {}),
+  };
+}
+
+function tsunamiAlert(over: Partial<RawTsunamiAlert> = {}): RawTsunamiAlert {
+  return {
+    id: over.id ?? 'ptwc-2026-001',
+    level: over.level ?? 'Warning',
+    region: over.region ?? 'Pacific Coast',
+    issuedAt: over.issuedAt ?? 1_700_000_000_000,
+    ...(over.lat !== undefined ? { lat: over.lat } : {}),
+    ...(over.lon !== undefined ? { lon: over.lon } : {}),
+    ...(over.sourceEventId !== undefined ? { sourceEventId: over.sourceEventId } : {}),
+  };
+}
+
+function eew(over: Partial<RawShakeAlertEEW> = {}): RawShakeAlertEEW {
+  return {
+    id: over.id ?? 'eew-2026-9001',
+    mmi: over.mmi ?? 'V',
+    issuedAt: over.issuedAt ?? 1_700_000_000_000,
+    lat: over.lat ?? 37.77,
+    lon: over.lon ?? -122.42,
+    ...(over.magnitude !== undefined ? { magnitude: over.magnitude } : {}),
+    ...(over.warningSeconds !== undefined ? { warningSeconds: over.warningSeconds } : {}),
+  };
+}
+
+// ── magnitudeRank ─────────────────────────────────────────────────────────
+
+test('magnitudeRank: M7+ maps to 4 (CRITICAL)', () => {
+  assert.equal(magnitudeRank(7.0), 4);
+  assert.equal(magnitudeRank(8.1), 4);
+});
+
+test('magnitudeRank: M6–7 maps to 3 (HIGH)', () => {
+  assert.equal(magnitudeRank(6.0), 3);
+  assert.equal(magnitudeRank(6.9), 3);
+});
+
+test('magnitudeRank: M5–6 maps to 2 (MEDIUM)', () => {
+  assert.equal(magnitudeRank(5.0), 2);
+  assert.equal(magnitudeRank(5.9), 2);
+});
+
+test('magnitudeRank: sub-M5 (and NaN / negative) all map to 1 (LOW)', () => {
+  assert.equal(magnitudeRank(4.9), 1);
+  assert.equal(magnitudeRank(0), 1);
+  assert.equal(magnitudeRank(-1), 1);
+  assert.equal(magnitudeRank(Number.NaN), 1);
+});
+
+// ── tsunamiLevelRank ──────────────────────────────────────────────────────
+
+test('tsunamiLevelRank: official ladder Warning > Watch > Advisory > Information', () => {
+  assert.equal(tsunamiLevelRank('Warning'), 4);
+  assert.equal(tsunamiLevelRank('Watch'), 3);
+  assert.equal(tsunamiLevelRank('Advisory'), 2);
+  assert.equal(tsunamiLevelRank('Information'), 1);
+});
+
+test('tsunamiLevelRank: matches case-insensitively and trims whitespace', () => {
+  assert.equal(tsunamiLevelRank('  WATCH  '), 3);
+  assert.equal(tsunamiLevelRank('advisory'), 2);
+});
+
+test('tsunamiLevelRank: unknown levels and non-strings fall back to 1', () => {
+  assert.equal(tsunamiLevelRank('Catastrophe'), 1);
+  assert.equal(tsunamiLevelRank(''), 1);
+  assert.equal(tsunamiLevelRank(null), 1);
+  assert.equal(tsunamiLevelRank(undefined), 1);
+});
+
+// ── mmiToInteger / mmiRank ────────────────────────────────────────────────
+
+test('mmiToInteger: Roman numerals I..XII map to 1..12', () => {
+  assert.equal(mmiToInteger('I'), 1);
+  assert.equal(mmiToInteger('IV'), 4);
+  assert.equal(mmiToInteger('VII'), 7);
+  assert.equal(mmiToInteger('XII'), 12);
+});
+
+test('mmiToInteger: plain integers and numeric strings pass through', () => {
+  assert.equal(mmiToInteger(7), 7);
+  assert.equal(mmiToInteger('5'), 5);
+  assert.equal(mmiToInteger('5.8'), 5); // floor
+});
+
+test('mmiToInteger: garbage / empty / null returns null', () => {
+  assert.equal(mmiToInteger(''), null);
+  assert.equal(mmiToInteger('XX'), null);
+  assert.equal(mmiToInteger(null), null);
+  assert.equal(mmiToInteger(undefined), null);
+});
+
+test('mmiRank: MMI VII+ → 4 (CRITICAL)', () => {
+  assert.equal(mmiRank('VII'), 4);
+  assert.equal(mmiRank('IX'), 4);
+  assert.equal(mmiRank(8), 4);
+});
+
+test('mmiRank: MMI V–VI → 3 (HIGH); MMI III–IV → 2 (MEDIUM)', () => {
+  assert.equal(mmiRank('V'), 3);
+  assert.equal(mmiRank('VI'), 3);
+  assert.equal(mmiRank('III'), 2);
+  assert.equal(mmiRank('IV'), 2);
+});
+
+test('mmiRank: MMI I–II and unknown → 1 (LOW)', () => {
+  assert.equal(mmiRank('I'), 1);
+  assert.equal(mmiRank('II'), 1);
+  assert.equal(mmiRank('garbage'), 1);
+  assert.equal(mmiRank(null), 1);
+});
+
+// ── rankToSeverity / formatting helpers ───────────────────────────────────
+
+test('rankToSeverity: 1→LOW, 2→MEDIUM, 3→HIGH, 4→CRITICAL', () => {
+  assert.equal(rankToSeverity(1), 'LOW');
+  assert.equal(rankToSeverity(2), 'MEDIUM');
+  assert.equal(rankToSeverity(3), 'HIGH');
+  assert.equal(rankToSeverity(4), 'CRITICAL');
+});
+
+test('integerToRoman: matches MMI table, clamps high inputs, returns "-" for negatives', () => {
+  assert.equal(integerToRoman(7), 'VII');
+  assert.equal(integerToRoman(12), 'XII');
+  assert.equal(integerToRoman(0), '-');
+  assert.equal(integerToRoman(-3), '-');
+});
+
+test('ruptureRadiusKm: doubles per magnitude unit and floors at 1', () => {
+  assert.equal(ruptureRadiusKm(2), 1);     // 2^0 = 1
+  assert.equal(ruptureRadiusKm(4), 4);     // 2^2 = 4
+  assert.equal(ruptureRadiusKm(7), 32);    // 2^5 = 32
+  assert.equal(ruptureRadiusKm(-5), 0);
+});
+
+// ── SeismicMissionBridge ──────────────────────────────────────────────────
+
+test('SeismicMissionBridge: domain="seismic" and feedId="usgs-earthquake"', () => {
+  const b = new SeismicMissionBridge(noopStorage());
+  const cfg = b.getConfig();
+  assert.equal(cfg.domain, 'seismic');
+  assert.equal(cfg.feedId, 'usgs-earthquake');
+});
+
+test('SeismicMissionBridge: normalize maps M7+ to CRITICAL and stamps tags', () => {
+  const b = new SeismicMissionBridge(noopStorage());
+  const evt = b.normalize(quake({ magnitude: 7.2, depthKm: 30 })) as ObservationEvent;
+  assert.ok(evt);
+  assert.equal(evt.severity, 'CRITICAL');
+  assert.equal(evt.id, 'usgs-earthquake:us7000abcd');
+  assert.equal(evt.sourceId, 'usgs-earthquake');
+  assert.match(evt.title, /M7\.2 earthquake near offshore Honshu/);
+  assert.ok(evt.tags.includes('earthquake'));
+  assert.ok(evt.tags.includes('rank-4'));
+  assert.ok(evt.tags.includes('severity-critical'));
+  assert.ok(evt.tags.includes('depth-30km'));
+  assert.deepEqual(
+    { lat: evt.location?.lat, lon: evt.location?.lon },
+    { lat: 38.3, lon: 142.4 },
+  );
+});
+
+test('SeismicMissionBridge: M6 maps to HIGH; M5 maps to MEDIUM', () => {
+  const b = new SeismicMissionBridge(noopStorage());
+  assert.equal(b.normalize(quake({ magnitude: 6 }))?.severity, 'HIGH');
+  assert.equal(b.normalize(quake({ magnitude: 5 }))?.severity, 'MEDIUM');
+});
+
+test('SeismicMissionBridge: drops M<5 events (returns null)', () => {
+  const b = new SeismicMissionBridge(noopStorage());
+  assert.equal(b.normalize(quake({ magnitude: 4.9 })), null);
+  assert.equal(b.normalize(quake({ magnitude: 2.5 })), null);
+});
+
+test('SeismicMissionBridge: rejects malformed payloads (missing id / NaN mag / wrong types)', () => {
+  const b = new SeismicMissionBridge(noopStorage());
+  assert.equal(b.normalize(null), null);
+  assert.equal(b.normalize({ ...quake(), id: '' }), null);
+  assert.equal(b.normalize({ ...quake(), magnitude: Number.NaN }), null);
+  assert.equal(b.normalize({ ...quake(), lat: 'oops' }), null);
+});
+
+test('SeismicMissionBridge: missing depth tags "depth-unknown"', () => {
+  const b = new SeismicMissionBridge(noopStorage());
+  const evt = b.normalize(quake({ magnitude: 6.5 })) as ObservationEvent;
+  assert.ok(evt.tags.includes('depth-unknown'));
+});
+
+test('SeismicMissionBridge: processCycle integrates fetcher + filter + cap', async () => {
+  const b = new SeismicMissionBridge({
+    ...noopStorage(),
+    fetcher: () => Promise.resolve([
+      quake({ id: 'a', magnitude: 7.4 }),
+      quake({ id: 'b', magnitude: 4.0 }),         // dropped (below M5)
+      quake({ id: 'c', magnitude: 5.5 }),
+    ]),
+  });
+  const events = await b.processCycle();
+  assert.equal(events.length, 2);
+  assert.deepEqual(events.map((e) => e.severity), ['CRITICAL', 'MEDIUM']);
+  const stats = b.getStats();
+  assert.equal(stats.cyclesRun, 1);
+  assert.equal(stats.totalObservations, 2);
+  assert.equal(stats.nullSkipped, 1);
+});
+
+test('SeismicMissionBridge: maxObservationsPerCycle caps the result list', async () => {
+  const b = new SeismicMissionBridge({
+    ...noopStorage(),
+    config: { maxObservationsPerCycle: 2 },
+    fetcher: () => Promise.resolve([
+      quake({ id: '1', magnitude: 7 }),
+      quake({ id: '2', magnitude: 7 }),
+      quake({ id: '3', magnitude: 7 }),
+    ]),
+  });
+  const events = await b.processCycle();
+  assert.equal(events.length, 2);
+});
+
+// ── TsunamiMissionBridge ──────────────────────────────────────────────────
+
+test('TsunamiMissionBridge: domain="seismic" and feedId="tsunami-alert"', () => {
+  const b = new TsunamiMissionBridge(noopStorage());
+  const cfg = b.getConfig();
+  assert.equal(cfg.domain, 'seismic');
+  assert.equal(cfg.feedId, 'tsunami-alert');
+});
+
+test('TsunamiMissionBridge: Warning → CRITICAL with rank-4 + tagged level', () => {
+  const b = new TsunamiMissionBridge(noopStorage());
+  const evt = b.normalize(tsunamiAlert({ level: 'Warning', region: 'Hawaii' })) as ObservationEvent;
+  assert.equal(evt.severity, 'CRITICAL');
+  assert.match(evt.title, /Tsunami Warning — Hawaii/);
+  assert.ok(evt.tags.includes('tsunami'));
+  assert.ok(evt.tags.includes('rank-4'));
+  assert.ok(evt.tags.includes('level-warning'));
+});
+
+test('TsunamiMissionBridge: Watch → HIGH, Advisory → MEDIUM, Information → LOW', () => {
+  const b = new TsunamiMissionBridge(noopStorage());
+  assert.equal(b.normalize(tsunamiAlert({ level: 'Watch' }))?.severity, 'HIGH');
+  assert.equal(b.normalize(tsunamiAlert({ level: 'Advisory' }))?.severity, 'MEDIUM');
+  assert.equal(b.normalize(tsunamiAlert({ level: 'Information' }))?.severity, 'LOW');
+});
+
+test('TsunamiMissionBridge: lat/lon present produces a location with 250km radius', () => {
+  const b = new TsunamiMissionBridge(noopStorage());
+  const evt = b.normalize(tsunamiAlert({ lat: 21.3, lon: -157.8 })) as ObservationEvent;
+  assert.deepEqual(evt.location, { lat: 21.3, lon: -157.8, radiusKm: 250 });
+});
+
+test('TsunamiMissionBridge: missing lat/lon yields undefined location, not malformed coords', () => {
+  const b = new TsunamiMissionBridge(noopStorage());
+  const evt = b.normalize(tsunamiAlert()) as ObservationEvent;
+  assert.equal(evt.location, undefined);
+});
+
+test('TsunamiMissionBridge: sourceEventId propagates as entityIds', () => {
+  const b = new TsunamiMissionBridge(noopStorage());
+  const evt = b.normalize(tsunamiAlert({ sourceEventId: 'us7000abcd' })) as ObservationEvent;
+  assert.deepEqual(evt.entityIds, ['us7000abcd']);
+});
+
+test('TsunamiMissionBridge: rejects malformed payloads', () => {
+  const b = new TsunamiMissionBridge(noopStorage());
+  assert.equal(b.normalize(null), null);
+  assert.equal(b.normalize({ ...tsunamiAlert(), id: '' }), null);
+  assert.equal(b.normalize({ ...tsunamiAlert(), issuedAt: Number.NaN }), null);
+});
+
+test('TsunamiMissionBridge: processCycle delivers events through the pipeline', async () => {
+  const b = new TsunamiMissionBridge({
+    ...noopStorage(),
+    fetcher: () => Promise.resolve([
+      tsunamiAlert({ id: 'w1', level: 'Warning' }),
+      tsunamiAlert({ id: 'w2', level: 'Watch' }),
+    ]),
+  });
+  const events = await b.processCycle();
+  assert.equal(events.length, 2);
+  assert.equal(events[0]?.severity, 'CRITICAL');
+  assert.equal(events[1]?.severity, 'HIGH');
+});
+
+// ── AfterShockMissionBridge ───────────────────────────────────────────────
+
+test('AfterShockMissionBridge: domain="seismic" and feedId="shakealert-eew"', () => {
+  const b = new AfterShockMissionBridge(noopStorage());
+  const cfg = b.getConfig();
+  assert.equal(cfg.domain, 'seismic');
+  assert.equal(cfg.feedId, 'shakealert-eew');
+});
+
+test('AfterShockMissionBridge: MMI VII → CRITICAL; MMI V → HIGH; MMI III → MEDIUM; MMI I → LOW', () => {
+  const b = new AfterShockMissionBridge(noopStorage());
+  assert.equal(b.normalize(eew({ mmi: 'VII' }))?.severity, 'CRITICAL');
+  assert.equal(b.normalize(eew({ mmi: 'V' }))?.severity, 'HIGH');
+  assert.equal(b.normalize(eew({ mmi: 'III' }))?.severity, 'MEDIUM');
+  assert.equal(b.normalize(eew({ mmi: 'I' }))?.severity, 'LOW');
+});
+
+test('AfterShockMissionBridge: integer MMI inputs are accepted alongside Roman numerals', () => {
+  const b = new AfterShockMissionBridge(noopStorage());
+  assert.equal(b.normalize(eew({ mmi: 9 }))?.severity, 'CRITICAL');
+  assert.equal(b.normalize(eew({ mmi: 4 }))?.severity, 'MEDIUM');
+});
+
+test('AfterShockMissionBridge: title renders predicted MMI in Roman with magnitude prefix', () => {
+  const b = new AfterShockMissionBridge(noopStorage());
+  const evt = b.normalize(eew({ mmi: 'VII', magnitude: 6.4 })) as ObservationEvent;
+  assert.match(evt.title, /^M6\.4 ShakeAlert — predicted MMI VII$/);
+});
+
+test('AfterShockMissionBridge: warningSeconds present produces a warning-Ns tag', () => {
+  const b = new AfterShockMissionBridge(noopStorage());
+  const evt = b.normalize(eew({ warningSeconds: 12 })) as ObservationEvent;
+  assert.ok(evt.tags.includes('warning-12s'));
+});
+
+test('AfterShockMissionBridge: missing or zero warningSeconds tags warning-immediate', () => {
+  const b = new AfterShockMissionBridge(noopStorage());
+  const noField = b.normalize(eew()) as ObservationEvent;
+  const zero = b.normalize(eew({ warningSeconds: 0 })) as ObservationEvent;
+  assert.ok(noField.tags.includes('warning-immediate'));
+  assert.ok(zero.tags.includes('warning-immediate'));
+});
+
+test('AfterShockMissionBridge: rejects malformed payloads (missing id / mmi / bad coords)', () => {
+  const b = new AfterShockMissionBridge(noopStorage());
+  assert.equal(b.normalize(null), null);
+  assert.equal(b.normalize({ ...eew(), id: '' }), null);
+  assert.equal(b.normalize({ ...eew(), mmi: undefined as never }), null);
+  assert.equal(b.normalize({ ...eew(), lat: Number.NaN }), null);
+});
+
+test('AfterShockMissionBridge: processCycle integrates fetcher and emits ObservationEvents', async () => {
+  const b = new AfterShockMissionBridge({
+    ...noopStorage(),
+    fetcher: () => Promise.resolve([
+      eew({ id: 'eew-a', mmi: 'VIII', magnitude: 7.0 }),
+      eew({ id: 'eew-b', mmi: 'III' }),
+      { broken: 'payload' },                          // dropped
+    ]),
+  });
+  const events = await b.processCycle();
+  assert.equal(events.length, 2);
+  assert.deepEqual(events.map((e) => e.severity), ['CRITICAL', 'MEDIUM']);
+  assert.equal(b.getStats().nullSkipped, 1);
+});
+
+// ── Cross-cutting: all three bridges run independently ───────────────────
+
+test('all three bridges produce non-overlapping ObservationEvent ids', async () => {
+  const seismic = new SeismicMissionBridge({
+    ...noopStorage(),
+    fetcher: () => Promise.resolve([quake({ id: 'q1', magnitude: 7 })]),
+  });
+  const tsunami = new TsunamiMissionBridge({
+    ...noopStorage(),
+    fetcher: () => Promise.resolve([tsunamiAlert({ id: 't1' })]),
+  });
+  const aftershock = new AfterShockMissionBridge({
+    ...noopStorage(),
+    fetcher: () => Promise.resolve([eew({ id: 'e1', mmi: 'VII' })]),
+  });
+  const [a, b, c] = await Promise.all([
+    seismic.processCycle(), tsunami.processCycle(), aftershock.processCycle(),
+  ]);
+  const ids = [a[0]?.id, b[0]?.id, c[0]?.id];
+  assert.equal(new Set(ids).size, 3); // all distinct
+  assert.deepEqual(ids, [
+    'usgs-earthquake:q1', 'tsunami-alert:t1', 'shakealert-eew:e1',
+  ]);
+});
+
+test('all three bridges record errors when the fetcher rejects', async () => {
+  const failingFetcher = () => Promise.reject(new Error('fetch failed'));
+  const seismic = new SeismicMissionBridge({ ...noopStorage(), fetcher: failingFetcher });
+  const tsunami = new TsunamiMissionBridge({ ...noopStorage(), fetcher: failingFetcher });
+  const aftershock = new AfterShockMissionBridge({ ...noopStorage(), fetcher: failingFetcher });
+  for (const b of [seismic, tsunami, aftershock]) {
+    await assert.rejects(() => b.processCycle(), /fetch failed/);
+    const s = b.getStats();
+    assert.equal(s.errorCount, 1);
+    assert.match(s.lastError ?? '', /fetch failed/);
+  }
+});


### PR DESCRIPTION
Three deterministic mission bridges extending `MissionBridgeBase` from `src/services/intelligence/mission-bridge-core.ts` to normalize raw feeds into `ObservationEvent` records.

## Bridges

- **SeismicMissionBridge** — USGS earthquake feed. Severity ladder: M7+→CRITICAL / M6-7→HIGH / M5-6→MEDIUM / else→LOW. Filters to M5+.
- **TsunamiMissionBridge** — PTWC tsunami alerts. Severity ladder: Warning→CRITICAL / Watch→HIGH / Advisory→MEDIUM / Information→LOW.
- **AfterShockMissionBridge** — ShakeAlert EEW intensity. Severity ladder: MMI VII+→CRITICAL / MMI V-VI→HIGH / MMI III-IV→MEDIUM / else→LOW.

## Files

- `src/services/intelligence/mission-bridges/seismic-mission-bridges.ts` — three bridge classes + pure rank/severity helpers + Roman-numeral MMI parsing + rupture radius helper.
- `tests/intelligence/mission-bridges/seismic-mission-bridges.test.mts` — 42 deterministic tests covering rank ladders, MMI parsing, normalize, processCycle, error recording.

## Verification

- `npm run typecheck:all` — clean
- ESLint — clean
- 42/42 tests pass

Cross-agent review: claude reviewed on 2026-05-18; outcome: pass