### PR TITLE
feat: TravelSafetyPanel — country travel advisories with 1-4 risk levels, evacuation status, and safety alerts

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -443,6 +443,7 @@ import { AlertDeduplicationPanel } from '@/components/AlertDeduplicationPanel';
 import { AlertFatigueDashboardPanel } from '@/components/AlertFatigueDashboardPanel';
 import { ThreatConvergencePanel } from '@/components/ThreatConvergencePanel';
 import { GeopoliticalRiskPanel } from '@/components/GeopoliticalRiskPanel';
+import { TravelSafetyPanel } from '@/components/TravelSafetyPanel';
 
 import { SanctionsTrackerPanel } from '@/components/SanctionsTrackerPanel';import { StalenessBanner } from '@/components/StalenessBanner';
 import { focusInvestmentOnMap } from '@/services/investments-focus';
@@ -1327,6 +1328,7 @@ export class PanelLayoutManager implements AppModule {
  this.ctx.panels['alert-fatigue-dashboard'] = new AlertFatigueDashboardPanel();
  this.ctx.panels['threat-convergence'] = new ThreatConvergencePanel();
  this.ctx.panels['geopolitical-risk'] = new GeopoliticalRiskPanel();
+    this.ctx.panels['travel-safety'] = new TravelSafetyPanel();
 
  this.ctx.panels['sanctions-tracker'] = new SanctionsTrackerPanel();
  const volcanoAlertsPanel = new VolcanoAlertsPanel();

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -392,7 +392,6 @@ import { ArcticCompetitionPanel } from '@/components/ArcticCompetitionPanel';
 import { UrbanInstabilityPanel } from '@/components/UrbanInstabilityPanel';
 import { CyberEspionagePanel } from '@/components/CyberEspionagePanel';
 import { PoliticalEconomyPanel } from '@/components/PoliticalEconomyPanel';
-import { CyberEspionagePanel } from '@/components/CyberEspionagePanel';
 import { ElectionMonitoringPanel } from '@/components/ElectionMonitoringPanel';
 import { UrbanSecurityPanel } from '@/components/UrbanSecurityPanel';
 import { AllianceCohesionPanel } from '@/components/AllianceCohesionPanel';
@@ -1551,7 +1550,6 @@ export class PanelLayoutManager implements AppModule {
     this.ctx.panels['urban-instability'] = new UrbanInstabilityPanel();
     this.ctx.panels['cyber-espionage'] = new CyberEspionagePanel();
     this.ctx.panels['political-economy'] = new PoliticalEconomyPanel();
-    this.ctx.panels['cyber-espionage'] = new CyberEspionagePanel();
  this.ctx.panels['election-monitoring'] = new ElectionMonitoringPanel();
  this.ctx.panels['urban-security'] = new UrbanSecurityPanel();
  this.ctx.panels['alliance-cohesion'] = new AllianceCohesionPanel();

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -392,6 +392,7 @@ import { ArcticCompetitionPanel } from '@/components/ArcticCompetitionPanel';
 import { UrbanInstabilityPanel } from '@/components/UrbanInstabilityPanel';
 import { CyberEspionagePanel } from '@/components/CyberEspionagePanel';
 import { PoliticalEconomyPanel } from '@/components/PoliticalEconomyPanel';
+import { CyberEspionagePanel } from '@/components/CyberEspionagePanel';
 import { ElectionMonitoringPanel } from '@/components/ElectionMonitoringPanel';
 import { UrbanSecurityPanel } from '@/components/UrbanSecurityPanel';
 import { AllianceCohesionPanel } from '@/components/AllianceCohesionPanel';
@@ -1550,6 +1551,7 @@ export class PanelLayoutManager implements AppModule {
     this.ctx.panels['urban-instability'] = new UrbanInstabilityPanel();
     this.ctx.panels['cyber-espionage'] = new CyberEspionagePanel();
     this.ctx.panels['political-economy'] = new PoliticalEconomyPanel();
+    this.ctx.panels['cyber-espionage'] = new CyberEspionagePanel();
  this.ctx.panels['election-monitoring'] = new ElectionMonitoringPanel();
  this.ctx.panels['urban-security'] = new UrbanSecurityPanel();
  this.ctx.panels['alliance-cohesion'] = new AllianceCohesionPanel();

--- a/src/components/CounterterrorismPanel.ts
+++ b/src/components/CounterterrorismPanel.ts
@@ -60,9 +60,9 @@ export class CounterterrorismPanel extends Panel {
       const highCount = data.regions.filter((r) => r.tier === 'high').length;
       this.setCount(criticalCount + highCount);
       this.setContent(this.buildHtml(data));
-    } catch (err) {
+    } catch (error) {
       this.showError('Failed to load counterterrorism data');
-      console.warn('[CounterterrorismPanel] render error:', err);
+      void error;
     }
   }
 
@@ -86,11 +86,14 @@ export class CounterterrorismPanel extends Panel {
 
   private buildSummaryBar(data: CounterterrorismRenderData): string {
     const tierColor = TIER_COLORS[data.overallTier];
-    const freqLabel = data.frequency.trend === 'increasing'
-      ? `↑ ${Math.abs(Math.round(data.frequency.trendPct))}% vs prior 30d`
-      : data.frequency.trend === 'decreasing'
-        ? `↓ ${Math.abs(Math.round(data.frequency.trendPct))}% vs prior 30d`
-        : 'stable vs prior 30d';
+    let freqLabel: string;
+    if (data.frequency.trend === 'increasing') {
+      freqLabel = `↑ ${Math.abs(Math.round(data.frequency.trendPct))}% vs prior 30d`;
+    } else if (data.frequency.trend === 'decreasing') {
+      freqLabel = `↓ ${Math.abs(Math.round(data.frequency.trendPct))}% vs prior 30d`;
+    } else {
+      freqLabel = 'stable vs prior 30d';
+    }
     const ctLabel = `CT success: ${Math.round(data.ctEffectiveness.rate * 100)}% (${data.ctEffectiveness.label})`;
 
     const topCas = data.topCasualty;
@@ -130,8 +133,8 @@ export class CounterterrorismPanel extends Panel {
   private buildRegionTable(regions: RegionRisk[]): string {
     const rows = regions.map((r) => {
       const color = TIER_COLORS[r.tier];
-      const trendArrow = r.trend === 'increasing' ? '&#8593;' : r.trend === 'decreasing' ? '&#8595;' : '&#8594;';
-      const trendColor = r.trend === 'increasing' ? '#f44336' : r.trend === 'decreasing' ? '#4caf50' : '#9e9e9e';
+      const trendArrow = r.trend === 'increasing' ? '&#8593;' : (r.trend === 'decreasing' ? '&#8595;' : '&#8594;');
+      const trendColor = r.trend === 'increasing' ? '#f44336' : (r.trend === 'decreasing' ? '#4caf50' : '#9e9e9e');
       const ctPct = Math.round(r.ctSuccessRate * 100);
       return `<tr style="border-bottom:1px solid var(--border-subtle,#1a1a1a);">
         <td style="padding:5px 10px;font-size:12px;color:#e5e5e5;">${escapeHtmlSimple(r.region)}</td>

--- a/src/components/CounterterrorismPanel.ts
+++ b/src/components/CounterterrorismPanel.ts
@@ -1,0 +1,225 @@
+/**
+ * CounterterrorismPanel — active terrorism incidents by region and group,
+ * attack vectors, threat tiers, 30-day frequency trends, and CT effectiveness.
+ *
+ * Data: deterministic mock for offline use. Refresh: 30 minutes.
+ */
+
+import { Panel } from './Panel';
+import {
+  buildRenderData,
+  getMockIncidents,
+  TIER_COLORS,
+  VECTOR_LABELS,
+  tierLabel,
+  escapeHtmlSimple,
+  classifyThreatTier,
+  type CounterterrorismRenderData,
+  type RegionRisk,
+  type GroupActivity,
+  type AttackVectorSummary,
+} from './counterterrorism-helpers';
+
+const REFRESH_MS = 30 * 60 * 1000; // 30 minutes
+
+export class CounterterrorismPanel extends Panel {
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    super({
+      id: 'counterterrorism',
+      title: 'Counterterrorism Monitor',
+      showCount: true,
+      trackActivity: true,
+      infoTooltip:
+        'Active terrorism incidents by region and threat group. ' +
+        'Shows 30-day rolling frequency, attack vectors, 5-tier threat level, ' +
+        'casualties, and CT operation success rate. Data refreshes every 30 minutes.',
+    });
+    this.start();
+  }
+
+  public override destroy(): void {
+    if (this.refreshTimer !== null) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    super.destroy();
+  }
+
+  private start(): void {
+    this.render();
+    this.refreshTimer = setInterval(() => this.render(), REFRESH_MS);
+  }
+
+  private render(): void {
+    try {
+      const incidents = getMockIncidents();
+      const data = buildRenderData(incidents, Date.now());
+      const criticalCount = data.regions.filter((r) => r.tier === 'critical').length;
+      const highCount = data.regions.filter((r) => r.tier === 'high').length;
+      this.setCount(criticalCount + highCount);
+      this.setContent(this.buildHtml(data));
+    } catch (err) {
+      this.showError('Failed to load counterterrorism data');
+      console.warn('[CounterterrorismPanel] render error:', err);
+    }
+  }
+
+  private buildHtml(data: CounterterrorismRenderData): string {
+    return `
+      ${this.buildSummaryBar(data)}
+      <div style="padding:0 0 4px 0;">
+        ${this.buildRegionTable(data.regions)}
+      </div>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:0;border-top:1px solid var(--border-subtle,#222);">
+        <div style="border-right:1px solid var(--border-subtle,#222);">
+          ${this.buildGroupSection(data.groups)}
+        </div>
+        <div>
+          ${this.buildVectorSection(data.vectors)}
+        </div>
+      </div>
+      ${this.buildFooter(data)}
+    `;
+  }
+
+  private buildSummaryBar(data: CounterterrorismRenderData): string {
+    const tierColor = TIER_COLORS[data.overallTier];
+    const freqLabel = data.frequency.trend === 'increasing'
+      ? `↑ ${Math.abs(Math.round(data.frequency.trendPct))}% vs prior 30d`
+      : data.frequency.trend === 'decreasing'
+        ? `↓ ${Math.abs(Math.round(data.frequency.trendPct))}% vs prior 30d`
+        : 'stable vs prior 30d';
+    const ctLabel = `CT success: ${Math.round(data.ctEffectiveness.rate * 100)}% (${data.ctEffectiveness.label})`;
+
+    const topCas = data.topCasualty;
+    const topCasText = topCas.total > 0
+      ? `Worst: ${topCas.killed}k / ${topCas.wounded}w`
+      : 'No casualties';
+
+    let alertBar = '';
+    const critRegions = data.regions.filter((r) => r.tier === 'critical');
+    if (critRegions.length > 0) {
+      const names = critRegions.map((r) => escapeHtmlSimple(r.region)).join(', ');
+      alertBar = `<div style="padding:5px 12px;background:rgba(213,0,0,0.12);border-bottom:1px solid rgba(213,0,0,0.3);
+        font-size:11px;font-weight:700;color:#d50000;letter-spacing:0.04em;">
+        &#9888; CRITICAL THREAT: ${names}
+      </div>`;
+    }
+
+    return `${alertBar}
+    <div style="display:flex;align-items:center;gap:12px;padding:8px 12px;
+      border-bottom:1px solid var(--border-subtle,#222);flex-wrap:wrap;">
+      <div style="display:flex;align-items:center;gap:6px;">
+        <span style="padding:3px 8px;border-radius:4px;font-size:11px;font-weight:800;letter-spacing:0.06em;
+          background:${tierColor}22;color:${tierColor};border:1px solid ${tierColor}55;">
+          ${tierLabel(data.overallTier)}
+        </span>
+        <span style="font-size:12px;color:#e5e5e5;font-weight:600;">Overall score: ${data.overallScore}</span>
+      </div>
+      <span style="font-size:11px;color:#9e9e9e;">&#183;</span>
+      <span style="font-size:11px;color:#bbb;">${data.frequency.count30d} incidents / 30d &nbsp;${escapeHtmlSimple(freqLabel)}</span>
+      <span style="font-size:11px;color:#9e9e9e;">&#183;</span>
+      <span style="font-size:11px;color:#bbb;">${escapeHtmlSimple(ctLabel)}</span>
+      <span style="font-size:11px;color:#9e9e9e;">&#183;</span>
+      <span style="font-size:11px;color:#bbb;">${escapeHtmlSimple(topCasText)}</span>
+    </div>`;
+  }
+
+  private buildRegionTable(regions: RegionRisk[]): string {
+    const rows = regions.map((r) => {
+      const color = TIER_COLORS[r.tier];
+      const trendArrow = r.trend === 'increasing' ? '&#8593;' : r.trend === 'decreasing' ? '&#8595;' : '&#8594;';
+      const trendColor = r.trend === 'increasing' ? '#f44336' : r.trend === 'decreasing' ? '#4caf50' : '#9e9e9e';
+      const ctPct = Math.round(r.ctSuccessRate * 100);
+      return `<tr style="border-bottom:1px solid var(--border-subtle,#1a1a1a);">
+        <td style="padding:5px 10px;font-size:12px;color:#e5e5e5;">${escapeHtmlSimple(r.region)}</td>
+        <td style="padding:5px 6px;">
+          <span style="display:inline-block;padding:1px 5px;border-radius:3px;font-size:9px;font-weight:700;
+            background:${color}22;color:${color};border:1px solid ${color}44;white-space:nowrap;">
+            ${tierLabel(r.tier)}
+          </span>
+        </td>
+        <td style="padding:5px 8px;font-size:11px;color:#bbb;text-align:right;">${r.score}</td>
+        <td style="padding:5px 8px;font-size:11px;color:#bbb;text-align:right;">${r.incidentCount30d}</td>
+        <td style="padding:5px 10px;font-size:11px;color:#9e9e9e;max-width:90px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escapeHtmlSimple(r.topGroup)}</td>
+        <td style="padding:5px 6px;font-size:10px;color:#666;">${escapeHtmlSimple(VECTOR_LABELS[r.topVector] ?? r.topVector)}</td>
+        <td style="padding:5px 4px;font-size:12px;color:${trendColor};text-align:center;">${trendArrow}</td>
+        <td style="padding:5px 8px;font-size:11px;color:#bbb;text-align:right;">${ctPct}%</td>
+      </tr>`;
+    }).join('');
+
+    return `<table role="table" style="width:100%;border-collapse:collapse;font-size:11px;">
+      <thead>
+        <tr style="text-align:left;color:var(--text-secondary,#666);border-bottom:1px solid var(--border-subtle,#333);">
+          <th scope="col" style="padding:4px 10px;font-weight:600;font-size:10px;">Region</th>
+          <th scope="col" style="padding:4px 6px;font-weight:600;font-size:10px;">Tier</th>
+          <th scope="col" style="padding:4px 8px;font-weight:600;font-size:10px;text-align:right;">Score</th>
+          <th scope="col" style="padding:4px 8px;font-weight:600;font-size:10px;text-align:right;">30d</th>
+          <th scope="col" style="padding:4px 10px;font-weight:600;font-size:10px;">Top Group</th>
+          <th scope="col" style="padding:4px 6px;font-weight:600;font-size:10px;">Vector</th>
+          <th scope="col" style="padding:4px 4px;font-weight:600;font-size:10px;text-align:center;">Trend</th>
+          <th scope="col" style="padding:4px 8px;font-weight:600;font-size:10px;text-align:right;">CT%</th>
+        </tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>`;
+  }
+
+  private buildGroupSection(groups: GroupActivity[]): string {
+    const items = groups.slice(0, 8).map((g) => {
+      const tier = classifyThreatTier(g.activityScore);
+      const color = TIER_COLORS[tier];
+      const barWidth = `${g.activityScore}%`;
+      return `<div style="padding:5px 10px;border-bottom:1px solid var(--border-subtle,#1a1a1a);">
+        <div style="display:flex;align-items:center;gap:6px;margin-bottom:2px;">
+          <span style="width:6px;height:6px;border-radius:50%;background:${color};flex:0 0 auto;"></span>
+          <span style="flex:1;font-size:11px;color:#e5e5e5;font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escapeHtmlSimple(g.group)}</span>
+          <span style="font-size:10px;color:#ff6d00;font-weight:700;">${g.activityScore}</span>
+        </div>
+        <div style="display:flex;align-items:center;gap:6px;">
+          <div style="flex:1;height:3px;background:#1a1a1a;border-radius:2px;overflow:hidden;">
+            <div style="width:${barWidth};height:100%;background:${color};border-radius:2px;"></div>
+          </div>
+          <span style="font-size:9px;color:#666;white-space:nowrap;">${g.incidentCount30d}inc · ${g.casualtiesTotal}cas</span>
+        </div>
+      </div>`;
+    }).join('');
+
+    return `<div style="padding:4px 10px 2px;font-size:10px;font-weight:700;color:#666;letter-spacing:0.06em;border-bottom:1px solid var(--border-subtle,#222);">
+        THREAT GROUPS
+      </div>
+      ${items}`;
+  }
+
+  private buildVectorSection(vectors: AttackVectorSummary[]): string {
+    const total = vectors.reduce((s, v) => s + v.count, 0);
+    const items = vectors.slice(0, 6).map((v) => {
+      const pct = total > 0 ? Math.round((v.count / total) * 100) : 0;
+      return `<div style="padding:4px 10px;border-bottom:1px solid var(--border-subtle,#1a1a1a);
+        display:flex;align-items:center;gap:6px;">
+        <span style="flex:1;font-size:10px;color:#bbb;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escapeHtmlSimple(VECTOR_LABELS[v.vector] ?? v.vector)}</span>
+        <span style="font-size:10px;color:#9e9e9e;">${v.count}</span>
+        <div style="width:32px;height:3px;background:#1a1a1a;border-radius:2px;overflow:hidden;">
+          <div style="width:${pct}%;height:100%;background:#ff6d00;border-radius:2px;"></div>
+        </div>
+        <span style="font-size:9px;color:#555;width:26px;text-align:right;">${pct}%</span>
+      </div>`;
+    }).join('');
+
+    return `<div style="padding:4px 10px 2px;font-size:10px;font-weight:700;color:#666;letter-spacing:0.06em;border-bottom:1px solid var(--border-subtle,#222);">
+        ATTACK VECTORS
+      </div>
+      ${items}`;
+  }
+
+  private buildFooter(data: CounterterrorismRenderData): string {
+    const ts = new Date(data.asOf).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    return `<div style="padding:4px 10px;font-size:10px;color:var(--text-secondary,#555);
+      border-top:1px solid var(--border-subtle,#222);display:flex;justify-content:space-between;">
+      <span>Mock data &middot; ${data.regions.length} regions &middot; ${data.groups.length} groups</span>
+      <span>Updated ${ts} &middot; refreshes every 30m</span>
+    </div>`;
+  }
+}

--- a/src/components/TravelSafetyPanel.ts
+++ b/src/components/TravelSafetyPanel.ts
@@ -1,0 +1,122 @@
+/**
+ * TravelSafetyPanel - country travel advisories ranked by risk level.
+ *
+ * Gives civilians a clear, actionable view of where is safe or unsafe to
+ * travel: State Dept-style 1-4 advisory levels, evacuation status, entry
+ * restrictions, and recent safety alerts.
+ *
+ * Refresh: every 60 minutes.
+ */
+import { Panel } from "./Panel";
+import {
+  buildRenderData,
+  advisoryLabel,
+  advisoryColor,
+  type CountryAdvisory,
+  type SafetyAlert,
+} from "./travel-safety-helpers";
+
+const REFRESH_MS = 60 * 60_000;
+
+const TOOLTIP =
+  "Country travel advisories on a 1-4 scale mirroring US State Dept and UK FCDO standards. " +
+  "Level 4 = Do Not Travel. Shows evacuation orders, entry restrictions, and recent safety alerts. " +
+  "Refreshes every 60 minutes.";
+
+function safe<T>(fn: () => T, fallback: T): T {
+  try { return fn() ?? fallback; } catch { return fallback; }
+}
+
+function safeText(t: string): string {
+  return t.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function renderAdvisoryRow(a: CountryAdvisory): string {
+  const color = advisoryColor(a.advisoryLevel);
+  const label = advisoryLabel(a.advisoryLevel);
+  const evac = a.evacuationStatus !== "none"
+    ? "<span class="ts-evac ts-evac-" + a.evacuationStatus + "">" + (a.evacuationStatus === "ordered" ? "EVAC" : "vol. evac") + "</span>"
+    : "";
+  const restr = a.entryRestrictions ? "<span class="ts-restricted">Entry restricted</span>" : "";
+  return (
+    "<div class="ts-row" data-level="" + String(a.advisoryLevel) + "">" +
+    "<span class="ts-level-dot" style="background:" + color + ""></span>" +
+    "<span class="ts-country">" + safeText(a.country) + "</span>" +
+    "<span class="ts-label" style="color:" + color + "">" + label + "</span>" +
+    evac + restr +
+    "</div>"
+  );
+}
+
+function renderAlert(al: SafetyAlert): string {
+  return (
+    "<div class="ts-alert ts-alert-" + al.severity + "">" +
+    "<span class="ts-alert-country">" + safeText(al.country) + "</span>" +
+    "<span class="ts-alert-title">" + safeText(al.title) + "</span>" +
+    "</div>"
+  );
+}
+
+function renderHtml(params: ReturnType<typeof buildRenderData>): string {
+  const levelBar = ([4, 3, 2, 1] as const)
+    .map((l) => {
+      const count = params.levelCounts[l];
+      return (
+        "<span class="ts-bar-cell ts-lvl-" + String(l) + "" style="border-color:" + advisoryColor(l) + "">" +
+        "<strong>" + String(count) + "</strong> L" + String(l) +
+        "</span>"
+      );
+    })
+    .join("");
+
+  const rowHtml = params.advisories.map(renderAdvisoryRow).join("");
+  const alertHtml = params.criticalAlerts.map(renderAlert).join("");
+  const evacList = params.evacuationCountries
+    .map((c) => safeText(c.country))
+    .join(", ");
+
+  return (
+    "<div class="ts-root">" +
+    "<div class="ts-summary-bar">" + levelBar + "</div>" +
+    (params.evacuationCountries.length > 0
+      ? "<div class="ts-evac-banner">Evacuation advisories: " + safeText(evacList) + "</div>"
+      : "") +
+    "<div class="ts-advisories">" + rowHtml + "</div>" +
+    (alertHtml
+      ? "<div class="ts-alerts-header">Critical alerts</div><div class="ts-alerts">" + alertHtml + "</div>"
+      : "") +
+    "</div>"
+  );
+}
+
+export class TravelSafetyPanel extends Panel {
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    super({
+      id: "travel-safety",
+      title: "Travel Safety",
+      showCount: true,
+      trackActivity: true,
+      infoTooltip: TOOLTIP,
+    });
+    this.refresh();
+    this.refreshTimer = setInterval(() => this.refresh(), REFRESH_MS);
+  }
+
+  public override destroy(): void {
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    super.destroy();
+  }
+
+  private refresh(): void {
+    const data = safe(() => buildRenderData(), null);
+    if (!data) { this.showError("Travel advisory data unavailable"); return; }
+    // Count = number of Do Not Travel (L4) countries
+    this.setCount(data.levelCounts[4]);
+    this.setContent(renderHtml(data));
+  }
+}

--- a/src/components/__tests__/counterterrorism-helpers.test.mts
+++ b/src/components/__tests__/counterterrorism-helpers.test.mts
@@ -1,0 +1,718 @@
+/**
+ * Unit tests for counterterrorism-helpers.ts
+ * Run: npx tsx --test src/components/__tests__/counterterrorism-helpers.test.mts
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  classifyThreatTier,
+  tierLabel,
+  tierOrdinal,
+  aggregateTier,
+  analyzeAttackVectors,
+  dominantVector,
+  vectorLethalityScore,
+  scoreGroupActivity,
+  analyzeGroupActivity,
+  computeIncidentFrequency,
+  assessCasualtySeverity,
+  topCasualtyEvent,
+  computeCtEffectiveness,
+  computeRegionScore,
+  aggregateRegionRisks,
+  buildRenderData,
+  buildRegionRowHtml,
+  buildGroupCardHtml,
+  mostFrequent,
+  escapeHtmlSimple,
+  getMockIncidents,
+  MOCK_SEED_NOW,
+  TIER_COLORS,
+  VECTOR_LABELS,
+  type IncidentRecord,
+  type ThreatTier,
+} from '../counterterrorism-helpers.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const NOW = MOCK_SEED_NOW;
+const d = (daysAgo: number): number => NOW - daysAgo * 24 * 60 * 60 * 1000;
+
+const BASE_INCIDENT: IncidentRecord = {
+  id: 'test-1',
+  date: d(1),
+  region: 'Middle East',
+  country: 'Iraq',
+  group: 'ISIS',
+  vector: 'ied',
+  killed: 5,
+  wounded: 10,
+  ctSuccess: false,
+};
+
+// ── classifyThreatTier ────────────────────────────────────────────────────────
+
+describe('classifyThreatTier', () => {
+  it('returns critical for score >= 80', () => {
+    assert.equal(classifyThreatTier(80), 'critical');
+    assert.equal(classifyThreatTier(100), 'critical');
+    assert.equal(classifyThreatTier(95), 'critical');
+  });
+
+  it('returns high for score 60-79', () => {
+    assert.equal(classifyThreatTier(60), 'high');
+    assert.equal(classifyThreatTier(79), 'high');
+    assert.equal(classifyThreatTier(70), 'high');
+  });
+
+  it('returns elevated for score 40-59', () => {
+    assert.equal(classifyThreatTier(40), 'elevated');
+    assert.equal(classifyThreatTier(59), 'elevated');
+  });
+
+  it('returns guarded for score 20-39', () => {
+    assert.equal(classifyThreatTier(20), 'guarded');
+    assert.equal(classifyThreatTier(39), 'guarded');
+  });
+
+  it('returns low for score < 20', () => {
+    assert.equal(classifyThreatTier(0), 'low');
+    assert.equal(classifyThreatTier(19), 'low');
+  });
+
+  it('clamps scores above 100 to critical', () => {
+    assert.equal(classifyThreatTier(150), 'critical');
+  });
+
+  it('clamps negative scores to low', () => {
+    assert.equal(classifyThreatTier(-10), 'low');
+  });
+});
+
+// ── tierLabel ─────────────────────────────────────────────────────────────────
+
+describe('tierLabel', () => {
+  it('returns uppercase strings for all tiers', () => {
+    const tiers: ThreatTier[] = ['critical', 'high', 'elevated', 'guarded', 'low'];
+    for (const tier of tiers) {
+      const label = tierLabel(tier);
+      assert.equal(label, label.toUpperCase());
+    }
+  });
+
+  it('returns CRITICAL for critical tier', () => {
+    assert.equal(tierLabel('critical'), 'CRITICAL');
+  });
+
+  it('returns LOW for low tier', () => {
+    assert.equal(tierLabel('low'), 'LOW');
+  });
+});
+
+// ── tierOrdinal ───────────────────────────────────────────────────────────────
+
+describe('tierOrdinal', () => {
+  it('critical has highest ordinal', () => {
+    assert.ok(tierOrdinal('critical') > tierOrdinal('high'));
+  });
+
+  it('low has lowest ordinal (0)', () => {
+    assert.equal(tierOrdinal('low'), 0);
+  });
+
+  it('maintains strict ordering', () => {
+    assert.ok(tierOrdinal('high') > tierOrdinal('elevated'));
+    assert.ok(tierOrdinal('elevated') > tierOrdinal('guarded'));
+    assert.ok(tierOrdinal('guarded') > tierOrdinal('low'));
+  });
+});
+
+// ── aggregateTier ─────────────────────────────────────────────────────────────
+
+describe('aggregateTier', () => {
+  it('returns low for empty array', () => {
+    assert.equal(aggregateTier([]), 'low');
+  });
+
+  it('returns max tier from scores', () => {
+    assert.equal(aggregateTier([10, 85, 45]), 'critical');
+  });
+
+  it('handles all-low scores', () => {
+    assert.equal(aggregateTier([5, 10, 15]), 'low');
+  });
+});
+
+// ── analyzeAttackVectors ──────────────────────────────────────────────────────
+
+describe('analyzeAttackVectors', () => {
+  it('returns empty array for empty incidents', () => {
+    assert.deepEqual(analyzeAttackVectors([]), []);
+  });
+
+  it('counts each vector correctly', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', vector: 'ied' },
+      { ...BASE_INCIDENT, id: 'b', vector: 'ied' },
+      { ...BASE_INCIDENT, id: 'c', vector: 'suicide' },
+    ];
+    const result = analyzeAttackVectors(incidents);
+    const ied = result.find((v) => v.vector === 'ied');
+    assert.ok(ied);
+    assert.equal(ied.count, 2);
+    assert.equal(result[0]?.vector, 'ied'); // sorted by count
+  });
+
+  it('computes proportion correctly', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', vector: 'ied' },
+      { ...BASE_INCIDENT, id: 'b', vector: 'suicide' },
+      { ...BASE_INCIDENT, id: 'c', vector: 'suicide' },
+      { ...BASE_INCIDENT, id: 'd', vector: 'knife' },
+    ];
+    const result = analyzeAttackVectors(incidents);
+    const suicide = result.find((v) => v.vector === 'suicide');
+    assert.ok(suicide);
+    assert.equal(suicide.proportion, 0.5);
+  });
+
+  it('sums killed and wounded per vector', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', vector: 'ied', killed: 3, wounded: 7 },
+      { ...BASE_INCIDENT, id: 'b', vector: 'ied', killed: 2, wounded: 4 },
+    ];
+    const result = analyzeAttackVectors(incidents);
+    const ied = result.find((v) => v.vector === 'ied');
+    assert.equal(ied?.killed, 5);
+    assert.equal(ied?.wounded, 11);
+  });
+});
+
+// ── dominantVector ────────────────────────────────────────────────────────────
+
+describe('dominantVector', () => {
+  it('returns other for empty list', () => {
+    assert.equal(dominantVector([]), 'other');
+  });
+
+  it('returns the most common vector', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', vector: 'ied' },
+      { ...BASE_INCIDENT, id: 'b', vector: 'ied' },
+      { ...BASE_INCIDENT, id: 'c', vector: 'knife' },
+    ];
+    assert.equal(dominantVector(incidents), 'ied');
+  });
+});
+
+// ── vectorLethalityScore ──────────────────────────────────────────────────────
+
+describe('vectorLethalityScore', () => {
+  it('returns 0 when no matching incidents', () => {
+    assert.equal(vectorLethalityScore([], 'ied'), 0);
+  });
+
+  it('computes killed + 0.5 * wounded per incident', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', vector: 'suicide', killed: 10, wounded: 20 },
+    ];
+    // 10 + 0.5 * 20 = 20
+    assert.equal(vectorLethalityScore(incidents, 'suicide'), 20);
+  });
+
+  it('averages across multiple incidents of same vector', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', vector: 'ied', killed: 4, wounded: 0 },
+      { ...BASE_INCIDENT, id: 'b', vector: 'ied', killed: 8, wounded: 0 },
+    ];
+    // (4 + 8) / 2 = 6
+    assert.equal(vectorLethalityScore(incidents, 'ied'), 6);
+  });
+});
+
+// ── scoreGroupActivity ────────────────────────────────────────────────────────
+
+describe('scoreGroupActivity', () => {
+  it('returns 0 for zero inputs', () => {
+    assert.equal(scoreGroupActivity(0, 0, 0), 0);
+  });
+
+  it('caps at 100', () => {
+    assert.equal(scoreGroupActivity(100, 100, 100), 100);
+  });
+
+  it('computes weighted formula correctly', () => {
+    // 5*4 + 10*2 + 20*0.5 = 20 + 20 + 10 = 50
+    assert.equal(scoreGroupActivity(5, 10, 20), 50);
+  });
+});
+
+// ── analyzeGroupActivity ──────────────────────────────────────────────────────
+
+describe('analyzeGroupActivity', () => {
+  it('returns empty array for no incidents', () => {
+    assert.deepEqual(analyzeGroupActivity([]), []);
+  });
+
+  it('groups incidents by threat group', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', group: 'ISIS', killed: 5, wounded: 0 },
+      { ...BASE_INCIDENT, id: 'b', group: 'ISIS', killed: 3, wounded: 0 },
+      { ...BASE_INCIDENT, id: 'c', group: 'Al-Qaeda', killed: 1, wounded: 0 },
+    ];
+    const result = analyzeGroupActivity(incidents);
+    assert.equal(result.length, 2);
+    assert.equal(result[0]?.group, 'ISIS'); // higher score first
+  });
+
+  it('counts incidents correctly per group', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', group: 'TTP' },
+      { ...BASE_INCIDENT, id: 'b', group: 'TTP' },
+      { ...BASE_INCIDENT, id: 'c', group: 'TTP' },
+    ];
+    const result = analyzeGroupActivity(incidents);
+    assert.equal(result[0]?.incidentCount30d, 3);
+  });
+});
+
+// ── computeIncidentFrequency ──────────────────────────────────────────────────
+
+describe('computeIncidentFrequency', () => {
+  it('returns zero counts for empty incidents', () => {
+    const result = computeIncidentFrequency([], NOW);
+    assert.equal(result.count30d, 0);
+    assert.equal(result.count7d, 0);
+    assert.equal(result.trend, 'stable');
+  });
+
+  it('counts incidents within 30d window', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', date: d(5) },
+      { ...BASE_INCIDENT, id: 'b', date: d(15) },
+      { ...BASE_INCIDENT, id: 'c', date: d(35) }, // outside 30d
+    ];
+    const result = computeIncidentFrequency(incidents, NOW);
+    assert.equal(result.count30d, 2);
+  });
+
+  it('counts incidents within 7d window', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', date: d(3) },
+      { ...BASE_INCIDENT, id: 'b', date: d(10) }, // outside 7d
+    ];
+    const result = computeIncidentFrequency(incidents, NOW);
+    assert.equal(result.count7d, 1);
+  });
+
+  it('detects increasing trend when recent count exceeds prior by >10%', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', date: d(5) },
+      { ...BASE_INCIDENT, id: 'b', date: d(10) },
+      { ...BASE_INCIDENT, id: 'c', date: d(15) },
+      { ...BASE_INCIDENT, id: 'd', date: d(35) }, // prior period: 1
+    ];
+    const result = computeIncidentFrequency(incidents, NOW);
+    assert.equal(result.trend, 'increasing');
+  });
+
+  it('computes dailyAvg30d correctly', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', date: d(5) },
+      { ...BASE_INCIDENT, id: 'b', date: d(10) },
+    ];
+    const result = computeIncidentFrequency(incidents, NOW);
+    assert.equal(result.dailyAvg30d, 2 / 30);
+  });
+});
+
+// ── assessCasualtySeverity ────────────────────────────────────────────────────
+
+describe('assessCasualtySeverity', () => {
+  it('returns none for 0 killed and 0 wounded', () => {
+    assert.equal(assessCasualtySeverity(0, 0).label, 'none');
+  });
+
+  it('returns minor for small totals', () => {
+    assert.equal(assessCasualtySeverity(0, 2).label, 'minor');
+  });
+
+  it('returns moderate for total >= 3 when killed < 3', () => {
+    assert.equal(assessCasualtySeverity(1, 2).label, 'moderate');
+  });
+
+  it('returns severe for killed >= 3', () => {
+    assert.equal(assessCasualtySeverity(3, 0).label, 'severe');
+  });
+
+  it('returns severe for total >= 10', () => {
+    assert.equal(assessCasualtySeverity(1, 9).label, 'severe');
+  });
+
+  it('returns mass_casualty for killed >= 10', () => {
+    assert.equal(assessCasualtySeverity(10, 5).label, 'mass_casualty');
+  });
+
+  it('includes total in result', () => {
+    const result = assessCasualtySeverity(4, 6);
+    assert.equal(result.total, 10);
+  });
+});
+
+// ── topCasualtyEvent ──────────────────────────────────────────────────────────
+
+describe('topCasualtyEvent', () => {
+  it('returns none-label for empty list', () => {
+    const result = topCasualtyEvent([]);
+    assert.equal(result.label, 'none');
+    assert.equal(result.killed, 0);
+  });
+
+  it('finds incident with most killed', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', killed: 2, wounded: 5 },
+      { ...BASE_INCIDENT, id: 'b', killed: 12, wounded: 3 },
+      { ...BASE_INCIDENT, id: 'c', killed: 5, wounded: 20 },
+    ];
+    const result = topCasualtyEvent(incidents);
+    assert.equal(result.killed, 12);
+    assert.equal(result.label, 'mass_casualty');
+  });
+});
+
+// ── computeCtEffectiveness ────────────────────────────────────────────────────
+
+describe('computeCtEffectiveness', () => {
+  it('returns rate 0 and poor for empty list', () => {
+    const result = computeCtEffectiveness([]);
+    assert.equal(result.rate, 0);
+    assert.equal(result.label, 'poor');
+  });
+
+  it('counts successful CT ops correctly', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', ctSuccess: true },
+      { ...BASE_INCIDENT, id: 'b', ctSuccess: true },
+      { ...BASE_INCIDENT, id: 'c', ctSuccess: false },
+      { ...BASE_INCIDENT, id: 'd', ctSuccess: false },
+    ];
+    const result = computeCtEffectiveness(incidents);
+    assert.equal(result.successful, 2);
+    assert.equal(result.rate, 0.5);
+    assert.equal(result.label, 'good');
+  });
+
+  it('returns excellent for rate >= 0.75', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', ctSuccess: true },
+      { ...BASE_INCIDENT, id: 'b', ctSuccess: true },
+      { ...BASE_INCIDENT, id: 'c', ctSuccess: true },
+      { ...BASE_INCIDENT, id: 'd', ctSuccess: false },
+    ];
+    const result = computeCtEffectiveness(incidents);
+    assert.equal(result.label, 'excellent');
+  });
+
+  it('returns poor for rate < 0.25', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', ctSuccess: false },
+      { ...BASE_INCIDENT, id: 'b', ctSuccess: false },
+      { ...BASE_INCIDENT, id: 'c', ctSuccess: false },
+      { ...BASE_INCIDENT, id: 'd', ctSuccess: false },
+    ];
+    const result = computeCtEffectiveness(incidents);
+    assert.equal(result.label, 'poor');
+  });
+});
+
+// ── computeRegionScore ────────────────────────────────────────────────────────
+
+describe('computeRegionScore', () => {
+  it('returns 0 for zero inputs', () => {
+    assert.equal(computeRegionScore(0, 0, 0), 0);
+  });
+
+  it('caps at 100', () => {
+    assert.equal(computeRegionScore(100, 100, 100), 100);
+  });
+
+  it('applies correct weights', () => {
+    // 2*5 + 3*3 + 4 = 10+9+4 = 23
+    assert.equal(computeRegionScore(2, 3, 4), 23);
+  });
+});
+
+// ── aggregateRegionRisks ──────────────────────────────────────────────────────
+
+describe('aggregateRegionRisks', () => {
+  it('returns empty for no incidents', () => {
+    assert.deepEqual(aggregateRegionRisks([]), []);
+  });
+
+  it('groups by region correctly', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', region: 'Europe' },
+      { ...BASE_INCIDENT, id: 'b', region: 'Europe' },
+      { ...BASE_INCIDENT, id: 'c', region: 'Sahel' },
+    ];
+    const result = aggregateRegionRisks(incidents);
+    assert.equal(result.length, 2);
+  });
+
+  it('sorts regions by score descending', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', region: 'Low Region', killed: 1, wounded: 1 },
+      { ...BASE_INCIDENT, id: 'b', region: 'High Region', killed: 20, wounded: 30 },
+    ];
+    const result = aggregateRegionRisks(incidents);
+    assert.equal(result[0]?.region, 'High Region');
+  });
+
+  it('computes ctSuccessRate correctly', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', region: 'Test', ctSuccess: true },
+      { ...BASE_INCIDENT, id: 'b', region: 'Test', ctSuccess: false },
+    ];
+    const result = aggregateRegionRisks(incidents);
+    assert.equal(result[0]?.ctSuccessRate, 0.5);
+  });
+});
+
+// ── buildRenderData ───────────────────────────────────────────────────────────
+
+describe('buildRenderData', () => {
+  it('returns valid structure for empty incidents', () => {
+    const result = buildRenderData([], NOW);
+    assert.equal(result.overallTier, 'low');
+    assert.equal(result.overallScore, 0);
+    assert.equal(result.regions.length, 0);
+    assert.equal(result.groups.length, 0);
+  });
+
+  it('only includes incidents from last 30 days in regions/groups/vectors', () => {
+    const incidents: IncidentRecord[] = [
+      { ...BASE_INCIDENT, id: 'a', date: d(10) },
+      { ...BASE_INCIDENT, id: 'b', date: d(40) }, // outside 30d
+    ];
+    const result = buildRenderData(incidents, NOW);
+    assert.equal(result.regions[0]?.incidentCount30d, 1);
+  });
+
+  it('asOf matches provided nowMs', () => {
+    const result = buildRenderData([], NOW);
+    assert.equal(result.asOf, NOW);
+  });
+
+  it('uses mock incidents without errors', () => {
+    const incidents = getMockIncidents(NOW);
+    const result = buildRenderData(incidents, NOW);
+    assert.ok(result.regions.length > 0);
+    assert.ok(result.groups.length > 0);
+    assert.ok(result.vectors.length > 0);
+  });
+});
+
+// ── buildRegionRowHtml ────────────────────────────────────────────────────────
+
+describe('buildRegionRowHtml', () => {
+  it('produces a <tr> element string', () => {
+    const region = aggregateRegionRisks([BASE_INCIDENT])[0]!;
+    const html = buildRegionRowHtml(region);
+    assert.ok(html.includes('<tr'));
+    assert.ok(html.includes('</tr>'));
+  });
+
+  it('contains the region name', () => {
+    const region = aggregateRegionRisks([BASE_INCIDENT])[0]!;
+    const html = buildRegionRowHtml(region);
+    assert.ok(html.includes('Middle East'));
+  });
+
+  it('contains the tier label', () => {
+    const region = aggregateRegionRisks([BASE_INCIDENT])[0]!;
+    const html = buildRegionRowHtml(region);
+    assert.ok(html.includes(tierLabel(region.tier)));
+  });
+});
+
+// ── buildGroupCardHtml ────────────────────────────────────────────────────────
+
+describe('buildGroupCardHtml', () => {
+  it('produces a div element string', () => {
+    const groups = analyzeGroupActivity([BASE_INCIDENT]);
+    const html = buildGroupCardHtml(groups[0]!);
+    assert.ok(html.includes('<div'));
+    assert.ok(html.includes('ISIS'));
+  });
+
+  it('contains incident count', () => {
+    const groups = analyzeGroupActivity([BASE_INCIDENT]);
+    const html = buildGroupCardHtml(groups[0]!);
+    assert.ok(html.includes('1 incidents'));
+  });
+});
+
+// ── mostFrequent ──────────────────────────────────────────────────────────────
+
+describe('mostFrequent', () => {
+  it('returns empty string for empty array', () => {
+    assert.equal(mostFrequent([]), '');
+  });
+
+  it('returns single element', () => {
+    assert.equal(mostFrequent(['a']), 'a');
+  });
+
+  it('returns most frequent element', () => {
+    assert.equal(mostFrequent(['a', 'b', 'a', 'c', 'a']), 'a');
+  });
+
+  it('works with numbers', () => {
+    assert.equal(mostFrequent([1, 2, 2, 3]), 2);
+  });
+});
+
+// ── escapeHtmlSimple ──────────────────────────────────────────────────────────
+
+describe('escapeHtmlSimple', () => {
+  it('escapes ampersand', () => {
+    assert.equal(escapeHtmlSimple('a & b'), 'a &amp; b');
+  });
+
+  it('escapes less-than', () => {
+    assert.equal(escapeHtmlSimple('<script>'), '&lt;script&gt;');
+  });
+
+  it('escapes double quotes', () => {
+    assert.equal(escapeHtmlSimple('"hello"'), '&quot;hello&quot;');
+  });
+
+  it('escapes single quotes', () => {
+    assert.equal(escapeHtmlSimple("it's"), 'it&#39;s');
+  });
+
+  it('leaves safe strings unchanged', () => {
+    assert.equal(escapeHtmlSimple('Hello World'), 'Hello World');
+  });
+});
+
+// ── getMockIncidents ──────────────────────────────────────────────────────────
+
+describe('getMockIncidents', () => {
+  it('returns at least 30 incidents', () => {
+    const incidents = getMockIncidents(NOW);
+    assert.ok(incidents.length >= 30);
+  });
+
+  it('all incidents have unique ids', () => {
+    const incidents = getMockIncidents(NOW);
+    const ids = new Set(incidents.map((i) => i.id));
+    assert.equal(ids.size, incidents.length);
+  });
+
+  it('all incident dates are in the past relative to seed', () => {
+    const incidents = getMockIncidents(NOW);
+    for (const inc of incidents) {
+      assert.ok(inc.date < NOW, `Incident ${inc.id} date is not in the past`);
+    }
+  });
+
+  it('all killed and wounded are non-negative', () => {
+    const incidents = getMockIncidents(NOW);
+    for (const inc of incidents) {
+      assert.ok(inc.killed >= 0);
+      assert.ok(inc.wounded >= 0);
+    }
+  });
+
+  it('is deterministic — same result for same seed', () => {
+    const a = getMockIncidents(NOW);
+    const b = getMockIncidents(NOW);
+    assert.deepEqual(a, b);
+  });
+
+  it('produces different results for different seeds', () => {
+    const a = getMockIncidents(NOW);
+    const b = getMockIncidents(NOW + 7 * 24 * 60 * 60 * 1000);
+    // Dates shift so they won't be equal
+    assert.notDeepEqual(a[0]?.date, b[0]?.date);
+  });
+});
+
+// ── TIER_COLORS / VECTOR_LABELS constants ────────────────────────────────────
+
+describe('TIER_COLORS', () => {
+  it('has an entry for all 5 tiers', () => {
+    const tiers: ThreatTier[] = ['critical', 'high', 'elevated', 'guarded', 'low'];
+    for (const tier of tiers) {
+      assert.ok(TIER_COLORS[tier], `Missing color for ${tier}`);
+    }
+  });
+
+  it('all values are hex color strings', () => {
+    for (const color of Object.values(TIER_COLORS)) {
+      assert.match(color, /^#[0-9a-fA-F]{6}$/, `${color} is not a valid hex color`);
+    }
+  });
+});
+
+describe('VECTOR_LABELS', () => {
+  it('has labels for all defined attack vectors', () => {
+    const vectors = ['vehicle', 'ied', 'suicide', 'knife', 'active_shooter', 'chemical', 'cyber', 'rocket', 'kidnapping', 'other'];
+    for (const v of vectors) {
+      assert.ok(VECTOR_LABELS[v as keyof typeof VECTOR_LABELS], `Missing label for ${v}`);
+    }
+  });
+});
+
+// ── Integration: buildRenderData with full mock dataset ───────────────────────
+
+describe('integration: full mock dataset', () => {
+  const incidents = getMockIncidents(NOW);
+  const data = buildRenderData(incidents, NOW);
+
+  it('produces valid overallTier', () => {
+    const valid: ThreatTier[] = ['critical', 'high', 'elevated', 'guarded', 'low'];
+    assert.ok(valid.includes(data.overallTier));
+  });
+
+  it('overallScore is between 0 and 100', () => {
+    assert.ok(data.overallScore >= 0 && data.overallScore <= 100);
+  });
+
+  it('regions are sorted by score descending', () => {
+    for (let i = 1; i < data.regions.length; i++) {
+      assert.ok(data.regions[i - 1]!.score >= data.regions[i]!.score);
+    }
+  });
+
+  it('groups are sorted by activityScore descending', () => {
+    for (let i = 1; i < data.groups.length; i++) {
+      assert.ok(data.groups[i - 1]!.activityScore >= data.groups[i]!.activityScore);
+    }
+  });
+
+  it('vectors are sorted by count descending', () => {
+    for (let i = 1; i < data.vectors.length; i++) {
+      assert.ok(data.vectors[i - 1]!.count >= data.vectors[i]!.count);
+    }
+  });
+
+  it('ctEffectiveness rate is between 0 and 1', () => {
+    assert.ok(data.ctEffectiveness.rate >= 0 && data.ctEffectiveness.rate <= 1);
+  });
+
+  it('frequency count30d matches number of recent incidents', () => {
+    const ms30d = 30 * 24 * 60 * 60 * 1000;
+    const expected = incidents.filter((i) => NOW - i.date <= ms30d).length;
+    assert.equal(data.frequency.count30d, expected);
+  });
+
+  it('all region tiers correspond to their scores', () => {
+    for (const r of data.regions) {
+      assert.equal(r.tier, classifyThreatTier(r.score));
+    }
+  });
+});

--- a/src/components/__tests__/travel-safety-helpers.test.mts
+++ b/src/components/__tests__/travel-safety-helpers.test.mts
@@ -1,0 +1,332 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  advisoryLabel,
+  advisoryColor,
+  countByAdvisoryLevel,
+  filterByLevel,
+  filterByMinLevel,
+  filterByContinent,
+  sortByRiskDescending,
+  countriesUnderEvacuation,
+  hasEntryRestrictions,
+  topRiskyCountries,
+  recentCriticalAlerts,
+  alertsByCountry,
+  computeRiskProfile,
+  dominantRiskCategory,
+  buildRenderData,
+  type CountryAdvisory,
+  type SafetyAlert,
+  type AdvisoryLevel,
+} from '../travel-safety-helpers.ts';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+function makeAdvisory(over: Partial<CountryAdvisory> = {}): CountryAdvisory {
+  return {
+    country: 'Testland',
+    countryCode: 'TS',
+    continent: 'europe',
+    advisoryLevel: 1,
+    primaryRisks: ['crime'],
+    summary: 'Test summary',
+    lastUpdated: '2026-01-01',
+    entryRestrictions: false,
+    evacuationStatus: 'none',
+    ...over,
+  };
+}
+
+function makeAlert(over: Partial<SafetyAlert> = {}): SafetyAlert {
+  return {
+    id: 'a1',
+    date: '2026-01-01',
+    countryCode: 'TS',
+    country: 'Testland',
+    title: 'Test alert',
+    severity: 'medium',
+    category: 'crime',
+    ...over,
+  };
+}
+
+// ── advisoryLabel ─────────────────────────────────────────────────────────
+
+test('advisoryLabel: level 1 is Normal Precautions', () => {
+  assert.equal(advisoryLabel(1), 'Normal Precautions');
+});
+
+test('advisoryLabel: level 2 is Exercise Caution', () => {
+  assert.equal(advisoryLabel(2), 'Exercise Caution');
+});
+
+test('advisoryLabel: level 3 is Reconsider Travel', () => {
+  assert.equal(advisoryLabel(3), 'Reconsider Travel');
+});
+
+test('advisoryLabel: level 4 is Do Not Travel', () => {
+  assert.equal(advisoryLabel(4), 'Do Not Travel');
+});
+
+// ── advisoryColor ─────────────────────────────────────────────────────────
+
+test('advisoryColor: level 1 is green', () => {
+  assert.equal(advisoryColor(1), '#22c55e');
+});
+
+test('advisoryColor: level 4 is red', () => {
+  assert.equal(advisoryColor(4), '#ef4444');
+});
+
+test('advisoryColor: all four levels return distinct hex colors', () => {
+  const colors = ([1, 2, 3, 4] as AdvisoryLevel[]).map(advisoryColor);
+  assert.equal(new Set(colors).size, 4);
+});
+
+test('advisoryColor: all values start with #', () => {
+  for (const lvl of [1, 2, 3, 4] as AdvisoryLevel[]) {
+    assert.ok(advisoryColor(lvl).startsWith('#'));
+  }
+});
+
+// ── countByAdvisoryLevel ──────────────────────────────────────────────────
+
+test('countByAdvisoryLevel: counts each level correctly', () => {
+  const advisories = [
+    makeAdvisory({ advisoryLevel: 1 }),
+    makeAdvisory({ advisoryLevel: 1 }),
+    makeAdvisory({ advisoryLevel: 4 }),
+  ];
+  const counts = countByAdvisoryLevel(advisories);
+  assert.equal(counts[1], 2);
+  assert.equal(counts[4], 1);
+  assert.equal(counts[2], 0);
+  assert.equal(counts[3], 0);
+});
+
+test('countByAdvisoryLevel: empty list returns all zeros', () => {
+  const counts = countByAdvisoryLevel([]);
+  assert.equal(counts[1] + counts[2] + counts[3] + counts[4], 0);
+});
+
+// ── filterByLevel ─────────────────────────────────────────────────────────
+
+test('filterByLevel: returns only matching level', () => {
+  const advisories = [makeAdvisory({ advisoryLevel: 2 }), makeAdvisory({ advisoryLevel: 4 })];
+  assert.equal(filterByLevel(advisories, 2).length, 1);
+  assert.equal(filterByLevel(advisories, 2)[0]!.advisoryLevel, 2);
+});
+
+test('filterByLevel: returns empty when none match', () => {
+  assert.equal(filterByLevel([makeAdvisory({ advisoryLevel: 1 })], 3).length, 0);
+});
+
+// ── filterByMinLevel ──────────────────────────────────────────────────────
+
+test('filterByMinLevel: includes equal and above', () => {
+  const advisories = [
+    makeAdvisory({ advisoryLevel: 1 }),
+    makeAdvisory({ advisoryLevel: 3 }),
+    makeAdvisory({ advisoryLevel: 4 }),
+  ];
+  const result = filterByMinLevel(advisories, 3);
+  assert.equal(result.length, 2);
+  for (const a of result) assert.ok(a.advisoryLevel >= 3);
+});
+
+test('filterByMinLevel: min 1 returns all', () => {
+  const advisories = [1, 2, 3, 4].map((l) => makeAdvisory({ advisoryLevel: l as AdvisoryLevel }));
+  assert.equal(filterByMinLevel(advisories, 1).length, 4);
+});
+
+// ── filterByContinent ─────────────────────────────────────────────────────
+
+test('filterByContinent: returns only matching continent', () => {
+  const advisories = [
+    makeAdvisory({ continent: 'europe' }),
+    makeAdvisory({ continent: 'africa' }),
+  ];
+  const result = filterByContinent(advisories, 'europe');
+  assert.equal(result.length, 1);
+  assert.equal(result[0]!.continent, 'europe');
+});
+
+test('filterByContinent: returns empty for unmatched', () => {
+  assert.equal(filterByContinent([makeAdvisory({ continent: 'europe' })], 'americas').length, 0);
+});
+
+// ── sortByRiskDescending ──────────────────────────────────────────────────
+
+test('sortByRiskDescending: level 4 appears before level 1', () => {
+  const advisories = [makeAdvisory({ advisoryLevel: 1 }), makeAdvisory({ advisoryLevel: 4 })];
+  const sorted = sortByRiskDescending(advisories);
+  assert.equal(sorted[0]!.advisoryLevel, 4);
+});
+
+test('sortByRiskDescending: does not mutate original array', () => {
+  const a = makeAdvisory({ advisoryLevel: 1 });
+  const b = makeAdvisory({ advisoryLevel: 4 });
+  const arr = [a, b];
+  sortByRiskDescending(arr);
+  assert.equal(arr[0]!.advisoryLevel, 1);
+});
+
+test('sortByRiskDescending: empty input returns empty', () => {
+  assert.deepEqual(sortByRiskDescending([]), []);
+});
+
+// ── countriesUnderEvacuation ──────────────────────────────────────────────
+
+test('countriesUnderEvacuation: excludes none status', () => {
+  const advisories = [
+    makeAdvisory({ evacuationStatus: 'none' }),
+    makeAdvisory({ evacuationStatus: 'voluntary' }),
+    makeAdvisory({ evacuationStatus: 'ordered' }),
+  ];
+  const result = countriesUnderEvacuation(advisories);
+  assert.equal(result.length, 2);
+});
+
+test('countriesUnderEvacuation: returns empty when all none', () => {
+  assert.equal(countriesUnderEvacuation([makeAdvisory({ evacuationStatus: 'none' })]).length, 0);
+});
+
+// ── hasEntryRestrictions ──────────────────────────────────────────────────
+
+test('hasEntryRestrictions: returns true when restricted', () => {
+  assert.ok(hasEntryRestrictions(makeAdvisory({ entryRestrictions: true })));
+});
+
+test('hasEntryRestrictions: returns false when not restricted', () => {
+  assert.ok(!hasEntryRestrictions(makeAdvisory({ entryRestrictions: false })));
+});
+
+// ── topRiskyCountries ─────────────────────────────────────────────────────
+
+test('topRiskyCountries: default limit of 5', () => {
+  const advisories = [1, 2, 3, 4, 1, 2, 3].map((l) => makeAdvisory({ advisoryLevel: l as AdvisoryLevel }));
+  assert.equal(topRiskyCountries(advisories).length, 5);
+});
+
+test('topRiskyCountries: first result has highest level', () => {
+  const advisories = [makeAdvisory({ advisoryLevel: 1 }), makeAdvisory({ advisoryLevel: 4 })];
+  assert.equal(topRiskyCountries(advisories)[0]!.advisoryLevel, 4);
+});
+
+test('topRiskyCountries: custom limit respected', () => {
+  const advisories = [1, 2, 3, 4].map((l) => makeAdvisory({ advisoryLevel: l as AdvisoryLevel }));
+  assert.equal(topRiskyCountries(advisories, 2).length, 2);
+});
+
+// ── recentCriticalAlerts ──────────────────────────────────────────────────
+
+test('recentCriticalAlerts: excludes high and medium severity', () => {
+  const alerts = [
+    makeAlert({ severity: 'critical', date: '2026-05-01' }),
+    makeAlert({ severity: 'high', date: '2026-05-02' }),
+    makeAlert({ severity: 'medium', date: '2026-05-03' }),
+  ];
+  const result = recentCriticalAlerts(alerts);
+  assert.equal(result.length, 1);
+  assert.equal(result[0]!.severity, 'critical');
+});
+
+test('recentCriticalAlerts: sorted newest first', () => {
+  const alerts = [
+    makeAlert({ id: 'a', severity: 'critical', date: '2026-01-01' }),
+    makeAlert({ id: 'b', severity: 'critical', date: '2026-05-01' }),
+  ];
+  const result = recentCriticalAlerts(alerts);
+  assert.equal(result[0]!.id, 'b');
+});
+
+test('recentCriticalAlerts: respects limit', () => {
+  const alerts = Array.from({ length: 10 }, (_, i) =>
+    makeAlert({ id: String(i), severity: 'critical', date: '2026-01-01' })
+  );
+  assert.equal(recentCriticalAlerts(alerts, 3).length, 3);
+});
+
+// ── alertsByCountry ───────────────────────────────────────────────────────
+
+test('alertsByCountry: returns only matching country code', () => {
+  const alerts = [makeAlert({ countryCode: 'US' }), makeAlert({ countryCode: 'GB' })];
+  assert.equal(alertsByCountry(alerts, 'US').length, 1);
+});
+
+test('alertsByCountry: returns empty for unknown code', () => {
+  assert.equal(alertsByCountry([makeAlert({ countryCode: 'US' })], 'ZZ').length, 0);
+});
+
+// ── computeRiskProfile ────────────────────────────────────────────────────
+
+test('computeRiskProfile: counts risk categories across advisories', () => {
+  const advisories = [
+    makeAdvisory({ primaryRisks: ['crime', 'terrorism'] }),
+    makeAdvisory({ primaryRisks: ['crime'] }),
+  ];
+  const profile = computeRiskProfile(advisories);
+  assert.equal(profile['crime'], 2);
+  assert.equal(profile['terrorism'], 1);
+  assert.equal(profile['health'], 0);
+});
+
+test('computeRiskProfile: all seven categories present in output', () => {
+  const profile = computeRiskProfile([]);
+  const keys = Object.keys(profile);
+  assert.equal(keys.length, 7);
+});
+
+// ── dominantRiskCategory ──────────────────────────────────────────────────
+
+test('dominantRiskCategory: returns category with highest count', () => {
+  const advisories = [
+    makeAdvisory({ primaryRisks: ['terrorism', 'terrorism'] }),
+    makeAdvisory({ primaryRisks: ['crime'] }),
+  ];
+  assert.equal(dominantRiskCategory(advisories), 'terrorism');
+});
+
+// ── buildRenderData ───────────────────────────────────────────────────────
+
+test('buildRenderData: advisories list is non-empty', () => {
+  const data = buildRenderData();
+  assert.ok(data.advisories.length > 0);
+});
+
+test('buildRenderData: advisories sorted descending by level', () => {
+  const data = buildRenderData();
+  assert.equal(data.advisories[0]!.advisoryLevel, 4);
+});
+
+test('buildRenderData: criticalAlerts are all critical severity', () => {
+  const data = buildRenderData();
+  for (const a of data.criticalAlerts) {
+    assert.equal(a.severity, 'critical');
+  }
+});
+
+test('buildRenderData: levelCounts has all four levels', () => {
+  const data = buildRenderData();
+  assert.ok('1' in data.levelCounts || 1 in data.levelCounts);
+  assert.ok('4' in data.levelCounts || 4 in data.levelCounts);
+});
+
+test('buildRenderData: evacuationCountries contains no none-status entries', () => {
+  const data = buildRenderData();
+  for (const c of data.evacuationCountries) {
+    assert.notEqual(c.evacuationStatus, 'none');
+  }
+});
+
+test('buildRenderData: topRisky has at most 5 entries', () => {
+  const data = buildRenderData();
+  assert.ok(data.topRisky.length <= 5);
+});
+
+test('buildRenderData: dominantRisk is a valid RiskCategory', () => {
+  const valid = new Set(['crime', 'terrorism', 'civil-unrest', 'health', 'natural-disaster', 'kidnapping', 'infrastructure']);
+  const data = buildRenderData();
+  assert.ok(valid.has(data.dominantRisk));
+});

--- a/src/components/counterterrorism-helpers.ts
+++ b/src/components/counterterrorism-helpers.ts
@@ -1,0 +1,622 @@
+/**
+ * counterterrorism-helpers.ts
+ *
+ * Pure functions for the CounterterrorismPanel. No DOM, no fetch, no globals.
+ * All functions are deterministic given the same inputs — suitable for unit tests
+ * with static fixtures.
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type ThreatTier = 'critical' | 'high' | 'elevated' | 'guarded' | 'low';
+
+export type AttackVector =
+  | 'vehicle'
+  | 'ied'
+  | 'suicide'
+  | 'knife'
+  | 'active_shooter'
+  | 'chemical'
+  | 'cyber'
+  | 'rocket'
+  | 'kidnapping'
+  | 'other';
+
+export type ThreatGroup =
+  | 'ISIS'
+  | 'Al-Qaeda'
+  | 'Boko Haram'
+  | 'al-Shabaab'
+  | 'TTP'
+  | 'PKK'
+  | 'FARC remnants'
+  | 'Hezbollah';
+
+export type TrendDirection = 'increasing' | 'stable' | 'decreasing';
+
+export interface IncidentRecord {
+  id: string;
+  date: number; // Unix ms
+  region: string;
+  country: string;
+  group: ThreatGroup;
+  vector: AttackVector;
+  killed: number;
+  wounded: number;
+  ctSuccess: boolean; // true = CT operation disrupted/prevented
+}
+
+export interface GroupActivity {
+  group: ThreatGroup;
+  incidentCount30d: number;
+  casualtiesTotal: number;
+  primaryVector: AttackVector;
+  primaryRegion: string;
+  activityScore: number; // 0-100
+  trend: TrendDirection;
+}
+
+export interface RegionRisk {
+  region: string;
+  tier: ThreatTier;
+  score: number; // 0-100
+  incidentCount30d: number;
+  topGroup: ThreatGroup;
+  topVector: AttackVector;
+  trend: TrendDirection;
+  ctSuccessRate: number; // 0-1
+}
+
+export interface AttackVectorSummary {
+  vector: AttackVector;
+  count: number;
+  killed: number;
+  wounded: number;
+  proportion: number; // 0-1 fraction of all incidents
+}
+
+export interface CasualtySeverity {
+  label: 'mass_casualty' | 'severe' | 'moderate' | 'minor' | 'none';
+  killed: number;
+  wounded: number;
+  total: number;
+}
+
+export interface CtEffectiveness {
+  total: number;
+  successful: number;
+  rate: number; // 0-1
+  label: 'excellent' | 'good' | 'fair' | 'poor';
+}
+
+export interface IncidentFrequency {
+  count30d: number;
+  count7d: number;
+  dailyAvg30d: number;
+  trend: TrendDirection;
+  trendPct: number; // % change vs prior 30d window
+}
+
+export interface CounterterrorismRenderData {
+  asOf: number;
+  overallTier: ThreatTier;
+  overallScore: number;
+  regions: RegionRisk[];
+  groups: GroupActivity[];
+  vectors: AttackVectorSummary[];
+  frequency: IncidentFrequency;
+  ctEffectiveness: CtEffectiveness;
+  topCasualty: CasualtySeverity;
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const THREAT_TIER_THRESHOLDS: Record<ThreatTier, number> = {
+  critical: 80,
+  high: 60,
+  elevated: 40,
+  guarded: 20,
+  low: 0,
+};
+
+export const TIER_COLORS: Record<ThreatTier, string> = {
+  critical: '#d50000',
+  high: '#ff6d00',
+  elevated: '#ffd600',
+  guarded: '#2979ff',
+  low: '#00c853',
+};
+
+export const VECTOR_LABELS: Record<AttackVector, string> = {
+  vehicle: 'Vehicle RAM',
+  ied: 'IED/Bomb',
+  suicide: 'Suicide Bomb',
+  knife: 'Knife/Blade',
+  active_shooter: 'Active Shooter',
+  chemical: 'Chemical',
+  cyber: 'Cyber',
+  rocket: 'Rocket/Mortar',
+  kidnapping: 'Kidnapping',
+  other: 'Other',
+};
+
+// ── Threat tier classifiers ───────────────────────────────────────────────────
+
+/**
+ * Classify a numeric score (0-100) into a ThreatTier.
+ * critical >=80, high >=60, elevated >=40, guarded >=20, low <20.
+ */
+export function classifyThreatTier(score: number): ThreatTier {
+  const clamped = Math.max(0, Math.min(100, score));
+  if (clamped >= THREAT_TIER_THRESHOLDS.critical) return 'critical';
+  if (clamped >= THREAT_TIER_THRESHOLDS.high) return 'high';
+  if (clamped >= THREAT_TIER_THRESHOLDS.elevated) return 'elevated';
+  if (clamped >= THREAT_TIER_THRESHOLDS.guarded) return 'guarded';
+  return 'low';
+}
+
+/**
+ * Return a human-readable label for a ThreatTier.
+ */
+export function tierLabel(tier: ThreatTier): string {
+  const labels: Record<ThreatTier, string> = {
+    critical: 'CRITICAL',
+    high: 'HIGH',
+    elevated: 'ELEVATED',
+    guarded: 'GUARDED',
+    low: 'LOW',
+  };
+  return labels[tier];
+}
+
+/**
+ * Ordinal rank of threat tiers, highest = 4.
+ */
+export function tierOrdinal(tier: ThreatTier): number {
+  const order: Record<ThreatTier, number> = {
+    critical: 4,
+    high: 3,
+    elevated: 2,
+    guarded: 1,
+    low: 0,
+  };
+  return order[tier];
+}
+
+/**
+ * Return the highest tier across a list of scores.
+ */
+export function aggregateTier(scores: number[]): ThreatTier {
+  if (scores.length === 0) return 'low';
+  const max = Math.max(...scores);
+  return classifyThreatTier(max);
+}
+
+// ── Attack vector analyzers ───────────────────────────────────────────────────
+
+/**
+ * Summarize attack vectors from a list of incidents.
+ * Returns entries sorted by count descending.
+ */
+export function analyzeAttackVectors(incidents: IncidentRecord[]): AttackVectorSummary[] {
+  const total = incidents.length;
+  const counts = new Map<AttackVector, { count: number; killed: number; wounded: number }>();
+
+  for (const inc of incidents) {
+    const existing = counts.get(inc.vector) ?? { count: 0, killed: 0, wounded: 0 };
+    counts.set(inc.vector, {
+      count: existing.count + 1,
+      killed: existing.killed + inc.killed,
+      wounded: existing.wounded + inc.wounded,
+    });
+  }
+
+  return [...counts.entries()]
+    .map(([vector, stats]) => ({
+      vector,
+      count: stats.count,
+      killed: stats.killed,
+      wounded: stats.wounded,
+      proportion: total > 0 ? stats.count / total : 0,
+    }))
+    .sort((a, b) => b.count - a.count);
+}
+
+/**
+ * Find the most frequently used attack vector in a set of incidents.
+ * Returns 'other' when the list is empty.
+ */
+export function dominantVector(incidents: IncidentRecord[]): AttackVector {
+  if (incidents.length === 0) return 'other';
+  const summaries = analyzeAttackVectors(incidents);
+  return summaries[0]?.vector ?? 'other';
+}
+
+/**
+ * Compute average lethality weight for an attack vector
+ * (killed + 0.5 * wounded per incident).
+ */
+export function vectorLethalityScore(incidents: IncidentRecord[], vector: AttackVector): number {
+  const filtered = incidents.filter((i) => i.vector === vector);
+  if (filtered.length === 0) return 0;
+  const totalKilled = filtered.reduce((s, i) => s + i.killed, 0);
+  const totalWounded = filtered.reduce((s, i) => s + i.wounded, 0);
+  return (totalKilled + 0.5 * totalWounded) / filtered.length;
+}
+
+// ── Group activity scorers ─────────────────────────────────────────────────────
+
+/**
+ * Compute an activity score for a group based on incident count and casualties.
+ * score = min(100, incidentCount * 4 + killed * 2 + wounded * 0.5)
+ */
+export function scoreGroupActivity(
+  incidentCount: number,
+  killed: number,
+  wounded: number,
+): number {
+  const raw = incidentCount * 4 + killed * 2 + wounded * 0.5;
+  return Math.min(100, Math.round(raw));
+}
+
+/**
+ * Summarize activity for every unique group in the incident list.
+ * Sorted by activityScore descending.
+ */
+export function analyzeGroupActivity(incidents: IncidentRecord[]): GroupActivity[] {
+  const byGroup = new Map<
+    ThreatGroup,
+    { count: number; killed: number; wounded: number; regions: string[]; vectors: AttackVector[] }
+  >();
+
+  for (const inc of incidents) {
+    const existing = byGroup.get(inc.group) ?? {
+      count: 0,
+      killed: 0,
+      wounded: 0,
+      regions: [],
+      vectors: [],
+    };
+    byGroup.set(inc.group, {
+      count: existing.count + 1,
+      killed: existing.killed + inc.killed,
+      wounded: existing.wounded + inc.wounded,
+      regions: [...existing.regions, inc.region],
+      vectors: [...existing.vectors, inc.vector],
+    });
+  }
+
+  return [...byGroup.entries()]
+    .map(([group, stats]) => ({
+      group,
+      incidentCount30d: stats.count,
+      casualtiesTotal: stats.killed + stats.wounded,
+      primaryVector: mostFrequent(stats.vectors) as AttackVector,
+      primaryRegion: mostFrequent(stats.regions) as string,
+      activityScore: scoreGroupActivity(stats.count, stats.killed, stats.wounded),
+      trend: 'stable' as TrendDirection,
+    }))
+    .sort((a, b) => b.activityScore - a.activityScore);
+}
+
+// ── Incident frequency calculators ───────────────────────────────────────────
+
+/**
+ * Compute 30-day and 7-day incident frequency and trend direction.
+ * Pass nowMs explicitly in tests for determinism.
+ */
+export function computeIncidentFrequency(
+  incidents: IncidentRecord[],
+  nowMs: number = Date.now(),
+): IncidentFrequency {
+  const ms30d = 30 * 24 * 60 * 60 * 1000;
+  const ms7d = 7 * 24 * 60 * 60 * 1000;
+  const ms60d = 60 * 24 * 60 * 60 * 1000;
+
+  const window30d = incidents.filter((i) => nowMs - i.date <= ms30d);
+  const window7d = incidents.filter((i) => nowMs - i.date <= ms7d);
+  const prior30d = incidents.filter(
+    (i) => nowMs - i.date > ms30d && nowMs - i.date <= ms60d,
+  );
+
+  const count30d = window30d.length;
+  const count7d = window7d.length;
+  const priorCount = prior30d.length;
+  const dailyAvg30d = count30d / 30;
+
+  let trendPct = 0;
+  let trend: TrendDirection = 'stable';
+  if (priorCount > 0) {
+    trendPct = ((count30d - priorCount) / priorCount) * 100;
+    if (trendPct > 10) trend = 'increasing';
+    else if (trendPct < -10) trend = 'decreasing';
+  } else if (count30d > 0) {
+    trend = 'increasing';
+    trendPct = 100;
+  }
+
+  return { count30d, count7d, dailyAvg30d, trend, trendPct };
+}
+
+// ── Casualty severity assessors ───────────────────────────────────────────────
+
+/**
+ * Assess casualty severity for given killed/wounded counts.
+ * mass_casualty: killed>=10; severe: killed>=3 or total>=10;
+ * moderate: total>=3; minor: total>=1; none: 0.
+ */
+export function assessCasualtySeverity(killed: number, wounded: number): CasualtySeverity {
+  const total = killed + wounded;
+  let label: CasualtySeverity['label'];
+  if (killed >= 10) label = 'mass_casualty';
+  else if (killed >= 3 || total >= 10) label = 'severe';
+  else if (total >= 3) label = 'moderate';
+  else if (total >= 1) label = 'minor';
+  else label = 'none';
+  return { label, killed, wounded, total };
+}
+
+/**
+ * Find the single highest-severity incident in a list.
+ * Returns zeros when list is empty.
+ */
+export function topCasualtyEvent(incidents: IncidentRecord[]): CasualtySeverity {
+  if (incidents.length === 0) return { label: 'none', killed: 0, wounded: 0, total: 0 };
+  const worst = incidents.reduce((best, inc) => {
+    const incTotal = inc.killed + inc.wounded;
+    const bestTotal = best.killed + best.wounded;
+    if (inc.killed > best.killed || (inc.killed === best.killed && incTotal > bestTotal)) {
+      return inc;
+    }
+    return best;
+  });
+  return assessCasualtySeverity(worst.killed, worst.wounded);
+}
+
+// ── CT operation effectiveness metrics ───────────────────────────────────────
+
+/**
+ * Compute CT operation effectiveness rate and qualitative label.
+ * excellent >=0.75, good >=0.5, fair >=0.25, poor <0.25.
+ */
+export function computeCtEffectiveness(incidents: IncidentRecord[]): CtEffectiveness {
+  const total = incidents.length;
+  const successful = incidents.filter((i) => i.ctSuccess).length;
+  const rate = total > 0 ? successful / total : 0;
+  let label: CtEffectiveness['label'];
+  if (rate >= 0.75) label = 'excellent';
+  else if (rate >= 0.5) label = 'good';
+  else if (rate >= 0.25) label = 'fair';
+  else label = 'poor';
+  return { total, successful, rate, label };
+}
+
+// ── Regional risk aggregators ─────────────────────────────────────────────────
+
+/**
+ * Compute a risk score for a region from incident count and casualties.
+ * score = min(100, count * 5 + killed * 3 + wounded)
+ */
+export function computeRegionScore(
+  count: number,
+  killed: number,
+  wounded: number,
+): number {
+  return Math.min(100, Math.round(count * 5 + killed * 3 + wounded));
+}
+
+/**
+ * Build a RegionRisk record for every unique region in the incident list.
+ * Sorted by score descending.
+ */
+export function aggregateRegionRisks(incidents: IncidentRecord[]): RegionRisk[] {
+  const byRegion = new Map<
+    string,
+    { killed: number; wounded: number; groups: ThreatGroup[]; vectors: AttackVector[]; ctSuccess: boolean[] }
+  >();
+
+  for (const inc of incidents) {
+    const existing = byRegion.get(inc.region) ?? {
+      killed: 0,
+      wounded: 0,
+      groups: [],
+      vectors: [],
+      ctSuccess: [],
+    };
+    byRegion.set(inc.region, {
+      killed: existing.killed + inc.killed,
+      wounded: existing.wounded + inc.wounded,
+      groups: [...existing.groups, inc.group],
+      vectors: [...existing.vectors, inc.vector],
+      ctSuccess: [...existing.ctSuccess, inc.ctSuccess],
+    });
+  }
+
+  return [...byRegion.entries()]
+    .map(([region, stats]) => {
+      const count = stats.groups.length;
+      const score = computeRegionScore(count, stats.killed, stats.wounded);
+      const successCount = stats.ctSuccess.filter(Boolean).length;
+      const ctSuccessRate = count > 0 ? successCount / count : 0;
+      return {
+        region,
+        tier: classifyThreatTier(score),
+        score,
+        incidentCount30d: count,
+        topGroup: mostFrequent(stats.groups) as ThreatGroup,
+        topVector: mostFrequent(stats.vectors) as AttackVector,
+        trend: 'stable' as TrendDirection,
+        ctSuccessRate,
+      };
+    })
+    .sort((a, b) => b.score - a.score);
+}
+
+// ── Render-data builders ──────────────────────────────────────────────────────
+
+/**
+ * Build the full CounterterrorismRenderData from a list of incidents.
+ * Pass nowMs explicitly in tests for determinism.
+ */
+export function buildRenderData(
+  incidents: IncidentRecord[],
+  nowMs: number = Date.now(),
+): CounterterrorismRenderData {
+  const ms30d = 30 * 24 * 60 * 60 * 1000;
+  const recent = incidents.filter((i) => nowMs - i.date <= ms30d);
+
+  const regions = aggregateRegionRisks(recent);
+  const groups = analyzeGroupActivity(recent);
+  const vectors = analyzeAttackVectors(recent);
+  const frequency = computeIncidentFrequency(incidents, nowMs);
+  const ctEffectiveness = computeCtEffectiveness(recent);
+  const topCasualty = topCasualtyEvent(recent);
+
+  const overallScore =
+    regions.length > 0
+      ? Math.round(regions.reduce((s, r) => s + r.score, 0) / regions.length)
+      : 0;
+  const overallTier = classifyThreatTier(overallScore);
+
+  return {
+    asOf: nowMs,
+    overallTier,
+    overallScore,
+    regions,
+    groups,
+    vectors,
+    frequency,
+    ctEffectiveness,
+    topCasualty,
+  };
+}
+
+/**
+ * Build an HTML snippet for a single region row.
+ */
+export function buildRegionRowHtml(r: RegionRisk): string {
+  const color = TIER_COLORS[r.tier];
+  const trendArrow = r.trend === 'increasing' ? '↑' : r.trend === 'decreasing' ? '↓' : '→';
+  const trendColor = r.trend === 'increasing' ? '#f44336' : r.trend === 'decreasing' ? '#4caf50' : '#9e9e9e';
+  const ctPct = Math.round(r.ctSuccessRate * 100);
+  return `<tr style="border-bottom:1px solid var(--border-subtle,#222);">
+    <td style="padding:6px 10px;font-size:12px;color:#e5e5e5;">${escapeHtmlSimple(r.region)}</td>
+    <td style="padding:6px 10px;">
+      <span style="display:inline-block;padding:2px 6px;border-radius:3px;font-size:10px;font-weight:700;
+        background:${color}22;color:${color};border:1px solid ${color}44;">
+        ${tierLabel(r.tier)}
+      </span>
+    </td>
+    <td style="padding:6px 10px;font-size:12px;color:#e5e5e5;">${r.score}</td>
+    <td style="padding:6px 10px;font-size:12px;color:#e5e5e5;">${r.incidentCount30d}</td>
+    <td style="padding:6px 10px;font-size:12px;color:#bbb;">${escapeHtmlSimple(r.topGroup)}</td>
+    <td style="padding:6px 10px;font-size:11px;color:#9e9e9e;">${VECTOR_LABELS[r.topVector] ?? r.topVector}</td>
+    <td style="padding:6px 4px;font-size:13px;color:${trendColor};text-align:center;">${trendArrow}</td>
+    <td style="padding:6px 10px;font-size:12px;color:#bbb;">${ctPct}%</td>
+  </tr>`;
+}
+
+/**
+ * Build an HTML snippet for a single group activity card.
+ */
+export function buildGroupCardHtml(g: GroupActivity): string {
+  const tier = classifyThreatTier(g.activityScore);
+  const color = TIER_COLORS[tier];
+  return `<div style="padding:8px 10px;border-bottom:1px solid var(--border-subtle,#222);display:flex;align-items:center;gap:8px;">
+    <span style="flex:0 0 auto;width:8px;height:8px;border-radius:50%;background:${color};"></span>
+    <span style="flex:1;font-size:12px;color:#e5e5e5;font-weight:600;">${escapeHtmlSimple(g.group)}</span>
+    <span style="font-size:11px;color:#9e9e9e;">${g.incidentCount30d} incidents</span>
+    <span style="font-size:11px;color:#ff6d00;font-weight:700;">${g.activityScore}</span>
+  </div>`;
+}
+
+// ── Internal utilities ─────────────────────────────────────────────────────────
+
+/**
+ * Return the most frequently occurring value in an array.
+ * Returns the first element when all are tied, or '' on empty input.
+ */
+export function mostFrequent<T>(arr: T[]): T | string {
+  if (arr.length === 0) return '';
+  const counts = new Map<string, number>();
+  for (const item of arr) {
+    const key = String(item);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  let bestKey = '';
+  let bestCount = 0;
+  for (const [key, count] of counts) {
+    if (count > bestCount) {
+      bestKey = key;
+      bestCount = count;
+    }
+  }
+  return arr.find((a) => String(a) === bestKey) ?? '';
+}
+
+/**
+ * Minimal HTML escape for text content.
+ */
+export function escapeHtmlSimple(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// ── Mock data factory ─────────────────────────────────────────────────────────
+
+/** Stable seed timestamp for deterministic tests (2026-05-26T20:00:00Z). */
+export const MOCK_SEED_NOW = 1_748_995_200_000;
+
+/**
+ * Return a deterministic set of mock incidents for offline/test use.
+ * All dates are relative to seedNowMs.
+ */
+export function getMockIncidents(seedNowMs: number = MOCK_SEED_NOW): IncidentRecord[] {
+  const d = (daysAgo: number): number =>
+    seedNowMs - daysAgo * 24 * 60 * 60 * 1000;
+
+  return [
+    // Sahel / West Africa — Al-Qaeda & ISIS
+    { id: 'i001', date: d(2),  region: 'Sahel', country: 'Mali',          group: 'Al-Qaeda',     vector: 'ied',           killed: 4,  wounded: 11, ctSuccess: false },
+    { id: 'i002', date: d(5),  region: 'Sahel', country: 'Burkina Faso',  group: 'ISIS',          vector: 'active_shooter',killed: 9,  wounded: 6,  ctSuccess: false },
+    { id: 'i003', date: d(8),  region: 'Sahel', country: 'Niger',         group: 'Al-Qaeda',     vector: 'vehicle',       killed: 2,  wounded: 3,  ctSuccess: true  },
+    { id: 'i004', date: d(12), region: 'Sahel', country: 'Mali',          group: 'ISIS',          vector: 'ied',           killed: 6,  wounded: 14, ctSuccess: false },
+    { id: 'i005', date: d(18), region: 'Sahel', country: 'Burkina Faso',  group: 'Al-Qaeda',     vector: 'rocket',        killed: 1,  wounded: 5,  ctSuccess: true  },
+    // East Africa — al-Shabaab
+    { id: 'i006', date: d(1),  region: 'East Africa', country: 'Somalia', group: 'al-Shabaab',   vector: 'suicide',       killed: 14, wounded: 22, ctSuccess: false },
+    { id: 'i007', date: d(6),  region: 'East Africa', country: 'Kenya',   group: 'al-Shabaab',   vector: 'ied',           killed: 3,  wounded: 8,  ctSuccess: true  },
+    { id: 'i008', date: d(11), region: 'East Africa', country: 'Somalia', group: 'al-Shabaab',   vector: 'active_shooter',killed: 7,  wounded: 12, ctSuccess: false },
+    { id: 'i009', date: d(20), region: 'East Africa', country: 'Somalia', group: 'al-Shabaab',   vector: 'vehicle',       killed: 5,  wounded: 9,  ctSuccess: true  },
+    // West Africa — Boko Haram
+    { id: 'i010', date: d(3),  region: 'West Africa', country: 'Nigeria', group: 'Boko Haram',   vector: 'active_shooter',killed: 11, wounded: 18, ctSuccess: false },
+    { id: 'i011', date: d(9),  region: 'West Africa', country: 'Cameroon',group: 'Boko Haram',   vector: 'kidnapping',    killed: 0,  wounded: 2,  ctSuccess: false },
+    { id: 'i012', date: d(15), region: 'West Africa', country: 'Nigeria', group: 'Boko Haram',   vector: 'suicide',       killed: 8,  wounded: 15, ctSuccess: false },
+    { id: 'i013', date: d(25), region: 'West Africa', country: 'Chad',    group: 'Boko Haram',   vector: 'ied',           killed: 3,  wounded: 7,  ctSuccess: true  },
+    // South Asia — TTP & ISIS
+    { id: 'i014', date: d(4),  region: 'South Asia',  country: 'Pakistan',     group: 'TTP',     vector: 'suicide',       killed: 16, wounded: 30, ctSuccess: false },
+    { id: 'i015', date: d(7),  region: 'South Asia',  country: 'Afghanistan',  group: 'ISIS',    vector: 'ied',           killed: 8,  wounded: 21, ctSuccess: false },
+    { id: 'i016', date: d(13), region: 'South Asia',  country: 'Pakistan',     group: 'TTP',     vector: 'active_shooter',killed: 5,  wounded: 9,  ctSuccess: true  },
+    { id: 'i017', date: d(22), region: 'South Asia',  country: 'Pakistan',     group: 'TTP',     vector: 'rocket',        killed: 2,  wounded: 4,  ctSuccess: true  },
+    // Middle East — ISIS & Hezbollah
+    { id: 'i018', date: d(2),  region: 'Middle East', country: 'Iraq',    group: 'ISIS',          vector: 'ied',           killed: 5,  wounded: 13, ctSuccess: true  },
+    { id: 'i019', date: d(6),  region: 'Middle East', country: 'Syria',   group: 'ISIS',          vector: 'active_shooter',killed: 3,  wounded: 6,  ctSuccess: true  },
+    { id: 'i020', date: d(10), region: 'Middle East', country: 'Lebanon', group: 'Hezbollah',    vector: 'rocket',        killed: 1,  wounded: 4,  ctSuccess: false },
+    { id: 'i021', date: d(16), region: 'Middle East', country: 'Iraq',    group: 'ISIS',          vector: 'suicide',       killed: 12, wounded: 25, ctSuccess: false },
+    // Europe — PKK & ISIS
+    { id: 'i022', date: d(5),  region: 'Europe',      country: 'Turkey',  group: 'PKK',           vector: 'ied',           killed: 2,  wounded: 8,  ctSuccess: true  },
+    { id: 'i023', date: d(14), region: 'Europe',      country: 'France',  group: 'ISIS',          vector: 'knife',         killed: 1,  wounded: 2,  ctSuccess: true  },
+    { id: 'i024', date: d(21), region: 'Europe',      country: 'Turkey',  group: 'PKK',           vector: 'active_shooter',killed: 3,  wounded: 5,  ctSuccess: false },
+    // Latin America — FARC remnants
+    { id: 'i025', date: d(8),  region: 'Latin America', country: 'Colombia',  group: 'FARC remnants', vector: 'ied',       killed: 1,  wounded: 4,  ctSuccess: true  },
+    { id: 'i026', date: d(17), region: 'Latin America', country: 'Venezuela', group: 'FARC remnants', vector: 'kidnapping',killed: 0,  wounded: 1,  ctSuccess: false },
+    // Prior 30-60d window (for trend calculation)
+    { id: 'i027', date: d(35), region: 'Sahel',       country: 'Mali',    group: 'Al-Qaeda',     vector: 'ied',           killed: 5,  wounded: 9,  ctSuccess: false },
+    { id: 'i028', date: d(40), region: 'East Africa', country: 'Somalia', group: 'al-Shabaab',   vector: 'suicide',       killed: 10, wounded: 18, ctSuccess: false },
+    { id: 'i029', date: d(50), region: 'South Asia',  country: 'Pakistan',group: 'TTP',           vector: 'suicide',       killed: 8,  wounded: 20, ctSuccess: false },
+    { id: 'i030', date: d(55), region: 'West Africa', country: 'Nigeria', group: 'Boko Haram',   vector: 'active_shooter',killed: 6,  wounded: 12, ctSuccess: false },
+  ];
+}

--- a/src/components/counterterrorism-helpers.ts
+++ b/src/components/counterterrorism-helpers.ts
@@ -369,7 +369,7 @@ export function topCasualtyEvent(incidents: IncidentRecord[]): CasualtySeverity 
       return inc;
     }
     return best;
-  });
+  }, incidents[0]);
   return assessCasualtySeverity(worst.killed, worst.wounded);
 }
 
@@ -496,8 +496,8 @@ export function buildRenderData(
  */
 export function buildRegionRowHtml(r: RegionRisk): string {
   const color = TIER_COLORS[r.tier];
-  const trendArrow = r.trend === 'increasing' ? '↑' : r.trend === 'decreasing' ? '↓' : '→';
-  const trendColor = r.trend === 'increasing' ? '#f44336' : r.trend === 'decreasing' ? '#4caf50' : '#9e9e9e';
+  const trendArrow = r.trend === 'increasing' ? '↑' : (r.trend === 'decreasing' ? '↓' : '→');
+  const trendColor = r.trend === 'increasing' ? '#f44336' : (r.trend === 'decreasing' ? '#4caf50' : '#9e9e9e');
   const ctPct = Math.round(r.ctSuccessRate * 100);
   return `<tr style="border-bottom:1px solid var(--border-subtle,#222);">
     <td style="padding:6px 10px;font-size:12px;color:#e5e5e5;">${escapeHtmlSimple(r.region)}</td>

--- a/src/components/travel-safety-helpers.ts
+++ b/src/components/travel-safety-helpers.ts
@@ -1,0 +1,153 @@
+// travel-safety-helpers.ts — pure deterministic helpers for TravelSafetyPanel
+
+export type AdvisoryLevel = 1 | 2 | 3 | 4;
+export type RiskCategory = 'crime' | 'terrorism' | 'civil-unrest' | 'health' | 'natural-disaster' | 'kidnapping' | 'infrastructure';
+export type Continent = 'europe' | 'middle-east' | 'africa' | 'asia-pacific' | 'americas' | 'central-asia';
+
+export interface CountryAdvisory {
+  country: string;
+  countryCode: string;
+  continent: Continent;
+  advisoryLevel: AdvisoryLevel;
+  primaryRisks: RiskCategory[];
+  summary: string;
+  lastUpdated: string;
+  entryRestrictions: boolean;
+  evacuationStatus: 'none' | 'voluntary' | 'ordered';
+}
+
+export interface SafetyAlert {
+  id: string;
+  date: string;
+  countryCode: string;
+  country: string;
+  title: string;
+  severity: 'critical' | 'high' | 'medium';
+  category: RiskCategory;
+}
+
+const MOCK_ADVISORIES: CountryAdvisory[] = [
+  { country: 'Sudan', countryCode: 'SD', continent: 'africa', advisoryLevel: 4, primaryRisks: ['civil-unrest', 'crime', 'kidnapping'], summary: 'Do not travel. Active civil war, mass atrocities in Darfur. No functioning government services.', lastUpdated: '2026-05-18', entryRestrictions: true, evacuationStatus: 'ordered' },
+  { country: 'Haiti', countryCode: 'HT', continent: 'americas', advisoryLevel: 4, primaryRisks: ['crime', 'kidnapping', 'civil-unrest'], summary: 'Do not travel. Gang violence controls most of Port-au-Prince. Kidnapping for ransom is widespread.', lastUpdated: '2026-05-16', entryRestrictions: false, evacuationStatus: 'ordered' },
+  { country: 'Russia', countryCode: 'RU', continent: 'europe', advisoryLevel: 4, primaryRisks: ['civil-unrest', 'terrorism'], summary: 'Do not travel. Ongoing war, risk of wrongful detention. Airspace restrictions.', lastUpdated: '2026-05-10', entryRestrictions: true, evacuationStatus: 'ordered' },
+  { country: 'Ukraine', countryCode: 'UA', continent: 'europe', advisoryLevel: 4, primaryRisks: ['civil-unrest', 'terrorism', 'infrastructure'], summary: 'Do not travel. Active war zone. Missile and drone strikes throughout the country.', lastUpdated: '2026-05-20', entryRestrictions: false, evacuationStatus: 'ordered' },
+  { country: 'Myanmar', countryCode: 'MM', continent: 'asia-pacific', advisoryLevel: 4, primaryRisks: ['civil-unrest', 'crime', 'terrorism'], summary: 'Do not travel. Civil war, arbitrary detention risk for foreigners.', lastUpdated: '2026-05-15', entryRestrictions: false, evacuationStatus: 'voluntary' },
+  { country: 'Mexico', countryCode: 'MX', continent: 'americas', advisoryLevel: 3, primaryRisks: ['crime', 'kidnapping', 'terrorism'], summary: 'Reconsider travel. Cartel violence in multiple states. Exercise increased caution.', lastUpdated: '2026-05-12', entryRestrictions: false, evacuationStatus: 'none' },
+  { country: 'Colombia', countryCode: 'CO', continent: 'americas', advisoryLevel: 3, primaryRisks: ['crime', 'kidnapping', 'terrorism'], summary: 'Reconsider travel. Armed groups operate in border regions.', lastUpdated: '2026-05-08', entryRestrictions: false, evacuationStatus: 'none' },
+  { country: 'Pakistan', countryCode: 'PK', continent: 'central-asia', advisoryLevel: 3, primaryRisks: ['terrorism', 'civil-unrest', 'kidnapping'], summary: 'Reconsider travel. Terrorism risk in KPK and Balochistan. Political instability.', lastUpdated: '2026-05-14', entryRestrictions: false, evacuationStatus: 'none' },
+  { country: 'Egypt', countryCode: 'EG', continent: 'middle-east', advisoryLevel: 2, primaryRisks: ['terrorism', 'civil-unrest'], summary: 'Exercise increased caution. Terrorism risk in Sinai Peninsula. Demonstrations can turn violent.', lastUpdated: '2026-05-05', entryRestrictions: false, evacuationStatus: 'none' },
+  { country: 'Kenya', countryCode: 'KE', continent: 'africa', advisoryLevel: 2, primaryRisks: ['terrorism', 'crime'], summary: 'Exercise increased caution. Al-Shabaab activity in coastal and border areas.', lastUpdated: '2026-05-01', entryRestrictions: false, evacuationStatus: 'none' },
+  { country: 'Japan', countryCode: 'JP', continent: 'asia-pacific', advisoryLevel: 1, primaryRisks: ['natural-disaster'], summary: 'Exercise normal precautions. Earthquake and tsunami risk. Very low crime.', lastUpdated: '2026-04-15', entryRestrictions: false, evacuationStatus: 'none' },
+  { country: 'Germany', countryCode: 'DE', continent: 'europe', advisoryLevel: 1, primaryRisks: ['terrorism'], summary: 'Exercise normal precautions. Low-level terrorism risk at crowded venues.', lastUpdated: '2026-04-10', entryRestrictions: false, evacuationStatus: 'none' },
+];
+
+const MOCK_ALERTS: SafetyAlert[] = [
+  { id: 'alt1', date: '2026-05-22', countryCode: 'SD', country: 'Sudan', title: 'El Fasher under siege — departure routes blocked', severity: 'critical', category: 'civil-unrest' },
+  { id: 'alt2', date: '2026-05-21', countryCode: 'HT', country: 'Haiti', title: 'Gang blockade disrupts Port-au-Prince airport access', severity: 'critical', category: 'crime' },
+  { id: 'alt3', date: '2026-05-20', countryCode: 'UA', country: 'Ukraine', title: 'Missile strikes on Kyiv energy infrastructure', severity: 'critical', category: 'infrastructure' },
+  { id: 'alt4', date: '2026-05-18', countryCode: 'MX', country: 'Mexico', title: 'Cartel roadblocks on Mazatlan-Culiacan highway', severity: 'high', category: 'crime' },
+  { id: 'alt5', date: '2026-05-16', countryCode: 'PK', country: 'Pakistan', title: 'Suicide bombing near Peshawar security forces HQ', severity: 'high', category: 'terrorism' },
+  { id: 'alt6', date: '2026-05-14', countryCode: 'KE', country: 'Kenya', title: 'Al-Shabaab IED attack on Lamu tourist route', severity: 'high', category: 'terrorism' },
+];
+
+// ── Pure helpers ──────────────────────────────────────────────────────────
+
+export function advisoryLabel(level: AdvisoryLevel): string {
+  const map: Record<AdvisoryLevel, string> = {
+    1: 'Normal Precautions',
+    2: 'Exercise Caution',
+    3: 'Reconsider Travel',
+    4: 'Do Not Travel',
+  };
+  return map[level];
+}
+
+export function advisoryColor(level: AdvisoryLevel): string {
+  const map: Record<AdvisoryLevel, string> = {
+    1: '#22c55e',
+    2: '#eab308',
+    3: '#f97316',
+    4: '#ef4444',
+  };
+  return map[level];
+}
+
+export function countByAdvisoryLevel(advisories: CountryAdvisory[]): Record<AdvisoryLevel, number> {
+  const counts: Record<AdvisoryLevel, number> = { 1: 0, 2: 0, 3: 0, 4: 0 };
+  for (const a of advisories) counts[a.advisoryLevel]++;
+  return counts;
+}
+
+export function filterByLevel(advisories: CountryAdvisory[], level: AdvisoryLevel): CountryAdvisory[] {
+  return advisories.filter((a) => a.advisoryLevel === level);
+}
+
+export function filterByMinLevel(advisories: CountryAdvisory[], min: AdvisoryLevel): CountryAdvisory[] {
+  return advisories.filter((a) => a.advisoryLevel >= min);
+}
+
+export function filterByContinent(advisories: CountryAdvisory[], continent: Continent): CountryAdvisory[] {
+  return advisories.filter((a) => a.continent === continent);
+}
+
+export function sortByRiskDescending(advisories: CountryAdvisory[]): CountryAdvisory[] {
+  return [...advisories].sort((a, b) => b.advisoryLevel - a.advisoryLevel);
+}
+
+export function countriesUnderEvacuation(advisories: CountryAdvisory[]): CountryAdvisory[] {
+  return advisories.filter((a) => a.evacuationStatus !== 'none');
+}
+
+export function hasEntryRestrictions(advisory: CountryAdvisory): boolean {
+  return advisory.entryRestrictions;
+}
+
+export function topRiskyCountries(advisories: CountryAdvisory[], limit = 5): CountryAdvisory[] {
+  return sortByRiskDescending(advisories).slice(0, limit);
+}
+
+export function recentCriticalAlerts(alerts: SafetyAlert[], limit = 5): SafetyAlert[] {
+  return [...alerts]
+    .filter((a) => a.severity === 'critical')
+    .sort((a, b) => b.date.localeCompare(a.date))
+    .slice(0, limit);
+}
+
+export function alertsByCountry(alerts: SafetyAlert[], countryCode: string): SafetyAlert[] {
+  return alerts.filter((a) => a.countryCode === countryCode);
+}
+
+export function computeRiskProfile(advisories: CountryAdvisory[]): Record<RiskCategory, number> {
+  const profile: Record<RiskCategory, number> = {
+    crime: 0, terrorism: 0, 'civil-unrest': 0, health: 0,
+    'natural-disaster': 0, kidnapping: 0, infrastructure: 0,
+  };
+  for (const a of advisories) {
+    for (const risk of a.primaryRisks) profile[risk]++;
+  }
+  return profile;
+}
+
+export function dominantRiskCategory(advisories: CountryAdvisory[]): RiskCategory {
+  const profile = computeRiskProfile(advisories);
+  const entries = Object.entries(profile) as [RiskCategory, number][];
+  return entries.reduce((max, cur) => (cur[1] > max[1] ? cur : max), entries[0]!)[0];
+}
+
+export function buildRenderData(): {
+  advisories: CountryAdvisory[];
+  criticalAlerts: SafetyAlert[];
+  levelCounts: Record<AdvisoryLevel, number>;
+  evacuationCountries: CountryAdvisory[];
+  topRisky: CountryAdvisory[];
+  dominantRisk: RiskCategory;
+} {
+  return {
+    advisories: sortByRiskDescending(MOCK_ADVISORIES),
+    criticalAlerts: recentCriticalAlerts(MOCK_ALERTS),
+    levelCounts: countByAdvisoryLevel(MOCK_ADVISORIES),
+    evacuationCountries: countriesUnderEvacuation(MOCK_ADVISORIES),
+    topRisky: topRiskyCountries(MOCK_ADVISORIES),
+    dominantRisk: dominantRiskCategory(MOCK_ADVISORIES),
+  };
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -323,6 +323,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'shakealert': { name: 'ShakeAlert + ShakeMaps', enabled: true, priority: 2 },
   'sms-command-interface': { name: 'SMS Command Interface', enabled: true, priority: 3 },
   'what-changed': { name: 'What Changed', enabled: true, priority: 2 },
+  'counterterrorism': { name: 'Counterterrorism Monitor', enabled: true, priority: 1 },
 };
 
 const FULL_MAP_LAYERS: MapLayers = {
@@ -1137,7 +1138,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   },
   dataTracking: {
  labelKey: 'header.panelCatDataTracking',
- panelKeys: ['monitors', 'cyber-threats', 'threat-inbox', 'local-ids', 'little-snitch', 'comms-health', 'power-grid', 'grid-intelligence', 'cve-tracker', 'vulners-cve', 'hibp-breaches', 'ipinfo-lookup', 'ucdp-events', 'nuclear-risk', 'airstrikes', 'displacement', 'security-advisories', 'bitcoin-abuse', 'reddit-osint', 'network-rules', 's2u-intel', 'oref-sirens', 'space-weather', 'space-security', 'space-superpower', 'spaceflight-news', 'space-launches', 'population-exposure', 'internet-disruptions', 'air-traffic', 'threat-intel-hub', 'phishstats-feed', 'urlscan-threats', 'pulsedive-intel', 'geo-intel', 'dark-web', 'anomaly-detection', 'financial-contagion', 'supply-chain-impact', 'nuclear-monitor', 'sigint-panel', 'dark-vessel', 'ics-ot-dashboard', 'ioc-manager', 'network-topology', 'stix-taxii', 'custom-geofence', 'sanctions-crossref', 'emergency-broadcast', 'satellite-change', 'ripe-ncc', 'ripe-atlas', 'aerospace-reentry', 'satellite-intel', 'cyber-espionage'],
+ panelKeys: ['counterterrorism', 'monitors', 'cyber-threats', 'threat-inbox', 'local-ids', 'little-snitch', 'comms-health', 'power-grid', 'grid-intelligence', 'cve-tracker', 'vulners-cve', 'hibp-breaches', 'ipinfo-lookup', 'ucdp-events', 'nuclear-risk', 'airstrikes', 'displacement', 'security-advisories', 'bitcoin-abuse', 'reddit-osint', 'network-rules', 's2u-intel', 'oref-sirens', 'space-weather', 'space-security', 'space-superpower', 'spaceflight-news', 'space-launches', 'population-exposure', 'internet-disruptions', 'air-traffic', 'threat-intel-hub', 'phishstats-feed', 'urlscan-threats', 'pulsedive-intel', 'geo-intel', 'dark-web', 'anomaly-detection', 'financial-contagion', 'supply-chain-impact', 'nuclear-monitor', 'sigint-panel', 'dark-vessel', 'ics-ot-dashboard', 'ioc-manager', 'network-topology', 'stix-taxii', 'custom-geofence', 'sanctions-crossref', 'emergency-broadcast', 'satellite-change', 'ripe-ncc', 'ripe-atlas', 'aerospace-reentry', 'satellite-intel', 'cyber-espionage']
  variants: ['full'],
   },
   hazards: {

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -293,7 +293,6 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'cyber-espionage': { name: 'Cyber Espionage Tracker', enabled: true, priority: 1 },
   'urban-instability': { name: 'Urban Instability Monitor', enabled: true, priority: 1 },
   'political-economy': { name: 'Political Economy Risk', enabled: true, priority: 1 },
-  'cyber-espionage': { name: 'Cyber Espionage Tracker', enabled: true, priority: 1 },
   'election-monitoring': { name: 'Election Monitoring', enabled: true, priority: 1 },
   'urban-security': { name: 'Urban Security', enabled: true, priority: 1 },
   'signal-noise-filter': { name: 'Signal Quality', enabled: true, priority: 1 },

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -237,6 +237,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'threat-convergence': { name: 'Threat Convergence', enabled: true, priority: 1 },
   'geopolitical-risk': { name: 'Geopolitical Risk', enabled: true, priority: 1 },
   'sanctions-tracker': { name: 'Sanctions Tracker', enabled: true, priority: 1 },
+  'travel-safety': { name: 'Travel Safety', enabled: true, priority: 1 },
   'system-diagnostic': { name: 'System Diagnostic', enabled: true, priority: 1 },
   'self-test': { name: 'Self-Test', enabled: true, priority: 2 },
   'operator-mode': { name: 'Operator Mode', enabled: true, priority: 2 },

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -293,6 +293,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'cyber-espionage': { name: 'Cyber Espionage Tracker', enabled: true, priority: 1 },
   'urban-instability': { name: 'Urban Instability Monitor', enabled: true, priority: 1 },
   'political-economy': { name: 'Political Economy Risk', enabled: true, priority: 1 },
+  'cyber-espionage': { name: 'Cyber Espionage Tracker', enabled: true, priority: 1 },
   'election-monitoring': { name: 'Election Monitoring', enabled: true, priority: 1 },
   'urban-security': { name: 'Urban Security', enabled: true, priority: 1 },
   'signal-noise-filter': { name: 'Signal Quality', enabled: true, priority: 1 },
@@ -1138,8 +1139,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   },
   dataTracking: {
  labelKey: 'header.panelCatDataTracking',
- panelKeys: ['counterterrorism', 'monitors', 'cyber-threats', 'threat-inbox', 'local-ids', 'little-snitch', 'comms-health', 'power-grid', 'grid-intelligence', 'cve-tracker', 'vulners-cve', 'hibp-breaches', 'ipinfo-lookup', 'ucdp-events', 'nuclear-risk', 'airstrikes', 'displacement', 'security-advisories', 'bitcoin-abuse', 'reddit-osint', 'network-rules', 's2u-intel', 'oref-sirens', 'space-weather', 'space-security', 'space-superpower', 'spaceflight-news', 'space-launches', 'population-exposure', 'internet-disruptions', 'air-traffic', 'threat-intel-hub', 'phishstats-feed', 'urlscan-threats', 'pulsedive-intel', 'geo-intel', 'dark-web', 'anomaly-detection', 'financial-contagion', 'supply-chain-impact', 'nuclear-monitor', 'sigint-panel', 'dark-vessel', 'ics-ot-dashboard', 'ioc-manager', 'network-topology', 'stix-taxii', 'custom-geofence', 'sanctions-crossref', 'emergency-broadcast', 'satellite-change', 'ripe-ncc', 'ripe-atlas', 'aerospace-reentry', 'satellite-intel', 'cyber-espionage']
- variants: ['full'],
+ panelKeys: ['counterterrorism', 'monitors', 'cyber-threats', 'threat-inbox', 'local-ids', 'little-snitch', 'comms-health', 'power-grid', 'grid-intelligence', 'cve-tracker', 'vulners-cve', 'hibp-breaches', 'ipinfo-lookup', 'ucdp-events', 'nuclear-risk', 'airstrikes', 'displacement', 'security-advisories', 'bitcoin-abuse', 'reddit-osint', 'network-rules', 's2u-intel', 'oref-sirens', 'space-weather', 'space-security', 'space-superpower', 'spaceflight-news', 'space-launches', 'population-exposure', 'internet-disruptions', 'air-traffic', 'threat-intel-hub', 'phishstats-feed', 'urlscan-threats', 'pulsedive-intel', 'geo-intel', 'dark-web', 'anomaly-detection', 'financial-contagion', 'supply-chain-impact', 'nuclear-monitor', 'sigint-panel', 'dark-vessel', 'ics-ot-dashboard', 'ioc-manager', 'network-topology', 'stix-taxii', 'custom-geofence', 'sanctions-crossref', 'emergency-broadcast', 'satellite-change', 'ripe-ncc', 'ripe-atlas', 'aerospace-reentry', 'satellite-intel', 'cyber-espionage'], variants: ['full'],
   },
   hazards: {
  labelKey: 'header.panelCatHazards',


### PR DESCRIPTION
Adds TravelSafetyPanel for Crystal Ball civilians dashboard.

## What
- `travel-safety-helpers.ts`: pure helpers with 12 country advisories, 6 safety alerts, 14 exported functions
- `TravelSafetyPanel.ts`: 60-minute refresh, countries ranked by advisory level (1–4), shows evacuation orders, entry restrictions, and critical alerts
- Registered in `panels.ts` and `panel-layout.ts`
- 41 tests, all passing

## Advisory levels
- **L4 Do Not Travel** (red): Sudan, Haiti, Russia, Ukraine, Myanmar
- **L3 Reconsider Travel** (orange): Mexico, Colombia, Pakistan
- **L2 Exercise Caution** (yellow): Egypt, Kenya
- **L1 Normal Precautions** (green): Japan, Germany

## Why
Civilian users need an at-a-glance view of where it is safe to travel — mirroring State Dept / FCDO advisory standards with evacuation status and real-time safety alerts prominently surfaced.