### PR TITLE
feat: QuantumTechRacePanel — quantum computing dominance and cryptographic threat tracking

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1547,6 +1547,7 @@ export class PanelLayoutManager implements AppModule {
  this.ctx.panels['arctic-monitoring'] = new ArcticMonitoringPanel();
  this.ctx.panels['climate-security-nexus'] = new ClimateSecurityNexusPanel();
  this.ctx.panels['arctic-competition'] = new ArcticCompetitionPanel();
+  this.ctx.panels['quantum-tech-race'] = new QuantumTechRacePanel();
     this.ctx.panels['urban-instability'] = new UrbanInstabilityPanel();
     this.ctx.panels['cyber-espionage'] = new CyberEspionagePanel();
     this.ctx.panels['political-economy'] = new PoliticalEconomyPanel();

--- a/src/components/QuantumTechRacePanel.ts
+++ b/src/components/QuantumTechRacePanel.ts
@@ -1,0 +1,200 @@
+import { Panel } from './Panel';
+import {
+  buildRenderData,
+} from './quantum-tech-race-helpers';
+import type { QuantumProgram, QuantumThreat } from './quantum-tech-race-helpers';
+
+const REFRESH_MS = 60 * 60 * 1000; // 1 hour
+
+export class QuantumTechRacePanel extends Panel {
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  private data: ReturnType<typeof buildRenderData>;
+
+  constructor() {
+    super({
+      id: 'quantum-tech-race',
+      title: 'Quantum Technology Race',
+      showCount: true,
+      trackActivity: true,
+    });
+    this.data = buildRenderData();
+    this.render();
+    if (typeof setInterval !== 'undefined') {
+      this.refreshTimer = setInterval(() => {
+        this.data = buildRenderData();
+        this.render();
+      }, REFRESH_MS);
+    }
+  }
+
+  private urgentThreatCount(): number {
+    return this.data.threats.filter(
+      (t) => t.urgency === 'immediate' || t.urgency === 'near-term',
+    ).length;
+  }
+
+  private render(): void {
+    const d = this.data;
+    const html = [
+      renderEncryptionThreatBanner(d.maxEncryptionThreat, d.leadingCountry),
+      renderDominanceRankings(d.programs),
+      renderUrgentThreats(d.threats),
+    ].join('');
+    this.setContent(
+      `<div class="quantum-tech-race-panel" style="padding:var(--space-3,12px);display:flex;flex-direction:column;gap:var(--space-4,16px);">${html}</div>`,
+    );
+    this.setCount(this.urgentThreatCount());
+    this.markFresh();
+  }
+
+  override destroy(): void {
+    if (this.refreshTimer !== null) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    super.destroy();
+  }
+}
+
+// ── Section renderers ──────────────────────────────────────────────────────────
+
+function esc(s: string | number): string {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function threatColor(level: number): string {
+  if (level >= 70) return '#ef4444';
+  if (level >= 40) return '#f97316';
+  if (level >= 20) return '#eab308';
+  return '#22c55e';
+}
+
+function maturityColor(maturity: string): string {
+  if (maturity === 'operational') return '#22c55e';
+  if (maturity === 'advanced-prototype') return '#3b82f6';
+  if (maturity === 'early-prototype') return '#a855f7';
+  if (maturity === 'experimental') return '#f97316';
+  return '#6b7280';
+}
+
+function urgencyColor(urgency: string): string {
+  if (urgency === 'immediate') return '#ef4444';
+  if (urgency === 'near-term') return '#f97316';
+  if (urgency === 'medium-term') return '#eab308';
+  return '#6b7280';
+}
+
+function domainLabel(domain: string): string {
+  const labels: Record<string, string> = {
+    computing: 'Computing',
+    communications: 'Comms',
+    sensing: 'Sensing',
+    cryptography: 'Crypto',
+  };
+  return labels[domain] ?? domain;
+}
+
+function renderEncryptionThreatBanner(maxThreat: number, leadingCountry: string): string {
+  const color = threatColor(maxThreat);
+  const label =
+    maxThreat >= 70 ? 'CRITICAL'
+    : maxThreat >= 40 ? 'ELEVATED'
+    : maxThreat >= 20 ? 'MODERATE'
+    : 'LOW';
+  return `
+    <div style="display:flex;align-items:center;gap:var(--space-3,12px);flex-wrap:wrap;">
+      <div style="background:${esc(color)};color:#fff;border-radius:6px;padding:4px 10px;font-weight:700;font-size:var(--text-sm,13px);letter-spacing:.02em;">
+        ENCRYPTION THREAT: ${esc(label)}
+      </div>
+      <div style="font-size:var(--text-2xl,22px);font-weight:700;color:#e5e5e5;">${esc(maxThreat)}</div>
+      <div style="font-size:var(--text-xs,11px);color:#888;">% toward RSA-2048 break</div>
+      <div style="margin-left:auto;font-size:var(--text-xs,11px);color:#666;">Leader: <span style="color:#e5e5e5;font-weight:600;">${esc(leadingCountry)}</span></div>
+    </div>
+    <div style="background:#1e1e1e;border-radius:2px;height:4px;overflow:hidden;">
+      <div style="width:${esc(maxThreat)}%;height:100%;background:${esc(color)};transition:width .3s;"></div>
+    </div>
+  `;
+}
+
+function renderDominanceRankings(programs: QuantumProgram[]): string {
+  const rows = programs.map((p, idx) => {
+    const color = maturityColor(p.maturity);
+    const qubitStr = p.qubitCount != null ? `${p.qubitCount.toLocaleString()} qubits` : 'N/A';
+    const invBn = (p.annualInvestmentUSD / 1e9).toFixed(1);
+    const milBadge = p.militaryApplication
+      ? `<span style="background:#ef444422;color:#ef4444;border-radius:4px;padding:1px 5px;font-size:10px;margin-left:4px;">MIL</span>`
+      : '';
+    return `
+      <tr style="border-bottom:1px solid #2a2a2a;">
+        <td style="padding:5px 6px;font-size:var(--text-sm,13px);color:#888;text-align:center;font-weight:600;">${esc(idx + 1)}</td>
+        <td style="padding:5px 6px;font-size:var(--text-sm,13px);color:#e5e5e5;font-weight:600;">
+          ${esc(p.country)}${milBadge}
+          <div style="font-size:10px;color:#888;font-weight:400;">${esc(domainLabel(p.domain))}</div>
+        </td>
+        <td style="padding:5px 6px;text-align:center;">
+          <span style="font-size:10px;background:${esc(color)}22;color:${esc(color)};border-radius:4px;padding:1px 5px;">${esc(p.maturity)}</span>
+        </td>
+        <td style="padding:5px 6px;font-size:var(--text-xs,11px);color:#aaa;text-align:right;">${esc(qubitStr)}</td>
+        <td style="padding:5px 6px;font-size:var(--text-xs,11px);color:#aaa;text-align:right;">$${esc(invBn)}B</td>
+        <td style="padding:5px 6px;font-size:var(--text-xs,11px);font-weight:700;color:${esc(color)};text-align:right;">${esc(p.dominanceScore)}</td>
+      </tr>
+    `;
+  }).join('');
+
+  return `
+    <div>
+      <div style="font-size:var(--text-xs,11px);font-weight:700;color:#888;letter-spacing:.08em;text-transform:uppercase;margin-bottom:6px;">Quantum Dominance Rankings</div>
+      <table style="width:100%;border-collapse:collapse;">
+        <thead>
+          <tr style="border-bottom:1px solid #444;">
+            <th style="padding:4px 6px;font-size:10px;color:#666;text-align:center;font-weight:600;">#</th>
+            <th style="padding:4px 6px;font-size:10px;color:#666;text-align:left;font-weight:600;">Country / Domain</th>
+            <th style="padding:4px 6px;font-size:10px;color:#666;text-align:center;font-weight:600;">Maturity</th>
+            <th style="padding:4px 6px;font-size:10px;color:#666;text-align:right;font-weight:600;">Qubits</th>
+            <th style="padding:4px 6px;font-size:10px;color:#666;text-align:right;font-weight:600;">Investment</th>
+            <th style="padding:4px 6px;font-size:10px;color:#666;text-align:right;font-weight:600;">Score</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>
+  `;
+}
+
+function renderUrgentThreats(threats: QuantumThreat[]): string {
+  const urgent = threats.filter(
+    (t) => t.urgency === 'immediate' || t.urgency === 'near-term',
+  );
+  if (urgent.length === 0) {
+    return `<div style="font-size:var(--text-xs,11px);color:#555;">No immediate or near-term threats identified.</div>`;
+  }
+
+  const items = urgent.map((t) => {
+    const color = urgencyColor(t.urgency);
+    const typeLabel = t.type.replace(/-/g, ' ').toUpperCase();
+    const systems = t.affectedSystems.slice(0, 3).join(', ');
+    return `
+      <div style="padding:6px 0;border-bottom:1px solid #2a2a2a;">
+        <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;">
+          <span style="background:${esc(color)}22;color:${esc(color)};border-radius:4px;padding:1px 6px;font-size:10px;font-weight:700;">${esc(t.urgency.toUpperCase())}</span>
+          <span style="font-size:var(--text-xs,11px);color:#aaa;font-weight:600;">${esc(typeLabel)}</span>
+          <span style="margin-left:auto;font-size:var(--text-xs,11px);color:#666;">${esc(t.actor)}</span>
+        </div>
+        <div style="font-size:var(--text-xs,11px);color:#ccc;margin-top:3px;">${esc(t.description)}</div>
+        <div style="font-size:10px;color:#555;margin-top:2px;">Affects: ${esc(systems)}</div>
+      </div>
+    `;
+  }).join('');
+
+  return `
+    <div>
+      <div style="font-size:var(--text-xs,11px);font-weight:700;color:#888;letter-spacing:.08em;text-transform:uppercase;margin-bottom:6px;">Urgent Threats (${esc(urgent.length)})</div>
+      ${items}
+    </div>
+  `;
+}

--- a/src/components/__tests__/quantum-tech-race-helpers.test.mts
+++ b/src/components/__tests__/quantum-tech-race-helpers.test.mts
@@ -1,0 +1,370 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import {
+  scoreQuantumDominance,
+  classifyMaturityTier,
+  getLeadingCountryByDomain,
+  computeEncryptionThreatLevel,
+  rankProgramsByDominance,
+  getTotalInvestment,
+  filterMilitaryPrograms,
+  getUrgentThreats,
+  buildRenderData,
+} from '../quantum-tech-race-helpers.ts';
+import type {
+  QuantumProgram,
+  QuantumThreat,
+  MaturityLevel,
+  QuantumDomain,
+} from '../quantum-tech-race-helpers.ts';
+
+// ── Test fixtures ─────────────────────────────────────────────────────────────
+
+const makeProgram = (overrides: Partial<QuantumProgram> = {}): QuantumProgram => ({
+  country: 'TestLand',
+  domain: 'computing',
+  maturity: 'experimental',
+  annualInvestmentUSD: 1_000_000,
+  militaryApplication: false,
+  threatToEncryption: 10,
+  leadingInstitutions: ['Test Uni'],
+  dominanceScore: 50,
+  ...overrides,
+});
+
+const makeThreat = (overrides: Partial<QuantumThreat> = {}): QuantumThreat => ({
+  id: 'test-threat',
+  type: 'post-quantum-migration',
+  actor: 'Global',
+  urgency: 'near-term',
+  affectedSystems: ['TLS'],
+  description: 'test description',
+  ...overrides,
+});
+
+// ── scoreQuantumDominance ─────────────────────────────────────────────────────
+
+describe('scoreQuantumDominance', () => {
+  it('returns the dominanceScore field directly', () => {
+    const p = makeProgram({ dominanceScore: 77 });
+    assert.equal(scoreQuantumDominance(p), 77);
+  });
+
+  it('returns 0 for dominanceScore of 0', () => {
+    assert.equal(scoreQuantumDominance(makeProgram({ dominanceScore: 0 })), 0);
+  });
+
+  it('returns 100 for dominanceScore of 100', () => {
+    assert.equal(scoreQuantumDominance(makeProgram({ dominanceScore: 100 })), 100);
+  });
+
+  it('returns a number type', () => {
+    assert.equal(typeof scoreQuantumDominance(makeProgram()), 'number');
+  });
+});
+
+// ── classifyMaturityTier ──────────────────────────────────────────────────────
+
+describe('classifyMaturityTier', () => {
+  it('operational returns near-term', () => {
+    assert.equal(classifyMaturityTier('operational'), 'near-term');
+  });
+
+  it('advanced-prototype returns near-term', () => {
+    assert.equal(classifyMaturityTier('advanced-prototype'), 'near-term');
+  });
+
+  it('experimental returns developmental', () => {
+    assert.equal(classifyMaturityTier('experimental'), 'developmental');
+  });
+
+  it('early-prototype returns developmental', () => {
+    assert.equal(classifyMaturityTier('early-prototype'), 'developmental');
+  });
+
+  it('theoretical returns developmental', () => {
+    assert.equal(classifyMaturityTier('theoretical'), 'developmental');
+  });
+
+  it('all MaturityLevel values return a valid tier', () => {
+    const levels: MaturityLevel[] = ['theoretical', 'experimental', 'early-prototype', 'advanced-prototype', 'operational'];
+    const validTiers = new Set(['operational', 'near-term', 'developmental']);
+    for (const level of levels) {
+      assert.ok(validTiers.has(classifyMaturityTier(level)), `unexpected tier for ${level}`);
+    }
+  });
+});
+
+// ── getLeadingCountryByDomain ─────────────────────────────────────────────────
+
+describe('getLeadingCountryByDomain', () => {
+  it('returns the country with highest dominanceScore in domain', () => {
+    const programs = [
+      makeProgram({ country: 'Alpha', domain: 'computing', dominanceScore: 60 }),
+      makeProgram({ country: 'Beta', domain: 'computing', dominanceScore: 85 }),
+      makeProgram({ country: 'Gamma', domain: 'sensing', dominanceScore: 90 }),
+    ];
+    assert.equal(getLeadingCountryByDomain(programs, 'computing'), 'Beta');
+  });
+
+  it('returns unknown for empty programs array', () => {
+    assert.equal(getLeadingCountryByDomain([], 'computing'), 'unknown');
+  });
+
+  it('returns unknown when no programs match domain', () => {
+    const programs = [makeProgram({ domain: 'sensing' })];
+    assert.equal(getLeadingCountryByDomain(programs, 'computing'), 'unknown');
+  });
+
+  it('correctly handles single-program domain', () => {
+    const programs = [makeProgram({ country: 'Solo', domain: 'cryptography', dominanceScore: 42 })];
+    assert.equal(getLeadingCountryByDomain(programs, 'cryptography'), 'Solo');
+  });
+
+  it('does not mutate original array', () => {
+    const programs = [
+      makeProgram({ country: 'A', domain: 'computing', dominanceScore: 70 }),
+      makeProgram({ country: 'B', domain: 'computing', dominanceScore: 90 }),
+    ];
+    const original = [...programs];
+    getLeadingCountryByDomain(programs, 'computing');
+    assert.equal(programs[0].country, original[0].country);
+  });
+});
+
+// ── computeEncryptionThreatLevel ──────────────────────────────────────────────
+
+describe('computeEncryptionThreatLevel', () => {
+  it('returns the maximum threatToEncryption across all programs', () => {
+    const programs = [
+      makeProgram({ threatToEncryption: 10 }),
+      makeProgram({ threatToEncryption: 45 }),
+      makeProgram({ threatToEncryption: 30 }),
+    ];
+    assert.equal(computeEncryptionThreatLevel(programs), 45);
+  });
+
+  it('returns 0 for all-zero threats', () => {
+    const programs = [
+      makeProgram({ threatToEncryption: 0 }),
+      makeProgram({ threatToEncryption: 0 }),
+    ];
+    assert.equal(computeEncryptionThreatLevel(programs), 0);
+  });
+
+  it('returns the single value for a one-element array', () => {
+    assert.equal(computeEncryptionThreatLevel([makeProgram({ threatToEncryption: 55 })]), 55);
+  });
+
+  it('returns a number', () => {
+    assert.equal(typeof computeEncryptionThreatLevel([makeProgram()]), 'number');
+  });
+});
+
+// ── rankProgramsByDominance ───────────────────────────────────────────────────
+
+describe('rankProgramsByDominance', () => {
+  it('returns programs sorted by dominanceScore descending', () => {
+    const programs = [
+      makeProgram({ country: 'Low', dominanceScore: 30 }),
+      makeProgram({ country: 'High', dominanceScore: 90 }),
+      makeProgram({ country: 'Mid', dominanceScore: 60 }),
+    ];
+    const ranked = rankProgramsByDominance(programs);
+    assert.equal(ranked[0].country, 'High');
+    assert.equal(ranked[1].country, 'Mid');
+    assert.equal(ranked[2].country, 'Low');
+  });
+
+  it('does not mutate the original array', () => {
+    const programs = [
+      makeProgram({ country: 'A', dominanceScore: 20 }),
+      makeProgram({ country: 'B', dominanceScore: 80 }),
+    ];
+    rankProgramsByDominance(programs);
+    assert.equal(programs[0].country, 'A');
+  });
+
+  it('returns an array of the same length', () => {
+    const programs = [makeProgram(), makeProgram(), makeProgram()];
+    assert.equal(rankProgramsByDominance(programs).length, 3);
+  });
+
+  it('handles empty array', () => {
+    assert.deepEqual(rankProgramsByDominance([]), []);
+  });
+
+  it('handles single-element array', () => {
+    const p = makeProgram({ dominanceScore: 42 });
+    assert.equal(rankProgramsByDominance([p])[0].dominanceScore, 42);
+  });
+});
+
+// ── getTotalInvestment ────────────────────────────────────────────────────────
+
+describe('getTotalInvestment', () => {
+  it('sums annualInvestmentUSD across programs', () => {
+    const programs = [
+      makeProgram({ annualInvestmentUSD: 1_000_000 }),
+      makeProgram({ annualInvestmentUSD: 2_000_000 }),
+      makeProgram({ annualInvestmentUSD: 3_000_000 }),
+    ];
+    assert.equal(getTotalInvestment(programs), 6_000_000);
+  });
+
+  it('returns 0 for empty array', () => {
+    assert.equal(getTotalInvestment([]), 0);
+  });
+
+  it('returns the single value for a one-element array', () => {
+    assert.equal(getTotalInvestment([makeProgram({ annualInvestmentUSD: 500 })]), 500);
+  });
+});
+
+// ── filterMilitaryPrograms ────────────────────────────────────────────────────
+
+describe('filterMilitaryPrograms', () => {
+  it('returns only programs with militaryApplication true', () => {
+    const programs = [
+      makeProgram({ militaryApplication: true }),
+      makeProgram({ militaryApplication: false }),
+      makeProgram({ militaryApplication: true }),
+    ];
+    const result = filterMilitaryPrograms(programs);
+    assert.equal(result.length, 2);
+    assert.ok(result.every(p => p.militaryApplication));
+  });
+
+  it('returns empty array when no military programs', () => {
+    const programs = [makeProgram({ militaryApplication: false })];
+    assert.deepEqual(filterMilitaryPrograms(programs), []);
+  });
+
+  it('returns all programs when all are military', () => {
+    const programs = [
+      makeProgram({ militaryApplication: true }),
+      makeProgram({ militaryApplication: true }),
+    ];
+    assert.equal(filterMilitaryPrograms(programs).length, 2);
+  });
+
+  it('returns empty array for empty input', () => {
+    assert.deepEqual(filterMilitaryPrograms([]), []);
+  });
+});
+
+// ── getUrgentThreats ──────────────────────────────────────────────────────────
+
+describe('getUrgentThreats', () => {
+  it('includes immediate threats', () => {
+    const threats = [makeThreat({ urgency: 'immediate' }), makeThreat({ urgency: 'long-term' })];
+    const result = getUrgentThreats(threats);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].urgency, 'immediate');
+  });
+
+  it('includes near-term threats', () => {
+    const threats = [makeThreat({ urgency: 'near-term' }), makeThreat({ urgency: 'medium-term' })];
+    const result = getUrgentThreats(threats);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].urgency, 'near-term');
+  });
+
+  it('excludes medium-term and long-term', () => {
+    const threats = [
+      makeThreat({ urgency: 'medium-term' }),
+      makeThreat({ urgency: 'long-term' }),
+    ];
+    assert.equal(getUrgentThreats(threats).length, 0);
+  });
+
+  it('returns all urgent when all are immediate or near-term', () => {
+    const threats = [
+      makeThreat({ urgency: 'immediate' }),
+      makeThreat({ urgency: 'near-term' }),
+      makeThreat({ urgency: 'immediate' }),
+    ];
+    assert.equal(getUrgentThreats(threats).length, 3);
+  });
+
+  it('returns empty for empty input', () => {
+    assert.deepEqual(getUrgentThreats([]), []);
+  });
+});
+
+// ── buildRenderData ───────────────────────────────────────────────────────────
+
+describe('buildRenderData', () => {
+  it('returns an object with expected keys', () => {
+    const data = buildRenderData();
+    assert.ok('programs' in data);
+    assert.ok('threats' in data);
+    assert.ok('maxEncryptionThreat' in data);
+    assert.ok('totalInvestment' in data);
+    assert.ok('leadingCountry' in data);
+  });
+
+  it('programs is a non-empty array', () => {
+    const { programs } = buildRenderData();
+    assert.ok(Array.isArray(programs) && programs.length > 0);
+  });
+
+  it('programs are sorted by dominanceScore descending', () => {
+    const { programs } = buildRenderData();
+    for (let i = 0; i < programs.length - 1; i++) {
+      assert.ok(programs[i].dominanceScore >= programs[i + 1].dominanceScore,
+        `program[${i}].dominanceScore (${programs[i].dominanceScore}) < program[${i+1}].dominanceScore (${programs[i+1].dominanceScore})`);
+    }
+  });
+
+  it('threats is a non-empty array', () => {
+    const { threats } = buildRenderData();
+    assert.ok(Array.isArray(threats) && threats.length > 0);
+  });
+
+  it('maxEncryptionThreat is a number >= 0', () => {
+    const { maxEncryptionThreat } = buildRenderData();
+    assert.equal(typeof maxEncryptionThreat, 'number');
+    assert.ok(maxEncryptionThreat >= 0);
+  });
+
+  it('maxEncryptionThreat is <= 100', () => {
+    assert.ok(buildRenderData().maxEncryptionThreat <= 100);
+  });
+
+  it('totalInvestment is a positive number', () => {
+    const { totalInvestment } = buildRenderData();
+    assert.ok(totalInvestment > 0);
+  });
+
+  it('leadingCountry is a non-empty string', () => {
+    const { leadingCountry } = buildRenderData();
+    assert.equal(typeof leadingCountry, 'string');
+    assert.ok(leadingCountry.length > 0);
+  });
+
+  it('leadingCountry matches the top-ranked program country', () => {
+    const { programs, leadingCountry } = buildRenderData();
+    assert.equal(leadingCountry, programs[0].country);
+  });
+
+  it('totalInvestment equals sum of all program investments', () => {
+    const { programs, totalInvestment } = buildRenderData();
+    const expected = programs.reduce((s, p) => s + p.annualInvestmentUSD, 0);
+    assert.equal(totalInvestment, expected);
+  });
+
+  it('all threat ids are unique', () => {
+    const { threats } = buildRenderData();
+    const ids = threats.map(t => t.id);
+    assert.equal(ids.length, new Set(ids).size);
+  });
+
+  it('all programs have valid domain values', () => {
+    const validDomains: QuantumDomain[] = ['computing', 'communications', 'sensing', 'cryptography'];
+    const { programs } = buildRenderData();
+    for (const p of programs) {
+      assert.ok(validDomains.includes(p.domain), `unexpected domain: ${p.domain}`);
+    }
+  });
+});

--- a/src/components/quantum-tech-race-helpers.ts
+++ b/src/components/quantum-tech-race-helpers.ts
@@ -1,0 +1,97 @@
+// quantum-tech-race-helpers.ts — pure deterministic helpers
+
+export type QuantumDomain = 'computing' | 'communications' | 'sensing' | 'cryptography';
+export type MaturityLevel = 'theoretical' | 'experimental' | 'early-prototype' | 'advanced-prototype' | 'operational';
+export type SecurityImplication = 'harvest-now-decrypt-later' | 'post-quantum-migration' | 'quantum-key-distribution' | 'quantum-sensor-threat' | 'quantum-radar';
+
+export interface QuantumProgram {
+  country: string;
+  domain: QuantumDomain;
+  maturity: MaturityLevel;
+  qubitCount?: number;
+  annualInvestmentUSD: number;
+  militaryApplication: boolean;
+  threatToEncryption: number; // 0-100 (how close to breaking RSA-2048)
+  leadingInstitutions: string[];
+  dominanceScore: number; // 0-100
+}
+
+export interface QuantumThreat {
+  id: string;
+  type: SecurityImplication;
+  actor: string;
+  urgency: 'immediate' | 'near-term' | 'medium-term' | 'long-term';
+  affectedSystems: string[];
+  description: string;
+}
+
+const MOCK_PROGRAMS: QuantumProgram[] = [
+  { country: 'USA', domain: 'computing', maturity: 'advanced-prototype', qubitCount: 1121, annualInvestmentUSD: 3200000000, militaryApplication: true, threatToEncryption: 45, leadingInstitutions: ['IBM', 'Google', 'NIST', 'DARPA'], dominanceScore: 88 },
+  { country: 'China', domain: 'computing', maturity: 'advanced-prototype', qubitCount: 504, annualInvestmentUSD: 15000000000, militaryApplication: true, threatToEncryption: 35, leadingInstitutions: ['USTC', 'Baidu', 'Alibaba Quantum Lab'], dominanceScore: 82 },
+  { country: 'China', domain: 'communications', maturity: 'operational', annualInvestmentUSD: 2000000000, militaryApplication: true, threatToEncryption: 0, leadingInstitutions: ['USTC', 'QuantumCTek'], dominanceScore: 95 },
+  { country: 'USA', domain: 'cryptography', maturity: 'operational', annualInvestmentUSD: 800000000, militaryApplication: true, threatToEncryption: 0, leadingInstitutions: ['NIST', 'NSA'], dominanceScore: 90 },
+  { country: 'EU', domain: 'computing', maturity: 'early-prototype', qubitCount: 127, annualInvestmentUSD: 1200000000, militaryApplication: false, threatToEncryption: 15, leadingInstitutions: ['IQM', 'Pasqal', 'QuTech'], dominanceScore: 65 },
+  { country: 'Russia', domain: 'sensing', maturity: 'experimental', annualInvestmentUSD: 500000000, militaryApplication: true, threatToEncryption: 0, leadingInstitutions: ['Rosatom', 'Moscow State University'], dominanceScore: 55 },
+  { country: 'UK', domain: 'computing', maturity: 'early-prototype', qubitCount: 56, annualInvestmentUSD: 700000000, militaryApplication: false, threatToEncryption: 10, leadingInstitutions: ['Oxford', 'Cambridge', 'Riverlane'], dominanceScore: 60 },
+  { country: 'Japan', domain: 'computing', maturity: 'advanced-prototype', qubitCount: 64, annualInvestmentUSD: 900000000, militaryApplication: false, threatToEncryption: 12, leadingInstitutions: ['Fujitsu', 'IBM Japan', 'RIKEN'], dominanceScore: 62 },
+];
+
+const MOCK_THREATS: QuantumThreat[] = [
+  { id: 'hndl-china', type: 'harvest-now-decrypt-later', actor: 'China', urgency: 'immediate', affectedSystems: ['diplomatic comms', 'military secrets', 'financial data'], description: 'Chinese actors collecting encrypted data now for future decryption when cryptographically-relevant QC arrives' },
+  { id: 'pqc-migration', type: 'post-quantum-migration', actor: 'Global', urgency: 'near-term', affectedSystems: ['PKI infrastructure', 'TLS', 'SSH', 'government comms'], description: 'Critical infrastructure must migrate to NIST PQC standards before Q-Day' },
+  { id: 'qkd-military', type: 'quantum-key-distribution', actor: 'China', urgency: 'near-term', affectedSystems: ['military C2', 'strategic comms'], description: 'China deploying QKD satellite network for unhackable military communications' },
+  { id: 'quantum-radar', type: 'quantum-radar', actor: 'China', urgency: 'medium-term', affectedSystems: ['stealth aircraft', 'UAVs'], description: 'Quantum radar systems could render stealth technology ineffective' },
+];
+
+export function scoreQuantumDominance(program: QuantumProgram): number {
+  return program.dominanceScore;
+}
+
+export function classifyMaturityTier(maturity: MaturityLevel): 'operational' | 'near-term' | 'developmental' {
+  if (maturity === 'operational' || maturity === 'advanced-prototype') return 'near-term';
+  if (maturity === 'experimental' || maturity === 'early-prototype') return 'developmental';
+  return 'developmental';
+}
+
+export function getLeadingCountryByDomain(programs: QuantumProgram[], domain: QuantumDomain): string {
+  const domainPrograms = programs.filter(p => p.domain === domain);
+  if (domainPrograms.length === 0) return 'unknown';
+  return domainPrograms.sort((a, b) => b.dominanceScore - a.dominanceScore)[0].country;
+}
+
+export function computeEncryptionThreatLevel(programs: QuantumProgram[]): number {
+  return Math.max(...programs.map(p => p.threatToEncryption));
+}
+
+export function rankProgramsByDominance(programs: QuantumProgram[]): QuantumProgram[] {
+  return [...programs].sort((a, b) => b.dominanceScore - a.dominanceScore);
+}
+
+export function getTotalInvestment(programs: QuantumProgram[]): number {
+  return programs.reduce((s, p) => s + p.annualInvestmentUSD, 0);
+}
+
+export function filterMilitaryPrograms(programs: QuantumProgram[]): QuantumProgram[] {
+  return programs.filter(p => p.militaryApplication);
+}
+
+export function getUrgentThreats(threats: QuantumThreat[]): QuantumThreat[] {
+  return threats.filter(t => t.urgency === 'immediate' || t.urgency === 'near-term');
+}
+
+export function buildRenderData(): {
+  programs: QuantumProgram[];
+  threats: QuantumThreat[];
+  maxEncryptionThreat: number;
+  totalInvestment: number;
+  leadingCountry: string;
+} {
+  const ranked = rankProgramsByDominance(MOCK_PROGRAMS);
+  return {
+    programs: ranked,
+    threats: MOCK_THREATS,
+    maxEncryptionThreat: computeEncryptionThreatLevel(MOCK_PROGRAMS),
+    totalInvestment: getTotalInvestment(MOCK_PROGRAMS),
+    leadingCountry: ranked[0]?.country ?? 'unknown',
+  };
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -290,6 +290,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'arctic-monitoring': { name: 'Arctic Intelligence', enabled: true, priority: 1 },
   'climate-security-nexus': { name: 'Climate-Security Nexus', enabled: true, priority: 1 },
   'arctic-competition': { name: 'Arctic Competition', enabled: true, priority: 1 },
+  'quantum-tech-race': { name: 'Quantum Technology Race', enabled: true, priority: 1 },
   'cyber-espionage': { name: 'Cyber Espionage Tracker', enabled: true, priority: 1 },
   'urban-instability': { name: 'Urban Instability Monitor', enabled: true, priority: 1 },
   'political-economy': { name: 'Political Economy Risk', enabled: true, priority: 1 },


### PR DESCRIPTION
Adds QuantumTechRacePanel with:

- Dominance rankings table across 8 programs (USA, China, EU, UK, Japan, Russia) with maturity, qubit counts, and investment data
- Encryption threat level banner (% toward RSA-2048 break) with color-coded severity
- Urgent threats section (immediate + near-term) covering harvest-now-decrypt-later, post-quantum migration, QKD satellite networks
- 1-hour refresh cycle
- 48 tests (all passing) covering all pure helper functions
- Registered in panels.ts and panel-layout.ts