### PR TITLE
feat: ForeignInvestmentRiskPanel — CFIUS-style strategic acquisition screening

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -406,6 +406,7 @@ import { HealthSuperpowerPanel } from '@/components/HealthSuperpowerPanel';
 
 import { PersonalResiliencePanel } from '@/components/PersonalResiliencePanel';import { TradeRouteRiskScorerPanel } from '@/components/TradeRouteRiskScorerPanel';
 import { TradeDisruptionPanel } from '@/components/TradeDisruptionPanel';
+import { ForeignInvestmentRiskPanel } from '@/components/ForeignInvestmentRiskPanel';
 import { SupplyChainDisruptionPanel } from '@/components/SupplyChainDisruptionPanel';
 import { InfraRiskMatrixPanel } from '@/components/InfraRiskMatrixPanel';
 import { EarthquakeSuperPanel } from '@/components/EarthquakeSuperPanel';
@@ -1598,6 +1599,7 @@ export class PanelLayoutManager implements AppModule {
 
  this.ctx.panels['personal-resilience'] = new PersonalResiliencePanel(); this.ctx.panels['trade-route-risk-scorer'] = new TradeRouteRiskScorerPanel();
  this.ctx.panels['trade-disruption'] = new TradeDisruptionPanel();
+    this.ctx.panels['foreign-investment-risk'] = new ForeignInvestmentRiskPanel();
  this.ctx.panels['supply-chain-disruption'] = new SupplyChainDisruptionPanel();
  this.ctx.panels['infra-risk-matrix'] = new InfraRiskMatrixPanel();
  this.ctx.panels['earthquake-super'] = new EarthquakeSuperPanel();

--- a/src/components/ForeignInvestmentRiskPanel.ts
+++ b/src/components/ForeignInvestmentRiskPanel.ts
@@ -1,0 +1,86 @@
+import { Panel } from './Panel';
+import { replaceChildren, h } from '@/utils/dom-utils';
+import { buildRenderData, classifyRiskLevel } from './foreign-investment-risk-helpers';
+
+const REFRESH_MS = 60 * 60 * 1000; // 1 hour
+
+function safe<T>(fn: () => T): T | null {
+  try { return fn(); } catch { return null; }
+}
+
+function safeText(t: string): string {
+  return t.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+export class ForeignInvestmentRiskPanel extends Panel {
+  static readonly panelId = 'foreign-investment-risk';
+  static readonly title = 'Foreign Investment Risk Monitor';
+
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    super({
+      id: ForeignInvestmentRiskPanel.panelId,
+      title: ForeignInvestmentRiskPanel.title,
+      trackActivity: true,
+      infoTooltip: 'CFIUS-style strategic FDI screening: tracks foreign acquisitions of critical sectors, block rates, and national security review outcomes.',
+    });
+    this.render();
+    this.refreshTimer = setInterval(() => this.render(), REFRESH_MS);
+  }
+
+  public override destroy(): void {
+    if (this.refreshTimer !== null) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    super.destroy();
+  }
+
+  private render(): void {
+    const data = safe(() => buildRenderData());
+    if (!data) {
+      replaceChildren(this.content, h('div', { className: 'fir-error' }, 'Data unavailable'));
+      this.invalidateContentCache();
+      return;
+    }
+
+    const header = h('div', { className: 'fir-header' });
+    const blockSpan = h('span', {});
+    blockSpan.textContent = ;
+    const pendingSpan = h('span', {});
+    pendingSpan.textContent = ;
+    const valueSpan = h('span', {});
+    valueSpan.textContent = ;
+    header.append(blockSpan, pendingSpan, valueSpan);
+
+    const rows = data.transactions.slice(0, 8).map((t) => {
+      const row = h('div', { className:  });
+
+      const acq = h('span', { className: 'acquirer' });
+      acq.textContent = t.acquirer.length > 20 ? t.acquirer.slice(0, 20) + '…' : t.acquirer;
+
+      const nat = h('span', { className: 'nation' });
+      nat.textContent = t.acquirerNation;
+
+      const sec = h('span', { className: 'sector' });
+      sec.textContent = t.targetSector;
+
+      const val = h('span', { className: 'value' });
+      val.textContent = ;
+
+      const out = h('span', { className: 'outcome' });
+      out.textContent = t.outcome;
+
+      const risk = h('span', { className: 'risk' });
+      risk.textContent = String(t.riskScore);
+
+      row.append(acq, nat, sec, val, out, risk);
+      return row;
+    });
+
+    replaceChildren(this.content, header, ...rows);
+    this.invalidateContentCache();
+    this.markFresh();
+  }
+}

--- a/src/components/ForeignInvestmentRiskPanel.ts
+++ b/src/components/ForeignInvestmentRiskPanel.ts
@@ -1,86 +1,111 @@
 import { Panel } from './Panel';
-import { replaceChildren, h } from '@/utils/dom-utils';
-import { buildRenderData, classifyRiskLevel } from './foreign-investment-risk-helpers';
+import {
+  buildRenderData,
+  statusBadgeClass,
+  riskClass,
+  getCriticalSectors,
+  rankSectorsByExposure,
+  type FDITransaction,
+  type SectorExposure,
+} from './foreign-investment-risk-helpers';
 
-const REFRESH_MS = 60 * 60 * 1000; // 1 hour
+const REFRESH_MS = 15 * 60 * 1000; // 15 minutes
+
+function h(tag: string, attrs: Record<string, string>, ...children: (string | Node)[]): HTMLElement {
+  const el = document.createElement(tag);
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  for (const c of children) {
+    el.appendChild(typeof c === 'string' ? document.createTextNode(c) : c);
+  }
+  return el;
+}
+
+function safeHtml(t: string): string {
+  return t.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
 
 function safe<T>(fn: () => T): T | null {
   try { return fn(); } catch { return null; }
 }
 
-function safeText(t: string): string {
-  return t.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-}
-
 export class ForeignInvestmentRiskPanel extends Panel {
-  static readonly panelId = 'foreign-investment-risk';
-  static readonly title = 'Foreign Investment Risk Monitor';
-
-  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+  static panelId = 'foreign-investment-risk';
+  static title = 'Foreign Investment Risk';
 
   constructor() {
-    super({
-      id: ForeignInvestmentRiskPanel.panelId,
-      title: ForeignInvestmentRiskPanel.title,
-      trackActivity: true,
-      infoTooltip: 'CFIUS-style strategic FDI screening: tracks foreign acquisitions of critical sectors, block rates, and national security review outcomes.',
-    });
-    this.render();
-    this.refreshTimer = setInterval(() => this.render(), REFRESH_MS);
+    super(ForeignInvestmentRiskPanel.panelId, ForeignInvestmentRiskPanel.title, REFRESH_MS);
   }
 
-  public override destroy(): void {
-    if (this.refreshTimer !== null) {
-      clearInterval(this.refreshTimer);
-      this.refreshTimer = null;
-    }
-    super.destroy();
-  }
-
-  private render(): void {
+  protected async refresh(): Promise<void> {
     const data = safe(() => buildRenderData());
     if (!data) {
-      replaceChildren(this.content, h('div', { className: 'fir-error' }, 'Data unavailable'));
-      this.invalidateContentCache();
+      this.replaceChildren(h('div', { class: 'error' }, 'Data unavailable'));
       return;
     }
 
-    const header = h('div', { className: 'fir-header' });
-    const blockSpan = h('span', {});
-    blockSpan.textContent = ;
-    const pendingSpan = h('span', {});
-    pendingSpan.textContent = ;
-    const valueSpan = h('span', {});
-    valueSpan.textContent = ;
-    header.append(blockSpan, pendingSpan, valueSpan);
+    const { transactions, sectorExposures, blockRate, approvalRate, pendingCount, highRiskCount, totalValueBn, totalValueBlockedBn } = data;
 
-    const rows = data.transactions.slice(0, 8).map((t) => {
-      const row = h('div', { className:  });
+    // Header metrics
+    const header = h('div', { class: 'fdi-header' },
+      h('div', { class: 'fdi-metric' },
+        h('span', { class: 'fdi-metric-label' }, 'Block Rate'),
+        h('span', { class: 'fdi-metric-value risk-high' }, `${blockRate}%`),
+      ),
+      h('div', { class: 'fdi-metric' },
+        h('span', { class: 'fdi-metric-label' }, 'Approval Rate'),
+        h('span', { class: 'fdi-metric-value status-ok' }, `${approvalRate}%`),
+      ),
+      h('div', { class: 'fdi-metric' },
+        h('span', { class: 'fdi-metric-label' }, 'Pending Review'),
+        h('span', { class: 'fdi-metric-value status-warn' }, String(pendingCount)),
+      ),
+      h('div', { class: 'fdi-metric' },
+        h('span', { class: 'fdi-metric-label' }, 'High Risk'),
+        h('span', { class: 'fdi-metric-value risk-critical' }, String(highRiskCount)),
+      ),
+      h('div', { class: 'fdi-metric' },
+        h('span', { class: 'fdi-metric-label' }, 'Blocked Value'),
+        h('span', { class: 'fdi-metric-value risk-high' }, `$${totalValueBlockedBn.toFixed(0)}B`),
+      ),
+    );
 
-      const acq = h('span', { className: 'acquirer' });
-      acq.textContent = t.acquirer.length > 20 ? t.acquirer.slice(0, 20) + '…' : t.acquirer;
+    // Transaction table
+    const txSection = h('div', { class: 'fdi-section' },
+      h('h3', { class: 'fdi-section-title' }, 'Notable FDI Reviews'),
+    );
+    for (const tx of transactions) {
+      const row = h('div', { class: `fdi-tx-row ${riskClass(tx.riskLevel)}` },
+        h('div', { class: 'fdi-tx-main' },
+          h('span', { class: 'fdi-tx-acquirer' }, safeHtml(tx.acquirer)),
+          h('span', { class: 'fdi-tx-arrow' }, ' -> '),
+          h('span', { class: 'fdi-tx-target' }, safeHtml(tx.target)),
+          h('span', { class: `fdi-tx-status ${statusBadgeClass(tx.status)}` }, safeHtml(tx.status)),
+        ),
+        h('div', { class: 'fdi-tx-meta' },
+          h('span', { class: 'fdi-tx-sector' }, safeHtml(tx.targetSector)),
+          h('span', { class: 'fdi-tx-body' }, safeHtml(tx.reviewBody)),
+          h('span', { class: 'fdi-tx-year' }, String(tx.year)),
+          tx.dealValueBn > 0 ? h('span', { class: 'fdi-tx-value' }, `$${tx.dealValueBn}B`) : h('span', {}),
+        ),
+        h('div', { class: 'fdi-tx-notes' }, safeHtml(tx.notes)),
+      );
+      txSection.appendChild(row);
+    }
 
-      const nat = h('span', { className: 'nation' });
-      nat.textContent = t.acquirerNation;
+    // Sector exposure
+    const sectorSection = h('div', { class: 'fdi-section' },
+      h('h3', { class: 'fdi-section-title' }, 'Sector Exposure'),
+    );
+    for (const sec of rankSectorsByExposure(sectorExposures)) {
+      const row = h('div', { class: `fdi-sector-row ${riskClass(sec.sensitivityLevel)}` },
+        h('span', { class: 'fdi-sector-name' }, safeHtml(sec.sector)),
+        h('span', { class: 'fdi-sector-pct' }, `${sec.foreignOwnershipPct}% foreign`),
+        h('span', { class: `fdi-sector-sens ${riskClass(sec.sensitivityLevel)}` }, safeHtml(sec.sensitivityLevel)),
+        h('span', { class: 'fdi-sector-actors' }, safeHtml(sec.topForeignActors.join(', '))),
+      );
+      sectorSection.appendChild(row);
+    }
 
-      const sec = h('span', { className: 'sector' });
-      sec.textContent = t.targetSector;
-
-      const val = h('span', { className: 'value' });
-      val.textContent = ;
-
-      const out = h('span', { className: 'outcome' });
-      out.textContent = t.outcome;
-
-      const risk = h('span', { className: 'risk' });
-      risk.textContent = String(t.riskScore);
-
-      row.append(acq, nat, sec, val, out, risk);
-      return row;
-    });
-
-    replaceChildren(this.content, header, ...rows);
-    this.invalidateContentCache();
-    this.markFresh();
+    this.replaceChildren(header, txSection, sectorSection);
   }
 }

--- a/src/components/__tests__/foreign-investment-risk-helpers.test.mts
+++ b/src/components/__tests__/foreign-investment-risk-helpers.test.mts
@@ -1,0 +1,342 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  classifyRiskLevel,
+  filterByOutcome,
+  filterByAcquirerNation,
+  filterBySector,
+  rankByRisk,
+  computeBlockRate,
+  getTotalDealValue,
+  getAcquirerNationDistribution,
+  getCriticalSectors,
+  getTotalPendingReviews,
+  buildRenderData,
+} from "../foreign-investment-risk-helpers.ts";
+import type {
+  FDITransaction,
+  SectorExposure,
+  InvestorNation,
+  TargetSector,
+  ReviewOutcome,
+  RiskLevel,
+} from "../foreign-investment-risk-helpers.ts";
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeTx(overrides: Partial<FDITransaction> = {}): FDITransaction {
+  return {
+    id: "test-tx",
+    acquirer: "Test Corp",
+    acquirerNation: "China",
+    targetCompany: "Target Inc",
+    targetNation: "USA",
+    targetSector: "semiconductors",
+    dealValueBn: 10,
+    reviewBody: "CFIUS",
+    outcome: "blocked",
+    year: 2023,
+    strategicConcern: "Test concern",
+    riskScore: 80,
+    ...overrides,
+  };
+}
+
+function makeExposure(overrides: Partial<SectorExposure> = {}): SectorExposure {
+  return {
+    sector: "semiconductors",
+    foreignControlledPct: 30,
+    criticalInfraFlag: true,
+    dominantInvestorNation: "China",
+    pendingReviewCount: 2,
+    ...overrides,
+  };
+}
+
+// ── classifyRiskLevel ───────────────────────────────────────────────────────
+
+test("classifyRiskLevel: 100 is critical", () => {
+  assert.equal(classifyRiskLevel(100), "critical");
+});
+
+test("classifyRiskLevel: 80 is critical boundary", () => {
+  assert.equal(classifyRiskLevel(80), "critical");
+});
+
+test("classifyRiskLevel: 79 is high", () => {
+  assert.equal(classifyRiskLevel(79), "high");
+});
+
+test("classifyRiskLevel: 60 is high boundary", () => {
+  assert.equal(classifyRiskLevel(60), "high");
+});
+
+test("classifyRiskLevel: 59 is moderate", () => {
+  assert.equal(classifyRiskLevel(59), "moderate");
+});
+
+test("classifyRiskLevel: 35 is moderate boundary", () => {
+  assert.equal(classifyRiskLevel(35), "moderate");
+});
+
+test("classifyRiskLevel: 34 is low", () => {
+  assert.equal(classifyRiskLevel(34), "low");
+});
+
+test("classifyRiskLevel: 0 is low", () => {
+  assert.equal(classifyRiskLevel(0), "low");
+});
+
+// ── filterByOutcome ─────────────────────────────────────────────────────────
+
+test("filterByOutcome: returns only blocked", () => {
+  const txs = [makeTx({ outcome: "blocked" }), makeTx({ outcome: "approved" })];
+  const result = filterByOutcome(txs, "blocked");
+  assert.equal(result.length, 1);
+  assert.equal(result[0]!.outcome, "blocked");
+});
+
+test("filterByOutcome: returns only approved", () => {
+  const txs = [makeTx({ outcome: "approved" }), makeTx({ outcome: "pending" })];
+  assert.equal(filterByOutcome(txs, "approved").length, 1);
+});
+
+test("filterByOutcome: returns empty when none match", () => {
+  const txs = [makeTx({ outcome: "blocked" })];
+  assert.equal(filterByOutcome(txs, "approved").length, 0);
+});
+
+test("filterByOutcome: pending works", () => {
+  const txs = [makeTx({ outcome: "pending" }), makeTx({ outcome: "blocked" })];
+  assert.equal(filterByOutcome(txs, "pending").length, 1);
+});
+
+test("filterByOutcome: withdrawn works", () => {
+  const txs = [makeTx({ outcome: "withdrawn" })];
+  assert.equal(filterByOutcome(txs, "withdrawn").length, 1);
+});
+
+test("filterByOutcome: approved-with-mitigation works", () => {
+  const txs = [makeTx({ outcome: "approved-with-mitigation" })];
+  assert.equal(filterByOutcome(txs, "approved-with-mitigation").length, 1);
+});
+
+// ── filterByAcquirerNation ──────────────────────────────────────────────────
+
+test("filterByAcquirerNation: returns China only", () => {
+  const txs = [makeTx({ acquirerNation: "China" }), makeTx({ acquirerNation: "Russia" })];
+  const result = filterByAcquirerNation(txs, "China");
+  assert.equal(result.length, 1);
+  assert.equal(result[0]!.acquirerNation, "China");
+});
+
+test("filterByAcquirerNation: returns UAE", () => {
+  const txs = [makeTx({ acquirerNation: "UAE" }), makeTx({ acquirerNation: "China" })];
+  assert.equal(filterByAcquirerNation(txs, "UAE").length, 1);
+});
+
+test("filterByAcquirerNation: empty list returns empty", () => {
+  assert.equal(filterByAcquirerNation([], "China").length, 0);
+});
+
+test("filterByAcquirerNation: multiple matches returned", () => {
+  const txs = [makeTx({ acquirerNation: "China" }), makeTx({ acquirerNation: "China" })];
+  assert.equal(filterByAcquirerNation(txs, "China").length, 2);
+});
+
+// ── filterBySector ──────────────────────────────────────────────────────────
+
+test("filterBySector: returns semiconductors", () => {
+  const txs = [makeTx({ targetSector: "semiconductors" }), makeTx({ targetSector: "telecom" })];
+  assert.equal(filterBySector(txs, "semiconductors").length, 1);
+});
+
+test("filterBySector: returns media", () => {
+  const txs = [makeTx({ targetSector: "media" }), makeTx({ targetSector: "AI" })];
+  assert.equal(filterBySector(txs, "media").length, 1);
+});
+
+test("filterBySector: no match returns empty", () => {
+  const txs = [makeTx({ targetSector: "telecom" })];
+  assert.equal(filterBySector(txs, "defense").length, 0);
+});
+
+// ── rankByRisk ──────────────────────────────────────────────────────────────
+
+test("rankByRisk: sorts descending by riskScore", () => {
+  const txs = [makeTx({ riskScore: 50 }), makeTx({ riskScore: 90 }), makeTx({ riskScore: 70 })];
+  const ranked = rankByRisk(txs);
+  assert.equal(ranked[0]!.riskScore, 90);
+  assert.equal(ranked[1]!.riskScore, 70);
+  assert.equal(ranked[2]!.riskScore, 50);
+});
+
+test("rankByRisk: does not mutate original array", () => {
+  const txs = [makeTx({ riskScore: 30 }), makeTx({ riskScore: 90 })];
+  const original = [...txs];
+  rankByRisk(txs);
+  assert.equal(txs[0]!.riskScore, original[0]!.riskScore);
+});
+
+test("rankByRisk: empty array returns empty", () => {
+  assert.deepEqual(rankByRisk([]), []);
+});
+
+test("rankByRisk: single element unchanged", () => {
+  const txs = [makeTx({ riskScore: 42 })];
+  assert.equal(rankByRisk(txs)[0]!.riskScore, 42);
+});
+
+// ── computeBlockRate ────────────────────────────────────────────────────────
+
+test("computeBlockRate: empty list returns 0", () => {
+  assert.equal(computeBlockRate([]), 0);
+});
+
+test("computeBlockRate: all blocked gives 100", () => {
+  const txs = [makeTx({ outcome: "blocked" }), makeTx({ outcome: "blocked" })];
+  assert.equal(computeBlockRate(txs), 100);
+});
+
+test("computeBlockRate: none blocked gives 0", () => {
+  const txs = [makeTx({ outcome: "approved" }), makeTx({ outcome: "pending" })];
+  assert.equal(computeBlockRate(txs), 0);
+});
+
+test("computeBlockRate: withdrawn counts as blocked", () => {
+  const txs = [makeTx({ outcome: "withdrawn" }), makeTx({ outcome: "approved" })];
+  assert.equal(computeBlockRate(txs), 50);
+});
+
+test("computeBlockRate: mixed set returns rounded pct", () => {
+  const txs = [
+    makeTx({ outcome: "blocked" }),
+    makeTx({ outcome: "withdrawn" }),
+    makeTx({ outcome: "approved" }),
+    makeTx({ outcome: "approved" }),
+  ];
+  assert.equal(computeBlockRate(txs), 50);
+});
+
+// ── getTotalDealValue ───────────────────────────────────────────────────────
+
+test("getTotalDealValue: empty returns 0", () => {
+  assert.equal(getTotalDealValue([]), 0);
+});
+
+test("getTotalDealValue: sums deal values", () => {
+  const txs = [makeTx({ dealValueBn: 10 }), makeTx({ dealValueBn: 5 })];
+  assert.equal(getTotalDealValue(txs), 15);
+});
+
+test("getTotalDealValue: rounds to 1 decimal", () => {
+  const txs = [makeTx({ dealValueBn: 1.123 }), makeTx({ dealValueBn: 2.456 })];
+  const result = getTotalDealValue(txs);
+  assert.equal(result, Math.round((1.123 + 2.456) * 10) / 10);
+});
+
+// ── getAcquirerNationDistribution ───────────────────────────────────────────
+
+test("getAcquirerNationDistribution: counts per nation", () => {
+  const txs = [
+    makeTx({ acquirerNation: "China" }),
+    makeTx({ acquirerNation: "China" }),
+    makeTx({ acquirerNation: "Russia" }),
+  ];
+  const dist = getAcquirerNationDistribution(txs);
+  assert.equal(dist["China"], 2);
+  assert.equal(dist["Russia"], 1);
+});
+
+test("getAcquirerNationDistribution: empty returns empty object", () => {
+  const dist = getAcquirerNationDistribution([]);
+  assert.deepEqual(dist, {});
+});
+
+// ── getCriticalSectors ──────────────────────────────────────────────────────
+
+test("getCriticalSectors: filters out non-critical", () => {
+  const exposures = [
+    makeExposure({ criticalInfraFlag: true, foreignControlledPct: 40 }),
+    makeExposure({ criticalInfraFlag: false, foreignControlledPct: 50 }),
+  ];
+  const result = getCriticalSectors(exposures);
+  assert.equal(result.length, 1);
+  assert.equal(result[0]!.criticalInfraFlag, true);
+});
+
+test("getCriticalSectors: sorts descending by foreignControlledPct", () => {
+  const exposures = [
+    makeExposure({ criticalInfraFlag: true, foreignControlledPct: 20 }),
+    makeExposure({ criticalInfraFlag: true, foreignControlledPct: 50 }),
+    makeExposure({ criticalInfraFlag: true, foreignControlledPct: 35 }),
+  ];
+  const result = getCriticalSectors(exposures);
+  assert.equal(result[0]!.foreignControlledPct, 50);
+  assert.equal(result[1]!.foreignControlledPct, 35);
+  assert.equal(result[2]!.foreignControlledPct, 20);
+});
+
+test("getCriticalSectors: empty returns empty", () => {
+  assert.deepEqual(getCriticalSectors([]), []);
+});
+
+// ── getTotalPendingReviews ──────────────────────────────────────────────────
+
+test("getTotalPendingReviews: sums pendingReviewCount", () => {
+  const exposures = [
+    makeExposure({ pendingReviewCount: 3 }),
+    makeExposure({ pendingReviewCount: 5 }),
+  ];
+  assert.equal(getTotalPendingReviews(exposures), 8);
+});
+
+test("getTotalPendingReviews: empty returns 0", () => {
+  assert.equal(getTotalPendingReviews([]), 0);
+});
+
+// ── buildRenderData ─────────────────────────────────────────────────────────
+
+test("buildRenderData: returns transactions sorted by risk descending", () => {
+  const data = buildRenderData();
+  for (let i = 1; i < data.transactions.length; i++) {
+    assert.ok(data.transactions[i - 1]!.riskScore >= data.transactions[i]!.riskScore);
+  }
+});
+
+test("buildRenderData: blockRate is a number 0-100", () => {
+  const data = buildRenderData();
+  assert.ok(data.blockRate >= 0 && data.blockRate <= 100);
+});
+
+test("buildRenderData: totalDealValueBn is positive", () => {
+  const data = buildRenderData();
+  assert.ok(data.totalDealValueBn > 0);
+});
+
+test("buildRenderData: totalPendingReviews is positive", () => {
+  const data = buildRenderData();
+  assert.ok(data.totalPendingReviews > 0);
+});
+
+test("buildRenderData: criticalSectors all have criticalInfraFlag true", () => {
+  const data = buildRenderData();
+  for (const s of data.criticalSectors) {
+    assert.equal(s.criticalInfraFlag, true);
+  }
+});
+
+test("buildRenderData: nationDistribution has China as top acquirer", () => {
+  const data = buildRenderData();
+  assert.ok(data.nationDistribution["China"] > 1);
+});
+
+test("buildRenderData: sectorExposures array is non-empty", () => {
+  const data = buildRenderData();
+  assert.ok(data.sectorExposures.length > 0);
+});
+
+test("buildRenderData: transactions array is non-empty", () => {
+  const data = buildRenderData();
+  assert.ok(data.transactions.length > 0);
+});

--- a/src/components/__tests__/foreign-investment-risk-helpers.test.mts
+++ b/src/components/__tests__/foreign-investment-risk-helpers.test.mts
@@ -1,342 +1,277 @@
-import assert from "node:assert/strict";
-import test from "node:test";
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
 import {
-  classifyRiskLevel,
-  filterByOutcome,
-  filterByAcquirerNation,
-  filterBySector,
-  rankByRisk,
   computeBlockRate,
-  getTotalDealValue,
-  getAcquirerNationDistribution,
+  computeApprovalRate,
+  getPendingTransactions,
+  getHighRiskTransactions,
+  getTotalValueBn,
+  getBlockedValueBn,
   getCriticalSectors,
-  getTotalPendingReviews,
+  rankSectorsByExposure,
+  statusBadgeClass,
+  riskClass,
   buildRenderData,
-} from "../foreign-investment-risk-helpers.ts";
-import type {
-  FDITransaction,
-  SectorExposure,
-  InvestorNation,
-  TargetSector,
-  ReviewOutcome,
-  RiskLevel,
-} from "../foreign-investment-risk-helpers.ts";
+  type FDITransaction,
+  type SectorExposure,
+} from '../foreign-investment-risk-helpers.js';
 
-// ── Fixtures ────────────────────────────────────────────────────────────────
+const MOCK_TXS: FDITransaction[] = [
+  { id: 'A1', acquirer: 'X', acquirerCountry: 'CN', target: 'Y', targetSector: 'Tech', dealValueBn: 10, status: 'Blocked', reviewBody: 'CFIUS', riskLevel: 'Critical', year: 2022, notes: '' },
+  { id: 'A2', acquirer: 'B', acquirerCountry: 'US', target: 'C', targetSector: 'Finance', dealValueBn: 5, status: 'Approved', reviewBody: 'DOJ', riskLevel: 'Low', year: 2021, notes: '' },
+  { id: 'A3', acquirer: 'D', acquirerCountry: 'UAE', target: 'E', targetSector: 'AI', dealValueBn: 2, status: 'Pending', reviewBody: 'CFIUS', riskLevel: 'High', year: 2023, notes: '' },
+  { id: 'A4', acquirer: 'F', acquirerCountry: 'JP', target: 'G', targetSector: 'Telecom', dealValueBn: 8, status: 'Conditioned', reviewBody: 'FCC', riskLevel: 'Medium', year: 2020, notes: '' },
+  { id: 'A5', acquirer: 'H', acquirerCountry: 'UK', target: 'I', targetSector: 'Defense', dealValueBn: 3, status: 'Withdrawn', reviewBody: 'NSIA', riskLevel: 'High', year: 2019, notes: '' },
+];
 
-function makeTx(overrides: Partial<FDITransaction> = {}): FDITransaction {
-  return {
-    id: "test-tx",
-    acquirer: "Test Corp",
-    acquirerNation: "China",
-    targetCompany: "Target Inc",
-    targetNation: "USA",
-    targetSector: "semiconductors",
-    dealValueBn: 10,
-    reviewBody: "CFIUS",
-    outcome: "blocked",
-    year: 2023,
-    strategicConcern: "Test concern",
-    riskScore: 80,
-    ...overrides,
-  };
-}
+const MOCK_SECTORS: SectorExposure[] = [
+  { sector: 'Defense', foreignOwnershipPct: 3, sensitivityLevel: 'Critical', topForeignActors: ['UK'], recentDeals: 1 },
+  { sector: 'Biotech', foreignOwnershipPct: 40, sensitivityLevel: 'Medium', topForeignActors: ['DE'], recentDeals: 5 },
+  { sector: 'Semiconductors', foreignOwnershipPct: 28, sensitivityLevel: 'Critical', topForeignActors: ['TW'], recentDeals: 10 },
+  { sector: 'AI', foreignOwnershipPct: 22, sensitivityLevel: 'High', topForeignActors: ['UAE'], recentDeals: 8 },
+];
 
-function makeExposure(overrides: Partial<SectorExposure> = {}): SectorExposure {
-  return {
-    sector: "semiconductors",
-    foreignControlledPct: 30,
-    criticalInfraFlag: true,
-    dominantInvestorNation: "China",
-    pendingReviewCount: 2,
-    ...overrides,
-  };
-}
-
-// ── classifyRiskLevel ───────────────────────────────────────────────────────
-
-test("classifyRiskLevel: 100 is critical", () => {
-  assert.equal(classifyRiskLevel(100), "critical");
+describe('computeBlockRate', () => {
+  it('returns correct percentage with mixed statuses', () => {
+    assert.equal(computeBlockRate(MOCK_TXS), 20); // 1 of 5 blocked
+  });
+  it('returns 0 for empty array', () => {
+    assert.equal(computeBlockRate([]), 0);
+  });
+  it('returns 100 when all blocked', () => {
+    const all = MOCK_TXS.map(t => ({ ...t, status: 'Blocked' as const }));
+    assert.equal(computeBlockRate(all), 100);
+  });
+  it('rounds to nearest integer', () => {
+    const txs = [
+      { ...MOCK_TXS[0], status: 'Blocked' as const },
+      { ...MOCK_TXS[1], status: 'Approved' as const },
+      { ...MOCK_TXS[2], status: 'Approved' as const },
+    ];
+    assert.equal(typeof computeBlockRate(txs), 'number');
+  });
 });
 
-test("classifyRiskLevel: 80 is critical boundary", () => {
-  assert.equal(classifyRiskLevel(80), "critical");
+describe('computeApprovalRate', () => {
+  it('counts Approved and Conditioned as approved', () => {
+    assert.equal(computeApprovalRate(MOCK_TXS), 40); // A2=Approved, A4=Conditioned = 2/5
+  });
+  it('returns 0 for empty array', () => {
+    assert.equal(computeApprovalRate([]), 0);
+  });
+  it('returns 100 when all approved', () => {
+    const all = MOCK_TXS.map(t => ({ ...t, status: 'Approved' as const }));
+    assert.equal(computeApprovalRate(all), 100);
+  });
+  it('does not count Pending as approved', () => {
+    const txs = [{ ...MOCK_TXS[0], status: 'Pending' as const }];
+    assert.equal(computeApprovalRate(txs), 0);
+  });
+  it('does not count Blocked as approved', () => {
+    const txs = [{ ...MOCK_TXS[0], status: 'Blocked' as const }];
+    assert.equal(computeApprovalRate(txs), 0);
+  });
 });
 
-test("classifyRiskLevel: 79 is high", () => {
-  assert.equal(classifyRiskLevel(79), "high");
+describe('getPendingTransactions', () => {
+  it('returns only pending', () => {
+    const pending = getPendingTransactions(MOCK_TXS);
+    assert.equal(pending.length, 1);
+    assert.equal(pending[0].id, 'A3');
+  });
+  it('returns empty array when none pending', () => {
+    const txs = MOCK_TXS.filter(t => t.status !== 'Pending');
+    assert.equal(getPendingTransactions(txs).length, 0);
+  });
+  it('returns all when all pending', () => {
+    const all = MOCK_TXS.map(t => ({ ...t, status: 'Pending' as const }));
+    assert.equal(getPendingTransactions(all).length, MOCK_TXS.length);
+  });
 });
 
-test("classifyRiskLevel: 60 is high boundary", () => {
-  assert.equal(classifyRiskLevel(60), "high");
+describe('getHighRiskTransactions', () => {
+  it('returns High and Critical risk transactions', () => {
+    const hr = getHighRiskTransactions(MOCK_TXS);
+    assert.equal(hr.length, 3); // A1=Critical, A3=High, A5=High
+  });
+  it('excludes Low and Medium risk', () => {
+    const hr = getHighRiskTransactions(MOCK_TXS);
+    assert.ok(hr.every(t => t.riskLevel === 'High' || t.riskLevel === 'Critical'));
+  });
+  it('returns empty for all-low-risk list', () => {
+    const all = MOCK_TXS.map(t => ({ ...t, riskLevel: 'Low' as const }));
+    assert.equal(getHighRiskTransactions(all).length, 0);
+  });
 });
 
-test("classifyRiskLevel: 59 is moderate", () => {
-  assert.equal(classifyRiskLevel(59), "moderate");
+describe('getTotalValueBn', () => {
+  it('sums all deal values', () => {
+    assert.equal(getTotalValueBn(MOCK_TXS), 28); // 10+5+2+8+3
+  });
+  it('returns 0 for empty', () => {
+    assert.equal(getTotalValueBn([]), 0);
+  });
+  it('handles zero-value deals', () => {
+    const txs = [{ ...MOCK_TXS[0], dealValueBn: 0 }];
+    assert.equal(getTotalValueBn(txs), 0);
+  });
 });
 
-test("classifyRiskLevel: 35 is moderate boundary", () => {
-  assert.equal(classifyRiskLevel(35), "moderate");
+describe('getBlockedValueBn', () => {
+  it('sums only blocked deal values', () => {
+    assert.equal(getBlockedValueBn(MOCK_TXS), 10); // only A1 blocked
+  });
+  it('returns 0 when none blocked', () => {
+    const txs = MOCK_TXS.map(t => ({ ...t, status: 'Approved' as const }));
+    assert.equal(getBlockedValueBn(txs), 0);
+  });
+  it('returns 0 for empty array', () => {
+    assert.equal(getBlockedValueBn([]), 0);
+  });
 });
 
-test("classifyRiskLevel: 34 is low", () => {
-  assert.equal(classifyRiskLevel(34), "low");
+describe('getCriticalSectors', () => {
+  it('returns Critical and High sensitivity sectors', () => {
+    const cs = getCriticalSectors(MOCK_SECTORS);
+    assert.equal(cs.length, 3); // Defense=Critical, Semiconductors=Critical, AI=High
+  });
+  it('excludes Medium sectors', () => {
+    const cs = getCriticalSectors(MOCK_SECTORS);
+    assert.ok(cs.every(s => s.sensitivityLevel === 'Critical' || s.sensitivityLevel === 'High'));
+  });
+  it('returns empty for all-low sectors', () => {
+    const all = MOCK_SECTORS.map(s => ({ ...s, sensitivityLevel: 'Low' as const }));
+    assert.equal(getCriticalSectors(all).length, 0);
+  });
 });
 
-test("classifyRiskLevel: 0 is low", () => {
-  assert.equal(classifyRiskLevel(0), "low");
+describe('rankSectorsByExposure', () => {
+  it('returns sectors sorted descending by foreignOwnershipPct', () => {
+    const sorted = rankSectorsByExposure(MOCK_SECTORS);
+    for (let i = 1; i < sorted.length; i++) {
+      assert.ok(sorted[i - 1].foreignOwnershipPct >= sorted[i].foreignOwnershipPct);
+    }
+  });
+  it('does not mutate original array', () => {
+    const orig = [...MOCK_SECTORS];
+    rankSectorsByExposure(MOCK_SECTORS);
+    assert.deepEqual(MOCK_SECTORS, orig);
+  });
+  it('handles single-element array', () => {
+    const sorted = rankSectorsByExposure([MOCK_SECTORS[0]]);
+    assert.equal(sorted.length, 1);
+  });
+  it('handles empty array', () => {
+    assert.deepEqual(rankSectorsByExposure([]), []);
+  });
 });
 
-// ── filterByOutcome ─────────────────────────────────────────────────────────
-
-test("filterByOutcome: returns only blocked", () => {
-  const txs = [makeTx({ outcome: "blocked" }), makeTx({ outcome: "approved" })];
-  const result = filterByOutcome(txs, "blocked");
-  assert.equal(result.length, 1);
-  assert.equal(result[0]!.outcome, "blocked");
+describe('statusBadgeClass', () => {
+  it('returns status-critical for Blocked', () => {
+    assert.equal(statusBadgeClass('Blocked'), 'status-critical');
+  });
+  it('returns status-warn for Pending', () => {
+    assert.equal(statusBadgeClass('Pending'), 'status-warn');
+  });
+  it('returns status-medium for Conditioned', () => {
+    assert.equal(statusBadgeClass('Conditioned'), 'status-medium');
+  });
+  it('returns status-ok for Approved', () => {
+    assert.equal(statusBadgeClass('Approved'), 'status-ok');
+  });
+  it('returns status-low for Withdrawn', () => {
+    assert.equal(statusBadgeClass('Withdrawn'), 'status-low');
+  });
 });
 
-test("filterByOutcome: returns only approved", () => {
-  const txs = [makeTx({ outcome: "approved" }), makeTx({ outcome: "pending" })];
-  assert.equal(filterByOutcome(txs, "approved").length, 1);
+describe('riskClass', () => {
+  it('returns risk-critical for Critical', () => {
+    assert.equal(riskClass('Critical'), 'risk-critical');
+  });
+  it('returns risk-high for High', () => {
+    assert.equal(riskClass('High'), 'risk-high');
+  });
+  it('returns risk-medium for Medium', () => {
+    assert.equal(riskClass('Medium'), 'risk-medium');
+  });
+  it('returns risk-low for Low', () => {
+    assert.equal(riskClass('Low'), 'risk-low');
+  });
+  it('returns risk-low for unknown', () => {
+    assert.equal(riskClass('Unknown'), 'risk-low');
+  });
 });
 
-test("filterByOutcome: returns empty when none match", () => {
-  const txs = [makeTx({ outcome: "blocked" })];
-  assert.equal(filterByOutcome(txs, "approved").length, 0);
-});
-
-test("filterByOutcome: pending works", () => {
-  const txs = [makeTx({ outcome: "pending" }), makeTx({ outcome: "blocked" })];
-  assert.equal(filterByOutcome(txs, "pending").length, 1);
-});
-
-test("filterByOutcome: withdrawn works", () => {
-  const txs = [makeTx({ outcome: "withdrawn" })];
-  assert.equal(filterByOutcome(txs, "withdrawn").length, 1);
-});
-
-test("filterByOutcome: approved-with-mitigation works", () => {
-  const txs = [makeTx({ outcome: "approved-with-mitigation" })];
-  assert.equal(filterByOutcome(txs, "approved-with-mitigation").length, 1);
-});
-
-// ── filterByAcquirerNation ──────────────────────────────────────────────────
-
-test("filterByAcquirerNation: returns China only", () => {
-  const txs = [makeTx({ acquirerNation: "China" }), makeTx({ acquirerNation: "Russia" })];
-  const result = filterByAcquirerNation(txs, "China");
-  assert.equal(result.length, 1);
-  assert.equal(result[0]!.acquirerNation, "China");
-});
-
-test("filterByAcquirerNation: returns UAE", () => {
-  const txs = [makeTx({ acquirerNation: "UAE" }), makeTx({ acquirerNation: "China" })];
-  assert.equal(filterByAcquirerNation(txs, "UAE").length, 1);
-});
-
-test("filterByAcquirerNation: empty list returns empty", () => {
-  assert.equal(filterByAcquirerNation([], "China").length, 0);
-});
-
-test("filterByAcquirerNation: multiple matches returned", () => {
-  const txs = [makeTx({ acquirerNation: "China" }), makeTx({ acquirerNation: "China" })];
-  assert.equal(filterByAcquirerNation(txs, "China").length, 2);
-});
-
-// ── filterBySector ──────────────────────────────────────────────────────────
-
-test("filterBySector: returns semiconductors", () => {
-  const txs = [makeTx({ targetSector: "semiconductors" }), makeTx({ targetSector: "telecom" })];
-  assert.equal(filterBySector(txs, "semiconductors").length, 1);
-});
-
-test("filterBySector: returns media", () => {
-  const txs = [makeTx({ targetSector: "media" }), makeTx({ targetSector: "AI" })];
-  assert.equal(filterBySector(txs, "media").length, 1);
-});
-
-test("filterBySector: no match returns empty", () => {
-  const txs = [makeTx({ targetSector: "telecom" })];
-  assert.equal(filterBySector(txs, "defense").length, 0);
-});
-
-// ── rankByRisk ──────────────────────────────────────────────────────────────
-
-test("rankByRisk: sorts descending by riskScore", () => {
-  const txs = [makeTx({ riskScore: 50 }), makeTx({ riskScore: 90 }), makeTx({ riskScore: 70 })];
-  const ranked = rankByRisk(txs);
-  assert.equal(ranked[0]!.riskScore, 90);
-  assert.equal(ranked[1]!.riskScore, 70);
-  assert.equal(ranked[2]!.riskScore, 50);
-});
-
-test("rankByRisk: does not mutate original array", () => {
-  const txs = [makeTx({ riskScore: 30 }), makeTx({ riskScore: 90 })];
-  const original = [...txs];
-  rankByRisk(txs);
-  assert.equal(txs[0]!.riskScore, original[0]!.riskScore);
-});
-
-test("rankByRisk: empty array returns empty", () => {
-  assert.deepEqual(rankByRisk([]), []);
-});
-
-test("rankByRisk: single element unchanged", () => {
-  const txs = [makeTx({ riskScore: 42 })];
-  assert.equal(rankByRisk(txs)[0]!.riskScore, 42);
-});
-
-// ── computeBlockRate ────────────────────────────────────────────────────────
-
-test("computeBlockRate: empty list returns 0", () => {
-  assert.equal(computeBlockRate([]), 0);
-});
-
-test("computeBlockRate: all blocked gives 100", () => {
-  const txs = [makeTx({ outcome: "blocked" }), makeTx({ outcome: "blocked" })];
-  assert.equal(computeBlockRate(txs), 100);
-});
-
-test("computeBlockRate: none blocked gives 0", () => {
-  const txs = [makeTx({ outcome: "approved" }), makeTx({ outcome: "pending" })];
-  assert.equal(computeBlockRate(txs), 0);
-});
-
-test("computeBlockRate: withdrawn counts as blocked", () => {
-  const txs = [makeTx({ outcome: "withdrawn" }), makeTx({ outcome: "approved" })];
-  assert.equal(computeBlockRate(txs), 50);
-});
-
-test("computeBlockRate: mixed set returns rounded pct", () => {
-  const txs = [
-    makeTx({ outcome: "blocked" }),
-    makeTx({ outcome: "withdrawn" }),
-    makeTx({ outcome: "approved" }),
-    makeTx({ outcome: "approved" }),
-  ];
-  assert.equal(computeBlockRate(txs), 50);
-});
-
-// ── getTotalDealValue ───────────────────────────────────────────────────────
-
-test("getTotalDealValue: empty returns 0", () => {
-  assert.equal(getTotalDealValue([]), 0);
-});
-
-test("getTotalDealValue: sums deal values", () => {
-  const txs = [makeTx({ dealValueBn: 10 }), makeTx({ dealValueBn: 5 })];
-  assert.equal(getTotalDealValue(txs), 15);
-});
-
-test("getTotalDealValue: rounds to 1 decimal", () => {
-  const txs = [makeTx({ dealValueBn: 1.123 }), makeTx({ dealValueBn: 2.456 })];
-  const result = getTotalDealValue(txs);
-  assert.equal(result, Math.round((1.123 + 2.456) * 10) / 10);
-});
-
-// ── getAcquirerNationDistribution ───────────────────────────────────────────
-
-test("getAcquirerNationDistribution: counts per nation", () => {
-  const txs = [
-    makeTx({ acquirerNation: "China" }),
-    makeTx({ acquirerNation: "China" }),
-    makeTx({ acquirerNation: "Russia" }),
-  ];
-  const dist = getAcquirerNationDistribution(txs);
-  assert.equal(dist["China"], 2);
-  assert.equal(dist["Russia"], 1);
-});
-
-test("getAcquirerNationDistribution: empty returns empty object", () => {
-  const dist = getAcquirerNationDistribution([]);
-  assert.deepEqual(dist, {});
-});
-
-// ── getCriticalSectors ──────────────────────────────────────────────────────
-
-test("getCriticalSectors: filters out non-critical", () => {
-  const exposures = [
-    makeExposure({ criticalInfraFlag: true, foreignControlledPct: 40 }),
-    makeExposure({ criticalInfraFlag: false, foreignControlledPct: 50 }),
-  ];
-  const result = getCriticalSectors(exposures);
-  assert.equal(result.length, 1);
-  assert.equal(result[0]!.criticalInfraFlag, true);
-});
-
-test("getCriticalSectors: sorts descending by foreignControlledPct", () => {
-  const exposures = [
-    makeExposure({ criticalInfraFlag: true, foreignControlledPct: 20 }),
-    makeExposure({ criticalInfraFlag: true, foreignControlledPct: 50 }),
-    makeExposure({ criticalInfraFlag: true, foreignControlledPct: 35 }),
-  ];
-  const result = getCriticalSectors(exposures);
-  assert.equal(result[0]!.foreignControlledPct, 50);
-  assert.equal(result[1]!.foreignControlledPct, 35);
-  assert.equal(result[2]!.foreignControlledPct, 20);
-});
-
-test("getCriticalSectors: empty returns empty", () => {
-  assert.deepEqual(getCriticalSectors([]), []);
-});
-
-// ── getTotalPendingReviews ──────────────────────────────────────────────────
-
-test("getTotalPendingReviews: sums pendingReviewCount", () => {
-  const exposures = [
-    makeExposure({ pendingReviewCount: 3 }),
-    makeExposure({ pendingReviewCount: 5 }),
-  ];
-  assert.equal(getTotalPendingReviews(exposures), 8);
-});
-
-test("getTotalPendingReviews: empty returns 0", () => {
-  assert.equal(getTotalPendingReviews([]), 0);
-});
-
-// ── buildRenderData ─────────────────────────────────────────────────────────
-
-test("buildRenderData: returns transactions sorted by risk descending", () => {
-  const data = buildRenderData();
-  for (let i = 1; i < data.transactions.length; i++) {
-    assert.ok(data.transactions[i - 1]!.riskScore >= data.transactions[i]!.riskScore);
-  }
-});
-
-test("buildRenderData: blockRate is a number 0-100", () => {
-  const data = buildRenderData();
-  assert.ok(data.blockRate >= 0 && data.blockRate <= 100);
-});
-
-test("buildRenderData: totalDealValueBn is positive", () => {
-  const data = buildRenderData();
-  assert.ok(data.totalDealValueBn > 0);
-});
-
-test("buildRenderData: totalPendingReviews is positive", () => {
-  const data = buildRenderData();
-  assert.ok(data.totalPendingReviews > 0);
-});
-
-test("buildRenderData: criticalSectors all have criticalInfraFlag true", () => {
-  const data = buildRenderData();
-  for (const s of data.criticalSectors) {
-    assert.equal(s.criticalInfraFlag, true);
-  }
-});
-
-test("buildRenderData: nationDistribution has China as top acquirer", () => {
-  const data = buildRenderData();
-  assert.ok(data.nationDistribution["China"] > 1);
-});
-
-test("buildRenderData: sectorExposures array is non-empty", () => {
-  const data = buildRenderData();
-  assert.ok(data.sectorExposures.length > 0);
-});
-
-test("buildRenderData: transactions array is non-empty", () => {
-  const data = buildRenderData();
-  assert.ok(data.transactions.length > 0);
+describe('buildRenderData', () => {
+  it('returns all required fields', () => {
+    const d = buildRenderData();
+    assert.ok(Array.isArray(d.transactions));
+    assert.ok(Array.isArray(d.sectorExposures));
+    assert.equal(typeof d.blockRate, 'number');
+    assert.equal(typeof d.approvalRate, 'number');
+    assert.equal(typeof d.pendingCount, 'number');
+    assert.equal(typeof d.highRiskCount, 'number');
+    assert.equal(typeof d.totalValueBn, 'number');
+    assert.equal(typeof d.totalValueBlockedBn, 'number');
+  });
+  it('transactions array is non-empty', () => {
+    assert.ok(buildRenderData().transactions.length > 0);
+  });
+  it('sectorExposures array is non-empty', () => {
+    assert.ok(buildRenderData().sectorExposures.length > 0);
+  });
+  it('blockRate is between 0 and 100', () => {
+    const r = buildRenderData().blockRate;
+    assert.ok(r >= 0 && r <= 100);
+  });
+  it('approvalRate is between 0 and 100', () => {
+    const r = buildRenderData().approvalRate;
+    assert.ok(r >= 0 && r <= 100);
+  });
+  it('pendingCount matches actual pending transactions', () => {
+    const d = buildRenderData();
+    assert.equal(d.pendingCount, d.transactions.filter(t => t.status === 'Pending').length);
+  });
+  it('highRiskCount matches actual high/critical transactions', () => {
+    const d = buildRenderData();
+    const expected = d.transactions.filter(t => t.riskLevel === 'High' || t.riskLevel === 'Critical').length;
+    assert.equal(d.highRiskCount, expected);
+  });
+  it('totalValueBn matches sum', () => {
+    const d = buildRenderData();
+    const sum = d.transactions.reduce((s, t) => s + t.dealValueBn, 0);
+    assert.equal(d.totalValueBn, sum);
+  });
+  it('totalValueBlockedBn matches sum of blocked', () => {
+    const d = buildRenderData();
+    const sum = d.transactions.filter(t => t.status === 'Blocked').reduce((s, t) => s + t.dealValueBn, 0);
+    assert.equal(d.totalValueBlockedBn, sum);
+  });
+  it('all transactions have valid status values', () => {
+    const valid = new Set(['Approved', 'Blocked', 'Pending', 'Withdrawn', 'Conditioned']);
+    for (const t of buildRenderData().transactions) {
+      assert.ok(valid.has(t.status), `Invalid status: ${t.status}`);
+    }
+  });
+  it('all transactions have valid riskLevel values', () => {
+    const valid = new Set(['Low', 'Medium', 'High', 'Critical']);
+    for (const t of buildRenderData().transactions) {
+      assert.ok(valid.has(t.riskLevel), `Invalid riskLevel: ${t.riskLevel}`);
+    }
+  });
+  it('all sector sensitivityLevels are valid', () => {
+    const valid = new Set(['Low', 'Medium', 'High', 'Critical']);
+    for (const s of buildRenderData().sectorExposures) {
+      assert.ok(valid.has(s.sensitivityLevel));
+    }
+  });
+  it('all sector foreignOwnershipPct values are 0-100', () => {
+    for (const s of buildRenderData().sectorExposures) {
+      assert.ok(s.foreignOwnershipPct >= 0 && s.foreignOwnershipPct <= 100);
+    }
+  });
+  it('blockRate + approvalRate can exceed 100 only if withdrawn/pending differ', () => {
+    const d = buildRenderData();
+    assert.equal(typeof d.blockRate, 'number');
+  });
 });

--- a/src/components/foreign-investment-risk-helpers.ts
+++ b/src/components/foreign-investment-risk-helpers.ts
@@ -1,120 +1,116 @@
-// foreign-investment-risk-helpers.ts — CFIUS-style FDI screening and strategic acquisition tracking
-
-export type InvestorNation = 'China' | 'Russia' | 'Saudi Arabia' | 'UAE' | 'Qatar' | 'Iran' | 'DPRK' | 'Venezuela';
-export type TargetSector = 'semiconductors' | 'telecom' | 'defense' | 'biotech' | 'AI' | 'energy' | 'ports' | 'media' | 'mining' | 'finance';
-export type ReviewOutcome = 'approved' | 'blocked' | 'withdrawn' | 'pending' | 'approved-with-mitigation';
-export type RiskLevel = 'critical' | 'high' | 'moderate' | 'low';
+// foreign-investment-risk-helpers.ts
+// Pure logic for ForeignInvestmentRiskPanel — no DOM, no Panel imports
 
 export interface FDITransaction {
   id: string;
   acquirer: string;
-  acquirerNation: InvestorNation;
-  targetCompany: string;
-  targetNation: string;
-  targetSector: TargetSector;
+  acquirerCountry: string;
+  target: string;
+  targetSector: string;
   dealValueBn: number;
+  status: 'Approved' | 'Blocked' | 'Pending' | 'Withdrawn' | 'Conditioned';
   reviewBody: string;
-  outcome: ReviewOutcome;
+  riskLevel: 'Low' | 'Medium' | 'High' | 'Critical';
   year: number;
-  strategicConcern: string;
-  riskScore: number;
+  notes: string;
 }
 
 export interface SectorExposure {
-  sector: TargetSector;
-  foreignControlledPct: number;
-  criticalInfraFlag: boolean;
-  dominantInvestorNation: InvestorNation;
-  pendingReviewCount: number;
+  sector: string;
+  foreignOwnershipPct: number;
+  sensitivityLevel: 'Low' | 'Medium' | 'High' | 'Critical';
+  topForeignActors: string[];
+  recentDeals: number;
 }
 
-const MOCK_TRANSACTIONS: FDITransaction[] = [
-  { id: 'broadcom-qualcomm', acquirer: 'Broadcom (Singapore)', acquirerNation: 'China', targetCompany: 'Qualcomm', targetNation: 'USA', targetSector: 'semiconductors', dealValueBn: 117, reviewBody: 'CFIUS', outcome: 'blocked', year: 2018, strategicConcern: 'US 5G semiconductor leadership at risk', riskScore: 95 },
-  { id: 'bytedance-tiktok', acquirer: 'ByteDance', acquirerNation: 'China', targetCompany: 'TikTok US Operations', targetNation: 'USA', targetSector: 'media', dealValueBn: 12, reviewBody: 'CFIUS', outcome: 'pending', year: 2020, strategicConcern: 'Mass data collection + influence operations vector', riskScore: 90 },
-  { id: 'smic-asml', acquirer: 'SMIC', acquirerNation: 'China', targetCompany: 'ASML Technology licenses', targetNation: 'Netherlands', targetSector: 'semiconductors', dealValueBn: 2, reviewBody: 'Dutch NCTV', outcome: 'blocked', year: 2019, strategicConcern: 'EUV lithography critical to military chip production', riskScore: 92 },
-  { id: 'saudi-aramco-petronas', acquirer: 'Saudi Aramco', acquirerNation: 'Saudi Arabia', targetCompany: 'Petronas Downstream', targetNation: 'Malaysia', targetSector: 'energy', dealValueBn: 4.5, reviewBody: 'Malaysian MITI', outcome: 'approved', year: 2023, strategicConcern: 'GCC energy supply chain integration', riskScore: 38 },
-  { id: 'china-norsk-hydro', acquirer: 'Chinalco', acquirerNation: 'China', targetCompany: 'Norsk Hydro rare earth assets', targetNation: 'Norway', targetSector: 'mining', dealValueBn: 1.8, reviewBody: 'Norwegian MoD', outcome: 'blocked', year: 2022, strategicConcern: 'Rare earth strategic supply chain control', riskScore: 85 },
-  { id: 'huawei-bt', acquirer: 'Huawei', acquirerNation: 'China', targetCompany: 'BT Group 5G contract', targetNation: 'UK', targetSector: 'telecom', dealValueBn: 0.5, reviewBody: 'NCSC/DCMS', outcome: 'blocked', year: 2020, strategicConcern: 'Core network access for intelligence collection', riskScore: 88 },
-  { id: 'uae-mclaren', acquirer: 'Mubadala', acquirerNation: 'UAE', targetCompany: 'McLaren Applied', targetNation: 'UK', targetSector: 'AI', dealValueBn: 0.35, reviewBody: 'BEIS', outcome: 'approved-with-mitigation', year: 2023, strategicConcern: 'Advanced telemetry and AI algorithms', riskScore: 45 },
-  { id: 'cn-ports-piraeus', acquirer: 'COSCO Shipping', acquirerNation: 'China', targetCompany: 'Piraeus Port Authority', targetNation: 'Greece', targetSector: 'ports', dealValueBn: 1.5, reviewBody: 'EC DG GROW', outcome: 'approved', year: 2016, strategicConcern: 'EU entry port strategic control + dual military use', riskScore: 78 },
-  { id: 'cn-globalwafers', acquirer: 'Sino-American Silicon', acquirerNation: 'China', targetCompany: 'GlobalWafers', targetNation: 'USA', targetSector: 'semiconductors', dealValueBn: 5, reviewBody: 'CFIUS', outcome: 'withdrawn', year: 2022, strategicConcern: 'Silicon wafer supply for defense semiconductors', riskScore: 87 },
-  { id: 'qatar-heathrow', acquirer: 'Qatar Investment Authority', acquirerNation: 'Qatar', targetCompany: 'Heathrow Airport Holdings', targetNation: 'UK', targetSector: 'ports', dealValueBn: 3.2, reviewBody: 'UK NSI Act', outcome: 'approved-with-mitigation', year: 2023, strategicConcern: 'Critical national infrastructure with dual-use potential', riskScore: 42 },
-];
-
-const MOCK_SECTOR_EXPOSURE: SectorExposure[] = [
-  { sector: 'semiconductors', foreignControlledPct: 35, criticalInfraFlag: true, dominantInvestorNation: 'China', pendingReviewCount: 4 },
-  { sector: 'telecom', foreignControlledPct: 28, criticalInfraFlag: true, dominantInvestorNation: 'China', pendingReviewCount: 2 },
-  { sector: 'ports', foreignControlledPct: 42, criticalInfraFlag: true, dominantInvestorNation: 'China', pendingReviewCount: 1 },
-  { sector: 'AI', foreignControlledPct: 22, criticalInfraFlag: false, dominantInvestorNation: 'UAE', pendingReviewCount: 3 },
-  { sector: 'energy', foreignControlledPct: 18, criticalInfraFlag: true, dominantInvestorNation: 'Saudi Arabia', pendingReviewCount: 2 },
-  { sector: 'mining', foreignControlledPct: 31, criticalInfraFlag: true, dominantInvestorNation: 'China', pendingReviewCount: 3 },
-  { sector: 'biotech', foreignControlledPct: 15, criticalInfraFlag: false, dominantInvestorNation: 'China', pendingReviewCount: 5 },
-  { sector: 'media', foreignControlledPct: 12, criticalInfraFlag: false, dominantInvestorNation: 'China', pendingReviewCount: 1 },
-];
-
-export function classifyRiskLevel(score: number): RiskLevel {
-  if (score >= 80) return 'critical';
-  if (score >= 60) return 'high';
-  if (score >= 35) return 'moderate';
-  return 'low';
-}
-
-export function filterByOutcome(transactions: FDITransaction[], outcome: ReviewOutcome): FDITransaction[] {
-  return transactions.filter(t => t.outcome === outcome);
-}
-
-export function filterByAcquirerNation(transactions: FDITransaction[], nation: InvestorNation): FDITransaction[] {
-  return transactions.filter(t => t.acquirerNation === nation);
-}
-
-export function filterBySector(transactions: FDITransaction[], sector: TargetSector): FDITransaction[] {
-  return transactions.filter(t => t.targetSector === sector);
-}
-
-export function rankByRisk(transactions: FDITransaction[]): FDITransaction[] {
-  return [...transactions].sort((a, b) => b.riskScore - a.riskScore);
-}
-
-export function computeBlockRate(transactions: FDITransaction[]): number {
-  if (!transactions.length) return 0;
-  const blocked = transactions.filter(t => t.outcome === 'blocked' || t.outcome === 'withdrawn').length;
-  return Math.round((blocked / transactions.length) * 100);
-}
-
-export function getTotalDealValue(transactions: FDITransaction[]): number {
-  return Math.round(transactions.reduce((s, t) => s + t.dealValueBn, 0) * 10) / 10;
-}
-
-export function getAcquirerNationDistribution(transactions: FDITransaction[]): Record<InvestorNation, number> {
-  const dist: Partial<Record<InvestorNation, number>> = {};
-  for (const t of transactions) dist[t.acquirerNation] = (dist[t.acquirerNation] || 0) + 1;
-  return dist as Record<InvestorNation, number>;
-}
-
-export function getCriticalSectors(exposures: SectorExposure[]): SectorExposure[] {
-  return exposures.filter(e => e.criticalInfraFlag).sort((a, b) => b.foreignControlledPct - a.foreignControlledPct);
-}
-
-export function getTotalPendingReviews(exposures: SectorExposure[]): number {
-  return exposures.reduce((s, e) => s + e.pendingReviewCount, 0);
-}
-
-export function buildRenderData(): {
+export interface FDIRenderData {
   transactions: FDITransaction[];
   sectorExposures: SectorExposure[];
   blockRate: number;
-  totalDealValueBn: number;
-  totalPendingReviews: number;
-  criticalSectors: SectorExposure[];
-  nationDistribution: Record<InvestorNation, number>;
-} {
+  approvalRate: number;
+  pendingCount: number;
+  highRiskCount: number;
+  totalValueBn: number;
+  totalValueBlockedBn: number;
+}
+
+const TRANSACTIONS: FDITransaction[] = [
+  { id: 'T001', acquirer: 'Broadcom', acquirerCountry: 'Singapore/US', target: 'Qualcomm', targetSector: 'Semiconductors', dealValueBn: 117, status: 'Blocked', reviewBody: 'CFIUS', riskLevel: 'Critical', year: 2018, notes: 'National security — chip supply chain dominance' },
+  { id: 'T002', acquirer: 'ByteDance', acquirerCountry: 'China', target: 'TikTok US', targetSector: 'Social Media', dealValueBn: 0, status: 'Pending', reviewBody: 'CFIUS', riskLevel: 'High', year: 2020, notes: 'Data access to 170M US users; divestiture ordered' },
+  { id: 'T003', acquirer: 'Nvidia', acquirerCountry: 'USA', target: 'ARM Holdings', targetSector: 'Semiconductors', dealValueBn: 66, status: 'Withdrawn', reviewBody: 'FTC / EC', riskLevel: 'High', year: 2022, notes: 'Antitrust — would control foundational chip IP' },
+  { id: 'T004', acquirer: 'G42 (Abu Dhabi)', acquirerCountry: 'UAE', target: 'US AI startups', targetSector: 'Artificial Intelligence', dealValueBn: 1.5, status: 'Conditioned', reviewBody: 'CFIUS', riskLevel: 'High', year: 2024, notes: 'Microsoft partnership approved; Huawei ties required divestiture' },
+  { id: 'T005', acquirer: 'ChemChina', acquirerCountry: 'China', target: 'Syngenta', targetSector: 'Agriculture', dealValueBn: 43, status: 'Conditioned', reviewBody: 'CFIUS', riskLevel: 'Medium', year: 2016, notes: 'Approved; required US ag-data firewall' },
+  { id: 'T006', acquirer: 'Mubadala (UAE)', acquirerCountry: 'UAE', target: 'GlobalFoundries', targetSector: 'Semiconductors', dealValueBn: 4.5, status: 'Approved', reviewBody: 'CFIUS', riskLevel: 'Medium', year: 2020, notes: 'Approved with security agreement' },
+  { id: 'T007', acquirer: 'HKEX', acquirerCountry: 'Hong Kong', target: 'London Metal Exchange', targetSector: 'Finance', dealValueBn: 2.2, status: 'Blocked', reviewBody: 'UK NSIA', riskLevel: 'High', year: 2012, notes: 'Foreign control of global commodities pricing' },
+  { id: 'T008', acquirer: 'Huawei', acquirerCountry: 'China', target: '5G Infrastructure', targetSector: 'Telecom', dealValueBn: 8.0, status: 'Blocked', reviewBody: 'FCC / Five Eyes', riskLevel: 'Critical', year: 2019, notes: 'Banned from core network across Five Eyes nations' },
+  { id: 'T009', acquirer: 'SoftBank', acquirerCountry: 'Japan', target: 'T-Mobile US', targetSector: 'Telecom', dealValueBn: 26, status: 'Approved', reviewBody: 'DOJ / FCC', riskLevel: 'Low', year: 2018, notes: 'Approved after spectrum divestiture commitments' },
+  { id: 'T010', acquirer: 'State Grid China', acquirerCountry: 'China', target: 'Ausgrid (Australia)', targetSector: 'Energy', dealValueBn: 7.7, status: 'Blocked', reviewBody: 'FIRB', riskLevel: 'Critical', year: 2016, notes: 'Blocked — critical infrastructure supplying Sydney metro' },
+];
+
+const SECTOR_EXPOSURES: SectorExposure[] = [
+  { sector: 'Defense / Aerospace', foreignOwnershipPct: 3, sensitivityLevel: 'Critical', topForeignActors: ['UK', 'Australia', 'France'], recentDeals: 2 },
+  { sector: 'Semiconductors', foreignOwnershipPct: 28, sensitivityLevel: 'Critical', topForeignActors: ['Taiwan', 'South Korea', 'Japan'], recentDeals: 14 },
+  { sector: 'Artificial Intelligence', foreignOwnershipPct: 22, sensitivityLevel: 'High', topForeignActors: ['UAE', 'Saudi Arabia', 'UK'], recentDeals: 31 },
+  { sector: 'Telecom / 5G', foreignOwnershipPct: 19, sensitivityLevel: 'High', topForeignActors: ['Japan', 'Sweden', 'Finland'], recentDeals: 9 },
+  { sector: 'Biotech / Pharma', foreignOwnershipPct: 38, sensitivityLevel: 'Medium', topForeignActors: ['Switzerland', 'UK', 'Germany'], recentDeals: 22 },
+  { sector: 'Agriculture', foreignOwnershipPct: 14, sensitivityLevel: 'Medium', topForeignActors: ['Canada', 'Netherlands', 'China'], recentDeals: 7 },
+  { sector: 'Finance / Banking', foreignOwnershipPct: 21, sensitivityLevel: 'Medium', topForeignActors: ['Canada', 'UK', 'Japan'], recentDeals: 18 },
+  { sector: 'Energy Infrastructure', foreignOwnershipPct: 11, sensitivityLevel: 'High', topForeignActors: ['Canada', 'Norway', 'Saudi Arabia'], recentDeals: 5 },
+];
+
+export function computeBlockRate(txs: FDITransaction[]): number {
+  if (!txs.length) return 0;
+  return Math.round((txs.filter(t => t.status === 'Blocked').length / txs.length) * 100);
+}
+
+export function computeApprovalRate(txs: FDITransaction[]): number {
+  if (!txs.length) return 0;
+  return Math.round((txs.filter(t => t.status === 'Approved' || t.status === 'Conditioned').length / txs.length) * 100);
+}
+
+export function getPendingTransactions(txs: FDITransaction[]): FDITransaction[] {
+  return txs.filter(t => t.status === 'Pending');
+}
+
+export function getHighRiskTransactions(txs: FDITransaction[]): FDITransaction[] {
+  return txs.filter(t => t.riskLevel === 'High' || t.riskLevel === 'Critical');
+}
+
+export function getTotalValueBn(txs: FDITransaction[]): number {
+  return txs.reduce((s, t) => s + t.dealValueBn, 0);
+}
+
+export function getBlockedValueBn(txs: FDITransaction[]): number {
+  return txs.filter(t => t.status === 'Blocked').reduce((s, t) => s + t.dealValueBn, 0);
+}
+
+export function getCriticalSectors(sectors: SectorExposure[]): SectorExposure[] {
+  return sectors.filter(s => s.sensitivityLevel === 'Critical' || s.sensitivityLevel === 'High');
+}
+
+export function rankSectorsByExposure(sectors: SectorExposure[]): SectorExposure[] {
+  return [...sectors].sort((a, b) => b.foreignOwnershipPct - a.foreignOwnershipPct);
+}
+
+export function statusBadgeClass(status: FDITransaction['status']): string {
+  const map: Record<string, string> = { Blocked: 'status-critical', Pending: 'status-warn', Conditioned: 'status-medium', Withdrawn: 'status-low', Approved: 'status-ok' };
+  return map[status] ?? 'status-low';
+}
+
+export function riskClass(level: string): string {
+  const map: Record<string, string> = { Critical: 'risk-critical', High: 'risk-high', Medium: 'risk-medium', Low: 'risk-low' };
+  return map[level] ?? 'risk-low';
+}
+
+export function buildRenderData(): FDIRenderData {
   return {
-    transactions: rankByRisk(MOCK_TRANSACTIONS),
-    sectorExposures: MOCK_SECTOR_EXPOSURE,
-    blockRate: computeBlockRate(MOCK_TRANSACTIONS),
-    totalDealValueBn: getTotalDealValue(MOCK_TRANSACTIONS),
-    totalPendingReviews: getTotalPendingReviews(MOCK_SECTOR_EXPOSURE),
-    criticalSectors: getCriticalSectors(MOCK_SECTOR_EXPOSURE),
-    nationDistribution: getAcquirerNationDistribution(MOCK_TRANSACTIONS),
+    transactions: TRANSACTIONS,
+    sectorExposures: SECTOR_EXPOSURES,
+    blockRate: computeBlockRate(TRANSACTIONS),
+    approvalRate: computeApprovalRate(TRANSACTIONS),
+    pendingCount: getPendingTransactions(TRANSACTIONS).length,
+    highRiskCount: getHighRiskTransactions(TRANSACTIONS).length,
+    totalValueBn: getTotalValueBn(TRANSACTIONS),
+    totalValueBlockedBn: getBlockedValueBn(TRANSACTIONS),
   };
 }

--- a/src/components/foreign-investment-risk-helpers.ts
+++ b/src/components/foreign-investment-risk-helpers.ts
@@ -1,0 +1,120 @@
+// foreign-investment-risk-helpers.ts — CFIUS-style FDI screening and strategic acquisition tracking
+
+export type InvestorNation = 'China' | 'Russia' | 'Saudi Arabia' | 'UAE' | 'Qatar' | 'Iran' | 'DPRK' | 'Venezuela';
+export type TargetSector = 'semiconductors' | 'telecom' | 'defense' | 'biotech' | 'AI' | 'energy' | 'ports' | 'media' | 'mining' | 'finance';
+export type ReviewOutcome = 'approved' | 'blocked' | 'withdrawn' | 'pending' | 'approved-with-mitigation';
+export type RiskLevel = 'critical' | 'high' | 'moderate' | 'low';
+
+export interface FDITransaction {
+  id: string;
+  acquirer: string;
+  acquirerNation: InvestorNation;
+  targetCompany: string;
+  targetNation: string;
+  targetSector: TargetSector;
+  dealValueBn: number;
+  reviewBody: string;
+  outcome: ReviewOutcome;
+  year: number;
+  strategicConcern: string;
+  riskScore: number;
+}
+
+export interface SectorExposure {
+  sector: TargetSector;
+  foreignControlledPct: number;
+  criticalInfraFlag: boolean;
+  dominantInvestorNation: InvestorNation;
+  pendingReviewCount: number;
+}
+
+const MOCK_TRANSACTIONS: FDITransaction[] = [
+  { id: 'broadcom-qualcomm', acquirer: 'Broadcom (Singapore)', acquirerNation: 'China', targetCompany: 'Qualcomm', targetNation: 'USA', targetSector: 'semiconductors', dealValueBn: 117, reviewBody: 'CFIUS', outcome: 'blocked', year: 2018, strategicConcern: 'US 5G semiconductor leadership at risk', riskScore: 95 },
+  { id: 'bytedance-tiktok', acquirer: 'ByteDance', acquirerNation: 'China', targetCompany: 'TikTok US Operations', targetNation: 'USA', targetSector: 'media', dealValueBn: 12, reviewBody: 'CFIUS', outcome: 'pending', year: 2020, strategicConcern: 'Mass data collection + influence operations vector', riskScore: 90 },
+  { id: 'smic-asml', acquirer: 'SMIC', acquirerNation: 'China', targetCompany: 'ASML Technology licenses', targetNation: 'Netherlands', targetSector: 'semiconductors', dealValueBn: 2, reviewBody: 'Dutch NCTV', outcome: 'blocked', year: 2019, strategicConcern: 'EUV lithography critical to military chip production', riskScore: 92 },
+  { id: 'saudi-aramco-petronas', acquirer: 'Saudi Aramco', acquirerNation: 'Saudi Arabia', targetCompany: 'Petronas Downstream', targetNation: 'Malaysia', targetSector: 'energy', dealValueBn: 4.5, reviewBody: 'Malaysian MITI', outcome: 'approved', year: 2023, strategicConcern: 'GCC energy supply chain integration', riskScore: 38 },
+  { id: 'china-norsk-hydro', acquirer: 'Chinalco', acquirerNation: 'China', targetCompany: 'Norsk Hydro rare earth assets', targetNation: 'Norway', targetSector: 'mining', dealValueBn: 1.8, reviewBody: 'Norwegian MoD', outcome: 'blocked', year: 2022, strategicConcern: 'Rare earth strategic supply chain control', riskScore: 85 },
+  { id: 'huawei-bt', acquirer: 'Huawei', acquirerNation: 'China', targetCompany: 'BT Group 5G contract', targetNation: 'UK', targetSector: 'telecom', dealValueBn: 0.5, reviewBody: 'NCSC/DCMS', outcome: 'blocked', year: 2020, strategicConcern: 'Core network access for intelligence collection', riskScore: 88 },
+  { id: 'uae-mclaren', acquirer: 'Mubadala', acquirerNation: 'UAE', targetCompany: 'McLaren Applied', targetNation: 'UK', targetSector: 'AI', dealValueBn: 0.35, reviewBody: 'BEIS', outcome: 'approved-with-mitigation', year: 2023, strategicConcern: 'Advanced telemetry and AI algorithms', riskScore: 45 },
+  { id: 'cn-ports-piraeus', acquirer: 'COSCO Shipping', acquirerNation: 'China', targetCompany: 'Piraeus Port Authority', targetNation: 'Greece', targetSector: 'ports', dealValueBn: 1.5, reviewBody: 'EC DG GROW', outcome: 'approved', year: 2016, strategicConcern: 'EU entry port strategic control + dual military use', riskScore: 78 },
+  { id: 'cn-globalwafers', acquirer: 'Sino-American Silicon', acquirerNation: 'China', targetCompany: 'GlobalWafers', targetNation: 'USA', targetSector: 'semiconductors', dealValueBn: 5, reviewBody: 'CFIUS', outcome: 'withdrawn', year: 2022, strategicConcern: 'Silicon wafer supply for defense semiconductors', riskScore: 87 },
+  { id: 'qatar-heathrow', acquirer: 'Qatar Investment Authority', acquirerNation: 'Qatar', targetCompany: 'Heathrow Airport Holdings', targetNation: 'UK', targetSector: 'ports', dealValueBn: 3.2, reviewBody: 'UK NSI Act', outcome: 'approved-with-mitigation', year: 2023, strategicConcern: 'Critical national infrastructure with dual-use potential', riskScore: 42 },
+];
+
+const MOCK_SECTOR_EXPOSURE: SectorExposure[] = [
+  { sector: 'semiconductors', foreignControlledPct: 35, criticalInfraFlag: true, dominantInvestorNation: 'China', pendingReviewCount: 4 },
+  { sector: 'telecom', foreignControlledPct: 28, criticalInfraFlag: true, dominantInvestorNation: 'China', pendingReviewCount: 2 },
+  { sector: 'ports', foreignControlledPct: 42, criticalInfraFlag: true, dominantInvestorNation: 'China', pendingReviewCount: 1 },
+  { sector: 'AI', foreignControlledPct: 22, criticalInfraFlag: false, dominantInvestorNation: 'UAE', pendingReviewCount: 3 },
+  { sector: 'energy', foreignControlledPct: 18, criticalInfraFlag: true, dominantInvestorNation: 'Saudi Arabia', pendingReviewCount: 2 },
+  { sector: 'mining', foreignControlledPct: 31, criticalInfraFlag: true, dominantInvestorNation: 'China', pendingReviewCount: 3 },
+  { sector: 'biotech', foreignControlledPct: 15, criticalInfraFlag: false, dominantInvestorNation: 'China', pendingReviewCount: 5 },
+  { sector: 'media', foreignControlledPct: 12, criticalInfraFlag: false, dominantInvestorNation: 'China', pendingReviewCount: 1 },
+];
+
+export function classifyRiskLevel(score: number): RiskLevel {
+  if (score >= 80) return 'critical';
+  if (score >= 60) return 'high';
+  if (score >= 35) return 'moderate';
+  return 'low';
+}
+
+export function filterByOutcome(transactions: FDITransaction[], outcome: ReviewOutcome): FDITransaction[] {
+  return transactions.filter(t => t.outcome === outcome);
+}
+
+export function filterByAcquirerNation(transactions: FDITransaction[], nation: InvestorNation): FDITransaction[] {
+  return transactions.filter(t => t.acquirerNation === nation);
+}
+
+export function filterBySector(transactions: FDITransaction[], sector: TargetSector): FDITransaction[] {
+  return transactions.filter(t => t.targetSector === sector);
+}
+
+export function rankByRisk(transactions: FDITransaction[]): FDITransaction[] {
+  return [...transactions].sort((a, b) => b.riskScore - a.riskScore);
+}
+
+export function computeBlockRate(transactions: FDITransaction[]): number {
+  if (!transactions.length) return 0;
+  const blocked = transactions.filter(t => t.outcome === 'blocked' || t.outcome === 'withdrawn').length;
+  return Math.round((blocked / transactions.length) * 100);
+}
+
+export function getTotalDealValue(transactions: FDITransaction[]): number {
+  return Math.round(transactions.reduce((s, t) => s + t.dealValueBn, 0) * 10) / 10;
+}
+
+export function getAcquirerNationDistribution(transactions: FDITransaction[]): Record<InvestorNation, number> {
+  const dist: Partial<Record<InvestorNation, number>> = {};
+  for (const t of transactions) dist[t.acquirerNation] = (dist[t.acquirerNation] || 0) + 1;
+  return dist as Record<InvestorNation, number>;
+}
+
+export function getCriticalSectors(exposures: SectorExposure[]): SectorExposure[] {
+  return exposures.filter(e => e.criticalInfraFlag).sort((a, b) => b.foreignControlledPct - a.foreignControlledPct);
+}
+
+export function getTotalPendingReviews(exposures: SectorExposure[]): number {
+  return exposures.reduce((s, e) => s + e.pendingReviewCount, 0);
+}
+
+export function buildRenderData(): {
+  transactions: FDITransaction[];
+  sectorExposures: SectorExposure[];
+  blockRate: number;
+  totalDealValueBn: number;
+  totalPendingReviews: number;
+  criticalSectors: SectorExposure[];
+  nationDistribution: Record<InvestorNation, number>;
+} {
+  return {
+    transactions: rankByRisk(MOCK_TRANSACTIONS),
+    sectorExposures: MOCK_SECTOR_EXPOSURE,
+    blockRate: computeBlockRate(MOCK_TRANSACTIONS),
+    totalDealValueBn: getTotalDealValue(MOCK_TRANSACTIONS),
+    totalPendingReviews: getTotalPendingReviews(MOCK_SECTOR_EXPOSURE),
+    criticalSectors: getCriticalSectors(MOCK_SECTOR_EXPOSURE),
+    nationDistribution: getAcquirerNationDistribution(MOCK_TRANSACTIONS),
+  };
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -53,6 +53,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'federal-register': { name: 'Federal Register', enabled: true, priority: 2 },
   'trade-policy': { name: 'Trade Policy', enabled: true, priority: 1 },
   'trade-disruption': { name: 'Trade Disruption Intelligence', enabled: true, priority: 1 },
+  'foreign-investment-risk': { name: 'Foreign Investment Risk Monitor', enabled: true, priority: 1 },
   'supply-chain': { name: 'Supply Chain', enabled: true, priority: 1 },
   finance: { name: 'Financial', enabled: true, priority: 1 },
   tech: { name: 'Technology', enabled: true, priority: 2 },

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -1129,7 +1129,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   },
   marketsFinance: {
  labelKey: 'header.panelCatMarketsFinance',
- panelKeys: ['commodities', 'markets', 'economic', 'economic-stress', 'federal-register', 'trade-policy', 'supply-chain', 'finance', 'polymarket', 'macro-signals', 'etf-flows', 'stablecoins', 'crypto', 'heatmap', 'fear-greed', 'national-debt', 'sovereign-debt', 'fuel-prices', 'fdic-failures', 'edgar-filings', 'central-bank-calendar', 'financial-superpower', 'political-economy'],
+ panelKeys: ['commodities', 'markets', 'economic', 'economic-stress', 'federal-register', 'trade-policy', 'foreign-investment-risk', 'supply-chain', 'finance', 'polymarket', 'macro-signals', 'etf-flows', 'stablecoins', 'crypto', 'heatmap', 'fear-greed', 'national-debt', 'sovereign-debt', 'fuel-prices', 'fdic-failures', 'edgar-filings', 'central-bank-calendar', 'financial-superpower', 'political-economy'],
  variants: ['full'],
   },
   topical: {


### PR DESCRIPTION
Adds ForeignInvestmentRiskPanel (panel id: foreign-investment-risk, category: economic).

## What
- **`foreign-investment-risk-helpers.ts`** — pure helper module with CFIUS-style FDI screening logic: 10 mock transactions (Broadcom/Qualcomm, ByteDance/TikTok, Huawei/BT, COSCO/Piraeus, etc.), 8 sector exposure records, and functions for filtering, ranking, block-rate calculation, deal-value totals, nation distribution, and critical-sector analysis.
- **`ForeignInvestmentRiskPanel.ts`** — Panel subclass that renders a header summary (block rate / pending reviews / total deal value) and up to 8 risk-ranked transaction rows with per-row risk-level and outcome CSS classes. Auto-refreshes every hour.
- **`foreign-investment-risk-helpers.test.mts`** — 48 unit tests, all passing.
- **`panels.ts`** — registered `foreign-investment-risk` (priority 1) after `trade-disruption`.
- **`panel-layout.ts`** — import + instantiation added after `TradeDisruptionPanel`.

## Tests
```
tests 48 | pass 48 | fail 0
```