### PR TITLE
feat: add EscalationLadderPanel

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -386,7 +386,7 @@ import { WaterSecurityPanel } from '@/components/WaterSecurityPanel';
 import { EnergySecurityPanel } from '@/components/EnergySecurityPanel';
 import { ArmsProliferationPanel } from '@/components/ArmsProliferationPanel';
 import { TerritorialDisputesPanel } from '@/components/TerritorialDisputesPanel';
-import { RegimeStabilityPanel } from '@/components/RegimeStabilityPanel';
+import { RegimeStabilityPanel } from '@/components/RegimeStabilityPanel';import { EscalationLadderPanel } from '@/components/EscalationLadderPanel';
 import { SpaceMilitarizationPanel } from '@/components/SpaceMilitarizationPanel';
 import { ArcticMonitoringPanel } from '@/components/ArcticMonitoringPanel';
 import { ClimateSecurityNexusPanel } from '@/components/ClimateSecurityNexusPanel';
@@ -1546,7 +1546,7 @@ export class PanelLayoutManager implements AppModule {
  this.ctx.panels['water-security'] = new WaterSecurityPanel();
  this.ctx.panels['energy-security'] = new EnergySecurityPanel();
  this.ctx.panels['arms-proliferation'] = new ArmsProliferationPanel();
- this.ctx.panels['territorial-disputes'] = new TerritorialDisputesPanel(); this.ctx.panels['regime-stability'] = new RegimeStabilityPanel();
+ this.ctx.panels['territorial-disputes'] = new TerritorialDisputesPanel(); this.ctx.panels['regime-stability'] = new RegimeStabilityPanel(); this.ctx.panels['escalation-ladder'] = new EscalationLadderPanel();
  this.ctx.panels['space-militarization'] = new SpaceMilitarizationPanel();
  this.ctx.panels['arctic-monitoring'] = new ArcticMonitoringPanel();
  this.ctx.panels['climate-security-nexus'] = new ClimateSecurityNexusPanel();

--- a/src/components/EscalationLadderPanel.ts
+++ b/src/components/EscalationLadderPanel.ts
@@ -1,0 +1,162 @@
+import { Panel } from './Panel';
+import { h, replaceChildren } from '@/utils/dom-utils';
+import {
+  buildRenderData,
+  rungLabel,
+  rungClass,
+  trendClass,
+  trendArrow,
+} from './escalation-ladder-helpers';
+
+const REFRESH_MS = 30 * 60 * 1000; // 30 minutes
+
+function safe<T>(fn: () => T): T | null {
+  try { return fn(); } catch { return null; }
+}
+
+export class EscalationLadderPanel extends Panel {
+  static readonly panelId = 'escalation-ladder';
+  static readonly title = 'Escalation Ladder';
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    super({
+      id: EscalationLadderPanel.panelId,
+      title: EscalationLadderPanel.title,
+      showCount: true,
+      trackActivity: false,
+      infoTooltip:
+        'Tracks multi-domain escalation dynamics across 8 active crises using a Kahn-style ladder model (0-20). Each crisis is positioned on an escalation rung with threshold crossings marked. Rungs: 0=Peace, 5=Crisis, 10=Military Action, 15=Limited War, 20=General War. Updates every 30 minutes.',
+    });
+    this.start();
+  }
+
+  public override destroy(): void {
+    if (this.refreshTimer !== null) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    super.destroy();
+  }
+
+  private start(): void {
+    this.render();
+    this.refreshTimer = setInterval(() => this.render(), REFRESH_MS);
+  }
+
+  private render(): void {
+    const data = safe(() => buildRenderData());
+    if (!data) {
+      replaceChildren(
+        this.getContentElement(),
+        h('div', { className: 'panel-empty' }, 'Data unavailable'),
+      );
+      return;
+    }
+
+    const { crises, globalBarometer, highEscalationCount, crossedThresholdCount, ascendingCount } =
+      data;
+
+    this.setCount(highEscalationCount);
+
+    let barometerClass: string;
+    if (globalBarometer >= 15) {
+      barometerClass = 'el-general-war';
+    } else if (globalBarometer >= 10) {
+      barometerClass = 'el-limited-war';
+    } else if (globalBarometer >= 5) {
+      barometerClass = 'el-crisis';
+    } else {
+      barometerClass = 'el-peace';
+    }
+
+    const header = h(
+      'div',
+      { className: 'el-header' },
+      h(
+        'div',
+        { className: 'el-metric' },
+        h('span', { className: 'el-label' }, 'Global Barometer'),
+        h('span', { className: `el-value ${barometerClass}` }, `${globalBarometer}/20`),
+      ),
+      h(
+        'div',
+        { className: 'el-metric' },
+        h('span', { className: 'el-label' }, 'High Escalation'),
+        h('span', { className: 'el-value el-limited-war' }, String(highEscalationCount)),
+      ),
+      h(
+        'div',
+        { className: 'el-metric' },
+        h('span', { className: 'el-label' }, 'At Threshold'),
+        h('span', { className: 'el-value el-crisis' }, String(crossedThresholdCount)),
+      ),
+      h(
+        'div',
+        { className: 'el-metric' },
+        h('span', { className: 'el-label' }, 'Ascending'),
+        h('span', { className: 'el-value el-trend-up' }, String(ascendingCount)),
+      ),
+    );
+
+    const ladderSection = h(
+      'div',
+      { className: 'el-ladder' },
+      h('h3', { className: 'el-section-title' }, 'Active Crisis Positions'),
+    );
+
+    for (const crisis of [...crises].sort((a, b) => b.rung - a.rung)) {
+      const barPct = Math.round((crisis.rung / 20) * 100);
+      const row = h(
+        'div',
+        { className: `el-crisis-row ${rungClass(crisis.rung)}` },
+        h(
+          'div',
+          { className: 'el-crisis-header' },
+          h('span', { className: 'el-crisis-name' }, crisis.name),
+          h(
+            'span',
+            { className: `el-rung-badge ${rungClass(crisis.rung)}` },
+            `Rung ${crisis.rung}/20`,
+          ),
+          h('span', { className: `el-trend ${trendClass(crisis.trend)}` }, trendArrow(crisis.trend)),
+          h('span', { className: 'el-rung-label' }, rungLabel(crisis.rung)),
+          h('span', { className: 'el-domain' }, crisis.domain),
+        ),
+        h('div', { className: 'el-description' }, crisis.description),
+        h(
+          'div',
+          { className: 'el-threshold' },
+          h('span', { className: 'el-threshold-label' }, 'Next rung: '),
+          crisis.thresholdToNext,
+        ),
+        h(
+          'div',
+          { className: 'el-rung-bar-container' },
+          h('div', {
+            className: `el-rung-bar ${rungClass(crisis.rung)}`,
+            style: `width: ${barPct}%`,
+          }),
+        ),
+      );
+      ladderSection.append(row);
+    }
+
+    const scaleSection = h(
+      'div',
+      { className: 'el-scale' },
+      h('h3', { className: 'el-section-title' }, 'Rung Reference'),
+      h(
+        'div',
+        { className: 'el-scale-row' },
+        h('span', { className: 'el-scale-item el-peace' }, '0 - Peace'),
+        h('span', { className: 'el-scale-item el-crisis' }, '5 - Crisis'),
+        h('span', { className: 'el-scale-item el-limited-war' }, '10 - Military Action'),
+        h('span', { className: 'el-scale-item el-general-war' }, '15 - Limited War'),
+        h('span', { className: 'el-scale-item el-general-war' }, '20 - General War'),
+      ),
+    );
+
+    replaceChildren(this.getContentElement(), header, ladderSection, scaleSection);
+  }
+}

--- a/src/components/__tests__/escalation-ladder-helpers.test.mts
+++ b/src/components/__tests__/escalation-ladder-helpers.test.mts
@@ -1,0 +1,384 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import {
+  rungLabel,
+  rungClass,
+  trendClass,
+  trendArrow,
+  getHighEscalation,
+  getCrossedThresholds,
+  computeGlobalBarometer,
+  buildRenderData,
+  RUNG_REFERENCE,
+  type CrisisEscalation,
+  type EscalationTrend,
+  type EscalationDomain,
+} from '../escalation-ladder-helpers.ts';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeCrisis(overrides: Partial<CrisisEscalation> = {}): CrisisEscalation {
+  return {
+    id: 'T001',
+    name: 'Test Crisis',
+    domain: 'Conventional Military' as EscalationDomain,
+    rung: 10,
+    maxRung: 20,
+    trend: 'stable',
+    description: 'Test description',
+    thresholdToNext: 'Test threshold',
+    weight: 1.0,
+    lastUpdated: '2025-05',
+    ...overrides,
+  };
+}
+
+const MOCK_CRISES: CrisisEscalation[] = [
+  makeCrisis({ id: 'C001', rung: 14, trend: 'stable', weight: 0.25 }),
+  makeCrisis({ id: 'C002', rung: 7, trend: 'ascending', weight: 0.22 }),
+  makeCrisis({ id: 'C003', rung: 11, trend: 'stable', weight: 0.18 }),
+  makeCrisis({ id: 'C004', rung: 6, trend: 'ascending', weight: 0.12 }),
+  makeCrisis({ id: 'C005', rung: 8, trend: 'ascending', weight: 0.10 }),
+  makeCrisis({ id: 'C006', rung: 8, trend: 'ascending', weight: 0.08 }),
+  makeCrisis({ id: 'C007', rung: 13, trend: 'stable', weight: 0.10 }),
+  makeCrisis({ id: 'C008', rung: 9, trend: 'ascending', weight: 0.15 }),
+];
+
+// ---------------------------------------------------------------------------
+// rungLabel
+// ---------------------------------------------------------------------------
+
+describe('rungLabel', () => {
+  it('returns Peace for rung 0', () => {
+    assert.equal(rungLabel(0), 'Peace');
+  });
+
+  it('returns Peace for rung 4', () => {
+    assert.equal(rungLabel(4), 'Peace');
+  });
+
+  it('returns Crisis for rung 5', () => {
+    assert.equal(rungLabel(5), 'Crisis');
+  });
+
+  it('returns Crisis for rung 9', () => {
+    assert.equal(rungLabel(9), 'Crisis');
+  });
+
+  it('returns Military Action for rung 10', () => {
+    assert.equal(rungLabel(10), 'Military Action');
+  });
+
+  it('returns Military Action for rung 14', () => {
+    assert.equal(rungLabel(14), 'Military Action');
+  });
+
+  it('returns Limited War for rung 15', () => {
+    assert.equal(rungLabel(15), 'Limited War');
+  });
+
+  it('returns General War for rung 20', () => {
+    assert.equal(rungLabel(20), 'General War');
+  });
+
+  it('returns Limited War for rung 19', () => {
+    assert.equal(rungLabel(19), 'Limited War');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rungClass
+// ---------------------------------------------------------------------------
+
+describe('rungClass', () => {
+  it('returns el-peace for rung 0', () => {
+    assert.equal(rungClass(0), 'el-peace');
+  });
+
+  it('returns el-peace for rung 4', () => {
+    assert.equal(rungClass(4), 'el-peace');
+  });
+
+  it('returns el-crisis for rung 5', () => {
+    assert.equal(rungClass(5), 'el-crisis');
+  });
+
+  it('returns el-crisis for rung 9', () => {
+    assert.equal(rungClass(9), 'el-crisis');
+  });
+
+  it('returns el-limited-war for rung 10', () => {
+    assert.equal(rungClass(10), 'el-limited-war');
+  });
+
+  it('returns el-limited-war for rung 14', () => {
+    assert.equal(rungClass(14), 'el-limited-war');
+  });
+
+  it('returns el-general-war for rung 15', () => {
+    assert.equal(rungClass(15), 'el-general-war');
+  });
+
+  it('returns el-general-war for rung 20', () => {
+    assert.equal(rungClass(20), 'el-general-war');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// trendClass
+// ---------------------------------------------------------------------------
+
+describe('trendClass', () => {
+  it('returns el-trend-up for ascending', () => {
+    assert.equal(trendClass('ascending'), 'el-trend-up');
+  });
+
+  it('returns el-trend-down for descending', () => {
+    assert.equal(trendClass('descending'), 'el-trend-down');
+  });
+
+  it('returns el-trend-stable for stable', () => {
+    assert.equal(trendClass('stable'), 'el-trend-stable');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// trendArrow
+// ---------------------------------------------------------------------------
+
+describe('trendArrow', () => {
+  it('returns up string for ascending', () => {
+    assert.equal(trendArrow('ascending'), 'up');
+  });
+
+  it('returns down string for descending', () => {
+    assert.equal(trendArrow('descending'), 'down');
+  });
+
+  it('returns stable string for stable', () => {
+    assert.equal(trendArrow('stable'), 'stable');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getHighEscalation
+// ---------------------------------------------------------------------------
+
+describe('getHighEscalation', () => {
+  it('returns crises at or above default threshold (10)', () => {
+    const result = getHighEscalation(MOCK_CRISES);
+    assert.ok(result.every(c => c.rung >= 10));
+  });
+
+  it('returns 3 crises at or above rung 10 in MOCK_CRISES', () => {
+    const result = getHighEscalation(MOCK_CRISES);
+    assert.equal(result.length, 3); // rungs 14, 11, 13
+  });
+
+  it('returns empty array when no crises meet threshold', () => {
+    const low = MOCK_CRISES.map(c => ({ ...c, rung: 3 }));
+    assert.deepEqual(getHighEscalation(low), []);
+  });
+
+  it('respects custom threshold', () => {
+    const result = getHighEscalation(MOCK_CRISES, 14);
+    assert.equal(result.length, 1);
+    assert.equal(result[0]!.id, 'C001');
+  });
+
+  it('includes crises exactly at threshold', () => {
+    const crisis = makeCrisis({ rung: 10 });
+    const result = getHighEscalation([crisis], 10);
+    assert.equal(result.length, 1);
+  });
+
+  it('returns all crises when threshold is 0', () => {
+    const result = getHighEscalation(MOCK_CRISES, 0);
+    assert.equal(result.length, MOCK_CRISES.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCrossedThresholds
+// ---------------------------------------------------------------------------
+
+describe('getCrossedThresholds', () => {
+  it('returns only crises at major rungs (5,10,15,20)', () => {
+    const crises = [
+      makeCrisis({ id: 'A', rung: 5 }),
+      makeCrisis({ id: 'B', rung: 10 }),
+      makeCrisis({ id: 'C', rung: 7 }),
+      makeCrisis({ id: 'D', rung: 15 }),
+      makeCrisis({ id: 'E', rung: 20 }),
+      makeCrisis({ id: 'F', rung: 3 }),
+    ];
+    const result = getCrossedThresholds(crises);
+    assert.equal(result.length, 4);
+    assert.ok(result.every(c => [5, 10, 15, 20].includes(c.rung)));
+  });
+
+  it('returns empty array when no crises are at major rungs', () => {
+    const crises = MOCK_CRISES.map(c => ({ ...c, rung: 3 }));
+    assert.deepEqual(getCrossedThresholds(crises), []);
+  });
+
+  it('returns empty for MOCK_CRISES (none hit 5,10,15,20 exactly)', () => {
+    // MOCK_CRISES have rungs 14,7,11,6,8,8,13,9 - none exactly 5/10/15/20
+    const result = getCrossedThresholds(MOCK_CRISES);
+    assert.equal(result.length, 0);
+  });
+
+  it('handles empty array', () => {
+    assert.deepEqual(getCrossedThresholds([]), []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeGlobalBarometer
+// ---------------------------------------------------------------------------
+
+describe('computeGlobalBarometer', () => {
+  it('returns 0 for empty array', () => {
+    assert.equal(computeGlobalBarometer([]), 0);
+  });
+
+  it('returns 0 when total weight is zero', () => {
+    const crises = MOCK_CRISES.map(c => ({ ...c, weight: 0 }));
+    assert.equal(computeGlobalBarometer(crises), 0);
+  });
+
+  it('returns rung value for single crisis with full weight', () => {
+    const crisis = makeCrisis({ rung: 14, weight: 1.0 });
+    assert.equal(computeGlobalBarometer([crisis]), 14);
+  });
+
+  it('weighted average is lower when low-rung crises have more weight', () => {
+    const high = makeCrisis({ rung: 18, weight: 0.1 });
+    const low = makeCrisis({ rung: 2, weight: 0.9 });
+    const result = computeGlobalBarometer([high, low]);
+    assert.ok(result < 10);
+  });
+
+  it('weighted average is higher when high-rung crises have more weight', () => {
+    const high = makeCrisis({ rung: 18, weight: 0.9 });
+    const low = makeCrisis({ rung: 2, weight: 0.1 });
+    const result = computeGlobalBarometer([high, low]);
+    assert.ok(result > 10);
+  });
+
+  it('result is rounded to one decimal place', () => {
+    const c1 = makeCrisis({ rung: 7, weight: 1 });
+    const c2 = makeCrisis({ rung: 8, weight: 2 });
+    const result = computeGlobalBarometer([c1, c2]);
+    // weighted avg = (7*1 + 8*2) / 3 = 23/3 = 7.666... -> 7.7
+    assert.equal(result, 7.7);
+  });
+
+  it('result is between 0 and 20 for real crisis data', () => {
+    const result = computeGlobalBarometer(MOCK_CRISES);
+    assert.ok(result >= 0 && result <= 20);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRenderData
+// ---------------------------------------------------------------------------
+
+describe('buildRenderData', () => {
+  it('returns 8 crises', () => {
+    const data = buildRenderData();
+    assert.equal(data.crises.length, 8);
+  });
+
+  it('globalBarometer is between 0 and 20', () => {
+    const { globalBarometer } = buildRenderData();
+    assert.ok(globalBarometer >= 0 && globalBarometer <= 20, `got ${globalBarometer}`);
+  });
+
+  it('highEscalationCount matches crises with rung >= 10', () => {
+    const data = buildRenderData();
+    const expected = data.crises.filter(c => c.rung >= 10).length;
+    assert.equal(data.highEscalationCount, expected);
+  });
+
+  it('crossedThresholdCount matches crises exactly at 5/10/15/20', () => {
+    const data = buildRenderData();
+    const expected = data.crises.filter(c => [5, 10, 15, 20].includes(c.rung)).length;
+    assert.equal(data.crossedThresholdCount, expected);
+  });
+
+  it('ascendingCount matches crises with trend ascending', () => {
+    const data = buildRenderData();
+    const expected = data.crises.filter(c => c.trend === 'ascending').length;
+    assert.equal(data.ascendingCount, expected);
+  });
+
+  it('all crises have rung in range 0-20', () => {
+    const { crises } = buildRenderData();
+    assert.ok(crises.every(c => c.rung >= 0 && c.rung <= 20));
+  });
+
+  it('all crises have weight > 0', () => {
+    const { crises } = buildRenderData();
+    assert.ok(crises.every(c => c.weight > 0));
+  });
+
+  it('all crises have non-empty id, name, description', () => {
+    const { crises } = buildRenderData();
+    for (const c of crises) {
+      assert.ok(c.id.length > 0, `id empty for ${c.name}`);
+      assert.ok(c.name.length > 0, `name empty for ${c.id}`);
+      assert.ok(c.description.length > 0, `description empty for ${c.id}`);
+    }
+  });
+
+  it('Ukraine-Russia is at rung 14', () => {
+    const { crises } = buildRenderData();
+    const ukr = crises.find(c => c.name.includes('Ukraine'));
+    assert.ok(ukr, 'Ukraine-Russia crisis not found');
+    assert.equal(ukr!.rung, 14);
+  });
+
+  it('Iran Nuclear Program is at rung 9 and ascending', () => {
+    const { crises } = buildRenderData();
+    const iran = crises.find(c => c.name.includes('Iran Nuclear'));
+    assert.ok(iran, 'Iran Nuclear Program not found');
+    assert.equal(iran!.rung, 9);
+    assert.equal(iran!.trend, 'ascending');
+  });
+
+  it('India-Pakistan is at rung 8', () => {
+    const { crises } = buildRenderData();
+    const ip = crises.find(c => c.name.includes('India'));
+    assert.ok(ip, 'India-Pakistan crisis not found');
+    assert.equal(ip!.rung, 8);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RUNG_REFERENCE
+// ---------------------------------------------------------------------------
+
+describe('RUNG_REFERENCE', () => {
+  it('has entry for rung 0 as Peace', () => {
+    assert.equal(RUNG_REFERENCE[0], 'Peace');
+  });
+
+  it('has entry for rung 5 as Crisis', () => {
+    assert.equal(RUNG_REFERENCE[5], 'Crisis');
+  });
+
+  it('has entry for rung 10 as Military Action', () => {
+    assert.equal(RUNG_REFERENCE[10], 'Military Action');
+  });
+
+  it('has entry for rung 15 as Limited War', () => {
+    assert.equal(RUNG_REFERENCE[15], 'Limited War');
+  });
+
+  it('has entry for rung 20 as General War', () => {
+    assert.equal(RUNG_REFERENCE[20], 'General War');
+  });
+});

--- a/src/components/escalation-ladder-helpers.ts
+++ b/src/components/escalation-ladder-helpers.ts
@@ -1,0 +1,252 @@
+// escalation-ladder-helpers.ts
+// Pure logic for EscalationLadderPanel — no DOM, no Panel imports
+
+export type EscalationTrend = 'ascending' | 'stable' | 'descending';
+
+export type EscalationDomain =
+  | 'Conventional Military'
+  | 'Nuclear'
+  | 'Proxy/Hybrid'
+  | 'Maritime'
+  | 'Economic'
+  | 'Paramilitary'
+  | 'Nuclear Adjacent';
+
+export interface CrisisEscalation {
+  id: string;
+  name: string;
+  domain: EscalationDomain;
+  rung: number; // 0-20 current position on Kahn ladder
+  maxRung: 20;
+  trend: EscalationTrend;
+  description: string; // current situation summary
+  thresholdToNext: string; // conditions that would move rung up
+  weight: number; // relative weight for global barometer (sums to ~1)
+  lastUpdated: string;
+}
+
+export interface EscalationRenderData {
+  crises: CrisisEscalation[];
+  globalBarometer: number; // weighted average rung, 0-20
+  highEscalationCount: number; // crises at rung >= 10
+  crossedThresholdCount: number; // crises exactly at a major rung (5,10,15,20)
+  ascendingCount: number; // crises with trend === 'ascending'
+}
+
+// ---------------------------------------------------------------------------
+// Static crisis dataset
+// ---------------------------------------------------------------------------
+
+const CRISES: CrisisEscalation[] = [
+  {
+    id: 'EL001',
+    name: 'Ukraine-Russia',
+    domain: 'Conventional Military',
+    rung: 14,
+    maxRung: 20,
+    trend: 'stable',
+    description:
+      'Strategic bombardment of Ukrainian energy infrastructure; Kremlin nuclear signaling via doctrine updates; NATO proxy involvement through arms transfers, intelligence sharing, and HIMARS/Patriot deployments.',
+    thresholdToNext:
+      'NATO direct-fire engagement with Russian forces; Russian tactical nuclear detonation in Ukraine; large-scale ICBM exercise explicitly targeting NATO capitals.',
+    weight: 0.25,
+    lastUpdated: '2025-05',
+  },
+  {
+    id: 'EL002',
+    name: 'Taiwan Strait',
+    domain: 'Conventional Military',
+    rung: 7,
+    maxRung: 20,
+    trend: 'ascending',
+    description:
+      'Sustained ADIZ incursions by PLAAF; large-scale PLA joint exercises simulating full blockade scenarios; economic coercion via rare-earth export restrictions; PRC coast guard confrontations in Taiwan-controlled waters.',
+    thresholdToNext:
+      'PLA live-fire exercise within 12 nm of Taiwan coastline; interdiction of Taiwan-bound US military shipments; US carrier strike group directly confronted by PLA surface combatants.',
+    weight: 0.22,
+    lastUpdated: '2025-05',
+  },
+  {
+    id: 'EL003',
+    name: 'Israel-Iran',
+    domain: 'Proxy/Hybrid',
+    rung: 11,
+    maxRung: 20,
+    trend: 'stable',
+    description:
+      'Direct missile and drone exchanges (April and October 2024); Israeli airstrikes on Iranian air-defense nodes and S-300 systems; sustained proxy attrition via Hezbollah, Houthi, and Iraqi militias.',
+    thresholdToNext:
+      'Israeli strike on Iranian nuclear enrichment facilities; Iranian ballistic missile salvo targeting Israeli population centers; US forces directly engaged in Iranian strikes.',
+    weight: 0.18,
+    lastUpdated: '2025-05',
+  },
+  {
+    id: 'EL004',
+    name: 'North Korea-USA/ROK',
+    domain: 'Nuclear',
+    rung: 6,
+    maxRung: 20,
+    trend: 'ascending',
+    description:
+      'ICBM tests at full range including Hwasong-18 solid-fuel missile; DPRK troops deployed to Russia; ROK-US Freedom Shield exercises at record scale; Kim Jong-un declares ROK a permanent enemy state in constitution.',
+    thresholdToNext:
+      'DPRK seventh nuclear detonation; provocative missile overflight of Japan targeting Pacific waters; DPRK conventional strike on ROK territory or US military installation.',
+    weight: 0.12,
+    lastUpdated: '2025-05',
+  },
+  {
+    id: 'EL005',
+    name: 'South China Sea',
+    domain: 'Maritime',
+    rung: 8,
+    maxRung: 20,
+    trend: 'ascending',
+    description:
+      'Kinetic maritime incidents including water cannons, laser dazzling, and ramming of Philippine Coast Guard vessels at Second Thomas Shoal; PLA artificial island militarization complete; PLAN gray-zone operations at full cadence.',
+    thresholdToNext:
+      'Sinking of a Philippine military or coast guard vessel with fatalities; US warship fired upon during freedom-of-navigation operation; PLA seizure of Philippine-occupied Ayungin Shoal.',
+    weight: 0.10,
+    lastUpdated: '2025-05',
+  },
+  {
+    id: 'EL006',
+    name: 'India-Pakistan',
+    domain: 'Nuclear Adjacent',
+    rung: 8,
+    maxRung: 20,
+    trend: 'ascending',
+    description:
+      'Post-Pahalgam terrorist attack (April 2025, 26 killed); Indian military mobilization along Line of Control; Pakistan Army placed on high alert; Indus Waters Treaty suspended; diplomatic ties severed.',
+    thresholdToNext:
+      'Indian surgical cross-LoC ground incursion; Pakistani artillery strikes on Indian forward positions; nuclear-capable missile test by either side as coercive signaling.',
+    weight: 0.08,
+    lastUpdated: '2025-05',
+  },
+  {
+    id: 'EL007',
+    name: 'Sudan Civil War',
+    domain: 'Paramilitary',
+    rung: 13,
+    maxRung: 20,
+    trend: 'stable',
+    description:
+      'Full-scale SAF vs RSF war since April 2023; resumption of Darfur genocide by RSF; UAE and Egyptian external interference with arms and logistics; 10M+ internally displaced, worst humanitarian crisis in the world.',
+    thresholdToNext:
+      'Direct military intervention by Egypt (SAF-allied) or overt UAE ground forces (RSF-allied); SAF use of confirmed chemical weapons; collapse of Khartoum creating regional state-failure contagion.',
+    weight: 0.10,
+    lastUpdated: '2025-05',
+  },
+  {
+    id: 'EL008',
+    name: 'Iran Nuclear Program',
+    domain: 'Nuclear Adjacent',
+    rung: 9,
+    maxRung: 20,
+    trend: 'ascending',
+    description:
+      '90% weapons-grade enrichment threshold crossed; breakout time estimated at days to weeks; IAEA comprehensive safeguards access blocked; US and Israeli military options publicly signaled at senior government levels.',
+    thresholdToNext:
+      'Iranian weaponization decision (produce functional nuclear device); Israeli or US unilateral preventive strike on Fordow or Natanz; Iranian NPT withdrawal declaration.',
+    weight: 0.15,
+    lastUpdated: '2025-05',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Kahn ladder rung reference
+// ---------------------------------------------------------------------------
+
+export const RUNG_REFERENCE: Record<number, string> = {
+  0: 'Peace',
+  5: 'Crisis',
+  10: 'Military Action',
+  15: 'Limited War',
+  20: 'General War',
+};
+
+const RUNG_THRESHOLDS: Array<{ min: number; label: string }> = [
+  { min: 20, label: 'General War' },
+  { min: 15, label: 'Limited War' },
+  { min: 10, label: 'Military Action' },
+  { min: 5, label: 'Crisis' },
+  { min: 0, label: 'Peace' },
+];
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+/** Returns the Kahn ladder label for a given rung (0-20). */
+export function rungLabel(rung: number): string {
+  for (const { min, label } of RUNG_THRESHOLDS) {
+    if (rung >= min) return label;
+  }
+  return 'Peace';
+}
+
+/** Returns a CSS class name reflecting the escalation severity of a rung. */
+export function rungClass(rung: number): string {
+  if (rung >= 15) return 'el-general-war';
+  if (rung >= 10) return 'el-limited-war';
+  if (rung >= 5) return 'el-crisis';
+  return 'el-peace';
+}
+
+/** Returns a CSS class for a trend direction. */
+export function trendClass(trend: EscalationTrend): string {
+  if (trend === 'ascending') return 'el-trend-up';
+  if (trend === 'descending') return 'el-trend-down';
+  return 'el-trend-stable';
+}
+
+/** Returns an arrow glyph for a trend direction. */
+export function trendArrow(trend: EscalationTrend): string {
+  if (trend === 'ascending') return 'up';
+  if (trend === 'descending') return 'down';
+  return 'stable';
+}
+
+/**
+ * Returns all crises at or above a given escalation rung threshold.
+ * Defaults to rung >= 10 (Military Action tier).
+ */
+export function getHighEscalation(
+  crises: CrisisEscalation[],
+  threshold = 10,
+): CrisisEscalation[] {
+  return crises.filter(c => c.rung >= threshold);
+}
+
+/**
+ * Returns crises whose rung exactly equals one of the major Kahn
+ * thresholds (5, 10, 15, 20), indicating a meaningful tier crossing.
+ */
+export function getCrossedThresholds(crises: CrisisEscalation[]): CrisisEscalation[] {
+  const majorRungs = new Set([5, 10, 15, 20]);
+  return crises.filter(c => majorRungs.has(c.rung));
+}
+
+/**
+ * Computes the global escalation barometer as a weighted average
+ * of all crisis rungs, rounded to one decimal place. Returns 0 for
+ * an empty array or zero total weight.
+ */
+export function computeGlobalBarometer(crises: CrisisEscalation[]): number {
+  if (crises.length === 0) return 0;
+  const totalWeight = crises.reduce((s, c) => s + c.weight, 0);
+  if (totalWeight === 0) return 0;
+  const weighted = crises.reduce((s, c) => s + c.rung * c.weight, 0);
+  return Math.round((weighted / totalWeight) * 10) / 10;
+}
+
+/** Builds the full render data object consumed by EscalationLadderPanel. */
+export function buildRenderData(): EscalationRenderData {
+  const crises = CRISES;
+  return {
+    crises,
+    globalBarometer: computeGlobalBarometer(crises),
+    highEscalationCount: getHighEscalation(crises).length,
+    crossedThresholdCount: getCrossedThresholds(crises).length,
+    ascendingCount: crises.filter(c => c.trend === 'ascending').length,
+  };
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -106,7 +106,7 @@ export { AskCrystalBallPanel } from './AskCrystalBallPanel';
 export { SurvivalAdvisorPanel } from './SurvivalAdvisorPanel';
 export { ThreatSynthesisPanel } from './ThreatSynthesisPanel';
 export { ScenarioSimulatorPanel } from './ScenarioSimulatorPanel';
-export { EscalationForecastPanel } from './EscalationForecastPanel';
+export { EscalationForecastPanel } from './EscalationForecastPanel';export { EscalationLadderPanel } from './EscalationLadderPanel';
 export { AnomalyDetectionPanel } from './AnomalyDetectionPanel';
 export { FinancialContagionPanel } from './FinancialContagionPanel';
 export { SupplyChainImpactPanel } from './SupplyChainImpactPanel';

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -326,7 +326,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'what-changed': { name: 'What Changed', enabled: true, priority: 2 },
   'counterterrorism': { name: 'Counterterrorism Monitor', enabled: true, priority: 1 },
   'territorial-disputes': { name: 'Territorial Disputes Tracker', enabled: true, priority: 1 },
-  'regime-stability': { name: 'Regime Stability', enabled: true, priority: 1 },
+  'regime-stability': { name: 'Regime Stability', enabled: true, priority: 1 },  'escalation-ladder': { name: 'Escalation Ladder', enabled: true, priority: 1 },
 };
 
 const FULL_MAP_LAYERS: MapLayers = {


### PR DESCRIPTION
## Summary

Adds `EscalationLadderPanel` — tracks multi-domain escalation dynamics across 8 active crises using a Kahn-style escalation ladder model.

## Files Changed

| File | Change |
|------|--------|
| `src/components/escalation-ladder-helpers.ts` | New — pure logic, 8 crisis datasets, all helpers |
| `src/components/EscalationLadderPanel.ts` | New — extends Panel, 30-min refresh |
| `src/components/__tests__/escalation-ladder-helpers.test.mts` | New — 56 tests, 9 suites, 0 failures |
| `src/components/index.ts` | Export added |
| `src/config/panels.ts` | `escalation-ladder` entry (security category) |
| `src/app/panel-layout.ts` | Import + `this.ctx.panels` registration |

## Crisis Coverage

| Crisis | Rung | Trend | Domain |
|--------|------|-------|--------|
| Ukraine-Russia | 14/20 | stable | Conventional Military |
| Sudan Civil War | 13/20 | stable | Paramilitary |
| Israel-Iran | 11/20 | stable | Proxy/Hybrid |
| Iran Nuclear Program | 9/20 | ascending | Nuclear Adjacent |
| South China Sea | 8/20 | ascending | Maritime |
| India-Pakistan | 8/20 | ascending | Nuclear Adjacent |
| Taiwan Strait | 7/20 | ascending | Conventional Military |
| North Korea-USA/ROK | 6/20 | ascending | Nuclear |

## Helper Functions

- `rungLabel(rung)` — Kahn ladder tier label (Peace/Crisis/Military Action/Limited War/General War)
- `rungClass(rung)` — CSS severity class
- `getHighEscalation(crises, threshold=10)` — crises at or above threshold
- `getCrossedThresholds(crises)` — crises exactly at major rungs (5,10,15,20)
- `computeGlobalBarometer(crises)` — weighted average rung across all crises
- `buildRenderData()` — assembles full render payload

## Tests

```
tests 56 | suites 9 | pass 56 | fail 0
```

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>