### PR TITLE
feat: add DebtTrapDiplomacyPanel

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -219,6 +219,7 @@ import { FearGreedPanel } from '@/components/FearGreedPanel';
 import { InternetDisruptionsPanel } from '@/components/InternetDisruptionsPanel';
 import { NationalDebtPanel } from '@/components/NationalDebtPanel';
 import { SovereignDebtPanel } from '@/components/SovereignDebtPanel';
+import { DebtTrapDiplomacyPanel } from '@/components/DebtTrapDiplomacyPanel';
 import { FuelPricesPanel } from '@/components/FuelPricesPanel';
 import { AirTrafficPanel } from '@/components/AirTrafficPanel';
 import { ThreatIntelHubPanel } from '@/components/ThreatIntelHubPanel';
@@ -1377,6 +1378,7 @@ export class PanelLayoutManager implements AppModule {
  this.ctx.panels['internet-disruptions'] = new InternetDisruptionsPanel();
  this.ctx.panels['national-debt'] = new NationalDebtPanel();
  this.ctx.panels['sovereign-debt'] = new SovereignDebtPanel();
+    this.ctx.panels['debt-trap-diplomacy'] = new DebtTrapDiplomacyPanel();
  this.ctx.panels['fuel-prices'] = new FuelPricesPanel();
  this.ctx.panels['air-traffic'] = new AirTrafficPanel();
  this.ctx.panels['threat-intel-hub'] = new ThreatIntelHubPanel();

--- a/src/components/DebtTrapDiplomacyPanel.ts
+++ b/src/components/DebtTrapDiplomacyPanel.ts
@@ -1,0 +1,129 @@
+import { Panel } from './Panel';
+import { h, replaceChildren } from '@/utils/dom-utils';
+import {
+  buildRenderData,
+  statusClass,
+  leverageClass,
+} from './debt-trap-diplomacy-helpers';
+
+const REFRESH_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+function safe<T>(fn: () => T): T | null {
+  try { return fn(); } catch { return null; }
+}
+
+export class DebtTrapDiplomacyPanel extends Panel {
+  static readonly panelId = 'debt-trap-diplomacy';
+  static readonly title = 'Debt Trap Diplomacy';
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    super({
+      id: DebtTrapDiplomacyPanel.panelId,
+      title: DebtTrapDiplomacyPanel.title,
+      showCount: true,
+      trackActivity: false,
+      infoTooltip:
+        'Tracks BRI debt trap diplomacy, sovereign debt vulnerability, and financial coercion ' +
+        'dynamics. Monitors 12 high-risk debtor nations (Sri Lanka, Zambia, Pakistan, Kenya, ' +
+        'Ecuador, Montenegro, Laos, Angola, Tanzania, Ethiopia, Argentina, Cambodia) with ' +
+        'Chinese debt exposure, strategic assets at risk, and current debt status.',
+    });
+    this.start();
+  }
+
+  public override destroy(): void {
+    if (this.refreshTimer !== null) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    super.destroy();
+  }
+
+  private start(): void {
+    this.render();
+    this.refreshTimer = setInterval(() => this.render(), REFRESH_MS);
+  }
+
+  private render(): void {
+    const data = safe(() => buildRenderData());
+    if (!data) {
+      replaceChildren(
+        this.getContentElement(),
+        h('div', { className: 'panel-empty' }, 'Data unavailable'),
+      );
+      return;
+    }
+
+    const { debtors, stats, atRiskCount, defaultedCount, restructuringCount } = data;
+    this.setCount(atRiskCount + defaultedCount + restructuringCount);
+
+    let idxClass: string;
+    if (stats.vulnerabilityIndex >= 70) {
+      idxClass = 'dtd-critical';
+    } else if (stats.vulnerabilityIndex >= 50) {
+      idxClass = 'dtd-high';
+    } else if (stats.vulnerabilityIndex >= 30) {
+      idxClass = 'dtd-moderate';
+    } else {
+      idxClass = 'dtd-low';
+    }
+
+    const header = h('div', { className: 'dtd-header' },
+      h('div', { className: 'dtd-metric' },
+        h('span', { className: 'dtd-label' }, 'Vulnerability Index'),
+        h('span', { className: 'dtd-value ' + idxClass }, String(stats.vulnerabilityIndex) + '/100'),
+      ),
+      h('div', { className: 'dtd-metric' },
+        h('span', { className: 'dtd-label' }, 'At Risk'),
+        h('span', { className: 'dtd-value dtd-at-risk' }, String(atRiskCount)),
+      ),
+      h('div', { className: 'dtd-metric' },
+        h('span', { className: 'dtd-label' }, 'Defaulted'),
+        h('span', { className: 'dtd-value dtd-defaulted' }, String(defaultedCount)),
+      ),
+      h('div', { className: 'dtd-metric' },
+        h('span', { className: 'dtd-label' }, 'Restructuring'),
+        h('span', { className: 'dtd-value dtd-restructuring' }, String(restructuringCount)),
+      ),
+    );
+
+    const lendingBar = h('div', { className: 'dtd-lending' },
+      h('div', { className: 'dtd-lending-title' }, 'China Overseas Lending vs. World Bank / IMF'),
+      h('div', { className: 'dtd-lending-row' },
+        h('span', { className: 'dtd-lender-china' }, 'China: $' + String(stats.chinaOverseasLendingBn) + 'B'),
+        h('span', { className: 'dtd-lender-wb' }, 'World Bank+IMF: $' + String(stats.worldBankImfCombinedBn) + 'B'),
+        h('span', { className: 'dtd-total-debt' }, 'BRI Tracked: $' + stats.totalBriDebtBn.toFixed(1) + 'B'),
+      ),
+    );
+
+    const countriesSection = h('div', { className: 'dtd-countries' });
+
+    const statusOrder: Record<string, number> = {
+      Defaulted: 0, Restructuring: 1, 'At Risk': 2, Repaying: 3,
+    };
+    const sorted = [...debtors].sort((a, b) => {
+      const od = (statusOrder[a.status] ?? 4) - (statusOrder[b.status] ?? 4);
+      return od !== 0 ? od : b.debtToChinaBn - a.debtToChinaBn;
+    });
+
+    for (const d of sorted) {
+      const sc = statusClass(d.status);
+      const lc = leverageClass(d.leverageType);
+      const row = h('div', { className: 'dtd-country-row ' + sc },
+        h('div', { className: 'dtd-country-header' },
+          h('span', { className: 'dtd-country-name' }, d.country),
+          h('span', { className: 'dtd-status-badge ' + sc }, d.status),
+          h('span', { className: 'dtd-leverage-badge ' + lc }, d.leverageType),
+          h('span', { className: 'dtd-debt-amount' }, '$' + String(d.debtToChinaBn) + 'B'),
+          h('span', { className: 'dtd-gdp-pct' }, String(d.chineseDebtToGdpPct) + '% GDP'),
+        ),
+        h('div', { className: 'dtd-strategic-asset' }, d.strategicAsset),
+        h('div', { className: 'dtd-notes' }, d.notes),
+      );
+      countriesSection.appendChild(row);
+    }
+
+    replaceChildren(this.getContentElement(), header, lendingBar, countriesSection);
+  }
+}

--- a/src/components/__tests__/debt-trap-diplomacy-helpers.test.mts
+++ b/src/components/__tests__/debt-trap-diplomacy-helpers.test.mts
@@ -1,0 +1,368 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  getAtRiskCountries,
+  getByStatus,
+  getHighDebtRatio,
+  computeVulnerabilityIndex,
+  statusClass,
+  leverageClass,
+  buildRenderData,
+  type BriDebtor,
+  type DebtorStatus,
+  type LeverageType,
+} from '../debt-trap-diplomacy-helpers.js';
+
+// ---- Fixtures ------------------------------------------------------------------
+
+function makeDebtor(overrides: Partial<BriDebtor> = {}): BriDebtor {
+  return {
+    id: 'TEST',
+    country: 'Testland',
+    iso3: 'TST',
+    debtToChinaBn: 5,
+    debtToGdpPct: 60,
+    chineseDebtToGdpPct: 15,
+    strategicAsset: 'Test Port',
+    status: 'At Risk',
+    leverageType: 'Port/Infrastructure',
+    notes: 'test notes',
+    ...overrides,
+  };
+}
+
+// ---- getAtRiskCountries --------------------------------------------------------
+
+describe('getAtRiskCountries', () => {
+  test('empty array returns empty array', () => {
+    assert.deepEqual(getAtRiskCountries([]), []);
+  });
+  test('returns only At Risk debtors', () => {
+    const pool = [
+      makeDebtor({ id: 'A', status: 'At Risk' }),
+      makeDebtor({ id: 'B', status: 'Defaulted' }),
+      makeDebtor({ id: 'C', status: 'At Risk' }),
+    ];
+    const result = getAtRiskCountries(pool);
+    assert.equal(result.length, 2);
+    assert.ok(result.every((d) => d.status === 'At Risk'));
+  });
+  test('excludes Defaulted', () => {
+    const pool = [makeDebtor({ status: 'Defaulted' })];
+    assert.equal(getAtRiskCountries(pool).length, 0);
+  });
+  test('excludes Restructuring', () => {
+    const pool = [makeDebtor({ status: 'Restructuring' })];
+    assert.equal(getAtRiskCountries(pool).length, 0);
+  });
+  test('excludes Repaying', () => {
+    const pool = [makeDebtor({ status: 'Repaying' })];
+    assert.equal(getAtRiskCountries(pool).length, 0);
+  });
+  test('all At Risk returns all', () => {
+    const pool = [makeDebtor({ status: 'At Risk' }), makeDebtor({ status: 'At Risk' })];
+    assert.equal(getAtRiskCountries(pool).length, 2);
+  });
+});
+
+// ---- getByStatus ---------------------------------------------------------------
+
+describe('getByStatus', () => {
+  const pool: BriDebtor[] = [
+    makeDebtor({ id: 'S1', status: 'At Risk' }),
+    makeDebtor({ id: 'S2', status: 'Defaulted' }),
+    makeDebtor({ id: 'S3', status: 'Restructuring' }),
+    makeDebtor({ id: 'S4', status: 'Repaying' }),
+    makeDebtor({ id: 'S5', status: 'At Risk' }),
+  ];
+  test('empty array returns empty', () => {
+    assert.deepEqual(getByStatus([], 'At Risk'), []);
+  });
+  test('At Risk filter returns matching', () => {
+    const r = getByStatus(pool, 'At Risk');
+    assert.equal(r.length, 2);
+    assert.ok(r.every((d) => d.status === 'At Risk'));
+  });
+  test('Defaulted filter', () => {
+    const r = getByStatus(pool, 'Defaulted');
+    assert.equal(r.length, 1);
+    assert.equal(r[0].id, 'S2');
+  });
+  test('Restructuring filter', () => {
+    const r = getByStatus(pool, 'Restructuring');
+    assert.equal(r.length, 1);
+    assert.equal(r[0].id, 'S3');
+  });
+  test('Repaying filter', () => {
+    const r = getByStatus(pool, 'Repaying');
+    assert.equal(r.length, 1);
+    assert.equal(r[0].id, 'S4');
+  });
+  test('no match returns empty', () => {
+    const r = getByStatus([makeDebtor({ status: 'Repaying' })], 'Defaulted');
+    assert.equal(r.length, 0);
+  });
+});
+
+// ---- getHighDebtRatio ----------------------------------------------------------
+
+describe('getHighDebtRatio', () => {
+  const pool: BriDebtor[] = [
+    makeDebtor({ id: 'H1', chineseDebtToGdpPct: 10 }),
+    makeDebtor({ id: 'H2', chineseDebtToGdpPct: 20 }),
+    makeDebtor({ id: 'H3', chineseDebtToGdpPct: 30 }),
+    makeDebtor({ id: 'H4', chineseDebtToGdpPct: 55 }),
+  ];
+  test('empty array returns empty', () => {
+    assert.deepEqual(getHighDebtRatio([]), []);
+  });
+  test('default threshold 20 returns >= 20', () => {
+    const r = getHighDebtRatio(pool);
+    assert.equal(r.length, 3); // H2, H3, H4
+    assert.ok(r.every((d) => d.chineseDebtToGdpPct >= 20));
+  });
+  test('custom threshold 30 returns >= 30', () => {
+    const r = getHighDebtRatio(pool, 30);
+    assert.equal(r.length, 2); // H3, H4
+  });
+  test('exact threshold value is included', () => {
+    const r = getHighDebtRatio(pool, 20);
+    assert.ok(r.some((d) => d.id === 'H2'));
+  });
+  test('below threshold excluded', () => {
+    const r = getHighDebtRatio(pool, 20);
+    assert.ok(!r.some((d) => d.id === 'H1'));
+  });
+  test('threshold 0 returns all', () => {
+    const r = getHighDebtRatio(pool, 0);
+    assert.equal(r.length, pool.length);
+  });
+  test('threshold above max returns empty', () => {
+    const r = getHighDebtRatio(pool, 100);
+    assert.equal(r.length, 0);
+  });
+});
+
+// ---- computeVulnerabilityIndex -------------------------------------------------
+
+describe('computeVulnerabilityIndex', () => {
+  test('empty array returns 0', () => {
+    assert.equal(computeVulnerabilityIndex([]), 0);
+  });
+  test('returns number type', () => {
+    assert.equal(typeof computeVulnerabilityIndex([makeDebtor()]), 'number');
+  });
+  test('all Defaulted returns 100', () => {
+    const pool = [makeDebtor({ status: 'Defaulted' }), makeDebtor({ status: 'Defaulted' })];
+    assert.equal(computeVulnerabilityIndex(pool), 100);
+  });
+  test('all Repaying returns 25', () => {
+    const pool = [makeDebtor({ status: 'Repaying' }), makeDebtor({ status: 'Repaying' })];
+    assert.equal(computeVulnerabilityIndex(pool), 25);
+  });
+  test('all At Risk returns 50', () => {
+    const pool = [makeDebtor({ status: 'At Risk' }), makeDebtor({ status: 'At Risk' })];
+    assert.equal(computeVulnerabilityIndex(pool), 50);
+  });
+  test('all Restructuring returns 75', () => {
+    const pool = [makeDebtor({ status: 'Restructuring' }), makeDebtor({ status: 'Restructuring' })];
+    assert.equal(computeVulnerabilityIndex(pool), 75);
+  });
+  test('single Defaulted returns 100', () => {
+    assert.equal(computeVulnerabilityIndex([makeDebtor({ status: 'Defaulted' })]), 100);
+  });
+  test('single Repaying returns 25', () => {
+    assert.equal(computeVulnerabilityIndex([makeDebtor({ status: 'Repaying' })]), 25);
+  });
+  test('mixed: Defaulted + Repaying averages correctly', () => {
+    const pool = [makeDebtor({ status: 'Defaulted' }), makeDebtor({ status: 'Repaying' })];
+    // score = 4+1 = 5; maxPossible = 8; 5/8 * 100 = 62.5 -> round = 63
+    assert.equal(computeVulnerabilityIndex(pool), 63);
+  });
+  test('result is always in range 0-100', () => {
+    const statuses: DebtorStatus[] = ['At Risk', 'Restructuring', 'Defaulted', 'Repaying'];
+    for (const s of statuses) {
+      const v = computeVulnerabilityIndex([makeDebtor({ status: s })]);
+      assert.ok(v >= 0 && v <= 100);
+    }
+  });
+});
+
+// ---- statusClass ---------------------------------------------------------------
+
+describe('statusClass', () => {
+  test('At Risk -> status-at-risk', () => {
+    assert.equal(statusClass('At Risk'), 'status-at-risk');
+  });
+  test('Defaulted -> status-defaulted', () => {
+    assert.equal(statusClass('Defaulted'), 'status-defaulted');
+  });
+  test('Restructuring -> status-restructuring', () => {
+    assert.equal(statusClass('Restructuring'), 'status-restructuring');
+  });
+  test('Repaying -> status-repaying', () => {
+    assert.equal(statusClass('Repaying'), 'status-repaying');
+  });
+  test('returns non-empty string for all valid values', () => {
+    const values: DebtorStatus[] = ['At Risk', 'Restructuring', 'Defaulted', 'Repaying'];
+    for (const v of values) {
+      assert.ok(statusClass(v).length > 0);
+    }
+  });
+});
+
+// ---- leverageClass -------------------------------------------------------------
+
+describe('leverageClass', () => {
+  test('Port/Infrastructure -> lev-port', () => {
+    assert.equal(leverageClass('Port/Infrastructure'), 'lev-port');
+  });
+  test('Resource Extraction -> lev-resource', () => {
+    assert.equal(leverageClass('Resource Extraction'), 'lev-resource');
+  });
+  test('Strategic Access -> lev-strategic', () => {
+    assert.equal(leverageClass('Strategic Access'), 'lev-strategic');
+  });
+  test('Currency Swap -> lev-currency', () => {
+    assert.equal(leverageClass('Currency Swap'), 'lev-currency');
+  });
+  test('Railway/Transport -> lev-railway', () => {
+    assert.equal(leverageClass('Railway/Transport'), 'lev-railway');
+  });
+  test('Mixed -> lev-mixed', () => {
+    assert.equal(leverageClass('Mixed'), 'lev-mixed');
+  });
+  test('returns string for all valid values', () => {
+    const values: LeverageType[] = [
+      'Port/Infrastructure', 'Resource Extraction', 'Strategic Access',
+      'Currency Swap', 'Railway/Transport', 'Mixed',
+    ];
+    for (const v of values) {
+      assert.equal(typeof leverageClass(v), 'string');
+    }
+  });
+});
+
+// ---- buildRenderData -----------------------------------------------------------
+
+describe('buildRenderData', () => {
+  const data = buildRenderData();
+
+  test('returns debtors array', () => {
+    assert.ok(Array.isArray(data.debtors));
+  });
+  test('debtors is non-empty', () => {
+    assert.ok(data.debtors.length > 0);
+  });
+  test('returns exactly 12 debtors', () => {
+    assert.equal(data.debtors.length, 12);
+  });
+  test('returns stats object', () => {
+    assert.ok(data.stats !== null && typeof data.stats === 'object');
+  });
+  test('vulnerabilityIndex is a number', () => {
+    assert.equal(typeof data.stats.vulnerabilityIndex, 'number');
+  });
+  test('vulnerabilityIndex is in range 0-100', () => {
+    assert.ok(data.stats.vulnerabilityIndex >= 0 && data.stats.vulnerabilityIndex <= 100);
+  });
+  test('chinaOverseasLendingBn > worldBankImfCombinedBn', () => {
+    assert.ok(data.stats.chinaOverseasLendingBn > data.stats.worldBankImfCombinedBn);
+  });
+  test('chinaOverseasLendingBn is 843', () => {
+    assert.equal(data.stats.chinaOverseasLendingBn, 843);
+  });
+  test('worldBankImfCombinedBn is 489', () => {
+    assert.equal(data.stats.worldBankImfCombinedBn, 489);
+  });
+  test('atRiskCount matches getByStatus At Risk', () => {
+    const expected = data.debtors.filter((d) => d.status === 'At Risk').length;
+    assert.equal(data.atRiskCount, expected);
+  });
+  test('defaultedCount matches getByStatus Defaulted', () => {
+    const expected = data.debtors.filter((d) => d.status === 'Defaulted').length;
+    assert.equal(data.defaultedCount, expected);
+  });
+  test('restructuringCount matches getByStatus Restructuring', () => {
+    const expected = data.debtors.filter((d) => d.status === 'Restructuring').length;
+    assert.equal(data.restructuringCount, expected);
+  });
+  test('briCountriesAtRisk equals atRiskCount', () => {
+    assert.equal(data.stats.briCountriesAtRisk, data.atRiskCount);
+  });
+  test('totalBriDebtBn is positive', () => {
+    assert.ok(data.stats.totalBriDebtBn > 0);
+  });
+  test('totalBriDebtBn matches sum of debtors', () => {
+    const sum = data.debtors.reduce((s, d) => s + d.debtToChinaBn, 0);
+    assert.ok(Math.abs(data.stats.totalBriDebtBn - Math.round(sum * 10) / 10) < 0.01);
+  });
+  test('Sri Lanka is present and Defaulted', () => {
+    const srilanka = data.debtors.find((d) => d.country === 'Sri Lanka');
+    assert.ok(srilanka !== undefined);
+    assert.equal(srilanka?.status, 'Defaulted');
+  });
+  test('Laos is present and At Risk', () => {
+    const laos = data.debtors.find((d) => d.country === 'Laos');
+    assert.ok(laos !== undefined);
+    assert.equal(laos?.status, 'At Risk');
+  });
+  test('Pakistan is present', () => {
+    assert.ok(data.debtors.some((d) => d.country === 'Pakistan'));
+  });
+  test('Cambodia is present', () => {
+    assert.ok(data.debtors.some((d) => d.country === 'Cambodia'));
+  });
+  test('Zambia is Restructuring', () => {
+    const zambia = data.debtors.find((d) => d.country === 'Zambia');
+    assert.equal(zambia?.status, 'Restructuring');
+  });
+  test('every debtor has non-empty strategicAsset', () => {
+    assert.ok(data.debtors.every((d) => d.strategicAsset.length > 0));
+  });
+  test('every debtor has positive debtToChinaBn', () => {
+    assert.ok(data.debtors.every((d) => d.debtToChinaBn > 0));
+  });
+  test('every debtor has non-empty country name', () => {
+    assert.ok(data.debtors.every((d) => d.country.length > 0));
+  });
+  test('every debtor has non-empty notes', () => {
+    assert.ok(data.debtors.every((d) => d.notes.length > 0));
+  });
+  test('every debtor chineseDebtToGdpPct is non-negative', () => {
+    assert.ok(data.debtors.every((d) => d.chineseDebtToGdpPct >= 0));
+  });
+  test('atRiskCount >= 1', () => {
+    assert.ok(data.atRiskCount >= 1);
+  });
+  test('defaultedCount >= 1', () => {
+    assert.ok(data.defaultedCount >= 1);
+  });
+  test('restructuringCount >= 1', () => {
+    assert.ok(data.restructuringCount >= 1);
+  });
+  test('vulnerabilityIndex equals computeVulnerabilityIndex(debtors)', () => {
+    const expected = computeVulnerabilityIndex(data.debtors);
+    assert.equal(data.stats.vulnerabilityIndex, expected);
+  });
+  test('Laos has highest chineseDebtToGdpPct', () => {
+    const maxPct = Math.max(...data.debtors.map((d) => d.chineseDebtToGdpPct));
+    const laos = data.debtors.find((d) => d.country === 'Laos');
+    assert.equal(laos?.chineseDebtToGdpPct, maxPct);
+  });
+  test('Pakistan has highest debtToChinaBn', () => {
+    const maxDebt = Math.max(...data.debtors.map((d) => d.debtToChinaBn));
+    const pak = data.debtors.find((d) => d.country === 'Pakistan');
+    assert.equal(pak?.debtToChinaBn, maxDebt);
+  });
+  test('every debtor id is unique', () => {
+    const ids = data.debtors.map((d) => d.id);
+    assert.equal(new Set(ids).size, ids.length);
+  });
+  test('every debtor iso3 is 3 characters', () => {
+    assert.ok(data.debtors.every((d) => d.iso3.length === 3));
+  });
+  test('Restructuring count >= 1', () => {
+    assert.ok(data.restructuringCount >= 1);
+  });
+});

--- a/src/components/debt-trap-diplomacy-helpers.ts
+++ b/src/components/debt-trap-diplomacy-helpers.ts
@@ -1,0 +1,295 @@
+// debt-trap-diplomacy-helpers.ts
+// Pure logic for DebtTrapDiplomacyPanel -- no DOM, no Panel imports
+
+export type LeverageType =
+  | 'Port/Infrastructure'
+  | 'Resource Extraction'
+  | 'Strategic Access'
+  | 'Currency Swap'
+  | 'Railway/Transport'
+  | 'Mixed';
+
+export type DebtorStatus =
+  | 'At Risk'
+  | 'Restructuring'
+  | 'Defaulted'
+  | 'Repaying';
+
+export interface BriDebtor {
+  id: string;
+  country: string;
+  iso3: string;
+  /** USD billions owed directly to Chinese entities (EXIM, CDB, PBOC). */
+  debtToChinaBn: number;
+  /** Total external debt as % of GDP. */
+  debtToGdpPct: number;
+  /** Chinese-held debt as % of GDP -- the primary coercion metric. */
+  chineseDebtToGdpPct: number;
+  strategicAsset: string;
+  status: DebtorStatus;
+  leverageType: LeverageType;
+  notes: string;
+}
+
+export interface GlobalBriStats {
+  /** China total overseas lending (Policy + commercial), USD billions. */
+  chinaOverseasLendingBn: number;
+  /** World Bank + IMF combined outstanding loans, USD billions. */
+  worldBankImfCombinedBn: number;
+  briCountriesAtRisk: number;
+  totalBriDebtBn: number;
+  /** 0-100 composite vulnerability index. */
+  vulnerabilityIndex: number;
+}
+
+export interface BriRenderData {
+  debtors: BriDebtor[];
+  stats: GlobalBriStats;
+  atRiskCount: number;
+  defaultedCount: number;
+  restructuringCount: number;
+}
+
+// ---- Country data ---------------------------------------------------------------
+
+const BRI_DEBTORS: BriDebtor[] = [
+  {
+    id: 'D001',
+    country: 'Sri Lanka',
+    iso3: 'LKA',
+    debtToChinaBn: 7.4,
+    debtToGdpPct: 119,
+    chineseDebtToGdpPct: 10,
+    strategicAsset: 'Hambantota Port (99-yr lease 2017)',
+    status: 'Defaulted',
+    leverageType: 'Port/Infrastructure',
+    notes: 'Defaulted on sovereign debt 2022; Hambantota Port leased 99 yrs to CMPort after default; IMF $2.9B bailout; textbook asset-seizure outcome.',
+  },
+  {
+    id: 'D002',
+    country: 'Zambia',
+    iso3: 'ZMB',
+    debtToChinaBn: 6.6,
+    debtToGdpPct: 143,
+    chineseDebtToGdpPct: 30,
+    strategicAsset: 'ZESCO power infrastructure; Copperbelt mining concessions',
+    status: 'Restructuring',
+    leverageType: 'Resource Extraction',
+    notes: 'First African BRI debt restructuring 2023 under G20 Common Framework; Chinese creditors hold ~30% external debt; copper sector leverage.',
+  },
+  {
+    id: 'D003',
+    country: 'Pakistan',
+    iso3: 'PAK',
+    debtToChinaBn: 65.0,
+    debtToGdpPct: 74,
+    chineseDebtToGdpPct: 22,
+    strategicAsset: 'Gwadar Port; CPEC corridor (3,000 km)',
+    status: 'At Risk',
+    leverageType: 'Port/Infrastructure',
+    notes: 'CPEC total commitment ~$65B; chronic IMF dependency; Gwadar Port provides PLAN Indian Ocean access; high-cost power agreements.',
+  },
+  {
+    id: 'D004',
+    country: 'Kenya',
+    iso3: 'KEN',
+    debtToChinaBn: 8.7,
+    debtToGdpPct: 67,
+    chineseDebtToGdpPct: 21,
+    strategicAsset: 'Mombasa Port (SGR loan collateral)',
+    status: 'At Risk',
+    leverageType: 'Railway/Transport',
+    notes: 'SGR Nairobi-Mombasa railway; Mombasa Port named as collateral in EXIM Bank contract; renegotiation ongoing; ~$5B owed to China.',
+  },
+  {
+    id: 'D005',
+    country: 'Ecuador',
+    iso3: 'ECU',
+    debtToChinaBn: 17.4,
+    debtToGdpPct: 58,
+    chineseDebtToGdpPct: 15,
+    strategicAsset: 'Coca Codo Sinclair hydrodam; oil reserves',
+    status: 'Repaying',
+    leverageType: 'Resource Extraction',
+    notes: 'Oil-backed loans to CNPC/Sinopec; dam defects post-construction; oil pre-sale repayment mechanism; governance concerns.',
+  },
+  {
+    id: 'D006',
+    country: 'Montenegro',
+    iso3: 'MNE',
+    debtToChinaBn: 1.0,
+    debtToGdpPct: 89,
+    chineseDebtToGdpPct: 25,
+    strategicAsset: 'E762 Bar-Boljare highway',
+    status: 'Restructuring',
+    leverageType: 'Port/Infrastructure',
+    notes: 'EXIM Bank loan at above-market rates; Montenegro sought EU bailout EUR 944M; EU intervened 2021 to prevent Chinese asset-seizure clause.',
+  },
+  {
+    id: 'D007',
+    country: 'Laos',
+    iso3: 'LAO',
+    debtToChinaBn: 13.3,
+    debtToGdpPct: 128,
+    chineseDebtToGdpPct: 55,
+    strategicAsset: 'Laos-China High-Speed Railway; national power grid stake',
+    status: 'At Risk',
+    leverageType: 'Railway/Transport',
+    notes: 'Chinese debt ~55% of GDP, highest ratio in BRI portfolio; transferred 90% of national grid operator EDL-T to Chinese firm as debt relief; railway $6B.',
+  },
+  {
+    id: 'D008',
+    country: 'Angola',
+    iso3: 'AGO',
+    debtToChinaBn: 25.0,
+    debtToGdpPct: 88,
+    chineseDebtToGdpPct: 40,
+    strategicAsset: 'Offshore oil blocks; Lobito corridor port',
+    status: 'Repaying',
+    leverageType: 'Resource Extraction',
+    notes: 'Largest African Chinese debtor; oil-backed loans from CDB/EXIM repaid via crude exports; Lobito corridor competes with US-backed rail project.',
+  },
+  {
+    id: 'D009',
+    country: 'Tanzania',
+    iso3: 'TZA',
+    debtToChinaBn: 4.2,
+    debtToGdpPct: 38,
+    chineseDebtToGdpPct: 8,
+    strategicAsset: 'Bagamoyo Port (mega-port; suspended)',
+    status: 'Repaying',
+    leverageType: 'Port/Infrastructure',
+    notes: 'Bagamoyo port ($10B) renegotiated after sovereignty concerns over exclusivity and operational control clauses; project stalled; Magufuli rejected terms.',
+  },
+  {
+    id: 'D010',
+    country: 'Ethiopia',
+    iso3: 'ETH',
+    debtToChinaBn: 13.7,
+    debtToGdpPct: 56,
+    chineseDebtToGdpPct: 30,
+    strategicAsset: 'Addis Ababa-Djibouti Railway; Djibouti port access',
+    status: 'Restructuring',
+    leverageType: 'Railway/Transport',
+    notes: 'EXIM Bank financed ADR; China is largest bilateral creditor; IMF/World Bank DSA indicates debt distress; G20 Common Framework restructuring talks.',
+  },
+  {
+    id: 'D011',
+    country: 'Argentina',
+    iso3: 'ARG',
+    debtToChinaBn: 18.5,
+    debtToGdpPct: 89,
+    chineseDebtToGdpPct: 9,
+    strategicAsset: 'PBOC currency swap line ($18.5B)',
+    status: 'At Risk',
+    leverageType: 'Currency Swap',
+    notes: 'PBOC swap used as emergency FX reserve lever; China demands policy concessions for renewals; Milei govt attempting exit from swap dependency.',
+  },
+  {
+    id: 'D012',
+    country: 'Cambodia',
+    iso3: 'KHM',
+    debtToChinaBn: 9.6,
+    debtToGdpPct: 72,
+    chineseDebtToGdpPct: 40,
+    strategicAsset: 'Ream Naval Base; Sihanoukville SEZ',
+    status: 'At Risk',
+    leverageType: 'Strategic Access',
+    notes: 'Ream Naval Base expanded with Chinese funding; US intelligence assesses exclusive PLAN access granted; ~40% of Sihanoukville Chinese-owned.',
+  },
+];
+
+/** Fixed reference lending figures (2023 AidData estimates). */
+const BASE_GLOBAL_STATS = {
+  chinaOverseasLendingBn: 843,
+  worldBankImfCombinedBn: 489,
+} as const;
+
+// ---- Helper functions -----------------------------------------------------------
+
+/** Returns debtors with status 'At Risk'. */
+export function getAtRiskCountries(debtors: BriDebtor[]): BriDebtor[] {
+  return debtors.filter((d) => d.status === 'At Risk');
+}
+
+/** Filters debtors by the given status value. */
+export function getByStatus(debtors: BriDebtor[], status: DebtorStatus): BriDebtor[] {
+  return debtors.filter((d) => d.status === status);
+}
+
+/**
+ * Returns debtors where chineseDebtToGdpPct >= thresholdPct.
+ * Default threshold is 20%, widely used as the 'high-leverage' benchmark.
+ */
+export function getHighDebtRatio(debtors: BriDebtor[], thresholdPct = 20): BriDebtor[] {
+  return debtors.filter((d) => d.chineseDebtToGdpPct >= thresholdPct);
+}
+
+/**
+ * Computes a 0-100 BRI vulnerability index for the supplied debtor set.
+ * Status weights: Defaulted=4, Restructuring=3, At Risk=2, Repaying=1.
+ * Score is normalised against the maximum possible (all Defaulted = 100).
+ */
+export function computeVulnerabilityIndex(debtors: BriDebtor[]): number {
+  if (!debtors.length) return 0;
+  const weights: Record<DebtorStatus, number> = {
+    Defaulted: 4,
+    Restructuring: 3,
+    'At Risk': 2,
+    Repaying: 1,
+  };
+  const score = debtors.reduce((s, d) => s + weights[d.status], 0);
+  const maxPossible = debtors.length * 4;
+  return Math.round((score / maxPossible) * 100);
+}
+
+const STATUS_CLASSES: Record<DebtorStatus, string> = {
+  'At Risk': 'status-at-risk',
+  Restructuring: 'status-restructuring',
+  Defaulted: 'status-defaulted',
+  Repaying: 'status-repaying',
+};
+
+/** Returns the CSS class name for a debtor status badge. */
+export function statusClass(status: DebtorStatus): string {
+  return STATUS_CLASSES[status] ?? 'status-unknown';
+}
+
+const LEVERAGE_CLASSES: Record<LeverageType, string> = {
+  'Port/Infrastructure': 'lev-port',
+  'Resource Extraction': 'lev-resource',
+  'Strategic Access': 'lev-strategic',
+  'Currency Swap': 'lev-currency',
+  'Railway/Transport': 'lev-railway',
+  Mixed: 'lev-mixed',
+};
+
+/** Returns the CSS class name for a leverage type badge. */
+export function leverageClass(type: LeverageType): string {
+  return LEVERAGE_CLASSES[type] ?? 'lev-mixed';
+}
+
+/** Builds the full render data payload for DebtTrapDiplomacyPanel. */
+export function buildRenderData(): BriRenderData {
+  const debtors = BRI_DEBTORS;
+  const totalBriDebtBn = debtors.reduce((s, d) => s + d.debtToChinaBn, 0);
+  const atRiskCount = getByStatus(debtors, 'At Risk').length;
+  const defaultedCount = getByStatus(debtors, 'Defaulted').length;
+  const restructuringCount = getByStatus(debtors, 'Restructuring').length;
+  const vulnerabilityIndex = computeVulnerabilityIndex(debtors);
+
+  const stats: GlobalBriStats = {
+    ...BASE_GLOBAL_STATS,
+    briCountriesAtRisk: atRiskCount,
+    totalBriDebtBn: Math.round(totalBriDebtBn * 10) / 10,
+    vulnerabilityIndex,
+  };
+
+  return {
+    debtors,
+    stats,
+    atRiskCount,
+    defaultedCount,
+    restructuringCount,
+  };
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -141,6 +141,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'internet-disruptions': { name: 'Internet Disruptions', enabled: true, priority: 2 },
   'national-debt': { name: 'National Debt', enabled: true, priority: 2 },
   'sovereign-debt': { name: 'Sovereign Debt', enabled: true, priority: 2 },
+  'debt-trap-diplomacy': { name: 'Debt Trap Diplomacy', enabled: true, priority: 2 },
   'fuel-prices': { name: 'Fuel Prices', enabled: true, priority: 2 },
   'faa-tfrs': { name: 'FAA TFRs', enabled: true, priority: 2 },
   'air-traffic': { name: 'Air Traffic', enabled: true, priority: 2 },
@@ -1132,7 +1133,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   },
   marketsFinance: {
  labelKey: 'header.panelCatMarketsFinance',
- panelKeys: ['commodities', 'markets', 'economic', 'economic-stress', 'federal-register', 'trade-policy', 'supply-chain', 'finance', 'polymarket', 'macro-signals', 'etf-flows', 'stablecoins', 'crypto', 'heatmap', 'fear-greed', 'national-debt', 'sovereign-debt', 'fuel-prices', 'fdic-failures', 'edgar-filings', 'central-bank-calendar', 'financial-superpower', 'political-economy'],
+ panelKeys: ['commodities', 'markets', 'economic', 'economic-stress', 'federal-register', 'trade-policy', 'supply-chain', 'finance', 'polymarket', 'macro-signals', 'etf-flows', 'stablecoins', 'crypto', 'heatmap', 'fear-greed', 'national-debt', 'sovereign-debt', 'debt-trap-diplomacy', 'fuel-prices', 'fdic-failures', 'edgar-filings', 'central-bank-calendar', 'financial-superpower', 'political-economy'],
  variants: ['full'],
   },
   topical: {


### PR DESCRIPTION
Tracks BRI debt trap diplomacy, sovereign debt vulnerability, and financial coercion dynamics between creditor and debtor nations.

## What

- **`debt-trap-diplomacy-helpers.ts`** — pure logic, no DOM. 12 high-risk debtor nations with BRI exposure (Sri Lanka/Hambantota Port, Zambia/Copperbelt, Pakistan/CPEC, Kenya/Mombasa, Ecuador/oil, Montenegro/E762, Laos/HSR, Angola/oil, Tanzania/Bagamoyo, Ethiopia/ADR, Argentina/PBOC swap, Cambodia/Ream Naval Base). Global stats: China overseas lending $843B vs World Bank+IMF $489B combined. Helpers: `getAtRiskCountries`, `getByStatus`, `getHighDebtRatio`, `computeVulnerabilityIndex`, `statusClass`, `leverageClass`, `buildRenderData`.
- **`DebtTrapDiplomacyPanel.ts`** — extends Panel, 24hr refresh, vulnerability index 0-100, rows sorted by severity (Defaulted > Restructuring > At Risk > Repaying) then debt size.
- **`debt-trap-diplomacy-helpers.test.mts`** — 75 unit tests across 7 describe blocks, 0 failures.
- Registered in `panels.ts` (economy category) and `panel-layout.ts`.

## Test results
```
tests 75 | pass 75 | fail 0
```