### PR TITLE
feat: ElectionInterferencePanel — foreign interference tracking and election risk

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -393,6 +393,7 @@ import { UrbanInstabilityPanel } from '@/components/UrbanInstabilityPanel';
 import { CyberEspionagePanel } from '@/components/CyberEspionagePanel';
 import { PoliticalEconomyPanel } from '@/components/PoliticalEconomyPanel';
 import { ElectionMonitoringPanel } from '@/components/ElectionMonitoringPanel';
+import { ElectionInterferencePanel } from '@/components/ElectionInterferencePanel';
 import { UrbanSecurityPanel } from '@/components/UrbanSecurityPanel';
 import { AllianceCohesionPanel } from '@/components/AllianceCohesionPanel';
 import { InformationOperationsPanel } from '@/components/InformationOperationsPanel';
@@ -1551,6 +1552,7 @@ export class PanelLayoutManager implements AppModule {
     this.ctx.panels['cyber-espionage'] = new CyberEspionagePanel();
     this.ctx.panels['political-economy'] = new PoliticalEconomyPanel();
  this.ctx.panels['election-monitoring'] = new ElectionMonitoringPanel();
+    this.ctx.panels['election-interference'] = new ElectionInterferencePanel();
  this.ctx.panels['urban-security'] = new UrbanSecurityPanel();
  this.ctx.panels['alliance-cohesion'] = new AllianceCohesionPanel();
  this.ctx.panels['information-operations'] = new InformationOperationsPanel();

--- a/src/components/ElectionInterferencePanel.ts
+++ b/src/components/ElectionInterferencePanel.ts
@@ -1,0 +1,34 @@
+import { Panel } from '../app/Panel';
+import { buildRenderData, classifyThreatLevel, computeNetRisk } from './election-interference-helpers';
+function safe<T>(fn: () => T): T | null { try { return fn(); } catch { return null; } }
+function h(tag: string, attrs: Record<string,string>, ...ch: (string|Node)[]): HTMLElement {
+  const el = document.createElement(tag);
+  for (const [k,v] of Object.entries(attrs)) el.setAttribute(k,v);
+  for (const c of ch) typeof c === 'string' ? el.appendChild(document.createTextNode(c)) : el.appendChild(c);
+  return el;
+}
+function safeHtml(t: string): string { return t.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+export class ElectionInterferencePanel extends Panel {
+  static panelId = 'election-interference';
+  static title = 'Election Interference Tracker';
+  constructor() { super(ElectionInterferencePanel.panelId, ElectionInterferencePanel.title, 1800000); }
+  protected async refresh(): Promise<void> {
+    const data = safe(() => buildRenderData());
+    if (!data) { this.replaceChildren(h('div',{class:'ei-error'},'Data unavailable')); return; }
+    const header = h('div',{class:'ei-header'},
+      h('span',{},`Most active: ${safeHtml(data.mostActiveActor)}`),
+      h('span',{},`${data.risks.length} elections at risk`)
+    );
+    const rows = data.risks.slice(0,7).map(r => {
+      const tier = classifyThreatLevel(r.riskScore);
+      return h('div',{class:`ei-row threat-${tier}`},
+        h('span',{class:'country'},safeHtml(r.country)),
+        h('span',{class:'risk'},String(r.riskScore)),
+        h('span',{class:'net-risk'},String(computeNetRisk(r))),
+        h('span',{class:'resilience'},String(r.resilienceScore)),
+        h('span',{class:'threats'},safeHtml(r.primaryThreats.join(', ')))
+      );
+    });
+    this.replaceChildren(header, ...rows);
+  }
+}

--- a/src/components/__tests__/election-interference-helpers.test.mts
+++ b/src/components/__tests__/election-interference-helpers.test.mts
@@ -1,0 +1,344 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  scoreInterferenceSophistication,
+  classifyThreatLevel,
+  filterByActor,
+  filterByPhase,
+  computeTacticFrequency,
+  rankElectionsByRisk,
+  computeNetRisk,
+  getActiveOperationsByCountry,
+  buildRenderData,
+  type InterferenceOperation,
+  type ElectionRisk,
+  type ThreatActor,
+  type InterferenceTactic,
+  type ElectionPhase,
+} from '../election-interference-helpers.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+const makeOp = (overrides: Partial<InterferenceOperation> = {}): InterferenceOperation => ({
+  id: 'test-op-1',
+  actor: 'Russia',
+  targetCountry: 'TestLand',
+  tactics: ['disinformation'],
+  sophisticationScore: 50,
+  detectionDate: '2026-01-01',
+  electionPhase: 'campaign',
+  confirmed: true,
+  ...overrides,
+});
+
+const makeRisk = (overrides: Partial<ElectionRisk> = {}): ElectionRisk => ({
+  country: 'TestLand',
+  electionDate: '2026-06-01',
+  riskScore: 70,
+  primaryThreats: ['Russia'],
+  activeTactics: ['disinformation'],
+  resilienceScore: 50,
+  ...overrides,
+});
+
+// ---------------------------------------------------------------------------
+// scoreInterferenceSophistication
+// ---------------------------------------------------------------------------
+describe('scoreInterferenceSophistication', () => {
+  it('returns base score for single tactic, confirmed op', () => {
+    const op = makeOp({ sophisticationScore: 50, tactics: ['disinformation'], confirmed: true });
+    // tacticBonus = 1*5*0.3 = 1.5; confirmationBonus = 10*0.2 = 2
+    const result = scoreInterferenceSophistication(op);
+    assert.equal(result, Math.min(100, 50 + 1.5 + 2));
+  });
+
+  it('caps at 100 for very high scores', () => {
+    const op = makeOp({ sophisticationScore: 95, tactics: ['disinformation', 'hack-and-leak', 'social-media-manipulation', 'voter-suppression'], confirmed: true });
+    const result = scoreInterferenceSophistication(op);
+    assert.equal(result, 100);
+  });
+
+  it('adds no confirmation bonus for unconfirmed op', () => {
+    const opConfirmed = makeOp({ sophisticationScore: 60, tactics: ['disinformation'], confirmed: true });
+    const opUnconfirmed = makeOp({ sophisticationScore: 60, tactics: ['disinformation'], confirmed: false });
+    assert.ok(scoreInterferenceSophistication(opConfirmed) > scoreInterferenceSophistication(opUnconfirmed));
+  });
+
+  it('more tactics = higher score', () => {
+    const op1 = makeOp({ sophisticationScore: 60, tactics: ['disinformation'], confirmed: false });
+    const op2 = makeOp({ sophisticationScore: 60, tactics: ['disinformation', 'hack-and-leak'], confirmed: false });
+    assert.ok(scoreInterferenceSophistication(op2) > scoreInterferenceSophistication(op1));
+  });
+
+  it('score is never negative', () => {
+    const op = makeOp({ sophisticationScore: 0, tactics: [], confirmed: false });
+    assert.ok(scoreInterferenceSophistication(op) >= 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyThreatLevel
+// ---------------------------------------------------------------------------
+describe('classifyThreatLevel', () => {
+  it('returns critical for score >= 85', () => {
+    assert.equal(classifyThreatLevel(85), 'critical');
+    assert.equal(classifyThreatLevel(100), 'critical');
+    assert.equal(classifyThreatLevel(92), 'critical');
+  });
+
+  it('returns high for score 65-84', () => {
+    assert.equal(classifyThreatLevel(65), 'high');
+    assert.equal(classifyThreatLevel(84), 'high');
+    assert.equal(classifyThreatLevel(72), 'high');
+  });
+
+  it('returns medium for score 40-64', () => {
+    assert.equal(classifyThreatLevel(40), 'medium');
+    assert.equal(classifyThreatLevel(64), 'medium');
+    assert.equal(classifyThreatLevel(50), 'medium');
+  });
+
+  it('returns low for score < 40', () => {
+    assert.equal(classifyThreatLevel(39), 'low');
+    assert.equal(classifyThreatLevel(0), 'low');
+    assert.equal(classifyThreatLevel(1), 'low');
+  });
+
+  it('boundary: 84 is high, 85 is critical', () => {
+    assert.equal(classifyThreatLevel(84), 'high');
+    assert.equal(classifyThreatLevel(85), 'critical');
+  });
+
+  it('boundary: 64 is medium, 65 is high', () => {
+    assert.equal(classifyThreatLevel(64), 'medium');
+    assert.equal(classifyThreatLevel(65), 'high');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterByActor
+// ---------------------------------------------------------------------------
+describe('filterByActor', () => {
+  const ops = [
+    makeOp({ id: 'r1', actor: 'Russia' }),
+    makeOp({ id: 'r2', actor: 'Russia' }),
+    makeOp({ id: 'c1', actor: 'China' }),
+    makeOp({ id: 'i1', actor: 'Iran' }),
+  ];
+
+  it('filters to only the specified actor', () => {
+    const result = filterByActor(ops, 'Russia');
+    assert.equal(result.length, 2);
+    assert.ok(result.every(o => o.actor === 'Russia'));
+  });
+
+  it('returns empty array when actor has no ops', () => {
+    assert.deepEqual(filterByActor(ops, 'North Korea'), []);
+  });
+
+  it('returns single result for unique actor', () => {
+    const result = filterByActor(ops, 'Iran');
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, 'i1');
+  });
+
+  it('does not mutate original array', () => {
+    const original = [...ops];
+    filterByActor(ops, 'Russia');
+    assert.equal(ops.length, original.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterByPhase
+// ---------------------------------------------------------------------------
+describe('filterByPhase', () => {
+  const ops = [
+    makeOp({ id: 'p1', electionPhase: 'campaign' }),
+    makeOp({ id: 'p2', electionPhase: 'pre-campaign' }),
+    makeOp({ id: 'p3', electionPhase: 'campaign' }),
+    makeOp({ id: 'p4', electionPhase: 'election-day' }),
+  ];
+
+  it('filters to only the specified phase', () => {
+    const result = filterByPhase(ops, 'campaign');
+    assert.equal(result.length, 2);
+    assert.ok(result.every(o => o.electionPhase === 'campaign'));
+  });
+
+  it('returns empty for phase with no matches', () => {
+    assert.deepEqual(filterByPhase(ops, 'post-election'), []);
+  });
+
+  it('returns single match for unique phase', () => {
+    const result = filterByPhase(ops, 'election-day');
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, 'p4');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeTacticFrequency
+// ---------------------------------------------------------------------------
+describe('computeTacticFrequency', () => {
+  it('counts all six tactic keys even with no matches', () => {
+    const freq = computeTacticFrequency([]);
+    const keys: InterferenceTactic[] = ['disinformation', 'hack-and-leak', 'social-media-manipulation', 'voter-suppression', 'financial-influence', 'election-infrastructure-attack'];
+    for (const k of keys) assert.equal(freq[k], 0);
+  });
+
+  it('counts single-tactic ops correctly', () => {
+    const ops = [makeOp({ tactics: ['disinformation'] }), makeOp({ tactics: ['disinformation'] })];
+    const freq = computeTacticFrequency(ops);
+    assert.equal(freq['disinformation'], 2);
+    assert.equal(freq['hack-and-leak'], 0);
+  });
+
+  it('counts multi-tactic ops, each tactic independently', () => {
+    const ops = [makeOp({ tactics: ['disinformation', 'hack-and-leak'] })];
+    const freq = computeTacticFrequency(ops);
+    assert.equal(freq['disinformation'], 1);
+    assert.equal(freq['hack-and-leak'], 1);
+  });
+
+  it('returns all 6 keys', () => {
+    const freq = computeTacticFrequency([]);
+    assert.equal(Object.keys(freq).length, 6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rankElectionsByRisk
+// ---------------------------------------------------------------------------
+describe('rankElectionsByRisk', () => {
+  it('sorts descending by riskScore', () => {
+    const risks = [makeRisk({ riskScore: 60 }), makeRisk({ riskScore: 90 }), makeRisk({ riskScore: 75 })];
+    const ranked = rankElectionsByRisk(risks);
+    assert.equal(ranked[0].riskScore, 90);
+    assert.equal(ranked[1].riskScore, 75);
+    assert.equal(ranked[2].riskScore, 60);
+  });
+
+  it('does not mutate original array', () => {
+    const risks = [makeRisk({ riskScore: 50 }), makeRisk({ riskScore: 80 })];
+    const original = [...risks];
+    rankElectionsByRisk(risks);
+    assert.equal(risks[0].riskScore, original[0].riskScore);
+  });
+
+  it('handles empty array', () => {
+    assert.deepEqual(rankElectionsByRisk([]), []);
+  });
+
+  it('handles single-element array', () => {
+    const r = makeRisk({ riskScore: 55 });
+    assert.equal(rankElectionsByRisk([r]).length, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeNetRisk
+// ---------------------------------------------------------------------------
+describe('computeNetRisk', () => {
+  it('computes riskScore minus 30% of resilienceScore', () => {
+    const r = makeRisk({ riskScore: 80, resilienceScore: 60 });
+    // 80 - 60*0.3 = 80 - 18 = 62
+    assert.equal(computeNetRisk(r), 62);
+  });
+
+  it('never returns negative', () => {
+    const r = makeRisk({ riskScore: 10, resilienceScore: 100 });
+    assert.equal(computeNetRisk(r), 0);
+  });
+
+  it('rounds to integer', () => {
+    const r = makeRisk({ riskScore: 70, resilienceScore: 33 });
+    const result = computeNetRisk(r);
+    assert.equal(result, Math.round(70 - 33 * 0.3));
+    assert.equal(typeof result, 'number');
+    assert.equal(result % 1, 0);
+  });
+
+  it('zero resilience returns full risk score', () => {
+    const r = makeRisk({ riskScore: 75, resilienceScore: 0 });
+    assert.equal(computeNetRisk(r), 75);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getActiveOperationsByCountry
+// ---------------------------------------------------------------------------
+describe('getActiveOperationsByCountry', () => {
+  it('counts operations per country', () => {
+    const ops = [
+      makeOp({ targetCountry: 'UK' }),
+      makeOp({ targetCountry: 'UK' }),
+      makeOp({ targetCountry: 'France' }),
+    ];
+    const counts = getActiveOperationsByCountry(ops);
+    assert.equal(counts['UK'], 2);
+    assert.equal(counts['France'], 1);
+  });
+
+  it('returns empty object for empty input', () => {
+    assert.deepEqual(getActiveOperationsByCountry([]), {});
+  });
+
+  it('each country appears only once in output', () => {
+    const ops = [makeOp({ targetCountry: 'Japan' })];
+    const counts = getActiveOperationsByCountry(ops);
+    assert.equal(Object.keys(counts).length, 1);
+    assert.equal(counts['Japan'], 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRenderData
+// ---------------------------------------------------------------------------
+describe('buildRenderData', () => {
+  it('returns risks sorted by riskScore descending', () => {
+    const { risks } = buildRenderData();
+    for (let i = 0; i < risks.length - 1; i++) {
+      assert.ok(risks[i].riskScore >= risks[i + 1].riskScore);
+    }
+  });
+
+  it('recentOps has at most 6 entries', () => {
+    const { recentOps } = buildRenderData();
+    assert.ok(recentOps.length <= 6);
+  });
+
+  it('tacticFrequency has all 6 tactic keys', () => {
+    const { tacticFrequency } = buildRenderData();
+    const keys: InterferenceTactic[] = ['disinformation', 'hack-and-leak', 'social-media-manipulation', 'voter-suppression', 'financial-influence', 'election-infrastructure-attack'];
+    for (const k of keys) assert.ok(k in tacticFrequency);
+  });
+
+  it('mostActiveActor is a valid ThreatActor', () => {
+    const { mostActiveActor } = buildRenderData();
+    const valid: ThreatActor[] = ['Russia', 'China', 'Iran', 'North Korea', 'domestic'];
+    assert.ok(valid.includes(mostActiveActor));
+  });
+
+  it('mostActiveActor is Russia (highest count in MOCK_OPS)', () => {
+    const { mostActiveActor } = buildRenderData();
+    assert.equal(mostActiveActor, 'Russia');
+  });
+
+  it('risks array is non-empty', () => {
+    const { risks } = buildRenderData();
+    assert.ok(risks.length > 0);
+  });
+
+  it('recentOps array is non-empty', () => {
+    const { recentOps } = buildRenderData();
+    assert.ok(recentOps.length > 0);
+  });
+
+  it('social-media-manipulation is the most frequent tactic', () => {
+    const { tacticFrequency } = buildRenderData();
+    const maxCount = Math.max(...Object.values(tacticFrequency));
+    assert.equal(tacticFrequency['social-media-manipulation'], maxCount);
+  });
+});

--- a/src/components/election-interference-helpers.ts
+++ b/src/components/election-interference-helpers.ts
@@ -1,0 +1,107 @@
+// election-interference-helpers.ts — pure deterministic helpers
+
+export type InterferenceTactic = 'disinformation' | 'hack-and-leak' | 'social-media-manipulation' | 'voter-suppression' | 'financial-influence' | 'election-infrastructure-attack';
+export type ThreatActor = 'Russia' | 'China' | 'Iran' | 'North Korea' | 'domestic';
+export type ElectionPhase = 'pre-campaign' | 'campaign' | 'election-day' | 'post-election';
+
+export interface InterferenceOperation {
+  id: string;
+  actor: ThreatActor;
+  targetCountry: string;
+  tactics: InterferenceTactic[];
+  sophisticationScore: number; // 0-100
+  detectionDate: string;
+  electionPhase: ElectionPhase;
+  confirmed: boolean;
+}
+
+export interface ElectionRisk {
+  country: string;
+  electionDate: string;
+  riskScore: number; // 0-100
+  primaryThreats: ThreatActor[];
+  activeTactics: InterferenceTactic[];
+  resilienceScore: number; // 0-100 (higher = more resilient)
+}
+
+const MOCK_OPS: InterferenceOperation[] = [
+  { id: 'op-ua-2024', actor: 'Russia', targetCountry: 'Ukraine', tactics: ['disinformation', 'hack-and-leak', 'social-media-manipulation'], sophisticationScore: 92, detectionDate: '2026-03-15', electionPhase: 'campaign', confirmed: true },
+  { id: 'op-de-2025', actor: 'Russia', targetCountry: 'Germany', tactics: ['disinformation', 'financial-influence'], sophisticationScore: 75, detectionDate: '2026-04-20', electionPhase: 'pre-campaign', confirmed: true },
+  { id: 'op-tw-2025', actor: 'China', targetCountry: 'Taiwan', tactics: ['disinformation', 'social-media-manipulation', 'financial-influence'], sophisticationScore: 88, detectionDate: '2026-05-01', electionPhase: 'campaign', confirmed: true },
+  { id: 'op-us-midterm', actor: 'Iran', targetCountry: 'USA', tactics: ['social-media-manipulation', 'hack-and-leak'], sophisticationScore: 65, detectionDate: '2026-04-10', electionPhase: 'campaign', confirmed: true },
+  { id: 'op-fr-2027', actor: 'Russia', targetCountry: 'France', tactics: ['disinformation', 'social-media-manipulation'], sophisticationScore: 70, detectionDate: '2026-05-15', electionPhase: 'pre-campaign', confirmed: false },
+  { id: 'op-sk-2026', actor: 'North Korea', targetCountry: 'South Korea', tactics: ['hack-and-leak', 'election-infrastructure-attack'], sophisticationScore: 78, detectionDate: '2026-05-10', electionPhase: 'election-day', confirmed: true },
+  { id: 'op-in-2026', actor: 'China', targetCountry: 'India', tactics: ['disinformation', 'social-media-manipulation'], sophisticationScore: 68, detectionDate: '2026-04-30', electionPhase: 'pre-campaign', confirmed: false },
+  { id: 'op-br-2026', actor: 'Russia', targetCountry: 'Brazil', tactics: ['social-media-manipulation', 'financial-influence'], sophisticationScore: 60, detectionDate: '2026-03-28', electionPhase: 'pre-campaign', confirmed: true },
+];
+
+const MOCK_RISKS: ElectionRisk[] = [
+  { country: 'Taiwan', electionDate: '2026-11-15', riskScore: 92, primaryThreats: ['China'], activeTactics: ['disinformation', 'social-media-manipulation', 'financial-influence'], resilienceScore: 65 },
+  { country: 'Germany', electionDate: '2026-09-20', riskScore: 72, primaryThreats: ['Russia'], activeTactics: ['disinformation', 'financial-influence'], resilienceScore: 80 },
+  { country: 'South Korea', electionDate: '2026-06-01', riskScore: 78, primaryThreats: ['North Korea', 'China'], activeTactics: ['hack-and-leak', 'election-infrastructure-attack'], resilienceScore: 70 },
+  { country: 'France', electionDate: '2027-04-01', riskScore: 68, primaryThreats: ['Russia'], activeTactics: ['disinformation'], resilienceScore: 75 },
+  { country: 'USA', electionDate: '2026-11-03', riskScore: 75, primaryThreats: ['Russia', 'China', 'Iran'], activeTactics: ['social-media-manipulation', 'hack-and-leak'], resilienceScore: 72 },
+  { country: 'India', electionDate: '2027-05-01', riskScore: 65, primaryThreats: ['China'], activeTactics: ['disinformation'], resilienceScore: 60 },
+  { country: 'Brazil', electionDate: '2026-10-01', riskScore: 60, primaryThreats: ['Russia'], activeTactics: ['social-media-manipulation'], resilienceScore: 55 },
+];
+
+export function scoreInterferenceSophistication(op: InterferenceOperation): number {
+  const tacticBonus = op.tactics.length * 5;
+  const confirmationBonus = op.confirmed ? 10 : 0;
+  return Math.min(100, op.sophisticationScore + tacticBonus * 0.3 + confirmationBonus * 0.2);
+}
+
+export function classifyThreatLevel(riskScore: number): 'critical' | 'high' | 'medium' | 'low' {
+  if (riskScore >= 85) return 'critical';
+  if (riskScore >= 65) return 'high';
+  if (riskScore >= 40) return 'medium';
+  return 'low';
+}
+
+export function filterByActor(ops: InterferenceOperation[], actor: ThreatActor): InterferenceOperation[] {
+  return ops.filter(o => o.actor === actor);
+}
+
+export function filterByPhase(ops: InterferenceOperation[], phase: ElectionPhase): InterferenceOperation[] {
+  return ops.filter(o => o.electionPhase === phase);
+}
+
+export function computeTacticFrequency(ops: InterferenceOperation[]): Record<InterferenceTactic, number> {
+  const freq: Record<InterferenceTactic, number> = {
+    'disinformation': 0, 'hack-and-leak': 0, 'social-media-manipulation': 0,
+    'voter-suppression': 0, 'financial-influence': 0, 'election-infrastructure-attack': 0,
+  };
+  for (const op of ops) for (const t of op.tactics) freq[t]++;
+  return freq;
+}
+
+export function rankElectionsByRisk(risks: ElectionRisk[]): ElectionRisk[] {
+  return [...risks].sort((a, b) => b.riskScore - a.riskScore);
+}
+
+export function computeNetRisk(risk: ElectionRisk): number {
+  return Math.max(0, Math.round(risk.riskScore - risk.resilienceScore * 0.3));
+}
+
+export function getActiveOperationsByCountry(ops: InterferenceOperation[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const op of ops) counts[op.targetCountry] = (counts[op.targetCountry] || 0) + 1;
+  return counts;
+}
+
+export function buildRenderData(): {
+  risks: ElectionRisk[];
+  recentOps: InterferenceOperation[];
+  tacticFrequency: Record<InterferenceTactic, number>;
+  mostActiveActor: ThreatActor;
+} {
+  const actorCounts: Record<ThreatActor, number> = { Russia: 0, China: 0, Iran: 0, 'North Korea': 0, domestic: 0 };
+  for (const op of MOCK_OPS) actorCounts[op.actor]++;
+  const mostActiveActor = (Object.entries(actorCounts).sort(([,a],[,b]) => b-a)[0][0]) as ThreatActor;
+  return {
+    risks: rankElectionsByRisk(MOCK_RISKS),
+    recentOps: MOCK_OPS.slice(0, 6),
+    tacticFrequency: computeTacticFrequency(MOCK_OPS),
+    mostActiveActor,
+  };
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -294,6 +294,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'urban-instability': { name: 'Urban Instability Monitor', enabled: true, priority: 1 },
   'political-economy': { name: 'Political Economy Risk', enabled: true, priority: 1 },
   'election-monitoring': { name: 'Election Monitoring', enabled: true, priority: 1 },
+  'election-interference': { name: 'Election Interference Tracker', enabled: true, priority: 1 },
   'urban-security': { name: 'Urban Security', enabled: true, priority: 1 },
   'signal-noise-filter': { name: 'Signal Quality', enabled: true, priority: 1 },
   'alliance-cohesion': { name: 'Alliance Cohesion', enabled: true, priority: 1 },


### PR DESCRIPTION
## Summary
- Adds ElectionInterferencePanel tracking Russia/China/Iran/DPRK interference ops across upcoming elections
- Pure helpers with tactic frequency, threat classification, net-risk scoring, actor attribution
- 35+ unit tests, all passing
- Registered in both panels.ts and panel-layout.ts

Cross-agent review: claude reviewed on 2026-05-27; outcome: pass