### PR TITLE
feat: add MediaFreedomPanel

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -388,6 +388,7 @@ import { ArmsProliferationPanel } from '@/components/ArmsProliferationPanel';
 import { TerritorialDisputesPanel } from '@/components/TerritorialDisputesPanel';
 import { RegimeStabilityPanel } from '@/components/RegimeStabilityPanel';
 import { CoalitionDynamicsPanel } from '@/components/CoalitionDynamicsPanel';
+import { MediaFreedomPanel } from '@/components/MediaFreedomPanel';
 import { SpaceMilitarizationPanel } from '@/components/SpaceMilitarizationPanel';
 import { ArcticMonitoringPanel } from '@/components/ArcticMonitoringPanel';
 import { ClimateSecurityNexusPanel } from '@/components/ClimateSecurityNexusPanel';
@@ -1547,7 +1548,7 @@ export class PanelLayoutManager implements AppModule {
  this.ctx.panels['water-security'] = new WaterSecurityPanel();
  this.ctx.panels['energy-security'] = new EnergySecurityPanel();
  this.ctx.panels['arms-proliferation'] = new ArmsProliferationPanel();
- this.ctx.panels['territorial-disputes'] = new TerritorialDisputesPanel(); this.ctx.panels['regime-stability'] = new RegimeStabilityPanel(); this.ctx.panels['coalition-dynamics'] = new CoalitionDynamicsPanel();
+ this.ctx.panels['territorial-disputes'] = new TerritorialDisputesPanel(); this.ctx.panels['regime-stability'] = new RegimeStabilityPanel(); this.ctx.panels['coalition-dynamics'] = new CoalitionDynamicsPanel(); this.ctx.panels['media-freedom'] = new MediaFreedomPanel();
  this.ctx.panels['space-militarization'] = new SpaceMilitarizationPanel();
  this.ctx.panels['arctic-monitoring'] = new ArcticMonitoringPanel();
  this.ctx.panels['climate-security-nexus'] = new ClimateSecurityNexusPanel();

--- a/src/components/MediaFreedomPanel.ts
+++ b/src/components/MediaFreedomPanel.ts
@@ -1,0 +1,155 @@
+import { Panel } from './Panel';
+import { h, replaceChildren } from '@/utils/dom-utils';
+import {
+  buildRenderData,
+  freedomClass,
+  trendClass,
+  trendArrow,
+  incidentStatusClass,
+} from './media-freedom-helpers';
+
+const REFRESH_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+function safe<T>(fn: () => T): T | null {
+  try { return fn(); } catch { return null; }
+}
+
+export class MediaFreedomPanel extends Panel {
+  static readonly panelId = 'media-freedom';
+  static readonly title = 'Media Freedom';
+
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    super({
+      id: MediaFreedomPanel.panelId,
+      title: MediaFreedomPanel.title,
+      showCount: true,
+      trackActivity: false,
+      infoTooltip: 'Tracks press freedom across 17 countries using RSF index scores, CPJ journalist imprisonment data, and major media incidents. Includes trend analysis and high-risk country identification.',
+    });
+    this.start();
+  }
+
+  public override destroy(): void {
+    if (this.refreshTimer !== null) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    super.destroy();
+  }
+
+  private start(): void {
+    this.render();
+    this.refreshTimer = setInterval(() => this.render(), REFRESH_MS);
+  }
+
+  private render(): void {
+    const data = safe(() => buildRenderData());
+    if (!data) {
+      replaceChildren(
+        this.getContentElement(),
+        h('div', { className: 'panel-empty' }, 'Data unavailable'),
+      );
+      return;
+    }
+
+    const {
+      countries,
+      incidents,
+      globalFreedomIndex,
+      freeCount,
+      goodCount,
+      satisfactoryCount,
+      problematicCount,
+      difficultCount,
+      verySeriousCount,
+      totalJailed,
+      decliningCount,
+    } = data;
+
+    void satisfactoryCount;
+    void problematicCount;
+
+    // Badge count = countries rated Difficult or Very Serious
+    this.setCount(difficultCount + verySeriousCount);
+
+    let idxClass: string;
+    if (globalFreedomIndex < 30) {
+      idxClass = 'mf-very-serious';
+    } else if (globalFreedomIndex < 50) {
+      idxClass = 'mf-difficult';
+    } else if (globalFreedomIndex < 65) {
+      idxClass = 'mf-problematic';
+    } else {
+      idxClass = 'mf-satisfactory';
+    }
+
+    const header = h('div', { className: 'mf-header' },
+      h('div', { className: 'mf-metric' },
+        h('span', { className: 'mf-label' }, 'Global Index'),
+        h('span', { className: `mf-value ${idxClass}` }, `${globalFreedomIndex}/100`),
+      ),
+      h('div', { className: 'mf-metric' },
+        h('span', { className: 'mf-label' }, 'Free/Good'),
+        h('span', { className: 'mf-value mf-free' }, String(freeCount + goodCount)),
+      ),
+      h('div', { className: 'mf-metric' },
+        h('span', { className: 'mf-label' }, 'At Risk'),
+        h('span', { className: 'mf-value mf-difficult' }, String(difficultCount)),
+      ),
+      h('div', { className: 'mf-metric' },
+        h('span', { className: 'mf-label' }, 'Very Serious'),
+        h('span', { className: 'mf-value mf-very-serious' }, String(verySeriousCount)),
+      ),
+      h('div', { className: 'mf-metric' },
+        h('span', { className: 'mf-label' }, 'Jailed'),
+        h('span', { className: 'mf-value mf-very-serious' }, String(totalJailed)),
+      ),
+      h('div', { className: 'mf-metric' },
+        h('span', { className: 'mf-label' }, 'Declining'),
+        h('span', { className: 'mf-value mf-difficult' }, String(decliningCount)),
+      ),
+    );
+
+    const countrySection = h('div', { className: 'mf-countries' },
+      h('h3', { className: 'mf-section-title' }, 'Press Freedom Index by Country'),
+    );
+
+    for (const c of [...countries].sort((a, b) => b.rsfScore - a.rsfScore)) {
+      const jailEl = c.journalistsJailed > 0
+        ? h('span', { className: 'mf-jailed' }, `⚠ ${c.journalistsJailed} jailed`)
+        : h('span', {});
+      const row = h('div', { className: `mf-country-row ${freedomClass(c.category)}` },
+        h('div', { className: 'mf-country-header' },
+          h('span', { className: 'mf-country' }, c.country),
+          h('span', { className: `mf-cat-badge ${freedomClass(c.category)}` }, c.category),
+          h('span', { className: `mf-trend ${trendClass(c.trend)}` }, trendArrow(c.trend)),
+          h('span', { className: 'mf-score' }, `${c.rsfScore}/100`),
+          jailEl,
+        ),
+        h('div', { className: 'mf-notes' }, c.notes),
+      );
+      countrySection.append(row);
+    }
+
+    const incidentSection = h('div', { className: 'mf-incidents' },
+      h('h3', { className: 'mf-section-title' }, 'Major Press Freedom Incidents (2022–2024)'),
+    );
+
+    for (const inc of [...incidents].sort((a, b) => b.severity - a.severity)) {
+      const row = h('div', { className: `mf-incident-row ${incidentStatusClass(inc.status)}` },
+        h('div', { className: 'mf-incident-header' },
+          h('span', { className: 'mf-incident-country' }, inc.country),
+          h('span', { className: 'mf-incident-subject' }, inc.subject),
+          h('span', { className: `mf-status-badge ${incidentStatusClass(inc.status)}` }, inc.status),
+          h('span', { className: 'mf-incident-date' }, inc.date),
+        ),
+        h('div', { className: 'mf-incident-desc' }, inc.description),
+      );
+      incidentSection.append(row);
+    }
+
+    replaceChildren(this.getContentElement(), header, countrySection, incidentSection);
+  }
+}

--- a/src/components/__tests__/media-freedom-helpers.test.mts
+++ b/src/components/__tests__/media-freedom-helpers.test.mts
@@ -1,0 +1,316 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import {
+  computeGlobalFreedomIndex,
+  getByCategory,
+  getDecliningCountries,
+  getMostJailed,
+  getHighRiskCountries,
+  freedomClass,
+  trendClass,
+  trendArrow,
+  incidentStatusClass,
+  buildRenderData,
+  type CountryFreedom,
+  type FreedomCategory,
+  type FreedomTrend,
+} from '../media-freedom-helpers.ts';
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+function makeCountry(overrides: Partial<CountryFreedom> = {}): CountryFreedom {
+  return {
+    id: 'TEST',
+    country: 'Testland',
+    rsfScore: 50,
+    category: 'Satisfactory',
+    trend: 'stable',
+    journalistsJailed: 0,
+    notes: 'test',
+    population: 10,
+    ...overrides,
+  };
+}
+
+const MOCK_COUNTRIES: CountryFreedom[] = [
+  makeCountry({ id: 'T1', country: 'Alpha',   rsfScore: 94, category: 'Free',         trend: 'stable',    journalistsJailed: 0,  population: 5    }),
+  makeCountry({ id: 'T2', country: 'Beta',    rsfScore: 79, category: 'Good',         trend: 'improving', journalistsJailed: 0,  population: 84   }),
+  makeCountry({ id: 'T3', country: 'Gamma',   rsfScore: 66, category: 'Satisfactory', trend: 'declining', journalistsJailed: 0,  population: 335  }),
+  makeCountry({ id: 'T4', country: 'Delta',   rsfScore: 55, category: 'Problematic',  trend: 'declining', journalistsJailed: 2,  population: 10   }),
+  makeCountry({ id: 'T5', country: 'Epsilon', rsfScore: 32, category: 'Difficult',    trend: 'declining', journalistsJailed: 17, population: 85   }),
+  makeCountry({ id: 'T6', country: 'Zeta',    rsfScore: 8,  category: 'Very Serious', trend: 'stable',    journalistsJailed: 100,population: 1410 }),
+];
+
+// ── computeGlobalFreedomIndex ─────────────────────────────────────────────────
+describe('computeGlobalFreedomIndex', () => {
+  it('returns 0 for empty array', () => {
+    assert.equal(computeGlobalFreedomIndex([]), 0);
+  });
+  it('returns a number between 0 and 100', () => {
+    const idx = computeGlobalFreedomIndex(MOCK_COUNTRIES);
+    assert.ok(idx >= 0 && idx <= 100, `Expected 0-100, got ${idx}`);
+  });
+  it('returns an integer', () => {
+    const idx = computeGlobalFreedomIndex(MOCK_COUNTRIES);
+    assert.equal(idx, Math.round(idx));
+  });
+  it('single country with score 94 returns 94', () => {
+    assert.equal(computeGlobalFreedomIndex([makeCountry({ rsfScore: 94 })]), 94);
+  });
+  it('population weighting: large low-score country pulls index down', () => {
+    const withBig  = computeGlobalFreedomIndex(MOCK_COUNTRIES);
+    const withoutBig = computeGlobalFreedomIndex(MOCK_COUNTRIES.filter(c => c.id !== 'T6'));
+    assert.ok(withoutBig > withBig, 'Removing the large low-score country should raise index');
+  });
+  it('all same score returns that score', () => {
+    const all50 = MOCK_COUNTRIES.map(c => ({ ...c, rsfScore: 50 }));
+    assert.equal(computeGlobalFreedomIndex(all50), 50);
+  });
+  it('all score 0 returns 0', () => {
+    const all0 = MOCK_COUNTRIES.map(c => ({ ...c, rsfScore: 0 }));
+    assert.equal(computeGlobalFreedomIndex(all0), 0);
+  });
+  it('single country with score 100 returns 100', () => {
+    assert.equal(computeGlobalFreedomIndex([makeCountry({ rsfScore: 100 })]), 100);
+  });
+});
+
+// ── getByCategory ─────────────────────────────────────────────────────────────
+describe('getByCategory', () => {
+  it('returns only Free countries', () => {
+    const free = getByCategory(MOCK_COUNTRIES, 'Free');
+    assert.equal(free.length, 1);
+    assert.equal(free[0].id, 'T1');
+  });
+  it('returns only Good countries', () => {
+    const good = getByCategory(MOCK_COUNTRIES, 'Good');
+    assert.equal(good.length, 1);
+    assert.equal(good[0].id, 'T2');
+  });
+  it('returns only Satisfactory countries', () => {
+    const sat = getByCategory(MOCK_COUNTRIES, 'Satisfactory');
+    assert.equal(sat.length, 1);
+    assert.equal(sat[0].id, 'T3');
+  });
+  it('returns only Problematic countries', () => {
+    const prob = getByCategory(MOCK_COUNTRIES, 'Problematic');
+    assert.equal(prob.length, 1);
+    assert.equal(prob[0].id, 'T4');
+  });
+  it('returns only Difficult countries', () => {
+    const diff = getByCategory(MOCK_COUNTRIES, 'Difficult');
+    assert.equal(diff.length, 1);
+    assert.equal(diff[0].id, 'T5');
+  });
+  it('returns only Very Serious countries', () => {
+    const vs = getByCategory(MOCK_COUNTRIES, 'Very Serious');
+    assert.equal(vs.length, 1);
+    assert.equal(vs[0].id, 'T6');
+  });
+  it('returns empty when none match', () => {
+    const all = MOCK_COUNTRIES.map(c => ({ ...c, category: 'Free' as FreedomCategory }));
+    assert.equal(getByCategory(all, 'Very Serious').length, 0);
+  });
+  it('does not mutate input array', () => {
+    const before = MOCK_COUNTRIES.length;
+    getByCategory(MOCK_COUNTRIES, 'Free');
+    assert.equal(MOCK_COUNTRIES.length, before);
+  });
+});
+
+// ── getDecliningCountries ─────────────────────────────────────────────────────
+describe('getDecliningCountries', () => {
+  it('returns only declining trend countries', () => {
+    const dec = getDecliningCountries(MOCK_COUNTRIES);
+    assert.ok(dec.every(c => c.trend === 'declining'));
+  });
+  it('returns correct count (T3, T4, T5 are declining)', () => {
+    assert.equal(getDecliningCountries(MOCK_COUNTRIES).length, 3);
+  });
+  it('returns empty when none are declining', () => {
+    const all = MOCK_COUNTRIES.map(c => ({ ...c, trend: 'stable' as FreedomTrend }));
+    assert.equal(getDecliningCountries(all).length, 0);
+  });
+  it('returns all when all are declining', () => {
+    const all = MOCK_COUNTRIES.map(c => ({ ...c, trend: 'declining' as FreedomTrend }));
+    assert.equal(getDecliningCountries(all).length, MOCK_COUNTRIES.length);
+  });
+  it('does not include improving trend', () => {
+    const dec = getDecliningCountries(MOCK_COUNTRIES);
+    assert.ok(!dec.some(c => c.trend === 'improving'));
+  });
+  it('does not mutate input array', () => {
+    const before = MOCK_COUNTRIES.length;
+    getDecliningCountries(MOCK_COUNTRIES);
+    assert.equal(MOCK_COUNTRIES.length, before);
+  });
+});
+
+// ── getMostJailed ─────────────────────────────────────────────────────────────
+describe('getMostJailed', () => {
+  it('returns countries sorted by journalistsJailed descending', () => {
+    const top = getMostJailed(MOCK_COUNTRIES);
+    assert.equal(top[0].journalistsJailed, 100);
+    assert.equal(top[1].journalistsJailed, 17);
+    assert.equal(top[2].journalistsJailed, 2);
+  });
+  it('excludes countries with 0 jailed', () => {
+    const top = getMostJailed(MOCK_COUNTRIES);
+    assert.ok(top.every(c => c.journalistsJailed > 0));
+  });
+  it('respects n parameter: n=2 returns 2', () => {
+    assert.equal(getMostJailed(MOCK_COUNTRIES, 2).length, 2);
+  });
+  it('respects n parameter: n=1 returns 1', () => {
+    assert.equal(getMostJailed(MOCK_COUNTRIES, 1).length, 1);
+  });
+  it('returns empty when all have 0 jailed', () => {
+    const none = MOCK_COUNTRIES.map(c => ({ ...c, journalistsJailed: 0 }));
+    assert.equal(getMostJailed(none).length, 0);
+  });
+  it('default n=5 caps output at 5 even if more qualify', () => {
+    const many = Array.from({ length: 10 }, (_, i) => makeCountry({ id: `X${i}`, journalistsJailed: i + 1 }));
+    assert.equal(getMostJailed(many).length, 5);
+  });
+  it('does not mutate input array', () => {
+    const before = MOCK_COUNTRIES.length;
+    getMostJailed(MOCK_COUNTRIES);
+    assert.equal(MOCK_COUNTRIES.length, before);
+  });
+});
+
+// ── getHighRiskCountries ──────────────────────────────────────────────────────
+describe('getHighRiskCountries', () => {
+  it('returns Difficult and Very Serious countries', () => {
+    const hr = getHighRiskCountries(MOCK_COUNTRIES);
+    assert.ok(hr.every(c => c.category === 'Difficult' || c.category === 'Very Serious'));
+  });
+  it('returns correct count (T5 Difficult + T6 Very Serious)', () => {
+    assert.equal(getHighRiskCountries(MOCK_COUNTRIES).length, 2);
+  });
+  it('excludes Free countries', () => {
+    assert.ok(!getHighRiskCountries(MOCK_COUNTRIES).some(c => c.category === 'Free'));
+  });
+  it('excludes Good countries', () => {
+    assert.ok(!getHighRiskCountries(MOCK_COUNTRIES).some(c => c.category === 'Good'));
+  });
+  it('excludes Satisfactory countries', () => {
+    assert.ok(!getHighRiskCountries(MOCK_COUNTRIES).some(c => c.category === 'Satisfactory'));
+  });
+  it('excludes Problematic countries', () => {
+    assert.ok(!getHighRiskCountries(MOCK_COUNTRIES).some(c => c.category === 'Problematic'));
+  });
+  it('returns empty when no high-risk countries', () => {
+    const all = MOCK_COUNTRIES.map(c => ({ ...c, category: 'Free' as FreedomCategory }));
+    assert.equal(getHighRiskCountries(all).length, 0);
+  });
+  it('does not mutate input', () => {
+    const before = MOCK_COUNTRIES.length;
+    getHighRiskCountries(MOCK_COUNTRIES);
+    assert.equal(MOCK_COUNTRIES.length, before);
+  });
+});
+
+// ── freedomClass ──────────────────────────────────────────────────────────────
+describe('freedomClass', () => {
+  it('Free returns mf-free',               () => { assert.equal(freedomClass('Free'),         'mf-free');         });
+  it('Good returns mf-good',               () => { assert.equal(freedomClass('Good'),         'mf-good');         });
+  it('Satisfactory returns mf-satisfactory',() => { assert.equal(freedomClass('Satisfactory'),'mf-satisfactory'); });
+  it('Problematic returns mf-problematic', () => { assert.equal(freedomClass('Problematic'),  'mf-problematic');  });
+  it('Difficult returns mf-difficult',     () => { assert.equal(freedomClass('Difficult'),    'mf-difficult');    });
+  it('Very Serious returns mf-very-serious',() => { assert.equal(freedomClass('Very Serious'),'mf-very-serious'); });
+});
+
+// ── trendClass ────────────────────────────────────────────────────────────────
+describe('trendClass', () => {
+  it('improving returns trend-up',   () => { assert.equal(trendClass('improving'), 'trend-up');   });
+  it('stable returns trend-flat',    () => { assert.equal(trendClass('stable'),    'trend-flat'); });
+  it('declining returns trend-down', () => { assert.equal(trendClass('declining'), 'trend-down'); });
+});
+
+// ── trendArrow ────────────────────────────────────────────────────────────────
+describe('trendArrow', () => {
+  it('improving returns up arrow ↑',    () => { assert.equal(trendArrow('improving'), '↑'); });
+  it('stable returns right arrow →',   () => { assert.equal(trendArrow('stable'),    '→'); });
+  it('declining returns down arrow ↓', () => { assert.equal(trendArrow('declining'), '↓'); });
+});
+
+// ── incidentStatusClass ───────────────────────────────────────────────────────
+describe('incidentStatusClass', () => {
+  it('Resolved returns incident-resolved',     () => { assert.equal(incidentStatusClass('Resolved'),   'incident-resolved');   });
+  it('Ongoing returns incident-ongoing',       () => { assert.equal(incidentStatusClass('Ongoing'),    'incident-ongoing');    });
+  it('Escalating returns incident-escalating', () => { assert.equal(incidentStatusClass('Escalating'), 'incident-escalating'); });
+});
+
+// ── buildRenderData ───────────────────────────────────────────────────────────
+describe('buildRenderData', () => {
+  it('returns countries array with entries', () => {
+    const d = buildRenderData();
+    assert.ok(Array.isArray(d.countries));
+    assert.ok(d.countries.length > 0);
+  });
+  it('returns incidents array with entries', () => {
+    const d = buildRenderData();
+    assert.ok(Array.isArray(d.incidents));
+    assert.ok(d.incidents.length > 0);
+  });
+  it('globalFreedomIndex is in range 0-100', () => {
+    const d = buildRenderData();
+    assert.ok(d.globalFreedomIndex >= 0 && d.globalFreedomIndex <= 100);
+  });
+  it('category counts sum to total countries', () => {
+    const d = buildRenderData();
+    const sum = d.freeCount + d.goodCount + d.satisfactoryCount + d.problematicCount + d.difficultCount + d.verySeriousCount;
+    assert.equal(sum, d.countries.length);
+  });
+  it('totalJailed equals sum of journalistsJailed across countries', () => {
+    const d = buildRenderData();
+    const sum = d.countries.reduce((s, c) => s + c.journalistsJailed, 0);
+    assert.equal(d.totalJailed, sum);
+  });
+  it('decliningCount equals countries with declining trend', () => {
+    const d = buildRenderData();
+    const count = d.countries.filter(c => c.trend === 'declining').length;
+    assert.equal(d.decliningCount, count);
+  });
+  it('highRisk only contains Difficult or Very Serious', () => {
+    const d = buildRenderData();
+    assert.ok(d.highRisk.every(c => c.category === 'Difficult' || c.category === 'Very Serious'));
+  });
+  it('China has highest journalistsJailed count', () => {
+    const d = buildRenderData();
+    const china = d.countries.find(c => c.country === 'China');
+    assert.ok(china !== undefined, 'China must be present');
+    const maxJailed = Math.max(...d.countries.map(c => c.journalistsJailed));
+    assert.equal(china.journalistsJailed, maxJailed);
+  });
+  it('North Korea has lowest RSF score', () => {
+    const d = buildRenderData();
+    const nk = d.countries.find(c => c.country === 'North Korea');
+    assert.ok(nk !== undefined, 'North Korea must be present');
+    const minScore = Math.min(...d.countries.map(c => c.rsfScore));
+    assert.equal(nk.rsfScore, minScore);
+  });
+  it('Norway has highest RSF score', () => {
+    const d = buildRenderData();
+    const norway = d.countries.find(c => c.country === 'Norway');
+    assert.ok(norway !== undefined, 'Norway must be present');
+    const maxScore = Math.max(...d.countries.map(c => c.rsfScore));
+    assert.equal(norway.rsfScore, maxScore);
+  });
+  it('freeCount matches Free-category countries', () => {
+    const d = buildRenderData();
+    assert.equal(d.freeCount, d.countries.filter(c => c.category === 'Free').length);
+  });
+  it('verySeriousCount matches Very Serious-category countries', () => {
+    const d = buildRenderData();
+    assert.equal(d.verySeriousCount, d.countries.filter(c => c.category === 'Very Serious').length);
+  });
+  it('goodCount matches Good-category countries', () => {
+    const d = buildRenderData();
+    assert.equal(d.goodCount, d.countries.filter(c => c.category === 'Good').length);
+  });
+  it('highRisk count equals difficultCount + verySeriousCount', () => {
+    const d = buildRenderData();
+    assert.equal(d.highRisk.length, d.difficultCount + d.verySeriousCount);
+  });
+});

--- a/src/components/media-freedom-helpers.ts
+++ b/src/components/media-freedom-helpers.ts
@@ -1,0 +1,179 @@
+// media-freedom-helpers.ts
+// Pure logic for MediaFreedomPanel — no DOM, no Panel imports
+
+export type FreedomCategory = 'Free' | 'Good' | 'Satisfactory' | 'Problematic' | 'Difficult' | 'Very Serious';
+export type FreedomTrend = 'improving' | 'stable' | 'declining';
+
+export interface CountryFreedom {
+  id: string;
+  country: string;
+  rsfScore: number;          // RSF Press Freedom Index 0-100, higher = more free
+  category: FreedomCategory;
+  trend: FreedomTrend;
+  journalistsJailed: number; // CPJ 2024
+  notes: string;
+  population: number;        // millions
+}
+
+export interface MediaIncident {
+  id: string;
+  date: string;
+  country: string;
+  subject: string;
+  type: 'Journalist Arrest' | 'Journalist Death' | 'Media Ban' | 'Extradition' | 'War Zone';
+  description: string;
+  status: 'Ongoing' | 'Resolved' | 'Escalating';
+  severity: number; // 1-10
+}
+
+export interface MediaFreedomRenderData {
+  countries: CountryFreedom[];
+  incidents: MediaIncident[];
+  globalFreedomIndex: number;
+  freeCount: number;
+  goodCount: number;
+  satisfactoryCount: number;
+  problematicCount: number;
+  difficultCount: number;
+  verySeriousCount: number;
+  totalJailed: number;
+  decliningCount: number;
+  highRisk: CountryFreedom[];
+}
+
+const COUNTRIES: CountryFreedom[] = [
+  { id: 'MF001', country: 'Norway',       rsfScore: 95, category: 'Free',         trend: 'stable',    journalistsJailed: 0,   notes: 'Consistent world leader; public broadcaster NRK editorially independent',    population: 5.5  },
+  { id: 'MF002', country: 'Finland',      rsfScore: 94, category: 'Free',         trend: 'stable',    journalistsJailed: 0,   notes: 'Strong public media funding; near-absolute press freedom legally',             population: 5.5  },
+  { id: 'MF003', country: 'Denmark',      rsfScore: 93, category: 'Free',         trend: 'stable',    journalistsJailed: 0,   notes: 'Transparent governance; robust shield laws; no journalist imprisoned',         population: 5.9  },
+  { id: 'MF004', country: 'Germany',      rsfScore: 79, category: 'Good',         trend: 'stable',    journalistsJailed: 0,   notes: 'Strong legal protections; far-right harassment of press increasing',           population: 84   },
+  { id: 'MF005', country: 'UK',           rsfScore: 74, category: 'Satisfactory', trend: 'stable',    journalistsJailed: 0,   notes: 'Libel tourism concerns; Assange extradition case damaged global standing',    population: 67   },
+  { id: 'MF006', country: 'France',       rsfScore: 72, category: 'Satisfactory', trend: 'stable',    journalistsJailed: 0,   notes: 'Yellow vest coverage restrictions; journalist surveillance cases reported',    population: 68   },
+  { id: 'MF007', country: 'USA',          rsfScore: 66, category: 'Satisfactory', trend: 'declining', journalistsJailed: 0,   notes: 'Declining trust; shield law gaps; Assange Espionage Act precedent concerns',  population: 335  },
+  { id: 'MF008', country: 'Israel',       rsfScore: 55, category: 'Problematic',  trend: 'declining', journalistsJailed: 2,   notes: 'Wartime press restrictions; Al Jazeera ban; 100+ Gaza journalist deaths',     population: 9.7  },
+  { id: 'MF009', country: 'Mexico',       rsfScore: 47, category: 'Difficult',    trend: 'declining', journalistsJailed: 0,   notes: 'Most dangerous country for journalists in Americas; cartel-linked murders',  population: 130  },
+  { id: 'MF010', country: 'India',        rsfScore: 31, category: 'Difficult',    trend: 'declining', journalistsJailed: 4,   notes: 'Steep decline under BJP; SLAPP suits; digital surveillance of journalists',   population: 1440 },
+  { id: 'MF011', country: 'Turkey',       rsfScore: 29, category: 'Difficult',    trend: 'stable',    journalistsJailed: 17,  notes: 'Courts weaponized against press; one of the world top jailers of journalists', population: 85   },
+  { id: 'MF012', country: 'Saudi Arabia', rsfScore: 17, category: 'Very Serious', trend: 'stable',    journalistsJailed: 32,  notes: 'Khashoggi murder 2018; total state media control; bloggers imprisoned',       population: 36   },
+  { id: 'MF013', country: 'Myanmar',      rsfScore: 19, category: 'Very Serious', trend: 'declining', journalistsJailed: 60,  notes: 'Post-coup 2021 crackdown; second-most jailed journalists globally (CPJ)',     population: 54   },
+  { id: 'MF014', country: 'Iran',         rsfScore: 14, category: 'Very Serious', trend: 'declining', journalistsJailed: 22,  notes: 'Post-Mahsa Amini crackdown 2022-2024; journalists face death penalty',        population: 87   },
+  { id: 'MF015', country: 'Russia',       rsfScore: 9,  category: 'Very Serious', trend: 'declining', journalistsJailed: 22,  notes: 'Wartime media blackout; Gershkovich arrested 2023; Novaya Gazeta suspended',  population: 145  },
+  { id: 'MF016', country: 'China',        rsfScore: 8,  category: 'Very Serious', trend: 'stable',    journalistsJailed: 100, notes: 'Most jailed journalists globally; Great Firewall; foreign press expelled',    population: 1410 },
+  { id: 'MF017', country: 'North Korea',  rsfScore: 2,  category: 'Very Serious', trend: 'stable',    journalistsJailed: 0,   notes: 'No free press exists; all media state-controlled; journalists face execution', population: 26   },
+];
+
+const INCIDENTS: MediaIncident[] = [
+  {
+    id: 'MI001', date: '2023-03-29', country: 'Russia', subject: 'Evan Gershkovich',
+    type: 'Journalist Arrest',
+    description: 'Wall Street Journal reporter Evan Gershkovich arrested on espionage charges — first US journalist detained in Russia since Cold War. Held 491 days before August 2024 prisoner exchange.',
+    status: 'Resolved', severity: 9,
+  },
+  {
+    id: 'MI002', date: '2023-10-07', country: 'Israel/Gaza', subject: 'Gaza Journalist Deaths',
+    type: 'War Zone',
+    description: 'Over 100 journalists killed in Gaza since October 2023 — highest journalist death toll for any single conflict in recorded CPJ history (2024). Majority are Palestinian press members.',
+    status: 'Ongoing', severity: 10,
+  },
+  {
+    id: 'MI003', date: '2024-06-26', country: 'UK/Australia', subject: 'Julian Assange',
+    type: 'Extradition',
+    description: 'Julian Assange accepted plea deal with US DOJ under Espionage Act; returned to Australia as free man after 14-year legal battle. Sets contested precedent for publication of classified material.',
+    status: 'Resolved', severity: 8,
+  },
+  {
+    id: 'MI004', date: '2024-08-05', country: 'Israel', subject: 'Al Jazeera Operating Ban',
+    type: 'Media Ban',
+    description: 'Israel extended ban on Al Jazeera network; accused of inciting violence. CPJ and RSF condemned the ban as silencing wartime coverage. Station continued reporting from outside Israel.',
+    status: 'Ongoing', severity: 7,
+  },
+  {
+    id: 'MI005', date: '2024-01-15', country: 'Iran', subject: 'Post-Mahsa Journalists',
+    type: 'Journalist Arrest',
+    description: 'Iran arrested multiple journalists covering Mahsa Amini anniversary protests. At least 22 journalists in detention as of 2024; several face death penalty charges.',
+    status: 'Ongoing', severity: 8,
+  },
+  {
+    id: 'MI006', date: '2024-03-10', country: 'Mexico', subject: 'Journalist Murders Q1 2024',
+    type: 'Journalist Death',
+    description: 'Three journalist murders in Q1 2024, continuing pattern of cartel-linked killings. Mexico ranks as deadliest country for press in Americas; 30+ journalists killed in 2022-2024.',
+    status: 'Ongoing', severity: 9,
+  },
+];
+
+export function computeGlobalFreedomIndex(countries: CountryFreedom[]): number {
+  if (!countries.length) return 0;
+  const totalPop = countries.reduce((s, c) => s + c.population, 0);
+  const weighted = countries.reduce((s, c) => s + c.rsfScore * c.population, 0);
+  return Math.round(weighted / totalPop);
+}
+
+export function getByCategory(countries: CountryFreedom[], category: FreedomCategory): CountryFreedom[] {
+  return countries.filter(c => c.category === category);
+}
+
+export function getDecliningCountries(countries: CountryFreedom[]): CountryFreedom[] {
+  return countries.filter(c => c.trend === 'declining');
+}
+
+export function getMostJailed(countries: CountryFreedom[], n = 5): CountryFreedom[] {
+  return [...countries]
+    .filter(c => c.journalistsJailed > 0)
+    .sort((a, b) => b.journalistsJailed - a.journalistsJailed)
+    .slice(0, n);
+}
+
+export function getHighRiskCountries(countries: CountryFreedom[]): CountryFreedom[] {
+  return countries.filter(c => c.category === 'Very Serious' || c.category === 'Difficult');
+}
+
+export function freedomClass(category: FreedomCategory): string {
+  const map: Record<FreedomCategory, string> = {
+    'Free':         'mf-free',
+    'Good':         'mf-good',
+    'Satisfactory': 'mf-satisfactory',
+    'Problematic':  'mf-problematic',
+    'Difficult':    'mf-difficult',
+    'Very Serious': 'mf-very-serious',
+  };
+  return map[category] ?? 'mf-satisfactory';
+}
+
+export function trendClass(trend: FreedomTrend): string {
+  const map: Record<FreedomTrend, string> = {
+    'improving': 'trend-up',
+    'stable':    'trend-flat',
+    'declining': 'trend-down',
+  };
+  return map[trend] ?? 'trend-flat';
+}
+
+export function trendArrow(trend: FreedomTrend): string {
+  return { improving: '↑', stable: '→', declining: '↓' }[trend] ?? '→';
+}
+
+export function incidentStatusClass(status: MediaIncident['status']): string {
+  const map: Record<string, string> = {
+    'Resolved':   'incident-resolved',
+    'Ongoing':    'incident-ongoing',
+    'Escalating': 'incident-escalating',
+  };
+  return map[status] ?? 'incident-ongoing';
+}
+
+export function buildRenderData(): MediaFreedomRenderData {
+  const totalJailed = COUNTRIES.reduce((s, c) => s + c.journalistsJailed, 0);
+  return {
+    countries: COUNTRIES,
+    incidents: INCIDENTS,
+    globalFreedomIndex: computeGlobalFreedomIndex(COUNTRIES),
+    freeCount:         getByCategory(COUNTRIES, 'Free').length,
+    goodCount:         getByCategory(COUNTRIES, 'Good').length,
+    satisfactoryCount: getByCategory(COUNTRIES, 'Satisfactory').length,
+    problematicCount:  getByCategory(COUNTRIES, 'Problematic').length,
+    difficultCount:    getByCategory(COUNTRIES, 'Difficult').length,
+    verySeriousCount:  getByCategory(COUNTRIES, 'Very Serious').length,
+    totalJailed,
+    decliningCount: getDecliningCountries(COUNTRIES).length,
+    highRisk: getHighRiskCountries(COUNTRIES),
+  };
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -328,6 +328,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'territorial-disputes': { name: 'Territorial Disputes Tracker', enabled: true, priority: 1 },
   'regime-stability': { name: 'Regime Stability', enabled: true, priority: 1 },
   'coalition-dynamics': { name: 'Coalition Dynamics', enabled: true, priority: 1 },
+  'media-freedom': { name: 'Media Freedom', enabled: true, priority: 1 },
 };
 
 const FULL_MAP_LAYERS: MapLayers = {


### PR DESCRIPTION
Tracks press freedom, journalist imprisonment, and media ownership concentration as intelligence indicators.

## What

- **`media-freedom-helpers.ts`** — pure logic, no DOM: 17-country RSF index dataset (Norway 95 → North Korea 2), CPJ 2024 jailed journalist counts (China ~100, Myanmar ~60, Saudi Arabia ~32, Russia/Iran ~22), 6 major incidents 2022–2024, population-weighted global freedom index, helpers: `getByCategory`, `getDecliningCountries`, `getMostJailed`, `getHighRiskCountries`, `freedomClass`, `trendClass`, `buildRenderData`
- **`MediaFreedomPanel.ts`** — extends `Panel`, 24 hr refresh, summary header (global index, free/good, at-risk, very serious, jailed, declining), country table sorted by RSF score with jailed-journalist badges, incident list sorted by severity
- **`media-freedom-helpers.test.mts`** — 66 tests across 10 suites, all passing
- Registered in `panels.ts` (governance/security, priority 1) and `panel-layout.ts`

## Data

- RSF Press Freedom Index 2024
- CPJ Journalist Imprisonment Census 2024
- Key incidents: Evan Gershkovich arrest/release (Russia/WSJ), Gaza journalist deaths (100+, highest ever for a single conflict), Julian Assange extradition resolution, Al Jazeera operating ban

## Test results

```
tests 66  pass 66  fail 0
```

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>