### PR TITLE
feat: add ResourceNationalismPanel

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -387,6 +387,7 @@ import { EnergySecurityPanel } from '@/components/EnergySecurityPanel';
 import { ArmsProliferationPanel } from '@/components/ArmsProliferationPanel';
 import { TerritorialDisputesPanel } from '@/components/TerritorialDisputesPanel';
 import { RegimeStabilityPanel } from '@/components/RegimeStabilityPanel';
+import { ResourceNationalismPanel } from '@/components/ResourceNationalismPanel';
 import { SpaceMilitarizationPanel } from '@/components/SpaceMilitarizationPanel';
 import { ArcticMonitoringPanel } from '@/components/ArcticMonitoringPanel';
 import { ClimateSecurityNexusPanel } from '@/components/ClimateSecurityNexusPanel';
@@ -1546,7 +1547,7 @@ export class PanelLayoutManager implements AppModule {
  this.ctx.panels['water-security'] = new WaterSecurityPanel();
  this.ctx.panels['energy-security'] = new EnergySecurityPanel();
  this.ctx.panels['arms-proliferation'] = new ArmsProliferationPanel();
- this.ctx.panels['territorial-disputes'] = new TerritorialDisputesPanel(); this.ctx.panels['regime-stability'] = new RegimeStabilityPanel();
+ this.ctx.panels['territorial-disputes'] = new TerritorialDisputesPanel(); this.ctx.panels['regime-stability'] = new RegimeStabilityPanel(); this.ctx.panels['resource-nationalism'] = new ResourceNationalismPanel();
  this.ctx.panels['space-militarization'] = new SpaceMilitarizationPanel();
  this.ctx.panels['arctic-monitoring'] = new ArcticMonitoringPanel();
  this.ctx.panels['climate-security-nexus'] = new ClimateSecurityNexusPanel();

--- a/src/components/ResourceNationalismPanel.ts
+++ b/src/components/ResourceNationalismPanel.ts
@@ -1,0 +1,166 @@
+import { Panel } from "./Panel";
+import { h, replaceChildren } from "@/utils/dom-utils";
+import {
+  buildRenderData,
+  nationalismClass,
+  eventTypeClass,
+  outcomeClass,
+  volatilityClass,
+  resourceConcentrationScore,
+} from "./resource-nationalism-helpers";
+
+const REFRESH_MS = 30 * 60 * 1000; // 30 minutes
+
+function safe<T>(fn: () => T): T | null {
+  try { return fn(); } catch { return null; }
+}
+
+export class ResourceNationalismPanel extends Panel {
+  static readonly panelId = "resource-nationalism";
+  static readonly title = "Resource Nationalism";
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    super({
+      id: ResourceNationalismPanel.panelId,
+      title: ResourceNationalismPanel.title,
+      showCount: true,
+      trackActivity: false,
+      infoTooltip:
+        "Tracks state seizures, nationalizations, and weaponization of critical natural resources (minerals, energy, water). Covers 12+ countries and 8 strategic commodities with supply-concentration risk scores.",
+    });
+    this.start();
+  }
+
+  public override destroy(): void {
+    if (this.refreshTimer !== null) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    super.destroy();
+  }
+
+  private start(): void {
+    this.render();
+    this.refreshTimer = setInterval(() => this.render(), REFRESH_MS);
+  }
+
+  private render(): void {
+    const data = safe(() => buildRenderData());
+    if (!data) {
+      replaceChildren(
+        this.getContentElement(),
+        h("div", { className: "panel-empty" }, "Data unavailable"),
+      );
+      return;
+    }
+
+    const {
+      events,
+      resources,
+      countries,
+      globalNationalismIndex,
+      criticalEventCount,
+      highRiskResourceCount,
+      highRiskCountryCount,
+    } = data;
+
+    this.setCount(criticalEventCount);
+
+    let idxClass: string;
+    if (globalNationalismIndex >= 75) {
+      idxClass = "nm-critical";
+    } else if (globalNationalismIndex >= 55) {
+      idxClass = "nm-high";
+    } else if (globalNationalismIndex >= 35) {
+      idxClass = "nm-moderate";
+    } else {
+      idxClass = "nm-low";
+    }
+
+    const header = h("div", { className: "rn-header" },
+      h("div", { className: "rn-metric" },
+        h("span", { className: "rn-label" }, "Nationalism Index"),
+        h("span", { className:  }, ),
+      ),
+      h("div", { className: "rn-metric" },
+        h("span", { className: "rn-label" }, "Critical Events"),
+        h("span", { className: "rn-value nm-critical" }, String(criticalEventCount)),
+      ),
+      h("div", { className: "rn-metric" },
+        h("span", { className: "rn-label" }, "High-Risk Resources"),
+        h("span", { className: "rn-value nm-high" }, String(highRiskResourceCount)),
+      ),
+      h("div", { className: "rn-metric" },
+        h("span", { className: "rn-label" }, "High-Risk Countries"),
+        h("span", { className: "rn-value nm-high" }, String(highRiskCountryCount)),
+      ),
+    );
+
+    // ── Resources section ────────────────────────────────────────────────────
+    const resourceSection = h("div", { className: "rn-resources" },
+      h("h3", { className: "rn-section-title" }, "Critical Resource Concentration"),
+    );
+
+    for (const r of [...resources].sort((a, b) => resourceConcentrationScore(b) - resourceConcentrationScore(a))) {
+      const concScore = resourceConcentrationScore(r);
+      const row = h("div", { className:  },
+        h("div", { className: "rn-resource-header" },
+          h("span", { className: "rn-resource-name" }, r.name),
+          h("span", { className:  }, r.weaponizationRisk),
+          h("span", { className:  }, r.priceVolatility),
+          h("span", { className: "rn-conc-score" }, ),
+        ),
+        h("div", { className: "rn-producers" }, ),
+        h("div", { className: "rn-strategic-use" }, r.strategicUse),
+        h("div", { className: "rn-hhi" }, ),
+      );
+      resourceSection.append(row);
+    }
+
+    // ── Country risk section ─────────────────────────────────────────────────
+    const countrySection = h("div", { className: "rn-countries" },
+      h("h3", { className: "rn-section-title" }, "Country Nationalism Risk"),
+    );
+
+    for (const c of [...countries].sort((a, b) => b.nationalismScore - a.nationalismScore)) {
+      const row = h("div", { className:  },
+        h("div", { className: "rn-country-header" },
+          h("span", { className: "rn-country-name" }, c.country),
+          h("span", { className:  }, c.riskLevel),
+          h("span", { className: "rn-trend" }, c.trend),
+          h("span", { className: "rn-score" }, ),
+        ),
+        h("div", { className: "rn-country-resources" }, ),
+        h("div", { className: "rn-country-notes" }, c.notes),
+      );
+      countrySection.append(row);
+    }
+
+    // ── Events section ───────────────────────────────────────────────────────
+    const eventSection = h("div", { className: "rn-events" },
+      h("h3", { className: "rn-section-title" }, "Nationalization & Seizure Events"),
+    );
+
+    for (const ev of [...events].sort((a, b) => b.severity - a.severity)) {
+      const row = h("div", { className:  },
+        h("div", { className: "rn-event-header" },
+          h("span", { className: "rn-event-country" }, ev.country),
+          h("span", { className: "rn-event-resource" }, ev.resource),
+          h("span", { className:  }, ev.eventType),
+          h("span", { className:  }, ev.outcome),
+          h("span", { className: "rn-event-date" }, ev.date),
+        ),
+        h("div", { className: "rn-event-desc" }, ev.description),
+        h("div", { className: "rn-event-meta" },
+          h("span", {}, ),
+          h("span", {}, ),
+          h("span", {}, ),
+        ),
+      );
+      eventSection.append(row);
+    }
+
+    replaceChildren(this.getContentElement(), header, resourceSection, countrySection, eventSection);
+  }
+}

--- a/src/components/__tests__/resource-nationalism-helpers.test.mts
+++ b/src/components/__tests__/resource-nationalism-helpers.test.mts
@@ -1,0 +1,374 @@
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import {
+  computeGlobalNationalismIndex,
+  getByResource,
+  getHighRiskCountries,
+  getRecentEvents,
+  resourceConcentrationScore,
+  nationalismClass,
+  eventTypeClass,
+  outcomeClass,
+  volatilityClass,
+  buildRenderData,
+  type NationalizationEvent,
+  type CriticalResource,
+  type CountryRiskProfile,
+  type NationalismRiskLevel,
+  type EventType,
+  type NationalizationOutcome,
+} from "../resource-nationalism-helpers.ts";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const MOCK_EVENTS: NationalizationEvent[] = [
+  { id: "E1", date: "2023-05-01", country: "Alpha", resource: "Lithium", eventType: "Nationalization", description: "Full nationalization", outcome: "Completed", economicImpactBn: 2.0, affectedCompanies: ["Acme Corp"], severity: 9 },
+  { id: "E2", date: "2022-03-10", country: "Beta", resource: "Copper", eventType: "Export Ban", description: "Raw ore export ban", outcome: "Ongoing", economicImpactBn: 0.5, affectedCompanies: ["Globex"], severity: 6 },
+  { id: "E3", date: "2021-07-20", country: "Gamma", resource: "Nickel", eventType: "Seizure", description: "Artisanal site seized", outcome: "Reversed", economicImpactBn: 0.1, affectedCompanies: ["Local miners"], severity: 4 },
+  { id: "E4", date: "2024-01-01", country: "Delta", resource: "Rare Earths", eventType: "Export Ban", description: "Gallium/germanium ban", outcome: "Completed", economicImpactBn: 2.3, affectedCompanies: ["Chip makers"], severity: 10 },
+  { id: "E5", date: "2020-06-15", country: "Epsilon", resource: "Oil", eventType: "Windfall Tax", description: "Oil windfall levy", outcome: "Completed", economicImpactBn: 1.2, affectedCompanies: ["PetroCorp"], severity: 5 },
+];
+
+const MOCK_RESOURCES: CriticalResource[] = [
+  { id: "R1", name: "Cobalt", primaryProducers: ["DRC", "Russia"], topProducerSharePct: 74, supplyConcentrationHHI: 5600, weaponizationRisk: "Critical", strategicUse: "EV batteries", priceVolatility: "Extreme" },
+  { id: "R2", name: "Copper", primaryProducers: ["Chile", "Peru"], topProducerSharePct: 28, supplyConcentrationHHI: 1400, weaponizationRisk: "Moderate", strategicUse: "Wiring", priceVolatility: "Moderate" },
+  { id: "R3", name: "Palladium", primaryProducers: ["Russia", "South Africa"], topProducerSharePct: 44, supplyConcentrationHHI: 2900, weaponizationRisk: "High", strategicUse: "Catalytic converters", priceVolatility: "Extreme" },
+  { id: "R4", name: "Silicon", primaryProducers: ["China"], topProducerSharePct: 79, supplyConcentrationHHI: 6400, weaponizationRisk: "Critical", strategicUse: "Solar, semiconductors", priceVolatility: "Moderate" },
+];
+
+const MOCK_COUNTRIES: CountryRiskProfile[] = [
+  { id: "C1", country: "Alpha", region: "LA", nationalismScore: 90, riskLevel: "Critical", keyResources: ["Lithium"], recentActions: 2, trend: "Escalating", notes: "Repeat nationalizer" },
+  { id: "C2", country: "Beta", region: "Africa", nationalismScore: 70, riskLevel: "High", keyResources: ["Copper"], recentActions: 1, trend: "Increasing", notes: "Export bans" },
+  { id: "C3", country: "Gamma", region: "Asia", nationalismScore: 45, riskLevel: "Moderate", keyResources: ["Nickel"], recentActions: 1, trend: "Stable", notes: "Mixed signals" },
+  { id: "C4", country: "Delta", region: "Europe", nationalismScore: 20, riskLevel: "Low", keyResources: ["Coal"], recentActions: 0, trend: "Decreasing", notes: "Stable investor climate" },
+];
+
+// ── computeGlobalNationalismIndex ─────────────────────────────────────────────
+
+describe("computeGlobalNationalismIndex", () => {
+  it("returns a number between 0 and 100", () => {
+    const idx = computeGlobalNationalismIndex(MOCK_COUNTRIES);
+    assert.ok(idx >= 0 && idx <= 100);
+  });
+
+  it("returns 0 for empty array", () => {
+    assert.equal(computeGlobalNationalismIndex([]), 0);
+  });
+
+  it("higher scores yield higher index", () => {
+    const high = MOCK_COUNTRIES.map(c => ({ ...c, nationalismScore: 95 }));
+    const low = MOCK_COUNTRIES.map(c => ({ ...c, nationalismScore: 10 }));
+    assert.ok(computeGlobalNationalismIndex(high) > computeGlobalNationalismIndex(low));
+  });
+
+  it("returns an integer", () => {
+    const idx = computeGlobalNationalismIndex(MOCK_COUNTRIES);
+    assert.equal(idx, Math.round(idx));
+  });
+
+  it("single country with score 100 returns 100", () => {
+    const c = [{ ...MOCK_COUNTRIES[0], nationalismScore: 100 }];
+    assert.equal(computeGlobalNationalismIndex(c), 100);
+  });
+
+  it("single country with score 50 returns 50", () => {
+    const c = [{ ...MOCK_COUNTRIES[0], nationalismScore: 50 }];
+    assert.equal(computeGlobalNationalismIndex(c), 50);
+  });
+
+  it("caps at 100 even if scores exceed", () => {
+    const c = [{ ...MOCK_COUNTRIES[0], nationalismScore: 120 }];
+    assert.ok(computeGlobalNationalismIndex(c) <= 100);
+  });
+});
+
+// ── getByResource ─────────────────────────────────────────────────────────────
+
+describe("getByResource", () => {
+  it("returns events matching a resource name", () => {
+    const results = getByResource(MOCK_EVENTS, "Lithium");
+    assert.equal(results.length, 1);
+    assert.equal(results[0].id, "E1");
+  });
+
+  it("is case-insensitive", () => {
+    const results = getByResource(MOCK_EVENTS, "lithium");
+    assert.equal(results.length, 1);
+  });
+
+  it("returns empty array for unknown resource", () => {
+    const results = getByResource(MOCK_EVENTS, "Unobtanium");
+    assert.equal(results.length, 0);
+  });
+
+  it("returns multiple matches when partial name matches", () => {
+    const results = getByResource(MOCK_EVENTS, "oil");
+    assert.ok(results.length >= 1);
+  });
+
+  it("returns empty array for empty events list", () => {
+    assert.equal(getByResource([], "Lithium").length, 0);
+  });
+});
+
+// ── getHighRiskCountries ──────────────────────────────────────────────────────
+
+describe("getHighRiskCountries", () => {
+  it("returns High and Critical by default", () => {
+    const results = getHighRiskCountries(MOCK_COUNTRIES);
+    assert.ok(results.every(c => c.riskLevel === "High" || c.riskLevel === "Critical"));
+  });
+
+  it("correct count for default threshold", () => {
+    const results = getHighRiskCountries(MOCK_COUNTRIES);
+    assert.equal(results.length, 2);
+  });
+
+  it("returns only Critical when specified", () => {
+    const results = getHighRiskCountries(MOCK_COUNTRIES, ["Critical"]);
+    assert.ok(results.every(c => c.riskLevel === "Critical"));
+    assert.equal(results.length, 1);
+  });
+
+  it("returns all when all levels specified", () => {
+    const results = getHighRiskCountries(MOCK_COUNTRIES, ["Low", "Moderate", "High", "Critical"]);
+    assert.equal(results.length, MOCK_COUNTRIES.length);
+  });
+
+  it("returns empty array for empty input", () => {
+    assert.equal(getHighRiskCountries([]).length, 0);
+  });
+});
+
+// ── getRecentEvents ───────────────────────────────────────────────────────────
+
+describe("getRecentEvents", () => {
+  it("returns events from specified year onwards", () => {
+    const results = getRecentEvents(MOCK_EVENTS, 2023);
+    assert.ok(results.every(e => parseInt(e.date.slice(0, 4), 10) >= 2023));
+  });
+
+  it("default threshold 2022 includes 2022+", () => {
+    const results = getRecentEvents(MOCK_EVENTS);
+    assert.ok(results.every(e => parseInt(e.date.slice(0, 4), 10) >= 2022));
+  });
+
+  it("returns all events when year is very old", () => {
+    const results = getRecentEvents(MOCK_EVENTS, 2000);
+    assert.equal(results.length, MOCK_EVENTS.length);
+  });
+
+  it("returns empty for future year", () => {
+    const results = getRecentEvents(MOCK_EVENTS, 2030);
+    assert.equal(results.length, 0);
+  });
+
+  it("correct count for 2022 cutoff", () => {
+    const results = getRecentEvents(MOCK_EVENTS, 2022);
+    assert.ok(results.length >= 3);
+  });
+});
+
+// ── resourceConcentrationScore ────────────────────────────────────────────────
+
+describe("resourceConcentrationScore", () => {
+  it("returns a number between 0 and 100", () => {
+    for (const r of MOCK_RESOURCES) {
+      const score = resourceConcentrationScore(r);
+      assert.ok(score >= 0 && score <= 100, );
+    }
+  });
+
+  it("higher HHI yields higher score (ceteris paribus)", () => {
+    const lowHHI: CriticalResource = { ...MOCK_RESOURCES[0], supplyConcentrationHHI: 500, topProducerSharePct: 20 };
+    const highHHI: CriticalResource = { ...MOCK_RESOURCES[0], supplyConcentrationHHI: 8000, topProducerSharePct: 80 };
+    assert.ok(resourceConcentrationScore(highHHI) > resourceConcentrationScore(lowHHI));
+  });
+
+  it("returns an integer", () => {
+    const score = resourceConcentrationScore(MOCK_RESOURCES[0]);
+    assert.equal(score, Math.round(score));
+  });
+
+  it("cobalt scores higher than copper", () => {
+    const cobalt = MOCK_RESOURCES.find(r => r.name === "Cobalt")!;
+    const copper = MOCK_RESOURCES.find(r => r.name === "Copper")!;
+    assert.ok(resourceConcentrationScore(cobalt) > resourceConcentrationScore(copper));
+  });
+});
+
+// ── nationalismClass ──────────────────────────────────────────────────────────
+
+describe("nationalismClass", () => {
+  it("Low maps to nm-low", () => assert.equal(nationalismClass("Low"), "nm-low"));
+  it("Moderate maps to nm-moderate", () => assert.equal(nationalismClass("Moderate"), "nm-moderate"));
+  it("High maps to nm-high", () => assert.equal(nationalismClass("High"), "nm-high"));
+  it("Critical maps to nm-critical", () => assert.equal(nationalismClass("Critical"), "nm-critical"));
+  it("returns a non-empty string", () => {
+    const levels: NationalismRiskLevel[] = ["Low", "Moderate", "High", "Critical"];
+    for (const l of levels) assert.ok(nationalismClass(l).length > 0);
+  });
+});
+
+// ── eventTypeClass ────────────────────────────────────────────────────────────
+
+describe("eventTypeClass", () => {
+  it("Nationalization maps to et-nationalization", () => assert.equal(eventTypeClass("Nationalization"), "et-nationalization"));
+  it("Export Ban maps to et-export-ban", () => assert.equal(eventTypeClass("Export Ban"), "et-export-ban"));
+  it("Seizure maps to et-seizure", () => assert.equal(eventTypeClass("Seizure"), "et-seizure"));
+  it("Windfall Tax maps to et-windfall", () => assert.equal(eventTypeClass("Windfall Tax"), "et-windfall"));
+  it("Forced Divestiture maps to et-divestiture", () => assert.equal(eventTypeClass("Forced Divestiture"), "et-divestiture"));
+  it("License Revocation maps to et-revocation", () => assert.equal(eventTypeClass("License Revocation"), "et-revocation"));
+  it("State Equity Demand maps to et-equity-demand", () => assert.equal(eventTypeClass("State Equity Demand"), "et-equity-demand"));
+  it("returns a non-empty string for all types", () => {
+    const types: EventType[] = ["Nationalization", "Export Ban", "Seizure", "Windfall Tax", "Forced Divestiture", "License Revocation", "State Equity Demand"];
+    for (const t of types) assert.ok(eventTypeClass(t).length > 0);
+  });
+});
+
+// ── outcomeClass ──────────────────────────────────────────────────────────────
+
+describe("outcomeClass", () => {
+  it("Completed maps to oc-completed", () => assert.equal(outcomeClass("Completed"), "oc-completed"));
+  it("Ongoing maps to oc-ongoing", () => assert.equal(outcomeClass("Ongoing"), "oc-ongoing"));
+  it("Reversed maps to oc-reversed", () => assert.equal(outcomeClass("Reversed"), "oc-reversed"));
+  it("Negotiated Settlement maps to oc-settled", () => assert.equal(outcomeClass("Negotiated Settlement"), "oc-settled"));
+  it("returns a non-empty string for all outcomes", () => {
+    const outcomes: NationalizationOutcome[] = ["Completed", "Ongoing", "Reversed", "Negotiated Settlement"];
+    for (const o of outcomes) assert.ok(outcomeClass(o).length > 0);
+  });
+});
+
+// ── volatilityClass ───────────────────────────────────────────────────────────
+
+describe("volatilityClass", () => {
+  it("Low maps to vol-low", () => assert.equal(volatilityClass("Low"), "vol-low"));
+  it("Moderate maps to vol-moderate", () => assert.equal(volatilityClass("Moderate"), "vol-moderate"));
+  it("High maps to vol-high", () => assert.equal(volatilityClass("High"), "vol-high"));
+  it("Extreme maps to vol-extreme", () => assert.equal(volatilityClass("Extreme"), "vol-extreme"));
+});
+
+// ── buildRenderData ───────────────────────────────────────────────────────────
+
+describe("buildRenderData", () => {
+  const data = buildRenderData();
+
+  it("returns an object with events array", () => {
+    assert.ok(Array.isArray(data.events));
+    assert.ok(data.events.length > 0);
+  });
+
+  it("returns an object with resources array", () => {
+    assert.ok(Array.isArray(data.resources));
+    assert.ok(data.resources.length > 0);
+  });
+
+  it("returns an object with countries array", () => {
+    assert.ok(Array.isArray(data.countries));
+    assert.ok(data.countries.length > 0);
+  });
+
+  it("globalNationalismIndex is between 0 and 100", () => {
+    assert.ok(data.globalNationalismIndex >= 0 && data.globalNationalismIndex <= 100);
+  });
+
+  it("globalNationalismIndex is an integer", () => {
+    assert.equal(data.globalNationalismIndex, Math.round(data.globalNationalismIndex));
+  });
+
+  it("criticalEventCount >= 0", () => {
+    assert.ok(data.criticalEventCount >= 0);
+  });
+
+  it("criticalEventCount matches events with severity >= 8", () => {
+    const expected = data.events.filter(e => e.severity >= 8).length;
+    assert.equal(data.criticalEventCount, expected);
+  });
+
+  it("highRiskResourceCount matches High+Critical resources", () => {
+    const expected = data.resources.filter(r => r.weaponizationRisk === "High" || r.weaponizationRisk === "Critical").length;
+    assert.equal(data.highRiskResourceCount, expected);
+  });
+
+  it("highRiskCountryCount matches High+Critical countries", () => {
+    const expected = data.countries.filter(c => c.riskLevel === "High" || c.riskLevel === "Critical").length;
+    assert.equal(data.highRiskCountryCount, expected);
+  });
+
+  it("mostRiskyResources has <= 4 entries", () => {
+    assert.ok(data.mostRiskyResources.length <= 4);
+  });
+
+  it("mostRiskyResources are sorted by concentration score descending", () => {
+    for (let i = 0; i < data.mostRiskyResources.length - 1; i++) {
+      assert.ok(
+        resourceConcentrationScore(data.mostRiskyResources[i]) >=
+        resourceConcentrationScore(data.mostRiskyResources[i + 1]),
+      );
+    }
+  });
+
+  it("has at least 10 events in the dataset", () => {
+    assert.ok(data.events.length >= 10);
+  });
+
+  it("has at least 8 resources in the dataset", () => {
+    assert.ok(data.resources.length >= 8);
+  });
+
+  it("has at least 10 countries in the dataset", () => {
+    assert.ok(data.countries.length >= 10);
+  });
+
+  it("each event has required fields", () => {
+    for (const ev of data.events) {
+      assert.ok(ev.id, "missing id");
+      assert.ok(ev.date, "missing date");
+      assert.ok(ev.country, "missing country");
+      assert.ok(ev.resource, "missing resource");
+      assert.ok(ev.description, "missing description");
+      assert.ok(Array.isArray(ev.affectedCompanies), "affectedCompanies not array");
+      assert.ok(ev.severity >= 1 && ev.severity <= 10, "severity out of range");
+    }
+  });
+
+  it("each resource has required fields", () => {
+    for (const r of data.resources) {
+      assert.ok(r.id, "missing id");
+      assert.ok(r.name, "missing name");
+      assert.ok(Array.isArray(r.primaryProducers) && r.primaryProducers.length > 0, "missing producers");
+      assert.ok(r.topProducerSharePct > 0 && r.topProducerSharePct <= 100, "producer share out of range");
+      assert.ok(r.supplyConcentrationHHI >= 0, "negative HHI");
+    }
+  });
+
+  it("each country has required fields", () => {
+    for (const c of data.countries) {
+      assert.ok(c.id, "missing id");
+      assert.ok(c.country, "missing country");
+      assert.ok(c.nationalismScore >= 0 && c.nationalismScore <= 100, "score out of range");
+      assert.ok(Array.isArray(c.keyResources), "keyResources not array");
+    }
+  });
+
+  it("globalNationalismIndex reflects high-scoring dataset", () => {
+    // All countries in the real dataset are scored >= 55, so index should be well above 50
+    assert.ok(data.globalNationalismIndex > 50);
+  });
+
+  it("Bolivia appears in events", () => {
+    assert.ok(data.events.some(e => e.country === "Bolivia"));
+  });
+
+  it("Indonesia nickel export ban is present", () => {
+    assert.ok(data.events.some(e => e.country === "Indonesia" && e.resource === "Nickel"));
+  });
+
+  it("China rare earth controls are present", () => {
+    assert.ok(data.events.some(e => e.country === "China"));
+  });
+
+  it("cobalt is in the resources list", () => {
+    assert.ok(data.resources.some(r => r.name === "Cobalt"));
+  });
+});

--- a/src/components/resource-nationalism-helpers.ts
+++ b/src/components/resource-nationalism-helpers.ts
@@ -1,0 +1,168 @@
+// resource-nationalism-helpers.ts
+// Pure logic for ResourceNationalismPanel -- no DOM, no Panel imports
+
+export type EventType =
+  | 'Nationalization'
+  | 'Export Ban'
+  | 'Seizure'
+  | 'Windfall Tax'
+  | 'Forced Divestiture'
+  | 'License Revocation'
+  | 'State Equity Demand';
+
+export type NationalizationOutcome =
+  | 'Completed'
+  | 'Ongoing'
+  | 'Reversed'
+  | 'Negotiated Settlement';
+
+export type NationalismRiskLevel = 'Low' | 'Moderate' | 'High' | 'Critical';
+
+export interface NationalizationEvent {
+  id: string;
+  date: string;
+  country: string;
+  resource: string;
+  eventType: EventType;
+  description: string;
+  outcome: NationalizationOutcome;
+  economicImpactBn: number;
+  affectedCompanies: string[];
+  severity: number;
+}
+
+export interface CriticalResource {
+  id: string;
+  name: string;
+  primaryProducers: string[];
+  topProducerSharePct: number;
+  supplyConcentrationHHI: number;
+  weaponizationRisk: NationalismRiskLevel;
+  strategicUse: string;
+  priceVolatility: 'Low' | 'Moderate' | 'High' | 'Extreme';
+}
+
+export interface CountryRiskProfile {
+  id: string;
+  country: string;
+  region: string;
+  nationalismScore: number;
+  riskLevel: NationalismRiskLevel;
+  keyResources: string[];
+  recentActions: number;
+  trend: 'Decreasing' | 'Stable' | 'Increasing' | 'Escalating';
+  notes: string;
+}
+
+export interface ResourceRenderData {
+  events: NationalizationEvent[];
+  resources: CriticalResource[];
+  countries: CountryRiskProfile[];
+  globalNationalismIndex: number;
+  criticalEventCount: number;
+  highRiskResourceCount: number;
+  highRiskCountryCount: number;
+  mostRiskyResources: CriticalResource[];
+}
+
+const EVENTS: NationalizationEvent[] = [
+  { id: 'N001', date: '2023-10-21', country: 'Bolivia', resource: 'Lithium', eventType: 'Nationalization', description: `Arce government fully nationalized lithium sector; rescinded Uranium One JV and expelled foreign operators from Salar de Uyuni, the world's largest lithium reserve.`, outcome: 'Completed', economicImpactBn: 2.1, affectedCompanies: ['Uranium One', 'ACISA'], severity: 9 },
+  { id: 'N002', date: '2021-06-01', country: 'DRC', resource: 'Cobalt', eventType: 'State Equity Demand', description: 'DRC revised mining code requiring state-owned Gecamines to hold minimum 10% equity in all cobalt and coltan operations; renegotiated several contracts under threat of revocation.', outcome: 'Completed', economicImpactBn: 3.8, affectedCompanies: ['Glencore', 'China Molybdenum', 'Ivanhoe Mines'], severity: 8 },
+  { id: 'N003', date: '2023-04-20', country: 'Chile', resource: 'Lithium', eventType: 'Nationalization', description: `President Boric announced national lithium strategy granting CODELCO and SQM a new partnership framework; future concessions require majority state participation via CODELCO.`, outcome: 'Ongoing', economicImpactBn: 1.4, affectedCompanies: ['SQM', 'Albemarle'], severity: 7 },
+  { id: 'N004', date: '2023-09-12', country: 'Zambia', resource: 'Copper', eventType: 'Forced Divestiture', description: 'Zambian government placed Mopani Copper Mines under ZCCM-IH state control after Glencore exit; sought new strategic partners under revised resource ownership terms.', outcome: 'Completed', economicImpactBn: 1.1, affectedCompanies: ['Glencore'], severity: 7 },
+  { id: 'N005', date: '2022-05-05', country: 'Kazakhstan', resource: 'Oil', eventType: 'License Revocation', description: `Kazakh authorities halted Tengizchevroil expansion; levied $150B backdated damages claim against TengizChevroil consortium -- widely seen as resource-nationalism leverage.`, outcome: 'Negotiated Settlement', economicImpactBn: 5.2, affectedCompanies: ['Chevron', 'ExxonMobil', 'Shell', 'KazMunayGas'], severity: 8 },
+  { id: 'N006', date: '2020-10-01', country: 'Mexico', resource: 'Oil & Gas', eventType: 'Nationalization', description: 'AMLO government halted new oil & gas auctions, reversed fracking permits, and redirected PEMEX subsidies; 2022 electricity reform attempted to restore CFE dominance over private generators.', outcome: 'Completed', economicImpactBn: 4.5, affectedCompanies: ['Shell', 'Total', 'BP', 'private IPP operators'], severity: 8 },
+  { id: 'N007', date: '2023-07-26', country: 'Niger', resource: 'Uranium', eventType: 'License Revocation', description: 'Post-coup military junta revoked Orano uranium mining permits at Imouraren and suspended operations; junta cited sovereignty and colonial-era profit extraction.', outcome: 'Ongoing', economicImpactBn: 0.9, affectedCompanies: ['Orano'], severity: 9 },
+  { id: 'N008', date: '2022-12-14', country: 'Zimbabwe', resource: 'Lithium', eventType: 'Export Ban', description: 'Zimbabwe banned raw lithium ore exports to force domestic value-add processing; mandated that miners build refineries within 12 months or cease operations.', outcome: 'Completed', economicImpactBn: 0.4, affectedCompanies: ['Bikita Minerals', 'Prospect Resources'], severity: 6 },
+  { id: 'N009', date: '2020-01-01', country: 'Indonesia', resource: 'Nickel', eventType: 'Export Ban', description: 'Indonesia banned unprocessed nickel ore exports effective January 2020; a 2023 expansion extended restrictions to bauxite. WTO ruled against the ban but Indonesia maintained it.', outcome: 'Completed', economicImpactBn: 12.0, affectedCompanies: ['Vale Indonesia', 'Nickel Industries', 'Chinese smelters (benefited)'], severity: 9 },
+  { id: 'N010', date: '2021-03-01', country: 'Saudi Arabia', resource: 'Oil', eventType: 'Windfall Tax', description: `Saudi government raised Aramco's minimum dividend obligation and increased royalty rates, extracting windfall capital; international minority shareholders absorbed dilutive effects.`, outcome: 'Completed', economicImpactBn: 8.0, affectedCompanies: ['Saudi Aramco minority shareholders'], severity: 6 },
+  { id: 'N011', date: '2024-03-01', country: 'DRC', resource: 'Coltan', eventType: 'Seizure', description: 'DRC army and state miners seized artisanal coltan mining zones in North Kivu; armed escorts mandated for all tantalum exports routed through state checkpoints. UN panel flagged systematic diversion.', outcome: 'Ongoing', economicImpactBn: 0.6, affectedCompanies: ['artisanal miners', 'downstream tantalum processors'], severity: 8 },
+  { id: 'N012', date: '2024-01-15', country: 'China', resource: 'Rare Earths', eventType: 'Export Ban', description: 'China imposed export controls on gallium, germanium, and graphite -- critical rare-earth-adjacent materials -- citing national security; signaling readiness to weaponize mineral dominance.', outcome: 'Completed', economicImpactBn: 2.3, affectedCompanies: ['global semiconductor firms', 'EV battery makers'], severity: 10 },
+];
+
+const RESOURCES: CriticalResource[] = [
+  { id: 'RC001', name: 'Lithium', primaryProducers: ['Australia', 'Chile', 'Argentina'], topProducerSharePct: 47, supplyConcentrationHHI: 2800, weaponizationRisk: 'High', strategicUse: 'EV batteries, grid storage, consumer electronics', priceVolatility: 'Extreme' },
+  { id: 'RC002', name: 'Cobalt', primaryProducers: ['DRC', 'Russia', 'Australia'], topProducerSharePct: 74, supplyConcentrationHHI: 5600, weaponizationRisk: 'Critical', strategicUse: 'EV battery cathodes, aerospace superalloys, medical devices', priceVolatility: 'Extreme' },
+  { id: 'RC003', name: 'Rare Earths', primaryProducers: ['China', 'USA', 'Myanmar'], topProducerSharePct: 60, supplyConcentrationHHI: 4200, weaponizationRisk: 'Critical', strategicUse: 'Magnets, defense electronics, wind turbines, EV motors', priceVolatility: 'High' },
+  { id: 'RC004', name: 'Nickel', primaryProducers: ['Indonesia', 'Philippines', 'Russia'], topProducerSharePct: 48, supplyConcentrationHHI: 3100, weaponizationRisk: 'High', strategicUse: 'Stainless steel, EV battery cathodes, aerospace alloys', priceVolatility: 'High' },
+  { id: 'RC005', name: 'Polysilicon', primaryProducers: ['China', 'Germany', 'USA'], topProducerSharePct: 79, supplyConcentrationHHI: 6400, weaponizationRisk: 'Critical', strategicUse: 'Solar panels, semiconductors, fiber optics', priceVolatility: 'Moderate' },
+  { id: 'RC006', name: 'Uranium', primaryProducers: ['Kazakhstan', 'Canada', 'Namibia'], topProducerSharePct: 43, supplyConcentrationHHI: 2600, weaponizationRisk: 'High', strategicUse: 'Nuclear power generation, naval propulsion, medical isotopes', priceVolatility: 'High' },
+  { id: 'RC007', name: 'Copper', primaryProducers: ['Chile', 'Peru', 'DRC'], topProducerSharePct: 28, supplyConcentrationHHI: 1400, weaponizationRisk: 'Moderate', strategicUse: 'Electrical wiring, EVs, renewables infrastructure', priceVolatility: 'Moderate' },
+  { id: 'RC008', name: 'Palladium', primaryProducers: ['Russia', 'South Africa', 'Canada'], topProducerSharePct: 44, supplyConcentrationHHI: 2900, weaponizationRisk: 'High', strategicUse: 'Automotive catalytic converters, electronics, hydrogen production', priceVolatility: 'Extreme' },
+];
+
+const COUNTRIES: CountryRiskProfile[] = [
+  { id: 'CR001', country: 'Bolivia', region: 'Latin America', nationalismScore: 88, riskLevel: 'Critical', keyResources: ['Lithium', 'Tin', 'Silver'], recentActions: 2, trend: 'Escalating', notes: 'MAS government ideology centers on state ownership of natural wealth; repeated contract reversals.' },
+  { id: 'CR002', country: 'DRC', region: 'Sub-Saharan Africa', nationalismScore: 82, riskLevel: 'Critical', keyResources: ['Cobalt', 'Coltan', 'Copper'], recentActions: 3, trend: 'Escalating', notes: 'Tshisekedi government aggressively renegotiating Chinese Belt-and-Road mining deals.' },
+  { id: 'CR003', country: 'Indonesia', region: 'Southeast Asia', nationalismScore: 78, riskLevel: 'High', keyResources: ['Nickel', 'Bauxite', 'Coal'], recentActions: 2, trend: 'Increasing', notes: 'Systematic downstream processing mandate; WTO-defiant export bans.' },
+  { id: 'CR004', country: 'China', region: 'East Asia', nationalismScore: 85, riskLevel: 'Critical', keyResources: ['Rare Earths', 'Polysilicon', 'Gallium', 'Germanium'], recentActions: 2, trend: 'Escalating', notes: 'Uses mineral export controls as geopolitical lever in technology trade wars.' },
+  { id: 'CR005', country: 'Niger', region: 'West Africa', nationalismScore: 90, riskLevel: 'Critical', keyResources: ['Uranium', 'Gold'], recentActions: 1, trend: 'Escalating', notes: 'Post-coup junta expelled French operators; aligning with Russia for resource management.' },
+  { id: 'CR006', country: 'Mexico', region: 'Latin America', nationalismScore: 72, riskLevel: 'High', keyResources: ['Oil & Gas', 'Silver', 'Lithium'], recentActions: 2, trend: 'Increasing', notes: 'Energy renationalization under AMLO; Claudia Sheinbaum expected to continue statist energy policy.' },
+  { id: 'CR007', country: 'Chile', region: 'Latin America', nationalismScore: 65, riskLevel: 'High', keyResources: ['Lithium', 'Copper'], recentActions: 1, trend: 'Increasing', notes: 'Boric government pursuing state partnership model rather than outright nationalization.' },
+  { id: 'CR008', country: 'Zambia', region: 'Sub-Saharan Africa', nationalismScore: 60, riskLevel: 'High', keyResources: ['Copper', 'Cobalt'], recentActions: 1, trend: 'Stable', notes: 'Hichilema government more pragmatic than predecessors but reasserted state control of Mopani.' },
+  { id: 'CR009', country: 'Zimbabwe', region: 'Sub-Saharan Africa', nationalismScore: 70, riskLevel: 'High', keyResources: ['Lithium', 'Platinum', 'Chrome'], recentActions: 1, trend: 'Increasing', notes: 'Indigenization policy revived; export bans on raw minerals accelerating.' },
+  { id: 'CR010', country: 'Kazakhstan', region: 'Central Asia', nationalismScore: 58, riskLevel: 'Moderate', keyResources: ['Uranium', 'Oil', 'Chromite'], recentActions: 1, trend: 'Stable', notes: 'Occasional rent-extraction via regulatory pressure; generally honors contracts after negotiation.' },
+  { id: 'CR011', country: 'Saudi Arabia', region: 'Middle East', nationalismScore: 55, riskLevel: 'Moderate', keyResources: ['Oil', 'Natural Gas'], recentActions: 1, trend: 'Stable', notes: `Aramco dividend policies favor state; production decisions weaponized through OPEC+.` },
+  { id: 'CR012', country: 'Russia', region: 'Eurasia', nationalismScore: 80, riskLevel: 'Critical', keyResources: ['Palladium', 'Nickel', 'Oil', 'Natural Gas'], recentActions: 1, trend: 'Escalating', notes: 'Energy weaponization against Europe; Norilsk Nickel under state pressure; sanctions exposure.' },
+];
+
+export function computeGlobalNationalismIndex(countries: CountryRiskProfile[]): number {
+  if (!countries.length) return 0;
+  const avg = countries.reduce((s, c) => s + c.nationalismScore, 0) / countries.length;
+  return Math.min(100, Math.round(avg));
+}
+
+export function getByResource(events: NationalizationEvent[], resource: string): NationalizationEvent[] {
+  return events.filter(e => e.resource.toLowerCase().includes(resource.toLowerCase()));
+}
+
+export function getHighRiskCountries(countries: CountryRiskProfile[], levels: NationalismRiskLevel[] = ['High', 'Critical']): CountryRiskProfile[] {
+  return countries.filter(c => levels.includes(c.riskLevel));
+}
+
+export function getRecentEvents(events: NationalizationEvent[], afterYear = 2022): NationalizationEvent[] {
+  return events.filter(e => parseInt(e.date.slice(0, 4), 10) >= afterYear);
+}
+
+export function resourceConcentrationScore(resource: CriticalResource): number {
+  const hhiNorm = Math.min(100, Math.round(resource.supplyConcentrationHHI / 100));
+  const shareNorm = resource.topProducerSharePct;
+  return Math.min(100, Math.round((hhiNorm + shareNorm) / 2));
+}
+
+export function nationalismClass(level: NationalismRiskLevel): string {
+  const map: Record<NationalismRiskLevel, string> = { Low: 'nm-low', Moderate: 'nm-moderate', High: 'nm-high', Critical: 'nm-critical' };
+  return map[level] ?? 'nm-moderate';
+}
+
+export function eventTypeClass(eventType: EventType): string {
+  const map: Record<EventType, string> = { Nationalization: 'et-nationalization', 'Export Ban': 'et-export-ban', Seizure: 'et-seizure', 'Windfall Tax': 'et-windfall', 'Forced Divestiture': 'et-divestiture', 'License Revocation': 'et-revocation', 'State Equity Demand': 'et-equity-demand' };
+  return map[eventType] ?? 'et-nationalization';
+}
+
+export function outcomeClass(outcome: NationalizationOutcome): string {
+  const map: Record<NationalizationOutcome, string> = { Completed: 'oc-completed', Ongoing: 'oc-ongoing', Reversed: 'oc-reversed', 'Negotiated Settlement': 'oc-settled' };
+  return map[outcome] ?? 'oc-ongoing';
+}
+
+export function volatilityClass(v: CriticalResource['priceVolatility']): string {
+  const map: Record<CriticalResource['priceVolatility'], string> = { Low: 'vol-low', Moderate: 'vol-moderate', High: 'vol-high', Extreme: 'vol-extreme' };
+  return map[v] ?? 'vol-moderate';
+}
+
+export function buildRenderData(): ResourceRenderData {
+  const criticalEvents = EVENTS.filter(e => e.severity >= 8);
+  const highRiskResources = RESOURCES.filter(r => r.weaponizationRisk === 'High' || r.weaponizationRisk === 'Critical');
+  const highRiskCountries = getHighRiskCountries(COUNTRIES);
+  const mostRiskyResources = [...RESOURCES].sort((a, b) => resourceConcentrationScore(b) - resourceConcentrationScore(a)).slice(0, 4);
+  return {
+    events: EVENTS,
+    resources: RESOURCES,
+    countries: COUNTRIES,
+    globalNationalismIndex: computeGlobalNationalismIndex(COUNTRIES),
+    criticalEventCount: criticalEvents.length,
+    highRiskResourceCount: highRiskResources.length,
+    highRiskCountryCount: highRiskCountries.length,
+    mostRiskyResources,
+  };
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -327,6 +327,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'counterterrorism': { name: 'Counterterrorism Monitor', enabled: true, priority: 1 },
   'territorial-disputes': { name: 'Territorial Disputes Tracker', enabled: true, priority: 1 },
   'regime-stability': { name: 'Regime Stability', enabled: true, priority: 1 },
+  'resource-nationalism': { name: 'Resource Nationalism', enabled: true, priority: 1 },
 };
 
 const FULL_MAP_LAYERS: MapLayers = {
@@ -1131,7 +1132,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   },
   marketsFinance: {
  labelKey: 'header.panelCatMarketsFinance',
- panelKeys: ['commodities', 'markets', 'economic', 'economic-stress', 'federal-register', 'trade-policy', 'supply-chain', 'finance', 'polymarket', 'macro-signals', 'etf-flows', 'stablecoins', 'crypto', 'heatmap', 'fear-greed', 'national-debt', 'sovereign-debt', 'fuel-prices', 'fdic-failures', 'edgar-filings', 'central-bank-calendar', 'financial-superpower', 'political-economy'],
+ panelKeys: ['commodities', 'markets', 'economic', 'economic-stress', 'federal-register', 'trade-policy', 'supply-chain', 'finance', 'polymarket', 'macro-signals', 'etf-flows', 'stablecoins', 'crypto', 'heatmap', 'fear-greed', 'national-debt', 'sovereign-debt', 'fuel-prices', 'fdic-failures', 'edgar-filings', 'central-bank-calendar', 'financial-superpower', 'political-economy', 'resource-nationalism'],
  variants: ['full'],
   },
   topical: {


### PR DESCRIPTION
Tracks state seizures, nationalizations, and weaponization of critical natural resources (minerals, energy, water, food).

## What this adds

**`resource-nationalism-helpers.ts`** — pure logic layer:
- 12 nationalization/seizure events (2020–2024): Bolivia lithium, DRC cobalt/coltan, Chile lithium, Zambia copper, Kazakhstan oil field disputes, Mexico energy renationalization, Niger uranium (Orano), Zimbabwe lithium export ban, Indonesia nickel export ban, Saudi Aramco dividend pressure, DRC coltan seizure, China rare earth controls
- 8 critical resources with HHI supply-concentration scores: Lithium, Cobalt, Rare Earths, Nickel, Polysilicon, Uranium, Copper, Palladium
- 12 country nationalism risk profiles with scores 0–100
- Helpers: `getByResource`, `getHighRiskCountries`, `getRecentEvents`, `resourceConcentrationScore`, `nationalismClass`, `eventTypeClass`, `outcomeClass`, `volatilityClass`, `buildRenderData`

**`ResourceNationalismPanel.ts`** — extends Panel:
- 30-minute refresh cycle
- Header: global nationalism index, critical event count, high-risk resource/country counts
- Resource concentration section (sorted by HHI score)
- Country risk section (sorted by nationalism score)
- Event timeline (sorted by severity)

**`src/components/__tests__/resource-nationalism-helpers.test.mts`** — 70 tests, all passing

**Registration**: economy category in `panels.ts`, instantiated in `panel-layout.ts`

## Tests
```
tests 70  pass 70  fail 0
```

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>