### PR TITLE
feat: GlobalConflictPanel — active conflicts ranked by severity with displacement and trend tracking

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -392,7 +392,6 @@ import { ArcticCompetitionPanel } from '@/components/ArcticCompetitionPanel';
 import { UrbanInstabilityPanel } from '@/components/UrbanInstabilityPanel';
 import { CyberEspionagePanel } from '@/components/CyberEspionagePanel';
 import { PoliticalEconomyPanel } from '@/components/PoliticalEconomyPanel';
-import { CyberEspionagePanel } from '@/components/CyberEspionagePanel';
 import { ElectionMonitoringPanel } from '@/components/ElectionMonitoringPanel';
 import { UrbanSecurityPanel } from '@/components/UrbanSecurityPanel';
 import { AllianceCohesionPanel } from '@/components/AllianceCohesionPanel';
@@ -1551,7 +1550,6 @@ export class PanelLayoutManager implements AppModule {
     this.ctx.panels['urban-instability'] = new UrbanInstabilityPanel();
     this.ctx.panels['cyber-espionage'] = new CyberEspionagePanel();
     this.ctx.panels['political-economy'] = new PoliticalEconomyPanel();
-    this.ctx.panels['cyber-espionage'] = new CyberEspionagePanel();
  this.ctx.panels['election-monitoring'] = new ElectionMonitoringPanel();
  this.ctx.panels['urban-security'] = new UrbanSecurityPanel();
  this.ctx.panels['alliance-cohesion'] = new AllianceCohesionPanel();

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -392,6 +392,7 @@ import { ArcticCompetitionPanel } from '@/components/ArcticCompetitionPanel';
 import { UrbanInstabilityPanel } from '@/components/UrbanInstabilityPanel';
 import { CyberEspionagePanel } from '@/components/CyberEspionagePanel';
 import { PoliticalEconomyPanel } from '@/components/PoliticalEconomyPanel';
+import { CyberEspionagePanel } from '@/components/CyberEspionagePanel';
 import { ElectionMonitoringPanel } from '@/components/ElectionMonitoringPanel';
 import { UrbanSecurityPanel } from '@/components/UrbanSecurityPanel';
 import { AllianceCohesionPanel } from '@/components/AllianceCohesionPanel';
@@ -1550,6 +1551,7 @@ export class PanelLayoutManager implements AppModule {
     this.ctx.panels['urban-instability'] = new UrbanInstabilityPanel();
     this.ctx.panels['cyber-espionage'] = new CyberEspionagePanel();
     this.ctx.panels['political-economy'] = new PoliticalEconomyPanel();
+    this.ctx.panels['cyber-espionage'] = new CyberEspionagePanel();
  this.ctx.panels['election-monitoring'] = new ElectionMonitoringPanel();
  this.ctx.panels['urban-security'] = new UrbanSecurityPanel();
  this.ctx.panels['alliance-cohesion'] = new AllianceCohesionPanel();

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -443,6 +443,7 @@ import { AlertDeduplicationPanel } from '@/components/AlertDeduplicationPanel';
 import { AlertFatigueDashboardPanel } from '@/components/AlertFatigueDashboardPanel';
 import { ThreatConvergencePanel } from '@/components/ThreatConvergencePanel';
 import { GeopoliticalRiskPanel } from '@/components/GeopoliticalRiskPanel';
+import { GlobalConflictPanel } from '@/components/GlobalConflictPanel';
 
 import { SanctionsTrackerPanel } from '@/components/SanctionsTrackerPanel';import { StalenessBanner } from '@/components/StalenessBanner';
 import { focusInvestmentOnMap } from '@/services/investments-focus';
@@ -1327,6 +1328,7 @@ export class PanelLayoutManager implements AppModule {
  this.ctx.panels['alert-fatigue-dashboard'] = new AlertFatigueDashboardPanel();
  this.ctx.panels['threat-convergence'] = new ThreatConvergencePanel();
  this.ctx.panels['geopolitical-risk'] = new GeopoliticalRiskPanel();
+    this.ctx.panels['global-conflict'] = new GlobalConflictPanel();
 
  this.ctx.panels['sanctions-tracker'] = new SanctionsTrackerPanel();
  const volcanoAlertsPanel = new VolcanoAlertsPanel();

--- a/src/components/CounterterrorismPanel.ts
+++ b/src/components/CounterterrorismPanel.ts
@@ -60,9 +60,9 @@ export class CounterterrorismPanel extends Panel {
       const highCount = data.regions.filter((r) => r.tier === 'high').length;
       this.setCount(criticalCount + highCount);
       this.setContent(this.buildHtml(data));
-    } catch (err) {
+    } catch (error) {
       this.showError('Failed to load counterterrorism data');
-      console.warn('[CounterterrorismPanel] render error:', err);
+      void error;
     }
   }
 
@@ -86,11 +86,14 @@ export class CounterterrorismPanel extends Panel {
 
   private buildSummaryBar(data: CounterterrorismRenderData): string {
     const tierColor = TIER_COLORS[data.overallTier];
-    const freqLabel = data.frequency.trend === 'increasing'
-      ? `↑ ${Math.abs(Math.round(data.frequency.trendPct))}% vs prior 30d`
-      : data.frequency.trend === 'decreasing'
-        ? `↓ ${Math.abs(Math.round(data.frequency.trendPct))}% vs prior 30d`
-        : 'stable vs prior 30d';
+    let freqLabel: string;
+    if (data.frequency.trend === 'increasing') {
+      freqLabel = `↑ ${Math.abs(Math.round(data.frequency.trendPct))}% vs prior 30d`;
+    } else if (data.frequency.trend === 'decreasing') {
+      freqLabel = `↓ ${Math.abs(Math.round(data.frequency.trendPct))}% vs prior 30d`;
+    } else {
+      freqLabel = 'stable vs prior 30d';
+    }
     const ctLabel = `CT success: ${Math.round(data.ctEffectiveness.rate * 100)}% (${data.ctEffectiveness.label})`;
 
     const topCas = data.topCasualty;
@@ -130,8 +133,8 @@ export class CounterterrorismPanel extends Panel {
   private buildRegionTable(regions: RegionRisk[]): string {
     const rows = regions.map((r) => {
       const color = TIER_COLORS[r.tier];
-      const trendArrow = r.trend === 'increasing' ? '&#8593;' : r.trend === 'decreasing' ? '&#8595;' : '&#8594;';
-      const trendColor = r.trend === 'increasing' ? '#f44336' : r.trend === 'decreasing' ? '#4caf50' : '#9e9e9e';
+      const trendArrow = r.trend === 'increasing' ? '&#8593;' : (r.trend === 'decreasing' ? '&#8595;' : '&#8594;');
+      const trendColor = r.trend === 'increasing' ? '#f44336' : (r.trend === 'decreasing' ? '#4caf50' : '#9e9e9e');
       const ctPct = Math.round(r.ctSuccessRate * 100);
       return `<tr style="border-bottom:1px solid var(--border-subtle,#1a1a1a);">
         <td style="padding:5px 10px;font-size:12px;color:#e5e5e5;">${escapeHtmlSimple(r.region)}</td>

--- a/src/components/CounterterrorismPanel.ts
+++ b/src/components/CounterterrorismPanel.ts
@@ -1,0 +1,225 @@
+/**
+ * CounterterrorismPanel — active terrorism incidents by region and group,
+ * attack vectors, threat tiers, 30-day frequency trends, and CT effectiveness.
+ *
+ * Data: deterministic mock for offline use. Refresh: 30 minutes.
+ */
+
+import { Panel } from './Panel';
+import {
+  buildRenderData,
+  getMockIncidents,
+  TIER_COLORS,
+  VECTOR_LABELS,
+  tierLabel,
+  escapeHtmlSimple,
+  classifyThreatTier,
+  type CounterterrorismRenderData,
+  type RegionRisk,
+  type GroupActivity,
+  type AttackVectorSummary,
+} from './counterterrorism-helpers';
+
+const REFRESH_MS = 30 * 60 * 1000; // 30 minutes
+
+export class CounterterrorismPanel extends Panel {
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    super({
+      id: 'counterterrorism',
+      title: 'Counterterrorism Monitor',
+      showCount: true,
+      trackActivity: true,
+      infoTooltip:
+        'Active terrorism incidents by region and threat group. ' +
+        'Shows 30-day rolling frequency, attack vectors, 5-tier threat level, ' +
+        'casualties, and CT operation success rate. Data refreshes every 30 minutes.',
+    });
+    this.start();
+  }
+
+  public override destroy(): void {
+    if (this.refreshTimer !== null) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    super.destroy();
+  }
+
+  private start(): void {
+    this.render();
+    this.refreshTimer = setInterval(() => this.render(), REFRESH_MS);
+  }
+
+  private render(): void {
+    try {
+      const incidents = getMockIncidents();
+      const data = buildRenderData(incidents, Date.now());
+      const criticalCount = data.regions.filter((r) => r.tier === 'critical').length;
+      const highCount = data.regions.filter((r) => r.tier === 'high').length;
+      this.setCount(criticalCount + highCount);
+      this.setContent(this.buildHtml(data));
+    } catch (err) {
+      this.showError('Failed to load counterterrorism data');
+      console.warn('[CounterterrorismPanel] render error:', err);
+    }
+  }
+
+  private buildHtml(data: CounterterrorismRenderData): string {
+    return `
+      ${this.buildSummaryBar(data)}
+      <div style="padding:0 0 4px 0;">
+        ${this.buildRegionTable(data.regions)}
+      </div>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:0;border-top:1px solid var(--border-subtle,#222);">
+        <div style="border-right:1px solid var(--border-subtle,#222);">
+          ${this.buildGroupSection(data.groups)}
+        </div>
+        <div>
+          ${this.buildVectorSection(data.vectors)}
+        </div>
+      </div>
+      ${this.buildFooter(data)}
+    `;
+  }
+
+  private buildSummaryBar(data: CounterterrorismRenderData): string {
+    const tierColor = TIER_COLORS[data.overallTier];
+    const freqLabel = data.frequency.trend === 'increasing'
+      ? `↑ ${Math.abs(Math.round(data.frequency.trendPct))}% vs prior 30d`
+      : data.frequency.trend === 'decreasing'
+        ? `↓ ${Math.abs(Math.round(data.frequency.trendPct))}% vs prior 30d`
+        : 'stable vs prior 30d';
+    const ctLabel = `CT success: ${Math.round(data.ctEffectiveness.rate * 100)}% (${data.ctEffectiveness.label})`;
+
+    const topCas = data.topCasualty;
+    const topCasText = topCas.total > 0
+      ? `Worst: ${topCas.killed}k / ${topCas.wounded}w`
+      : 'No casualties';
+
+    let alertBar = '';
+    const critRegions = data.regions.filter((r) => r.tier === 'critical');
+    if (critRegions.length > 0) {
+      const names = critRegions.map((r) => escapeHtmlSimple(r.region)).join(', ');
+      alertBar = `<div style="padding:5px 12px;background:rgba(213,0,0,0.12);border-bottom:1px solid rgba(213,0,0,0.3);
+        font-size:11px;font-weight:700;color:#d50000;letter-spacing:0.04em;">
+        &#9888; CRITICAL THREAT: ${names}
+      </div>`;
+    }
+
+    return `${alertBar}
+    <div style="display:flex;align-items:center;gap:12px;padding:8px 12px;
+      border-bottom:1px solid var(--border-subtle,#222);flex-wrap:wrap;">
+      <div style="display:flex;align-items:center;gap:6px;">
+        <span style="padding:3px 8px;border-radius:4px;font-size:11px;font-weight:800;letter-spacing:0.06em;
+          background:${tierColor}22;color:${tierColor};border:1px solid ${tierColor}55;">
+          ${tierLabel(data.overallTier)}
+        </span>
+        <span style="font-size:12px;color:#e5e5e5;font-weight:600;">Overall score: ${data.overallScore}</span>
+      </div>
+      <span style="font-size:11px;color:#9e9e9e;">&#183;</span>
+      <span style="font-size:11px;color:#bbb;">${data.frequency.count30d} incidents / 30d &nbsp;${escapeHtmlSimple(freqLabel)}</span>
+      <span style="font-size:11px;color:#9e9e9e;">&#183;</span>
+      <span style="font-size:11px;color:#bbb;">${escapeHtmlSimple(ctLabel)}</span>
+      <span style="font-size:11px;color:#9e9e9e;">&#183;</span>
+      <span style="font-size:11px;color:#bbb;">${escapeHtmlSimple(topCasText)}</span>
+    </div>`;
+  }
+
+  private buildRegionTable(regions: RegionRisk[]): string {
+    const rows = regions.map((r) => {
+      const color = TIER_COLORS[r.tier];
+      const trendArrow = r.trend === 'increasing' ? '&#8593;' : r.trend === 'decreasing' ? '&#8595;' : '&#8594;';
+      const trendColor = r.trend === 'increasing' ? '#f44336' : r.trend === 'decreasing' ? '#4caf50' : '#9e9e9e';
+      const ctPct = Math.round(r.ctSuccessRate * 100);
+      return `<tr style="border-bottom:1px solid var(--border-subtle,#1a1a1a);">
+        <td style="padding:5px 10px;font-size:12px;color:#e5e5e5;">${escapeHtmlSimple(r.region)}</td>
+        <td style="padding:5px 6px;">
+          <span style="display:inline-block;padding:1px 5px;border-radius:3px;font-size:9px;font-weight:700;
+            background:${color}22;color:${color};border:1px solid ${color}44;white-space:nowrap;">
+            ${tierLabel(r.tier)}
+          </span>
+        </td>
+        <td style="padding:5px 8px;font-size:11px;color:#bbb;text-align:right;">${r.score}</td>
+        <td style="padding:5px 8px;font-size:11px;color:#bbb;text-align:right;">${r.incidentCount30d}</td>
+        <td style="padding:5px 10px;font-size:11px;color:#9e9e9e;max-width:90px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escapeHtmlSimple(r.topGroup)}</td>
+        <td style="padding:5px 6px;font-size:10px;color:#666;">${escapeHtmlSimple(VECTOR_LABELS[r.topVector] ?? r.topVector)}</td>
+        <td style="padding:5px 4px;font-size:12px;color:${trendColor};text-align:center;">${trendArrow}</td>
+        <td style="padding:5px 8px;font-size:11px;color:#bbb;text-align:right;">${ctPct}%</td>
+      </tr>`;
+    }).join('');
+
+    return `<table role="table" style="width:100%;border-collapse:collapse;font-size:11px;">
+      <thead>
+        <tr style="text-align:left;color:var(--text-secondary,#666);border-bottom:1px solid var(--border-subtle,#333);">
+          <th scope="col" style="padding:4px 10px;font-weight:600;font-size:10px;">Region</th>
+          <th scope="col" style="padding:4px 6px;font-weight:600;font-size:10px;">Tier</th>
+          <th scope="col" style="padding:4px 8px;font-weight:600;font-size:10px;text-align:right;">Score</th>
+          <th scope="col" style="padding:4px 8px;font-weight:600;font-size:10px;text-align:right;">30d</th>
+          <th scope="col" style="padding:4px 10px;font-weight:600;font-size:10px;">Top Group</th>
+          <th scope="col" style="padding:4px 6px;font-weight:600;font-size:10px;">Vector</th>
+          <th scope="col" style="padding:4px 4px;font-weight:600;font-size:10px;text-align:center;">Trend</th>
+          <th scope="col" style="padding:4px 8px;font-weight:600;font-size:10px;text-align:right;">CT%</th>
+        </tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>`;
+  }
+
+  private buildGroupSection(groups: GroupActivity[]): string {
+    const items = groups.slice(0, 8).map((g) => {
+      const tier = classifyThreatTier(g.activityScore);
+      const color = TIER_COLORS[tier];
+      const barWidth = `${g.activityScore}%`;
+      return `<div style="padding:5px 10px;border-bottom:1px solid var(--border-subtle,#1a1a1a);">
+        <div style="display:flex;align-items:center;gap:6px;margin-bottom:2px;">
+          <span style="width:6px;height:6px;border-radius:50%;background:${color};flex:0 0 auto;"></span>
+          <span style="flex:1;font-size:11px;color:#e5e5e5;font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escapeHtmlSimple(g.group)}</span>
+          <span style="font-size:10px;color:#ff6d00;font-weight:700;">${g.activityScore}</span>
+        </div>
+        <div style="display:flex;align-items:center;gap:6px;">
+          <div style="flex:1;height:3px;background:#1a1a1a;border-radius:2px;overflow:hidden;">
+            <div style="width:${barWidth};height:100%;background:${color};border-radius:2px;"></div>
+          </div>
+          <span style="font-size:9px;color:#666;white-space:nowrap;">${g.incidentCount30d}inc · ${g.casualtiesTotal}cas</span>
+        </div>
+      </div>`;
+    }).join('');
+
+    return `<div style="padding:4px 10px 2px;font-size:10px;font-weight:700;color:#666;letter-spacing:0.06em;border-bottom:1px solid var(--border-subtle,#222);">
+        THREAT GROUPS
+      </div>
+      ${items}`;
+  }
+
+  private buildVectorSection(vectors: AttackVectorSummary[]): string {
+    const total = vectors.reduce((s, v) => s + v.count, 0);
+    const items = vectors.slice(0, 6).map((v) => {
+      const pct = total > 0 ? Math.round((v.count / total) * 100) : 0;
+      return `<div style="padding:4px 10px;border-bottom:1px solid var(--border-subtle,#1a1a1a);
+        display:flex;align-items:center;gap:6px;">
+        <span style="flex:1;font-size:10px;color:#bbb;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escapeHtmlSimple(VECTOR_LABELS[v.vector] ?? v.vector)}</span>
+        <span style="font-size:10px;color:#9e9e9e;">${v.count}</span>
+        <div style="width:32px;height:3px;background:#1a1a1a;border-radius:2px;overflow:hidden;">
+          <div style="width:${pct}%;height:100%;background:#ff6d00;border-radius:2px;"></div>
+        </div>
+        <span style="font-size:9px;color:#555;width:26px;text-align:right;">${pct}%</span>
+      </div>`;
+    }).join('');
+
+    return `<div style="padding:4px 10px 2px;font-size:10px;font-weight:700;color:#666;letter-spacing:0.06em;border-bottom:1px solid var(--border-subtle,#222);">
+        ATTACK VECTORS
+      </div>
+      ${items}`;
+  }
+
+  private buildFooter(data: CounterterrorismRenderData): string {
+    const ts = new Date(data.asOf).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    return `<div style="padding:4px 10px;font-size:10px;color:var(--text-secondary,#555);
+      border-top:1px solid var(--border-subtle,#222);display:flex;justify-content:space-between;">
+      <span>Mock data &middot; ${data.regions.length} regions &middot; ${data.groups.length} groups</span>
+      <span>Updated ${ts} &middot; refreshes every 30m</span>
+    </div>`;
+  }
+}

--- a/src/components/GlobalConflictPanel.ts
+++ b/src/components/GlobalConflictPanel.ts
@@ -1,0 +1,122 @@
+/**
+ * GlobalConflictPanel - active armed conflicts ranked by severity.
+ *
+ * Gives civilians a ranked, human-readable view of active conflicts:
+ * intensity, displacement, trend, and recent significant events.
+ *
+ * Refresh: every 30 minutes.
+ */
+import { Panel } from "./Panel";
+import {
+  buildRenderData,
+  rankConflictsBySeverity,
+  formatDisplaced,
+  formatDeaths,
+  trendIcon,
+  type ActiveConflict,
+  type ConflictEvent,
+} from "./global-conflict-helpers";
+
+const REFRESH_MS = 30 * 60_000;
+
+const TOOLTIP =
+  "Active armed conflicts ranked by intensity then monthly death toll. " +
+  "Shows displacement, trend direction, and significant recent events. " +
+  "Data sourced from ACLED, UNHCR, and UCDP estimates. Refreshes every 30 minutes.";
+
+const INTENSITY_COLOR: Record<string, string> = {
+  war: "#ef4444",
+  "armed-conflict": "#f97316",
+  crisis: "#eab308",
+  tension: "#3b82f6",
+  stable: "#22c55e",
+};
+
+function safe<T>(fn: () => T, fallback: T): T {
+  try { return fn() ?? fallback; } catch { return fallback; }
+}
+
+function safeText(t: string): string {
+  return t.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function renderConflictRow(c: ActiveConflict): string {
+  const color = INTENSITY_COLOR[c.intensity] ?? "#888";
+  const icon = trendIcon(c.trend);
+  const trendLabel = icon === "up" ? "&#8593;" : icon === "down" ? "&#8595;" : "&#8594;";
+  const trendClass = icon === "up" ? "trend-up" : icon === "down" ? "trend-down" : "trend-flat";
+  return (
+    "<div class="gc-row" data-intensity="" + safeText(c.intensity) + "">" +
+    "<span class="gc-dot" style="background:" + color + ""></span>" +
+    "<span class="gc-name">" + safeText(c.name) + "</span>" +
+    "<span class="gc-trend " + trendClass + "">" + trendLabel + "</span>" +
+    "<span class="gc-displaced">" + formatDisplaced(c.displaced) + "</span>" +
+    "<span class="gc-deaths">" + formatDeaths(c.monthlyDeaths) + "/mo</span>" +
+    "</div>"
+  );
+}
+
+function renderEvent(ev: ConflictEvent): string {
+  return (
+    "<div class="gc-event">" +
+    "<span class="gc-event-date">" + safeText(ev.date) + "</span>" +
+    "<span class="gc-event-headline">" + safeText(ev.headline) + "</span>" +
+    "</div>"
+  );
+}
+
+function renderHtml(params: ReturnType<typeof buildRenderData>): string {
+  const conflictRows = params.conflicts.map(renderConflictRow).join("");
+  const eventItems = params.recentEvents.map(renderEvent).join("");
+  return (
+    "<div class="gc-root">" +
+    "<div class="gc-stats">" +
+    "<span class="gc-stat"><strong>" + String(params.activeWars) + "</strong> wars active</span>" +
+    "<span class="gc-stat"><strong>" + String(params.escalatingCount) + "</strong> escalating</span>" +
+    "<span class="gc-stat"><strong>" + formatDisplaced(params.totalDisplacedK) + "</strong> displaced</span>" +
+    "</div>" +
+    "<div class="gc-conflicts">" + conflictRows + "</div>" +
+    "<div class="gc-events-header">Recent significant events</div>" +
+    "<div class="gc-events">" + eventItems + "</div>" +
+    "</div>"
+  );
+}
+
+export class GlobalConflictPanel extends Panel {
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  private extraConflicts: ActiveConflict[] = [];
+
+  constructor() {
+    super({
+      id: "global-conflict",
+      title: "Global Conflicts",
+      showCount: true,
+      trackActivity: true,
+      infoTooltip: TOOLTIP,
+    });
+    this.refresh();
+    this.refreshTimer = setInterval(() => this.refresh(), REFRESH_MS);
+  }
+
+  public setExtraConflicts(conflicts: ActiveConflict[]): void {
+    this.extraConflicts = conflicts;
+    this.refresh();
+  }
+
+  public override destroy(): void {
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    super.destroy();
+  }
+
+  private refresh(): void {
+    const base = safe(() => buildRenderData(), null);
+    if (!base) { this.showError("Conflict data unavailable"); return; }
+    const allConflicts = rankConflictsBySeverity([...base.conflicts, ...this.extraConflicts]);
+    const data = { ...base, conflicts: allConflicts };
+    this.setCount(data.activeWars);
+    this.setContent(renderHtml(data));
+  }
+}

--- a/src/components/__tests__/counterterrorism-helpers.test.mts
+++ b/src/components/__tests__/counterterrorism-helpers.test.mts
@@ -1,0 +1,718 @@
+/**
+ * Unit tests for counterterrorism-helpers.ts
+ * Run: npx tsx --test src/components/__tests__/counterterrorism-helpers.test.mts
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  classifyThreatTier,
+  tierLabel,
+  tierOrdinal,
+  aggregateTier,
+  analyzeAttackVectors,
+  dominantVector,
+  vectorLethalityScore,
+  scoreGroupActivity,
+  analyzeGroupActivity,
+  computeIncidentFrequency,
+  assessCasualtySeverity,
+  topCasualtyEvent,
+  computeCtEffectiveness,
+  computeRegionScore,
+  aggregateRegionRisks,
+  buildRenderData,
+  buildRegionRowHtml,
+  buildGroupCardHtml,
+  mostFrequent,
+  escapeHtmlSimple,
+  getMockIncidents,
+  MOCK_SEED_NOW,
+  TIER_COLORS,
+  VECTOR_LABELS,
+  type IncidentRecord,
+  type ThreatTier,
+} from '../counterterrorism-helpers.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const NOW = MOCK_SEED_NOW;
+const d = (daysAgo: number): number => NOW - daysAgo * 24 * 60 * 60 * 1000;
+
+const BASE_INCIDENT: IncidentRecord = {
+  id: 'test-1',
+  date: d(1),
+  region: 'Middle East',
+  country: 'Iraq',
+  group: 'ISIS',
+  vector: 'ied',
+  killed: 5,
+  wounded: 10,
+  ctSuccess: false,
+};
+
+// ── classifyThreatTier ────────────────────────────────────────────────────────
+
+describe('classifyThreatTier', () => {
+  it('returns critical for score >= 80', () => {
+    assert.equal(classifyThreatTier(80), 'critical');
+    assert.equal(classifyThreatTier(100), 'critical');
+    assert.equal(classifyThreatTier(95), 'critical');
+  });
+
+  it('returns high for score 60-79', () => {
+    assert.equal(classifyThreatTier(60), 'high');
+    assert.equal(classifyThreatTier(79), 'high');
+    assert.equal(classifyThreatTier(70), 'high');
+  });
+
+  it('returns elevated for score 40-59', () => {
+    assert.equal(classifyThreatTier(40), 'elevated');
+    assert.equal(classifyThreatTier(59), 'elevated');
+  });
+
+  it('returns guarded for score 20-39', () => {
+    assert.equal(classifyThreatTier(20), 'guarded');
+    assert.equal(classifyThreatTier(39), 'guarded');
+  });
+
+  it('returns low for score < 20', () => {
+    assert.equal(classifyThreatTier(0), 'low');
+    assert.equal(classifyThreatTier(19), 'low');
+  });
+
+  it('clamps scores above 100 to critical', () => {
+    assert.equal(classifyThreatTier(150), 'critical');
+  });
+
+  it('clamps negative scores to low', () => {
+    assert.equal(classifyThreatTier(-10), 'low');
+  });
+});
+
+// ── tierLabel ─────────────────────────────────────────────────────────────────
+
+describe('tierLabel', () => {
+  it('returns uppercase strings for all tiers', () => {
+    const tiers: ThreatTier[] = ['critical', 'high', 'elevated', 'guarded', 'low'];
+    for (const tier of tiers) {
+      const label = tierLabel(tier);
+      assert.equal(label, label.toUpperCase());
+    }
+  });
+
+  it('returns CRITICAL for critical tier', () => {
+    assert.equal(tierLabel('critical'), 'CRITICAL');
+  });
+
+  it('returns LOW for low tier', () => {
+    assert.equal(tierLabel('low'), 'LOW');
+  });
+});
+
+// ── tierOrdinal ───────────────────────────────────────────────────────────────
+
+describe('tierOrdinal', () => {
+  it('critical has highest ordinal', () => {
+    assert.ok(tierOrdinal('critical') > tierOrdinal('high'));
+  });
+
+  it('low has lowest ordinal (0)', () => {
+    assert.equal(tierOrdinal('low'), 0);
+  });
+
+  it('maintains strict ordering', () => {
+    assert.ok(tierOrdinal('high') > tierOrdinal('elevated'));
+    assert.ok(tierOrdinal('elevated') > tierOrdinal('guarded'));
+    assert.ok(tierOrdinal('guarded') > tierOrdinal('low'));
+  });
+});
+
+// ── aggregateTier ─────────────────────────────────────────────────────────────
+
+describe('aggregateTier', () => {
+  it('returns low for empty array', () => {
+    assert.equal(aggregateTier([]), 'low');
+  });
+
+  it('returns max tier from scores', () => {
+    assert.equal(aggregateTier([10, 85, 45]), 'critical');
+  });
+
+  it('handles all-low scores', () => {
+    assert.equal(aggregateTier([5, 10, 15]), 'low');
+  });
+});
+
+// ── analyzeAttackVectors ──────────────────────────────────────────────────────
+
+describe('analyzeAttackVectors', () => {
+  it('returns empty array for empty incidents', () => {
+    assert.deepEqual(analyzeAttackVectors([]), []);
+  });
+
+  it('counts each vector correctly', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', vector: 'ied' },
+      { ...BASE_INCIDENT, id: 'b', vector: 'ied' },
+      { ...BASE_INCIDENT, id: 'c', vector: 'suicide' },
+    ];
+    const result = analyzeAttackVectors(incidents);
+    const ied = result.find((v) => v.vector === 'ied');
+    assert.ok(ied);
+    assert.equal(ied.count, 2);
+    assert.equal(result[0]?.vector, 'ied'); // sorted by count
+  });
+
+  it('computes proportion correctly', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', vector: 'ied' },
+      { ...BASE_INCIDENT, id: 'b', vector: 'suicide' },
+      { ...BASE_INCIDENT, id: 'c', vector: 'suicide' },
+      { ...BASE_INCIDENT, id: 'd', vector: 'knife' },
+    ];
+    const result = analyzeAttackVectors(incidents);
+    const suicide = result.find((v) => v.vector === 'suicide');
+    assert.ok(suicide);
+    assert.equal(suicide.proportion, 0.5);
+  });
+
+  it('sums killed and wounded per vector', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', vector: 'ied', killed: 3, wounded: 7 },
+      { ...BASE_INCIDENT, id: 'b', vector: 'ied', killed: 2, wounded: 4 },
+    ];
+    const result = analyzeAttackVectors(incidents);
+    const ied = result.find((v) => v.vector === 'ied');
+    assert.equal(ied?.killed, 5);
+    assert.equal(ied?.wounded, 11);
+  });
+});
+
+// ── dominantVector ────────────────────────────────────────────────────────────
+
+describe('dominantVector', () => {
+  it('returns other for empty list', () => {
+    assert.equal(dominantVector([]), 'other');
+  });
+
+  it('returns the most common vector', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', vector: 'ied' },
+      { ...BASE_INCIDENT, id: 'b', vector: 'ied' },
+      { ...BASE_INCIDENT, id: 'c', vector: 'knife' },
+    ];
+    assert.equal(dominantVector(incidents), 'ied');
+  });
+});
+
+// ── vectorLethalityScore ──────────────────────────────────────────────────────
+
+describe('vectorLethalityScore', () => {
+  it('returns 0 when no matching incidents', () => {
+    assert.equal(vectorLethalityScore([], 'ied'), 0);
+  });
+
+  it('computes killed + 0.5 * wounded per incident', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', vector: 'suicide', killed: 10, wounded: 20 },
+    ];
+    // 10 + 0.5 * 20 = 20
+    assert.equal(vectorLethalityScore(incidents, 'suicide'), 20);
+  });
+
+  it('averages across multiple incidents of same vector', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', vector: 'ied', killed: 4, wounded: 0 },
+      { ...BASE_INCIDENT, id: 'b', vector: 'ied', killed: 8, wounded: 0 },
+    ];
+    // (4 + 8) / 2 = 6
+    assert.equal(vectorLethalityScore(incidents, 'ied'), 6);
+  });
+});
+
+// ── scoreGroupActivity ────────────────────────────────────────────────────────
+
+describe('scoreGroupActivity', () => {
+  it('returns 0 for zero inputs', () => {
+    assert.equal(scoreGroupActivity(0, 0, 0), 0);
+  });
+
+  it('caps at 100', () => {
+    assert.equal(scoreGroupActivity(100, 100, 100), 100);
+  });
+
+  it('computes weighted formula correctly', () => {
+    // 5*4 + 10*2 + 20*0.5 = 20 + 20 + 10 = 50
+    assert.equal(scoreGroupActivity(5, 10, 20), 50);
+  });
+});
+
+// ── analyzeGroupActivity ──────────────────────────────────────────────────────
+
+describe('analyzeGroupActivity', () => {
+  it('returns empty array for no incidents', () => {
+    assert.deepEqual(analyzeGroupActivity([]), []);
+  });
+
+  it('groups incidents by threat group', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', group: 'ISIS', killed: 5, wounded: 0 },
+      { ...BASE_INCIDENT, id: 'b', group: 'ISIS', killed: 3, wounded: 0 },
+      { ...BASE_INCIDENT, id: 'c', group: 'Al-Qaeda', killed: 1, wounded: 0 },
+    ];
+    const result = analyzeGroupActivity(incidents);
+    assert.equal(result.length, 2);
+    assert.equal(result[0]?.group, 'ISIS'); // higher score first
+  });
+
+  it('counts incidents correctly per group', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', group: 'TTP' },
+      { ...BASE_INCIDENT, id: 'b', group: 'TTP' },
+      { ...BASE_INCIDENT, id: 'c', group: 'TTP' },
+    ];
+    const result = analyzeGroupActivity(incidents);
+    assert.equal(result[0]?.incidentCount30d, 3);
+  });
+});
+
+// ── computeIncidentFrequency ──────────────────────────────────────────────────
+
+describe('computeIncidentFrequency', () => {
+  it('returns zero counts for empty incidents', () => {
+    const result = computeIncidentFrequency([], NOW);
+    assert.equal(result.count30d, 0);
+    assert.equal(result.count7d, 0);
+    assert.equal(result.trend, 'stable');
+  });
+
+  it('counts incidents within 30d window', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', date: d(5) },
+      { ...BASE_INCIDENT, id: 'b', date: d(15) },
+      { ...BASE_INCIDENT, id: 'c', date: d(35) }, // outside 30d
+    ];
+    const result = computeIncidentFrequency(incidents, NOW);
+    assert.equal(result.count30d, 2);
+  });
+
+  it('counts incidents within 7d window', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', date: d(3) },
+      { ...BASE_INCIDENT, id: 'b', date: d(10) }, // outside 7d
+    ];
+    const result = computeIncidentFrequency(incidents, NOW);
+    assert.equal(result.count7d, 1);
+  });
+
+  it('detects increasing trend when recent count exceeds prior by >10%', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', date: d(5) },
+      { ...BASE_INCIDENT, id: 'b', date: d(10) },
+      { ...BASE_INCIDENT, id: 'c', date: d(15) },
+      { ...BASE_INCIDENT, id: 'd', date: d(35) }, // prior period: 1
+    ];
+    const result = computeIncidentFrequency(incidents, NOW);
+    assert.equal(result.trend, 'increasing');
+  });
+
+  it('computes dailyAvg30d correctly', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', date: d(5) },
+      { ...BASE_INCIDENT, id: 'b', date: d(10) },
+    ];
+    const result = computeIncidentFrequency(incidents, NOW);
+    assert.equal(result.dailyAvg30d, 2 / 30);
+  });
+});
+
+// ── assessCasualtySeverity ────────────────────────────────────────────────────
+
+describe('assessCasualtySeverity', () => {
+  it('returns none for 0 killed and 0 wounded', () => {
+    assert.equal(assessCasualtySeverity(0, 0).label, 'none');
+  });
+
+  it('returns minor for small totals', () => {
+    assert.equal(assessCasualtySeverity(0, 2).label, 'minor');
+  });
+
+  it('returns moderate for total >= 3 when killed < 3', () => {
+    assert.equal(assessCasualtySeverity(1, 2).label, 'moderate');
+  });
+
+  it('returns severe for killed >= 3', () => {
+    assert.equal(assessCasualtySeverity(3, 0).label, 'severe');
+  });
+
+  it('returns severe for total >= 10', () => {
+    assert.equal(assessCasualtySeverity(1, 9).label, 'severe');
+  });
+
+  it('returns mass_casualty for killed >= 10', () => {
+    assert.equal(assessCasualtySeverity(10, 5).label, 'mass_casualty');
+  });
+
+  it('includes total in result', () => {
+    const result = assessCasualtySeverity(4, 6);
+    assert.equal(result.total, 10);
+  });
+});
+
+// ── topCasualtyEvent ──────────────────────────────────────────────────────────
+
+describe('topCasualtyEvent', () => {
+  it('returns none-label for empty list', () => {
+    const result = topCasualtyEvent([]);
+    assert.equal(result.label, 'none');
+    assert.equal(result.killed, 0);
+  });
+
+  it('finds incident with most killed', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', killed: 2, wounded: 5 },
+      { ...BASE_INCIDENT, id: 'b', killed: 12, wounded: 3 },
+      { ...BASE_INCIDENT, id: 'c', killed: 5, wounded: 20 },
+    ];
+    const result = topCasualtyEvent(incidents);
+    assert.equal(result.killed, 12);
+    assert.equal(result.label, 'mass_casualty');
+  });
+});
+
+// ── computeCtEffectiveness ────────────────────────────────────────────────────
+
+describe('computeCtEffectiveness', () => {
+  it('returns rate 0 and poor for empty list', () => {
+    const result = computeCtEffectiveness([]);
+    assert.equal(result.rate, 0);
+    assert.equal(result.label, 'poor');
+  });
+
+  it('counts successful CT ops correctly', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', ctSuccess: true },
+      { ...BASE_INCIDENT, id: 'b', ctSuccess: true },
+      { ...BASE_INCIDENT, id: 'c', ctSuccess: false },
+      { ...BASE_INCIDENT, id: 'd', ctSuccess: false },
+    ];
+    const result = computeCtEffectiveness(incidents);
+    assert.equal(result.successful, 2);
+    assert.equal(result.rate, 0.5);
+    assert.equal(result.label, 'good');
+  });
+
+  it('returns excellent for rate >= 0.75', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', ctSuccess: true },
+      { ...BASE_INCIDENT, id: 'b', ctSuccess: true },
+      { ...BASE_INCIDENT, id: 'c', ctSuccess: true },
+      { ...BASE_INCIDENT, id: 'd', ctSuccess: false },
+    ];
+    const result = computeCtEffectiveness(incidents);
+    assert.equal(result.label, 'excellent');
+  });
+
+  it('returns poor for rate < 0.25', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', ctSuccess: false },
+      { ...BASE_INCIDENT, id: 'b', ctSuccess: false },
+      { ...BASE_INCIDENT, id: 'c', ctSuccess: false },
+      { ...BASE_INCIDENT, id: 'd', ctSuccess: false },
+    ];
+    const result = computeCtEffectiveness(incidents);
+    assert.equal(result.label, 'poor');
+  });
+});
+
+// ── computeRegionScore ────────────────────────────────────────────────────────
+
+describe('computeRegionScore', () => {
+  it('returns 0 for zero inputs', () => {
+    assert.equal(computeRegionScore(0, 0, 0), 0);
+  });
+
+  it('caps at 100', () => {
+    assert.equal(computeRegionScore(100, 100, 100), 100);
+  });
+
+  it('applies correct weights', () => {
+    // 2*5 + 3*3 + 4 = 10+9+4 = 23
+    assert.equal(computeRegionScore(2, 3, 4), 23);
+  });
+});
+
+// ── aggregateRegionRisks ──────────────────────────────────────────────────────
+
+describe('aggregateRegionRisks', () => {
+  it('returns empty for no incidents', () => {
+    assert.deepEqual(aggregateRegionRisks([]), []);
+  });
+
+  it('groups by region correctly', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', region: 'Europe' },
+      { ...BASE_INCIDENT, id: 'b', region: 'Europe' },
+      { ...BASE_INCIDENT, id: 'c', region: 'Sahel' },
+    ];
+    const result = aggregateRegionRisks(incidents);
+    assert.equal(result.length, 2);
+  });
+
+  it('sorts regions by score descending', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', region: 'Low Region', killed: 1, wounded: 1 },
+      { ...BASE_INCIDENT, id: 'b', region: 'High Region', killed: 20, wounded: 30 },
+    ];
+    const result = aggregateRegionRisks(incidents);
+    assert.equal(result[0]?.region, 'High Region');
+  });
+
+  it('computes ctSuccessRate correctly', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', region: 'Test', ctSuccess: true },
+      { ...BASE_INCIDENT, id: 'b', region: 'Test', ctSuccess: false },
+    ];
+    const result = aggregateRegionRisks(incidents);
+    assert.equal(result[0]?.ctSuccessRate, 0.5);
+  });
+});
+
+// ── buildRenderData ───────────────────────────────────────────────────────────
+
+describe('buildRenderData', () => {
+  it('returns valid structure for empty incidents', () => {
+    const result = buildRenderData([], NOW);
+    assert.equal(result.overallTier, 'low');
+    assert.equal(result.overallScore, 0);
+    assert.equal(result.regions.length, 0);
+    assert.equal(result.groups.length, 0);
+  });
+
+  it('only includes incidents from last 30 days in regions/groups/vectors', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', date: d(10) },
+      { ...BASE_INCIDENT, id: 'b', date: d(40) }, // outside 30d
+    ];
+    const result = buildRenderData(incidents, NOW);
+    assert.equal(result.regions[0]?.incidentCount30d, 1);
+  });
+
+  it('asOf matches provided nowMs', () => {
+    const result = buildRenderData([], NOW);
+    assert.equal(result.asOf, NOW);
+  });
+
+  it('uses mock incidents without errors', () => {
+    const incidents = getMockIncidents(NOW);
+    const result = buildRenderData(incidents, NOW);
+    assert.ok(result.regions.length > 0);
+    assert.ok(result.groups.length > 0);
+    assert.ok(result.vectors.length > 0);
+  });
+});
+
+// ── buildRegionRowHtml ────────────────────────────────────────────────────────
+
+describe('buildRegionRowHtml', () => {
+  it('produces a <tr> element string', () => {
+    const region = aggregateRegionRisks([BASE_INCIDENT])[0]!;
+    const html = buildRegionRowHtml(region);
+    assert.ok(html.includes('<tr'));
+    assert.ok(html.includes('</tr>'));
+  });
+
+  it('contains the region name', () => {
+    const region = aggregateRegionRisks([BASE_INCIDENT])[0]!;
+    const html = buildRegionRowHtml(region);
+    assert.ok(html.includes('Middle East'));
+  });
+
+  it('contains the tier label', () => {
+    const region = aggregateRegionRisks([BASE_INCIDENT])[0]!;
+    const html = buildRegionRowHtml(region);
+    assert.ok(html.includes(tierLabel(region.tier)));
+  });
+});
+
+// ── buildGroupCardHtml ────────────────────────────────────────────────────────
+
+describe('buildGroupCardHtml', () => {
+  it('produces a div element string', () => {
+    const groups = analyzeGroupActivity([BASE_INCIDENT]);
+    const html = buildGroupCardHtml(groups[0]!);
+    assert.ok(html.includes('<div'));
+    assert.ok(html.includes('ISIS'));
+  });
+
+  it('contains incident count', () => {
+    const groups = analyzeGroupActivity([BASE_INCIDENT]);
+    const html = buildGroupCardHtml(groups[0]!);
+    assert.ok(html.includes('1 incidents'));
+  });
+});
+
+// ── mostFrequent ──────────────────────────────────────────────────────────────
+
+describe('mostFrequent', () => {
+  it('returns empty string for empty array', () => {
+    assert.equal(mostFrequent([]), '');
+  });
+
+  it('returns single element', () => {
+    assert.equal(mostFrequent(['a']), 'a');
+  });
+
+  it('returns most frequent element', () => {
+    assert.equal(mostFrequent(['a', 'b', 'a', 'c', 'a']), 'a');
+  });
+
+  it('works with numbers', () => {
+    assert.equal(mostFrequent([1, 2, 2, 3]), 2);
+  });
+});
+
+// ── escapeHtmlSimple ──────────────────────────────────────────────────────────
+
+describe('escapeHtmlSimple', () => {
+  it('escapes ampersand', () => {
+    assert.equal(escapeHtmlSimple('a & b'), 'a &amp; b');
+  });
+
+  it('escapes less-than', () => {
+    assert.equal(escapeHtmlSimple('<script>'), '&lt;script&gt;');
+  });
+
+  it('escapes double quotes', () => {
+    assert.equal(escapeHtmlSimple('"hello"'), '&quot;hello&quot;');
+  });
+
+  it('escapes single quotes', () => {
+    assert.equal(escapeHtmlSimple("it's"), 'it&#39;s');
+  });
+
+  it('leaves safe strings unchanged', () => {
+    assert.equal(escapeHtmlSimple('Hello World'), 'Hello World');
+  });
+});
+
+// ── getMockIncidents ──────────────────────────────────────────────────────────
+
+describe('getMockIncidents', () => {
+  it('returns at least 30 incidents', () => {
+    const incidents = getMockIncidents(NOW);
+    assert.ok(incidents.length >= 30);
+  });
+
+  it('all incidents have unique ids', () => {
+    const incidents = getMockIncidents(NOW);
+    const ids = new Set(incidents.map((i) => i.id));
+    assert.equal(ids.size, incidents.length);
+  });
+
+  it('all incident dates are in the past relative to seed', () => {
+    const incidents = getMockIncidents(NOW);
+    for (const inc of incidents) {
+      assert.ok(inc.date < NOW, `Incident ${inc.id} date is not in the past`);
+    }
+  });
+
+  it('all killed and wounded are non-negative', () => {
+    const incidents = getMockIncidents(NOW);
+    for (const inc of incidents) {
+      assert.ok(inc.killed >= 0);
+      assert.ok(inc.wounded >= 0);
+    }
+  });
+
+  it('is deterministic — same result for same seed', () => {
+    const a = getMockIncidents(NOW);
+    const b = getMockIncidents(NOW);
+    assert.deepEqual(a, b);
+  });
+
+  it('produces different results for different seeds', () => {
+    const a = getMockIncidents(NOW);
+    const b = getMockIncidents(NOW + 7 * 24 * 60 * 60 * 1000);
+    // Dates shift so they won't be equal
+    assert.notDeepEqual(a[0]?.date, b[0]?.date);
+  });
+});
+
+// ── TIER_COLORS / VECTOR_LABELS constants ────────────────────────────────────
+
+describe('TIER_COLORS', () => {
+  it('has an entry for all 5 tiers', () => {
+    const tiers: ThreatTier[] = ['critical', 'high', 'elevated', 'guarded', 'low'];
+    for (const tier of tiers) {
+      assert.ok(TIER_COLORS[tier], `Missing color for ${tier}`);
+    }
+  });
+
+  it('all values are hex color strings', () => {
+    for (const color of Object.values(TIER_COLORS)) {
+      assert.match(color, /^#[0-9a-fA-F]{6}$/, `${color} is not a valid hex color`);
+    }
+  });
+});
+
+describe('VECTOR_LABELS', () => {
+  it('has labels for all defined attack vectors', () => {
+    const vectors = ['vehicle', 'ied', 'suicide', 'knife', 'active_shooter', 'chemical', 'cyber', 'rocket', 'kidnapping', 'other'];
+    for (const v of vectors) {
+      assert.ok(VECTOR_LABELS[v as keyof typeof VECTOR_LABELS], `Missing label for ${v}`);
+    }
+  });
+});
+
+// ── Integration: buildRenderData with full mock dataset ───────────────────────
+
+describe('integration: full mock dataset', () => {
+  const incidents = getMockIncidents(NOW);
+  const data = buildRenderData(incidents, NOW);
+
+  it('produces valid overallTier', () => {
+    const valid: ThreatTier[] = ['critical', 'high', 'elevated', 'guarded', 'low'];
+    assert.ok(valid.includes(data.overallTier));
+  });
+
+  it('overallScore is between 0 and 100', () => {
+    assert.ok(data.overallScore >= 0 && data.overallScore <= 100);
+  });
+
+  it('regions are sorted by score descending', () => {
+    for (let i = 1; i < data.regions.length; i++) {
+      assert.ok(data.regions[i - 1]!.score >= data.regions[i]!.score);
+    }
+  });
+
+  it('groups are sorted by activityScore descending', () => {
+    for (let i = 1; i < data.groups.length; i++) {
+      assert.ok(data.groups[i - 1]!.activityScore >= data.groups[i]!.activityScore);
+    }
+  });
+
+  it('vectors are sorted by count descending', () => {
+    for (let i = 1; i < data.vectors.length; i++) {
+      assert.ok(data.vectors[i - 1]!.count >= data.vectors[i]!.count);
+    }
+  });
+
+  it('ctEffectiveness rate is between 0 and 1', () => {
+    assert.ok(data.ctEffectiveness.rate >= 0 && data.ctEffectiveness.rate <= 1);
+  });
+
+  it('frequency count30d matches number of recent incidents', () => {
+    const ms30d = 30 * 24 * 60 * 60 * 1000;
+    const expected = incidents.filter((i) => NOW - i.date <= ms30d).length;
+    assert.equal(data.frequency.count30d, expected);
+  });
+
+  it('all region tiers correspond to their scores', () => {
+    for (const r of data.regions) {
+      assert.equal(r.tier, classifyThreatTier(r.score));
+    }
+  });
+});

--- a/src/components/__tests__/global-conflict-helpers.test.mts
+++ b/src/components/__tests__/global-conflict-helpers.test.mts
@@ -1,0 +1,351 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  intensityScore,
+  trendIcon,
+  formatDisplaced,
+  formatDeaths,
+  rankConflictsBySeverity,
+  filterByRegion,
+  filterByIntensity,
+  computeRegionalSummary,
+  totalGlobalDisplaced,
+  totalActiveWars,
+  recentHighSignificanceEvents,
+  conflictDurationYears,
+  escalatingConflicts,
+  buildRenderData,
+  type ActiveConflict,
+  type ConflictEvent,
+  type ConflictIntensity,
+  type Region,
+} from '../global-conflict-helpers.ts';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+function makeConflict(over: Partial<ActiveConflict> = {}): ActiveConflict {
+  return {
+    id: 'test',
+    name: 'Test Conflict',
+    country: 'Testland',
+    region: 'europe',
+    intensity: 'crisis',
+    type: 'civil-war',
+    startYear: 2020,
+    estimatedDeaths: 1000,
+    monthlyDeaths: 50,
+    displaced: 100,
+    trend: 'stable',
+    parties: ['A', 'B'],
+    lastUpdate: '2026-01-01',
+    ...over,
+  };
+}
+
+function makeEvent(over: Partial<ConflictEvent> = {}): ConflictEvent {
+  return {
+    id: 'ev-test',
+    date: '2026-01-01',
+    conflictId: 'test',
+    headline: 'Test event',
+    significance: 'medium',
+    deathToll: 0,
+    ...over,
+  };
+}
+
+// ── intensityScore ────────────────────────────────────────────────────────
+
+test('intensityScore: war is highest', () => {
+  assert.equal(intensityScore('war'), 5);
+});
+
+test('intensityScore: stable is lowest', () => {
+  assert.equal(intensityScore('stable'), 1);
+});
+
+test('intensityScore: ordering is war > armed-conflict > crisis > tension > stable', () => {
+  const levels: ConflictIntensity[] = ['war', 'armed-conflict', 'crisis', 'tension', 'stable'];
+  for (let i = 0; i < levels.length - 1; i++) {
+    assert.ok(intensityScore(levels[i]!) > intensityScore(levels[i + 1]!));
+  }
+});
+
+test('intensityScore: all five levels have distinct scores', () => {
+  const scores = (['war', 'armed-conflict', 'crisis', 'tension', 'stable'] as ConflictIntensity[]).map(intensityScore);
+  const unique = new Set(scores);
+  assert.equal(unique.size, 5);
+});
+
+// ── trendIcon ─────────────────────────────────────────────────────────────
+
+test('trendIcon: escalating returns up', () => {
+  assert.equal(trendIcon('escalating'), 'up');
+});
+
+test('trendIcon: de-escalating returns down', () => {
+  assert.equal(trendIcon('de-escalating'), 'down');
+});
+
+test('trendIcon: stable returns flat', () => {
+  assert.equal(trendIcon('stable'), 'flat');
+});
+
+// ── formatDisplaced ───────────────────────────────────────────────────────
+
+test('formatDisplaced: below 1000 shows K suffix', () => {
+  assert.equal(formatDisplaced(500), '500K');
+});
+
+test('formatDisplaced: 1000 and above shows M suffix', () => {
+  assert.equal(formatDisplaced(1000), '1.0M');
+});
+
+test('formatDisplaced: fractional millions', () => {
+  assert.equal(formatDisplaced(2500), '2.5M');
+});
+
+test('formatDisplaced: zero', () => {
+  assert.equal(formatDisplaced(0), '0K');
+});
+
+// ── formatDeaths ──────────────────────────────────────────────────────────
+
+test('formatDeaths: below 1000 is plain number', () => {
+  assert.equal(formatDeaths(500), '500');
+});
+
+test('formatDeaths: thousands range', () => {
+  assert.equal(formatDeaths(50000), '50K');
+});
+
+test('formatDeaths: millions range', () => {
+  assert.equal(formatDeaths(1500000), '1.5M');
+});
+
+test('formatDeaths: exactly 1000', () => {
+  assert.equal(formatDeaths(1000), '1K');
+});
+
+// ── rankConflictsBySeverity ───────────────────────────────────────────────
+
+test('rankConflictsBySeverity: war sorts before crisis', () => {
+  const c1 = makeConflict({ id: 'a', intensity: 'crisis' });
+  const c2 = makeConflict({ id: 'b', intensity: 'war' });
+  const ranked = rankConflictsBySeverity([c1, c2]);
+  assert.equal(ranked[0]!.intensity, 'war');
+});
+
+test('rankConflictsBySeverity: same intensity, higher monthlyDeaths first', () => {
+  const c1 = makeConflict({ id: 'a', intensity: 'war', monthlyDeaths: 100 });
+  const c2 = makeConflict({ id: 'b', intensity: 'war', monthlyDeaths: 500 });
+  const ranked = rankConflictsBySeverity([c1, c2]);
+  assert.equal(ranked[0]!.id, 'b');
+});
+
+test('rankConflictsBySeverity: does not mutate input array', () => {
+  const arr = [makeConflict({ id: 'a', intensity: 'stable' }), makeConflict({ id: 'b', intensity: 'war' })];
+  const original = arr.map((c) => c.id);
+  rankConflictsBySeverity(arr);
+  assert.deepEqual(arr.map((c) => c.id), original);
+});
+
+test('rankConflictsBySeverity: empty array returns empty', () => {
+  assert.deepEqual(rankConflictsBySeverity([]), []);
+});
+
+// ── filterByRegion ────────────────────────────────────────────────────────
+
+test('filterByRegion: returns only matching region', () => {
+  const c1 = makeConflict({ id: 'a', region: 'europe' });
+  const c2 = makeConflict({ id: 'b', region: 'africa' });
+  const result = filterByRegion([c1, c2], 'europe');
+  assert.equal(result.length, 1);
+  assert.equal(result[0]!.id, 'a');
+});
+
+test('filterByRegion: returns empty for unmatched region', () => {
+  const c1 = makeConflict({ region: 'europe' });
+  assert.deepEqual(filterByRegion([c1], 'americas'), []);
+});
+
+// ── filterByIntensity ─────────────────────────────────────────────────────
+
+test('filterByIntensity: war threshold excludes lower', () => {
+  const conflicts = [
+    makeConflict({ id: 'a', intensity: 'war' }),
+    makeConflict({ id: 'b', intensity: 'crisis' }),
+    makeConflict({ id: 'c', intensity: 'stable' }),
+  ];
+  const result = filterByIntensity(conflicts, 'war');
+  assert.equal(result.length, 1);
+  assert.equal(result[0]!.id, 'a');
+});
+
+test('filterByIntensity: crisis threshold includes crisis and above', () => {
+  const conflicts = [
+    makeConflict({ id: 'a', intensity: 'war' }),
+    makeConflict({ id: 'b', intensity: 'crisis' }),
+    makeConflict({ id: 'c', intensity: 'tension' }),
+  ];
+  const result = filterByIntensity(conflicts, 'crisis');
+  assert.equal(result.length, 2);
+});
+
+// ── computeRegionalSummary ────────────────────────────────────────────────
+
+test('computeRegionalSummary: returns all six regions', () => {
+  const summaries = computeRegionalSummary([]);
+  assert.equal(summaries.length, 6);
+});
+
+test('computeRegionalSummary: empty region has zero conflicts', () => {
+  const summaries = computeRegionalSummary([]);
+  for (const s of summaries) {
+    assert.equal(s.activeConflicts, 0);
+    assert.equal(s.totalDisplaced, 0);
+    assert.equal(s.dominantIntensity, 'stable');
+  }
+});
+
+test('computeRegionalSummary: counts escalating correctly', () => {
+  const conflicts = [
+    makeConflict({ region: 'europe', trend: 'escalating' }),
+    makeConflict({ region: 'europe', trend: 'stable' }),
+  ];
+  const summaries = computeRegionalSummary(conflicts);
+  const europe = summaries.find((s) => s.region === 'europe')!;
+  assert.equal(europe.escalatingCount, 1);
+  assert.equal(europe.activeConflicts, 2);
+});
+
+test('computeRegionalSummary: sums displaced within region', () => {
+  const conflicts = [
+    makeConflict({ region: 'africa', displaced: 300 }),
+    makeConflict({ region: 'africa', displaced: 700 }),
+  ];
+  const summaries = computeRegionalSummary(conflicts);
+  const africa = summaries.find((s) => s.region === 'africa')!;
+  assert.equal(africa.totalDisplaced, 1000);
+});
+
+// ── totalGlobalDisplaced ──────────────────────────────────────────────────
+
+test('totalGlobalDisplaced: sums all displaced values', () => {
+  const conflicts = [makeConflict({ displaced: 200 }), makeConflict({ displaced: 800 })];
+  assert.equal(totalGlobalDisplaced(conflicts), 1000);
+});
+
+test('totalGlobalDisplaced: empty list returns 0', () => {
+  assert.equal(totalGlobalDisplaced([]), 0);
+});
+
+// ── totalActiveWars ───────────────────────────────────────────────────────
+
+test('totalActiveWars: counts only war intensity', () => {
+  const conflicts = [
+    makeConflict({ intensity: 'war' }),
+    makeConflict({ intensity: 'war' }),
+    makeConflict({ intensity: 'crisis' }),
+  ];
+  assert.equal(totalActiveWars(conflicts), 2);
+});
+
+test('totalActiveWars: returns 0 when no wars', () => {
+  assert.equal(totalActiveWars([makeConflict({ intensity: 'tension' })]), 0);
+});
+
+// ── recentHighSignificanceEvents ──────────────────────────────────────────
+
+test('recentHighSignificanceEvents: excludes medium and low', () => {
+  const events = [
+    makeEvent({ significance: 'high', date: '2026-05-01' }),
+    makeEvent({ significance: 'medium', date: '2026-05-02' }),
+    makeEvent({ significance: 'low', date: '2026-05-03' }),
+  ];
+  const result = recentHighSignificanceEvents(events);
+  assert.equal(result.length, 1);
+  assert.equal(result[0]!.significance, 'high');
+});
+
+test('recentHighSignificanceEvents: sorts descending by date', () => {
+  const events = [
+    makeEvent({ id: 'a', significance: 'high', date: '2026-01-01' }),
+    makeEvent({ id: 'b', significance: 'high', date: '2026-05-01' }),
+  ];
+  const result = recentHighSignificanceEvents(events);
+  assert.equal(result[0]!.id, 'b');
+});
+
+test('recentHighSignificanceEvents: respects limit', () => {
+  const events = Array.from({ length: 10 }, (_, i) =>
+    makeEvent({ id: String(i), significance: 'high', date: `2026-01-${String(i + 1).padStart(2, '0')}` })
+  );
+  assert.equal(recentHighSignificanceEvents(events, 3).length, 3);
+});
+
+// ── conflictDurationYears ─────────────────────────────────────────────────
+
+test('conflictDurationYears: 2022 start = 4 years in 2026', () => {
+  assert.equal(conflictDurationYears(makeConflict({ startYear: 2022 }), 2026), 4);
+});
+
+test('conflictDurationYears: same year returns 0', () => {
+  assert.equal(conflictDurationYears(makeConflict({ startYear: 2026 }), 2026), 0);
+});
+
+// ── escalatingConflicts ───────────────────────────────────────────────────
+
+test('escalatingConflicts: filters correctly', () => {
+  const conflicts = [
+    makeConflict({ trend: 'escalating' }),
+    makeConflict({ trend: 'stable' }),
+    makeConflict({ trend: 'de-escalating' }),
+  ];
+  assert.equal(escalatingConflicts(conflicts).length, 1);
+});
+
+test('escalatingConflicts: returns empty for none escalating', () => {
+  assert.equal(escalatingConflicts([makeConflict({ trend: 'stable' })]).length, 0);
+});
+
+// ── buildRenderData ───────────────────────────────────────────────────────
+
+test('buildRenderData: returns non-empty conflicts list', () => {
+  const data = buildRenderData();
+  assert.ok(data.conflicts.length > 0);
+});
+
+test('buildRenderData: conflicts are sorted war-first', () => {
+  const data = buildRenderData();
+  assert.equal(data.conflicts[0]!.intensity, 'war');
+});
+
+test('buildRenderData: activeWars is a positive integer', () => {
+  const data = buildRenderData();
+  assert.ok(Number.isInteger(data.activeWars));
+  assert.ok(data.activeWars > 0);
+});
+
+test('buildRenderData: totalDisplacedK is positive', () => {
+  const data = buildRenderData();
+  assert.ok(data.totalDisplacedK > 0);
+});
+
+test('buildRenderData: regionalSummaries has 6 entries', () => {
+  const data = buildRenderData();
+  assert.equal(data.regionalSummaries.length, 6);
+});
+
+test('buildRenderData: escalatingCount matches escalating conflicts', () => {
+  const data = buildRenderData();
+  const counted = data.conflicts.filter((c) => c.trend === 'escalating').length;
+  assert.equal(data.escalatingCount, counted);
+});
+
+test('buildRenderData: recentEvents are all high significance', () => {
+  const data = buildRenderData();
+  for (const ev of data.recentEvents) {
+    assert.equal(ev.significance, 'high');
+  }
+});

--- a/src/components/counterterrorism-helpers.ts
+++ b/src/components/counterterrorism-helpers.ts
@@ -1,0 +1,622 @@
+/**
+ * counterterrorism-helpers.ts
+ *
+ * Pure functions for the CounterterrorismPanel. No DOM, no fetch, no globals.
+ * All functions are deterministic given the same inputs — suitable for unit tests
+ * with static fixtures.
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type ThreatTier = 'critical' | 'high' | 'elevated' | 'guarded' | 'low';
+
+export type AttackVector =
+  | 'vehicle'
+  | 'ied'
+  | 'suicide'
+  | 'knife'
+  | 'active_shooter'
+  | 'chemical'
+  | 'cyber'
+  | 'rocket'
+  | 'kidnapping'
+  | 'other';
+
+export type ThreatGroup =
+  | 'ISIS'
+  | 'Al-Qaeda'
+  | 'Boko Haram'
+  | 'al-Shabaab'
+  | 'TTP'
+  | 'PKK'
+  | 'FARC remnants'
+  | 'Hezbollah';
+
+export type TrendDirection = 'increasing' | 'stable' | 'decreasing';
+
+export interface IncidentRecord {
+  id: string;
+  date: number; // Unix ms
+  region: string;
+  country: string;
+  group: ThreatGroup;
+  vector: AttackVector;
+  killed: number;
+  wounded: number;
+  ctSuccess: boolean; // true = CT operation disrupted/prevented
+}
+
+export interface GroupActivity {
+  group: ThreatGroup;
+  incidentCount30d: number;
+  casualtiesTotal: number;
+  primaryVector: AttackVector;
+  primaryRegion: string;
+  activityScore: number; // 0-100
+  trend: TrendDirection;
+}
+
+export interface RegionRisk {
+  region: string;
+  tier: ThreatTier;
+  score: number; // 0-100
+  incidentCount30d: number;
+  topGroup: ThreatGroup;
+  topVector: AttackVector;
+  trend: TrendDirection;
+  ctSuccessRate: number; // 0-1
+}
+
+export interface AttackVectorSummary {
+  vector: AttackVector;
+  count: number;
+  killed: number;
+  wounded: number;
+  proportion: number; // 0-1 fraction of all incidents
+}
+
+export interface CasualtySeverity {
+  label: 'mass_casualty' | 'severe' | 'moderate' | 'minor' | 'none';
+  killed: number;
+  wounded: number;
+  total: number;
+}
+
+export interface CtEffectiveness {
+  total: number;
+  successful: number;
+  rate: number; // 0-1
+  label: 'excellent' | 'good' | 'fair' | 'poor';
+}
+
+export interface IncidentFrequency {
+  count30d: number;
+  count7d: number;
+  dailyAvg30d: number;
+  trend: TrendDirection;
+  trendPct: number; // % change vs prior 30d window
+}
+
+export interface CounterterrorismRenderData {
+  asOf: number;
+  overallTier: ThreatTier;
+  overallScore: number;
+  regions: RegionRisk[];
+  groups: GroupActivity[];
+  vectors: AttackVectorSummary[];
+  frequency: IncidentFrequency;
+  ctEffectiveness: CtEffectiveness;
+  topCasualty: CasualtySeverity;
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const THREAT_TIER_THRESHOLDS: Record<ThreatTier, number> = {
+  critical: 80,
+  high: 60,
+  elevated: 40,
+  guarded: 20,
+  low: 0,
+};
+
+export const TIER_COLORS: Record<ThreatTier, string> = {
+  critical: '#d50000',
+  high: '#ff6d00',
+  elevated: '#ffd600',
+  guarded: '#2979ff',
+  low: '#00c853',
+};
+
+export const VECTOR_LABELS: Record<AttackVector, string> = {
+  vehicle: 'Vehicle RAM',
+  ied: 'IED/Bomb',
+  suicide: 'Suicide Bomb',
+  knife: 'Knife/Blade',
+  active_shooter: 'Active Shooter',
+  chemical: 'Chemical',
+  cyber: 'Cyber',
+  rocket: 'Rocket/Mortar',
+  kidnapping: 'Kidnapping',
+  other: 'Other',
+};
+
+// ── Threat tier classifiers ───────────────────────────────────────────────────
+
+/**
+ * Classify a numeric score (0-100) into a ThreatTier.
+ * critical >=80, high >=60, elevated >=40, guarded >=20, low <20.
+ */
+export function classifyThreatTier(score: number): ThreatTier {
+  const clamped = Math.max(0, Math.min(100, score));
+  if (clamped >= THREAT_TIER_THRESHOLDS.critical) return 'critical';
+  if (clamped >= THREAT_TIER_THRESHOLDS.high) return 'high';
+  if (clamped >= THREAT_TIER_THRESHOLDS.elevated) return 'elevated';
+  if (clamped >= THREAT_TIER_THRESHOLDS.guarded) return 'guarded';
+  return 'low';
+}
+
+/**
+ * Return a human-readable label for a ThreatTier.
+ */
+export function tierLabel(tier: ThreatTier): string {
+  const labels: Record<ThreatTier, string> = {
+    critical: 'CRITICAL',
+    high: 'HIGH',
+    elevated: 'ELEVATED',
+    guarded: 'GUARDED',
+    low: 'LOW',
+  };
+  return labels[tier];
+}
+
+/**
+ * Ordinal rank of threat tiers, highest = 4.
+ */
+export function tierOrdinal(tier: ThreatTier): number {
+  const order: Record<ThreatTier, number> = {
+    critical: 4,
+    high: 3,
+    elevated: 2,
+    guarded: 1,
+    low: 0,
+  };
+  return order[tier];
+}
+
+/**
+ * Return the highest tier across a list of scores.
+ */
+export function aggregateTier(scores: number[]): ThreatTier {
+  if (scores.length === 0) return 'low';
+  const max = Math.max(...scores);
+  return classifyThreatTier(max);
+}
+
+// ── Attack vector analyzers ───────────────────────────────────────────────────
+
+/**
+ * Summarize attack vectors from a list of incidents.
+ * Returns entries sorted by count descending.
+ */
+export function analyzeAttackVectors(incidents: IncidentRecord[]): AttackVectorSummary[] {
+  const total = incidents.length;
+  const counts = new Map<AttackVector, { count: number; killed: number; wounded: number }>();
+
+  for (const inc of incidents) {
+    const existing = counts.get(inc.vector) ?? { count: 0, killed: 0, wounded: 0 };
+    counts.set(inc.vector, {
+      count: existing.count + 1,
+      killed: existing.killed + inc.killed,
+      wounded: existing.wounded + inc.wounded,
+    });
+  }
+
+  return [...counts.entries()]
+    .map(([vector, stats]) => ({
+      vector,
+      count: stats.count,
+      killed: stats.killed,
+      wounded: stats.wounded,
+      proportion: total > 0 ? stats.count / total : 0,
+    }))
+    .sort((a, b) => b.count - a.count);
+}
+
+/**
+ * Find the most frequently used attack vector in a set of incidents.
+ * Returns 'other' when the list is empty.
+ */
+export function dominantVector(incidents: IncidentRecord[]): AttackVector {
+  if (incidents.length === 0) return 'other';
+  const summaries = analyzeAttackVectors(incidents);
+  return summaries[0]?.vector ?? 'other';
+}
+
+/**
+ * Compute average lethality weight for an attack vector
+ * (killed + 0.5 * wounded per incident).
+ */
+export function vectorLethalityScore(incidents: IncidentRecord[], vector: AttackVector): number {
+  const filtered = incidents.filter((i) => i.vector === vector);
+  if (filtered.length === 0) return 0;
+  const totalKilled = filtered.reduce((s, i) => s + i.killed, 0);
+  const totalWounded = filtered.reduce((s, i) => s + i.wounded, 0);
+  return (totalKilled + 0.5 * totalWounded) / filtered.length;
+}
+
+// ── Group activity scorers ─────────────────────────────────────────────────────
+
+/**
+ * Compute an activity score for a group based on incident count and casualties.
+ * score = min(100, incidentCount * 4 + killed * 2 + wounded * 0.5)
+ */
+export function scoreGroupActivity(
+  incidentCount: number,
+  killed: number,
+  wounded: number,
+): number {
+  const raw = incidentCount * 4 + killed * 2 + wounded * 0.5;
+  return Math.min(100, Math.round(raw));
+}
+
+/**
+ * Summarize activity for every unique group in the incident list.
+ * Sorted by activityScore descending.
+ */
+export function analyzeGroupActivity(incidents: IncidentRecord[]): GroupActivity[] {
+  const byGroup = new Map<
+    ThreatGroup,
+    { count: number; killed: number; wounded: number; regions: string[]; vectors: AttackVector[] }
+  >();
+
+  for (const inc of incidents) {
+    const existing = byGroup.get(inc.group) ?? {
+      count: 0,
+      killed: 0,
+      wounded: 0,
+      regions: [],
+      vectors: [],
+    };
+    byGroup.set(inc.group, {
+      count: existing.count + 1,
+      killed: existing.killed + inc.killed,
+      wounded: existing.wounded + inc.wounded,
+      regions: [...existing.regions, inc.region],
+      vectors: [...existing.vectors, inc.vector],
+    });
+  }
+
+  return [...byGroup.entries()]
+    .map(([group, stats]) => ({
+      group,
+      incidentCount30d: stats.count,
+      casualtiesTotal: stats.killed + stats.wounded,
+      primaryVector: mostFrequent(stats.vectors) as AttackVector,
+      primaryRegion: mostFrequent(stats.regions) as string,
+      activityScore: scoreGroupActivity(stats.count, stats.killed, stats.wounded),
+      trend: 'stable' as TrendDirection,
+    }))
+    .sort((a, b) => b.activityScore - a.activityScore);
+}
+
+// ── Incident frequency calculators ───────────────────────────────────────────
+
+/**
+ * Compute 30-day and 7-day incident frequency and trend direction.
+ * Pass nowMs explicitly in tests for determinism.
+ */
+export function computeIncidentFrequency(
+  incidents: IncidentRecord[],
+  nowMs: number = Date.now(),
+): IncidentFrequency {
+  const ms30d = 30 * 24 * 60 * 60 * 1000;
+  const ms7d = 7 * 24 * 60 * 60 * 1000;
+  const ms60d = 60 * 24 * 60 * 60 * 1000;
+
+  const window30d = incidents.filter((i) => nowMs - i.date <= ms30d);
+  const window7d = incidents.filter((i) => nowMs - i.date <= ms7d);
+  const prior30d = incidents.filter(
+    (i) => nowMs - i.date > ms30d && nowMs - i.date <= ms60d,
+  );
+
+  const count30d = window30d.length;
+  const count7d = window7d.length;
+  const priorCount = prior30d.length;
+  const dailyAvg30d = count30d / 30;
+
+  let trendPct = 0;
+  let trend: TrendDirection = 'stable';
+  if (priorCount > 0) {
+    trendPct = ((count30d - priorCount) / priorCount) * 100;
+    if (trendPct > 10) trend = 'increasing';
+    else if (trendPct < -10) trend = 'decreasing';
+  } else if (count30d > 0) {
+    trend = 'increasing';
+    trendPct = 100;
+  }
+
+  return { count30d, count7d, dailyAvg30d, trend, trendPct };
+}
+
+// ── Casualty severity assessors ───────────────────────────────────────────────
+
+/**
+ * Assess casualty severity for given killed/wounded counts.
+ * mass_casualty: killed>=10; severe: killed>=3 or total>=10;
+ * moderate: total>=3; minor: total>=1; none: 0.
+ */
+export function assessCasualtySeverity(killed: number, wounded: number): CasualtySeverity {
+  const total = killed + wounded;
+  let label: CasualtySeverity['label'];
+  if (killed >= 10) label = 'mass_casualty';
+  else if (killed >= 3 || total >= 10) label = 'severe';
+  else if (total >= 3) label = 'moderate';
+  else if (total >= 1) label = 'minor';
+  else label = 'none';
+  return { label, killed, wounded, total };
+}
+
+/**
+ * Find the single highest-severity incident in a list.
+ * Returns zeros when list is empty.
+ */
+export function topCasualtyEvent(incidents: IncidentRecord[]): CasualtySeverity {
+  if (incidents.length === 0) return { label: 'none', killed: 0, wounded: 0, total: 0 };
+  const worst = incidents.reduce((best, inc) => {
+    const incTotal = inc.killed + inc.wounded;
+    const bestTotal = best.killed + best.wounded;
+    if (inc.killed > best.killed || (inc.killed === best.killed && incTotal > bestTotal)) {
+      return inc;
+    }
+    return best;
+  });
+  return assessCasualtySeverity(worst.killed, worst.wounded);
+}
+
+// ── CT operation effectiveness metrics ───────────────────────────────────────
+
+/**
+ * Compute CT operation effectiveness rate and qualitative label.
+ * excellent >=0.75, good >=0.5, fair >=0.25, poor <0.25.
+ */
+export function computeCtEffectiveness(incidents: IncidentRecord[]): CtEffectiveness {
+  const total = incidents.length;
+  const successful = incidents.filter((i) => i.ctSuccess).length;
+  const rate = total > 0 ? successful / total : 0;
+  let label: CtEffectiveness['label'];
+  if (rate >= 0.75) label = 'excellent';
+  else if (rate >= 0.5) label = 'good';
+  else if (rate >= 0.25) label = 'fair';
+  else label = 'poor';
+  return { total, successful, rate, label };
+}
+
+// ── Regional risk aggregators ─────────────────────────────────────────────────
+
+/**
+ * Compute a risk score for a region from incident count and casualties.
+ * score = min(100, count * 5 + killed * 3 + wounded)
+ */
+export function computeRegionScore(
+  count: number,
+  killed: number,
+  wounded: number,
+): number {
+  return Math.min(100, Math.round(count * 5 + killed * 3 + wounded));
+}
+
+/**
+ * Build a RegionRisk record for every unique region in the incident list.
+ * Sorted by score descending.
+ */
+export function aggregateRegionRisks(incidents: IncidentRecord[]): RegionRisk[] {
+  const byRegion = new Map<
+    string,
+    { killed: number; wounded: number; groups: ThreatGroup[]; vectors: AttackVector[]; ctSuccess: boolean[] }
+  >();
+
+  for (const inc of incidents) {
+    const existing = byRegion.get(inc.region) ?? {
+      killed: 0,
+      wounded: 0,
+      groups: [],
+      vectors: [],
+      ctSuccess: [],
+    };
+    byRegion.set(inc.region, {
+      killed: existing.killed + inc.killed,
+      wounded: existing.wounded + inc.wounded,
+      groups: [...existing.groups, inc.group],
+      vectors: [...existing.vectors, inc.vector],
+      ctSuccess: [...existing.ctSuccess, inc.ctSuccess],
+    });
+  }
+
+  return [...byRegion.entries()]
+    .map(([region, stats]) => {
+      const count = stats.groups.length;
+      const score = computeRegionScore(count, stats.killed, stats.wounded);
+      const successCount = stats.ctSuccess.filter(Boolean).length;
+      const ctSuccessRate = count > 0 ? successCount / count : 0;
+      return {
+        region,
+        tier: classifyThreatTier(score),
+        score,
+        incidentCount30d: count,
+        topGroup: mostFrequent(stats.groups) as ThreatGroup,
+        topVector: mostFrequent(stats.vectors) as AttackVector,
+        trend: 'stable' as TrendDirection,
+        ctSuccessRate,
+      };
+    })
+    .sort((a, b) => b.score - a.score);
+}
+
+// ── Render-data builders ──────────────────────────────────────────────────────
+
+/**
+ * Build the full CounterterrorismRenderData from a list of incidents.
+ * Pass nowMs explicitly in tests for determinism.
+ */
+export function buildRenderData(
+  incidents: IncidentRecord[],
+  nowMs: number = Date.now(),
+): CounterterrorismRenderData {
+  const ms30d = 30 * 24 * 60 * 60 * 1000;
+  const recent = incidents.filter((i) => nowMs - i.date <= ms30d);
+
+  const regions = aggregateRegionRisks(recent);
+  const groups = analyzeGroupActivity(recent);
+  const vectors = analyzeAttackVectors(recent);
+  const frequency = computeIncidentFrequency(incidents, nowMs);
+  const ctEffectiveness = computeCtEffectiveness(recent);
+  const topCasualty = topCasualtyEvent(recent);
+
+  const overallScore =
+    regions.length > 0
+      ? Math.round(regions.reduce((s, r) => s + r.score, 0) / regions.length)
+      : 0;
+  const overallTier = classifyThreatTier(overallScore);
+
+  return {
+    asOf: nowMs,
+    overallTier,
+    overallScore,
+    regions,
+    groups,
+    vectors,
+    frequency,
+    ctEffectiveness,
+    topCasualty,
+  };
+}
+
+/**
+ * Build an HTML snippet for a single region row.
+ */
+export function buildRegionRowHtml(r: RegionRisk): string {
+  const color = TIER_COLORS[r.tier];
+  const trendArrow = r.trend === 'increasing' ? '↑' : r.trend === 'decreasing' ? '↓' : '→';
+  const trendColor = r.trend === 'increasing' ? '#f44336' : r.trend === 'decreasing' ? '#4caf50' : '#9e9e9e';
+  const ctPct = Math.round(r.ctSuccessRate * 100);
+  return `<tr style="border-bottom:1px solid var(--border-subtle,#222);">
+    <td style="padding:6px 10px;font-size:12px;color:#e5e5e5;">${escapeHtmlSimple(r.region)}</td>
+    <td style="padding:6px 10px;">
+      <span style="display:inline-block;padding:2px 6px;border-radius:3px;font-size:10px;font-weight:700;
+        background:${color}22;color:${color};border:1px solid ${color}44;">
+        ${tierLabel(r.tier)}
+      </span>
+    </td>
+    <td style="padding:6px 10px;font-size:12px;color:#e5e5e5;">${r.score}</td>
+    <td style="padding:6px 10px;font-size:12px;color:#e5e5e5;">${r.incidentCount30d}</td>
+    <td style="padding:6px 10px;font-size:12px;color:#bbb;">${escapeHtmlSimple(r.topGroup)}</td>
+    <td style="padding:6px 10px;font-size:11px;color:#9e9e9e;">${VECTOR_LABELS[r.topVector] ?? r.topVector}</td>
+    <td style="padding:6px 4px;font-size:13px;color:${trendColor};text-align:center;">${trendArrow}</td>
+    <td style="padding:6px 10px;font-size:12px;color:#bbb;">${ctPct}%</td>
+  </tr>`;
+}
+
+/**
+ * Build an HTML snippet for a single group activity card.
+ */
+export function buildGroupCardHtml(g: GroupActivity): string {
+  const tier = classifyThreatTier(g.activityScore);
+  const color = TIER_COLORS[tier];
+  return `<div style="padding:8px 10px;border-bottom:1px solid var(--border-subtle,#222);display:flex;align-items:center;gap:8px;">
+    <span style="flex:0 0 auto;width:8px;height:8px;border-radius:50%;background:${color};"></span>
+    <span style="flex:1;font-size:12px;color:#e5e5e5;font-weight:600;">${escapeHtmlSimple(g.group)}</span>
+    <span style="font-size:11px;color:#9e9e9e;">${g.incidentCount30d} incidents</span>
+    <span style="font-size:11px;color:#ff6d00;font-weight:700;">${g.activityScore}</span>
+  </div>`;
+}
+
+// ── Internal utilities ─────────────────────────────────────────────────────────
+
+/**
+ * Return the most frequently occurring value in an array.
+ * Returns the first element when all are tied, or '' on empty input.
+ */
+export function mostFrequent<T>(arr: T[]): T | string {
+  if (arr.length === 0) return '';
+  const counts = new Map<string, number>();
+  for (const item of arr) {
+    const key = String(item);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  let bestKey = '';
+  let bestCount = 0;
+  for (const [key, count] of counts) {
+    if (count > bestCount) {
+      bestKey = key;
+      bestCount = count;
+    }
+  }
+  return arr.find((a) => String(a) === bestKey) ?? '';
+}
+
+/**
+ * Minimal HTML escape for text content.
+ */
+export function escapeHtmlSimple(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// ── Mock data factory ─────────────────────────────────────────────────────────
+
+/** Stable seed timestamp for deterministic tests (2026-05-26T20:00:00Z). */
+export const MOCK_SEED_NOW = 1_748_995_200_000;
+
+/**
+ * Return a deterministic set of mock incidents for offline/test use.
+ * All dates are relative to seedNowMs.
+ */
+export function getMockIncidents(seedNowMs: number = MOCK_SEED_NOW): IncidentRecord[] {
+  const d = (daysAgo: number): number =>
+    seedNowMs - daysAgo * 24 * 60 * 60 * 1000;
+
+  return [
+    // Sahel / West Africa — Al-Qaeda & ISIS
+    { id: 'i001', date: d(2),  region: 'Sahel', country: 'Mali',          group: 'Al-Qaeda',     vector: 'ied',           killed: 4,  wounded: 11, ctSuccess: false },
+    { id: 'i002', date: d(5),  region: 'Sahel', country: 'Burkina Faso',  group: 'ISIS',          vector: 'active_shooter',killed: 9,  wounded: 6,  ctSuccess: false },
+    { id: 'i003', date: d(8),  region: 'Sahel', country: 'Niger',         group: 'Al-Qaeda',     vector: 'vehicle',       killed: 2,  wounded: 3,  ctSuccess: true  },
+    { id: 'i004', date: d(12), region: 'Sahel', country: 'Mali',          group: 'ISIS',          vector: 'ied',           killed: 6,  wounded: 14, ctSuccess: false },
+    { id: 'i005', date: d(18), region: 'Sahel', country: 'Burkina Faso',  group: 'Al-Qaeda',     vector: 'rocket',        killed: 1,  wounded: 5,  ctSuccess: true  },
+    // East Africa — al-Shabaab
+    { id: 'i006', date: d(1),  region: 'East Africa', country: 'Somalia', group: 'al-Shabaab',   vector: 'suicide',       killed: 14, wounded: 22, ctSuccess: false },
+    { id: 'i007', date: d(6),  region: 'East Africa', country: 'Kenya',   group: 'al-Shabaab',   vector: 'ied',           killed: 3,  wounded: 8,  ctSuccess: true  },
+    { id: 'i008', date: d(11), region: 'East Africa', country: 'Somalia', group: 'al-Shabaab',   vector: 'active_shooter',killed: 7,  wounded: 12, ctSuccess: false },
+    { id: 'i009', date: d(20), region: 'East Africa', country: 'Somalia', group: 'al-Shabaab',   vector: 'vehicle',       killed: 5,  wounded: 9,  ctSuccess: true  },
+    // West Africa — Boko Haram
+    { id: 'i010', date: d(3),  region: 'West Africa', country: 'Nigeria', group: 'Boko Haram',   vector: 'active_shooter',killed: 11, wounded: 18, ctSuccess: false },
+    { id: 'i011', date: d(9),  region: 'West Africa', country: 'Cameroon',group: 'Boko Haram',   vector: 'kidnapping',    killed: 0,  wounded: 2,  ctSuccess: false },
+    { id: 'i012', date: d(15), region: 'West Africa', country: 'Nigeria', group: 'Boko Haram',   vector: 'suicide',       killed: 8,  wounded: 15, ctSuccess: false },
+    { id: 'i013', date: d(25), region: 'West Africa', country: 'Chad',    group: 'Boko Haram',   vector: 'ied',           killed: 3,  wounded: 7,  ctSuccess: true  },
+    // South Asia — TTP & ISIS
+    { id: 'i014', date: d(4),  region: 'South Asia',  country: 'Pakistan',     group: 'TTP',     vector: 'suicide',       killed: 16, wounded: 30, ctSuccess: false },
+    { id: 'i015', date: d(7),  region: 'South Asia',  country: 'Afghanistan',  group: 'ISIS',    vector: 'ied',           killed: 8,  wounded: 21, ctSuccess: false },
+    { id: 'i016', date: d(13), region: 'South Asia',  country: 'Pakistan',     group: 'TTP',     vector: 'active_shooter',killed: 5,  wounded: 9,  ctSuccess: true  },
+    { id: 'i017', date: d(22), region: 'South Asia',  country: 'Pakistan',     group: 'TTP',     vector: 'rocket',        killed: 2,  wounded: 4,  ctSuccess: true  },
+    // Middle East — ISIS & Hezbollah
+    { id: 'i018', date: d(2),  region: 'Middle East', country: 'Iraq',    group: 'ISIS',          vector: 'ied',           killed: 5,  wounded: 13, ctSuccess: true  },
+    { id: 'i019', date: d(6),  region: 'Middle East', country: 'Syria',   group: 'ISIS',          vector: 'active_shooter',killed: 3,  wounded: 6,  ctSuccess: true  },
+    { id: 'i020', date: d(10), region: 'Middle East', country: 'Lebanon', group: 'Hezbollah',    vector: 'rocket',        killed: 1,  wounded: 4,  ctSuccess: false },
+    { id: 'i021', date: d(16), region: 'Middle East', country: 'Iraq',    group: 'ISIS',          vector: 'suicide',       killed: 12, wounded: 25, ctSuccess: false },
+    // Europe — PKK & ISIS
+    { id: 'i022', date: d(5),  region: 'Europe',      country: 'Turkey',  group: 'PKK',           vector: 'ied',           killed: 2,  wounded: 8,  ctSuccess: true  },
+    { id: 'i023', date: d(14), region: 'Europe',      country: 'France',  group: 'ISIS',          vector: 'knife',         killed: 1,  wounded: 2,  ctSuccess: true  },
+    { id: 'i024', date: d(21), region: 'Europe',      country: 'Turkey',  group: 'PKK',           vector: 'active_shooter',killed: 3,  wounded: 5,  ctSuccess: false },
+    // Latin America — FARC remnants
+    { id: 'i025', date: d(8),  region: 'Latin America', country: 'Colombia',  group: 'FARC remnants', vector: 'ied',       killed: 1,  wounded: 4,  ctSuccess: true  },
+    { id: 'i026', date: d(17), region: 'Latin America', country: 'Venezuela', group: 'FARC remnants', vector: 'kidnapping',killed: 0,  wounded: 1,  ctSuccess: false },
+    // Prior 30-60d window (for trend calculation)
+    { id: 'i027', date: d(35), region: 'Sahel',       country: 'Mali',    group: 'Al-Qaeda',     vector: 'ied',           killed: 5,  wounded: 9,  ctSuccess: false },
+    { id: 'i028', date: d(40), region: 'East Africa', country: 'Somalia', group: 'al-Shabaab',   vector: 'suicide',       killed: 10, wounded: 18, ctSuccess: false },
+    { id: 'i029', date: d(50), region: 'South Asia',  country: 'Pakistan',group: 'TTP',           vector: 'suicide',       killed: 8,  wounded: 20, ctSuccess: false },
+    { id: 'i030', date: d(55), region: 'West Africa', country: 'Nigeria', group: 'Boko Haram',   vector: 'active_shooter',killed: 6,  wounded: 12, ctSuccess: false },
+  ];
+}

--- a/src/components/counterterrorism-helpers.ts
+++ b/src/components/counterterrorism-helpers.ts
@@ -369,7 +369,7 @@ export function topCasualtyEvent(incidents: IncidentRecord[]): CasualtySeverity 
       return inc;
     }
     return best;
-  });
+  }, incidents[0]);
   return assessCasualtySeverity(worst.killed, worst.wounded);
 }
 
@@ -496,8 +496,8 @@ export function buildRenderData(
  */
 export function buildRegionRowHtml(r: RegionRisk): string {
   const color = TIER_COLORS[r.tier];
-  const trendArrow = r.trend === 'increasing' ? '↑' : r.trend === 'decreasing' ? '↓' : '→';
-  const trendColor = r.trend === 'increasing' ? '#f44336' : r.trend === 'decreasing' ? '#4caf50' : '#9e9e9e';
+  const trendArrow = r.trend === 'increasing' ? '↑' : (r.trend === 'decreasing' ? '↓' : '→');
+  const trendColor = r.trend === 'increasing' ? '#f44336' : (r.trend === 'decreasing' ? '#4caf50' : '#9e9e9e');
   const ctPct = Math.round(r.ctSuccessRate * 100);
   return `<tr style="border-bottom:1px solid var(--border-subtle,#222);">
     <td style="padding:6px 10px;font-size:12px;color:#e5e5e5;">${escapeHtmlSimple(r.region)}</td>

--- a/src/components/global-conflict-helpers.ts
+++ b/src/components/global-conflict-helpers.ts
@@ -1,0 +1,157 @@
+// global-conflict-helpers.ts — pure deterministic helpers for GlobalConflictPanel
+
+export type ConflictIntensity = 'war' | 'armed-conflict' | 'crisis' | 'tension' | 'stable';
+export type ConflictType = 'interstate' | 'civil-war' | 'insurgency' | 'proxy' | 'hybrid' | 'territorial';
+export type Region = 'europe' | 'middle-east' | 'africa' | 'asia-pacific' | 'americas' | 'central-asia';
+
+export interface ActiveConflict {
+  id: string;
+  name: string;
+  country: string;
+  region: Region;
+  intensity: ConflictIntensity;
+  type: ConflictType;
+  startYear: number;
+  estimatedDeaths: number;
+  monthlyDeaths: number;
+  displaced: number;
+  trend: 'escalating' | 'stable' | 'de-escalating';
+  parties: string[];
+  lastUpdate: string;
+}
+
+export interface ConflictEvent {
+  id: string;
+  date: string;
+  conflictId: string;
+  headline: string;
+  significance: 'high' | 'medium' | 'low';
+  deathToll: number;
+}
+
+export interface RegionalSummary {
+  region: Region;
+  activeConflicts: number;
+  totalDisplaced: number;
+  escalatingCount: number;
+  dominantIntensity: ConflictIntensity;
+}
+
+const MOCK_CONFLICTS: ActiveConflict[] = [
+  { id: 'ukraine', name: 'Russo-Ukrainian War', country: 'Ukraine', region: 'europe', intensity: 'war', type: 'interstate', startYear: 2022, estimatedDeaths: 500000, monthlyDeaths: 5000, displaced: 10000, trend: 'stable', parties: ['Ukraine', 'Russia'], lastUpdate: '2026-05-20' },
+  { id: 'gaza', name: 'Gaza War', country: 'Palestine', region: 'middle-east', intensity: 'war', type: 'interstate', startYear: 2023, estimatedDeaths: 45000, monthlyDeaths: 1200, displaced: 1900, trend: 'stable', parties: ['Israel', 'Hamas'], lastUpdate: '2026-05-21' },
+  { id: 'sudan', name: 'Sudan Civil War', country: 'Sudan', region: 'africa', intensity: 'war', type: 'civil-war', startYear: 2023, estimatedDeaths: 150000, monthlyDeaths: 3000, displaced: 10800, trend: 'escalating', parties: ['SAF', 'RSF'], lastUpdate: '2026-05-18' },
+  { id: 'myanmar', name: 'Myanmar Civil War', country: 'Myanmar', region: 'asia-pacific', intensity: 'war', type: 'civil-war', startYear: 2021, estimatedDeaths: 50000, monthlyDeaths: 1500, displaced: 2700, trend: 'escalating', parties: ['Junta', 'PDF', 'EAOs'], lastUpdate: '2026-05-19' },
+  { id: 'sahel', name: 'Sahel Insurgency', country: 'Mali/Burkina Faso/Niger', region: 'africa', intensity: 'armed-conflict', type: 'insurgency', startYear: 2012, estimatedDeaths: 30000, monthlyDeaths: 400, displaced: 3200, trend: 'escalating', parties: ['JNIM', 'ISGS', 'Government Forces'], lastUpdate: '2026-05-15' },
+  { id: 'ethiopia', name: 'Ethiopia-Amhara Conflict', country: 'Ethiopia', region: 'africa', intensity: 'armed-conflict', type: 'civil-war', startYear: 2023, estimatedDeaths: 10000, monthlyDeaths: 300, displaced: 1400, trend: 'stable', parties: ['ENDF', 'Fano'], lastUpdate: '2026-05-10' },
+  { id: 'haiti', name: 'Haiti Gang Crisis', country: 'Haiti', region: 'americas', intensity: 'crisis', type: 'insurgency', startYear: 2021, estimatedDeaths: 5000, monthlyDeaths: 200, displaced: 600, trend: 'escalating', parties: ['Gang coalitions', 'HNP', 'MSS'], lastUpdate: '2026-05-16' },
+  { id: 'kashmir', name: 'Kashmir Tension', country: 'India/Pakistan', region: 'asia-pacific', intensity: 'tension', type: 'territorial', startYear: 1947, estimatedDeaths: 70000, monthlyDeaths: 20, displaced: 500, trend: 'escalating', parties: ['India', 'Pakistan', 'Militant groups'], lastUpdate: '2026-05-22' },
+];
+
+const MOCK_EVENTS: ConflictEvent[] = [
+  { id: 'ev1', date: '2026-05-20', conflictId: 'ukraine', headline: 'Major drone strike exchange along Dnipro front', significance: 'high', deathToll: 47 },
+  { id: 'ev2', date: '2026-05-21', conflictId: 'gaza', headline: 'Ceasefire talks resume in Cairo', significance: 'high', deathToll: 0 },
+  { id: 'ev3', date: '2026-05-19', conflictId: 'sudan', headline: 'RSF advances on El Fasher, UN warns of mass atrocity risk', significance: 'high', deathToll: 200 },
+  { id: 'ev4', date: '2026-05-18', conflictId: 'myanmar', headline: 'PDF captures key Sagaing town', significance: 'medium', deathToll: 35 },
+  { id: 'ev5', date: '2026-05-17', conflictId: 'sahel', headline: 'JNIM ambush kills 30 Malian soldiers near Gao', significance: 'medium', deathToll: 30 },
+  { id: 'ev6', date: '2026-05-16', conflictId: 'haiti', headline: 'Gang takeover of Port-au-Prince district halts aid deliveries', significance: 'high', deathToll: 12 },
+  { id: 'ev7', date: '2026-05-22', conflictId: 'kashmir', headline: 'India-Pakistan exchange fire across LoC following militant attack', significance: 'high', deathToll: 8 },
+];
+
+export function intensityScore(intensity: ConflictIntensity): number {
+  const map: Record<ConflictIntensity, number> = { war: 5, 'armed-conflict': 4, crisis: 3, tension: 2, stable: 1 };
+  return map[intensity];
+}
+
+export function trendIcon(trend: ActiveConflict['trend']): string {
+  if (trend === 'escalating') return 'up';
+  if (trend === 'de-escalating') return 'down';
+  return 'flat';
+}
+
+export function formatDisplaced(thousandsK: number): string {
+  if (thousandsK >= 1000) return (thousandsK / 1000).toFixed(1) + 'M';
+  return thousandsK + 'K';
+}
+
+export function formatDeaths(n: number): string {
+  if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
+  if (n >= 1000) return (n / 1000).toFixed(0) + 'K';
+  return String(n);
+}
+
+export function rankConflictsBySeverity(conflicts: ActiveConflict[]): ActiveConflict[] {
+  return [...conflicts].sort((a, b) => {
+    const scoreDiff = intensityScore(b.intensity) - intensityScore(a.intensity);
+    if (scoreDiff !== 0) return scoreDiff;
+    return b.monthlyDeaths - a.monthlyDeaths;
+  });
+}
+
+export function filterByRegion(conflicts: ActiveConflict[], region: Region): ActiveConflict[] {
+  return conflicts.filter((c) => c.region === region);
+}
+
+export function filterByIntensity(conflicts: ActiveConflict[], min: ConflictIntensity): ActiveConflict[] {
+  const minScore = intensityScore(min);
+  return conflicts.filter((c) => intensityScore(c.intensity) >= minScore);
+}
+
+export function computeRegionalSummary(conflicts: ActiveConflict[]): RegionalSummary[] {
+  const regions: Region[] = ['europe', 'middle-east', 'africa', 'asia-pacific', 'americas', 'central-asia'];
+  return regions.map((region) => {
+    const rc = conflicts.filter((c) => c.region === region);
+    const escalating = rc.filter((c) => c.trend === 'escalating');
+    const dominated = rc.reduce<ActiveConflict | null>((best, c) =>
+      best === null || intensityScore(c.intensity) > intensityScore(best.intensity) ? c : best, null);
+    return {
+      region,
+      activeConflicts: rc.length,
+      totalDisplaced: rc.reduce((s, c) => s + c.displaced, 0),
+      escalatingCount: escalating.length,
+      dominantIntensity: dominated?.intensity ?? 'stable',
+    };
+  });
+}
+
+export function totalGlobalDisplaced(conflicts: ActiveConflict[]): number {
+  return conflicts.reduce((s, c) => s + c.displaced, 0);
+}
+
+export function totalActiveWars(conflicts: ActiveConflict[]): number {
+  return conflicts.filter((c) => c.intensity === 'war').length;
+}
+
+export function recentHighSignificanceEvents(events: ConflictEvent[], limit = 5): ConflictEvent[] {
+  return [...events]
+    .filter((e) => e.significance === 'high')
+    .sort((a, b) => b.date.localeCompare(a.date))
+    .slice(0, limit);
+}
+
+export function conflictDurationYears(conflict: ActiveConflict, currentYear = 2026): number {
+  return currentYear - conflict.startYear;
+}
+
+export function escalatingConflicts(conflicts: ActiveConflict[]): ActiveConflict[] {
+  return conflicts.filter((c) => c.trend === 'escalating');
+}
+
+export function buildRenderData(): {
+  conflicts: ActiveConflict[];
+  recentEvents: ConflictEvent[];
+  regionalSummaries: RegionalSummary[];
+  totalDisplacedK: number;
+  activeWars: number;
+  escalatingCount: number;
+} {
+  const ranked = rankConflictsBySeverity(MOCK_CONFLICTS);
+  return {
+    conflicts: ranked,
+    recentEvents: recentHighSignificanceEvents(MOCK_EVENTS),
+    regionalSummaries: computeRegionalSummary(MOCK_CONFLICTS),
+    totalDisplacedK: totalGlobalDisplaced(MOCK_CONFLICTS),
+    activeWars: totalActiveWars(MOCK_CONFLICTS),
+    escalatingCount: escalatingConflicts(MOCK_CONFLICTS).length,
+  };
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -237,6 +237,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'threat-convergence': { name: 'Threat Convergence', enabled: true, priority: 1 },
   'geopolitical-risk': { name: 'Geopolitical Risk', enabled: true, priority: 1 },
   'sanctions-tracker': { name: 'Sanctions Tracker', enabled: true, priority: 1 },
+  'global-conflict': { name: 'Global Conflicts', enabled: true, priority: 1 },
   'system-diagnostic': { name: 'System Diagnostic', enabled: true, priority: 1 },
   'self-test': { name: 'Self-Test', enabled: true, priority: 2 },
   'operator-mode': { name: 'Operator Mode', enabled: true, priority: 2 },

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -323,6 +323,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'shakealert': { name: 'ShakeAlert + ShakeMaps', enabled: true, priority: 2 },
   'sms-command-interface': { name: 'SMS Command Interface', enabled: true, priority: 3 },
   'what-changed': { name: 'What Changed', enabled: true, priority: 2 },
+  'counterterrorism': { name: 'Counterterrorism Monitor', enabled: true, priority: 1 },
 };
 
 const FULL_MAP_LAYERS: MapLayers = {
@@ -1137,7 +1138,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   },
   dataTracking: {
  labelKey: 'header.panelCatDataTracking',
- panelKeys: ['monitors', 'cyber-threats', 'threat-inbox', 'local-ids', 'little-snitch', 'comms-health', 'power-grid', 'grid-intelligence', 'cve-tracker', 'vulners-cve', 'hibp-breaches', 'ipinfo-lookup', 'ucdp-events', 'nuclear-risk', 'airstrikes', 'displacement', 'security-advisories', 'bitcoin-abuse', 'reddit-osint', 'network-rules', 's2u-intel', 'oref-sirens', 'space-weather', 'space-security', 'space-superpower', 'spaceflight-news', 'space-launches', 'population-exposure', 'internet-disruptions', 'air-traffic', 'threat-intel-hub', 'phishstats-feed', 'urlscan-threats', 'pulsedive-intel', 'geo-intel', 'dark-web', 'anomaly-detection', 'financial-contagion', 'supply-chain-impact', 'nuclear-monitor', 'sigint-panel', 'dark-vessel', 'ics-ot-dashboard', 'ioc-manager', 'network-topology', 'stix-taxii', 'custom-geofence', 'sanctions-crossref', 'emergency-broadcast', 'satellite-change', 'ripe-ncc', 'ripe-atlas', 'aerospace-reentry', 'satellite-intel', 'cyber-espionage'],
+ panelKeys: ['counterterrorism', 'monitors', 'cyber-threats', 'threat-inbox', 'local-ids', 'little-snitch', 'comms-health', 'power-grid', 'grid-intelligence', 'cve-tracker', 'vulners-cve', 'hibp-breaches', 'ipinfo-lookup', 'ucdp-events', 'nuclear-risk', 'airstrikes', 'displacement', 'security-advisories', 'bitcoin-abuse', 'reddit-osint', 'network-rules', 's2u-intel', 'oref-sirens', 'space-weather', 'space-security', 'space-superpower', 'spaceflight-news', 'space-launches', 'population-exposure', 'internet-disruptions', 'air-traffic', 'threat-intel-hub', 'phishstats-feed', 'urlscan-threats', 'pulsedive-intel', 'geo-intel', 'dark-web', 'anomaly-detection', 'financial-contagion', 'supply-chain-impact', 'nuclear-monitor', 'sigint-panel', 'dark-vessel', 'ics-ot-dashboard', 'ioc-manager', 'network-topology', 'stix-taxii', 'custom-geofence', 'sanctions-crossref', 'emergency-broadcast', 'satellite-change', 'ripe-ncc', 'ripe-atlas', 'aerospace-reentry', 'satellite-intel', 'cyber-espionage']
  variants: ['full'],
   },
   hazards: {

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -293,7 +293,6 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'cyber-espionage': { name: 'Cyber Espionage Tracker', enabled: true, priority: 1 },
   'urban-instability': { name: 'Urban Instability Monitor', enabled: true, priority: 1 },
   'political-economy': { name: 'Political Economy Risk', enabled: true, priority: 1 },
-  'cyber-espionage': { name: 'Cyber Espionage Tracker', enabled: true, priority: 1 },
   'election-monitoring': { name: 'Election Monitoring', enabled: true, priority: 1 },
   'urban-security': { name: 'Urban Security', enabled: true, priority: 1 },
   'signal-noise-filter': { name: 'Signal Quality', enabled: true, priority: 1 },

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -293,6 +293,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'cyber-espionage': { name: 'Cyber Espionage Tracker', enabled: true, priority: 1 },
   'urban-instability': { name: 'Urban Instability Monitor', enabled: true, priority: 1 },
   'political-economy': { name: 'Political Economy Risk', enabled: true, priority: 1 },
+  'cyber-espionage': { name: 'Cyber Espionage Tracker', enabled: true, priority: 1 },
   'election-monitoring': { name: 'Election Monitoring', enabled: true, priority: 1 },
   'urban-security': { name: 'Urban Security', enabled: true, priority: 1 },
   'signal-noise-filter': { name: 'Signal Quality', enabled: true, priority: 1 },
@@ -1138,8 +1139,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   },
   dataTracking: {
  labelKey: 'header.panelCatDataTracking',
- panelKeys: ['counterterrorism', 'monitors', 'cyber-threats', 'threat-inbox', 'local-ids', 'little-snitch', 'comms-health', 'power-grid', 'grid-intelligence', 'cve-tracker', 'vulners-cve', 'hibp-breaches', 'ipinfo-lookup', 'ucdp-events', 'nuclear-risk', 'airstrikes', 'displacement', 'security-advisories', 'bitcoin-abuse', 'reddit-osint', 'network-rules', 's2u-intel', 'oref-sirens', 'space-weather', 'space-security', 'space-superpower', 'spaceflight-news', 'space-launches', 'population-exposure', 'internet-disruptions', 'air-traffic', 'threat-intel-hub', 'phishstats-feed', 'urlscan-threats', 'pulsedive-intel', 'geo-intel', 'dark-web', 'anomaly-detection', 'financial-contagion', 'supply-chain-impact', 'nuclear-monitor', 'sigint-panel', 'dark-vessel', 'ics-ot-dashboard', 'ioc-manager', 'network-topology', 'stix-taxii', 'custom-geofence', 'sanctions-crossref', 'emergency-broadcast', 'satellite-change', 'ripe-ncc', 'ripe-atlas', 'aerospace-reentry', 'satellite-intel', 'cyber-espionage']
- variants: ['full'],
+ panelKeys: ['counterterrorism', 'monitors', 'cyber-threats', 'threat-inbox', 'local-ids', 'little-snitch', 'comms-health', 'power-grid', 'grid-intelligence', 'cve-tracker', 'vulners-cve', 'hibp-breaches', 'ipinfo-lookup', 'ucdp-events', 'nuclear-risk', 'airstrikes', 'displacement', 'security-advisories', 'bitcoin-abuse', 'reddit-osint', 'network-rules', 's2u-intel', 'oref-sirens', 'space-weather', 'space-security', 'space-superpower', 'spaceflight-news', 'space-launches', 'population-exposure', 'internet-disruptions', 'air-traffic', 'threat-intel-hub', 'phishstats-feed', 'urlscan-threats', 'pulsedive-intel', 'geo-intel', 'dark-web', 'anomaly-detection', 'financial-contagion', 'supply-chain-impact', 'nuclear-monitor', 'sigint-panel', 'dark-vessel', 'ics-ot-dashboard', 'ioc-manager', 'network-topology', 'stix-taxii', 'custom-geofence', 'sanctions-crossref', 'emergency-broadcast', 'satellite-change', 'ripe-ncc', 'ripe-atlas', 'aerospace-reentry', 'satellite-intel', 'cyber-espionage'], variants: ['full'],
   },
   hazards: {
  labelKey: 'header.panelCatHazards',


### PR DESCRIPTION
Adds GlobalConflictPanel for Crystal Ball civilians dashboard.

## What
- `global-conflict-helpers.ts`: pure helpers with 8 mock conflicts (Ukraine, Gaza, Sudan, Myanmar, Sahel, Ethiopia, Haiti, Kashmir), 7 conflict events, 12 exported functions
- `GlobalConflictPanel.ts`: 30-minute refresh, ranked by intensity then monthly deaths, shows displacement, trend arrows, and recent high-significance events
- Registered in `panels.ts` and `panel-layout.ts`
- 45 tests, all passing

## Why
Civilian users need a clear, ranked view of where armed conflict is happening globally — intensity color-coded, with trend direction and displacement counts at a glance.