### PR TITLE
feat: add ForeignAidWeaponizationPanel

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -389,6 +389,7 @@ import { TerritorialDisputesPanel } from '@/components/TerritorialDisputesPanel'
 import { RegimeStabilityPanel } from '@/components/RegimeStabilityPanel';
 import { CoalitionDynamicsPanel } from '@/components/CoalitionDynamicsPanel';
 import { TransnationalRepressionPanel } from '@/components/TransnationalRepressionPanel';
+import { ForeignAidWeaponizationPanel } from '@/components/ForeignAidWeaponizationPanel';
 import { SpaceMilitarizationPanel } from '@/components/SpaceMilitarizationPanel';
 import { ArcticMonitoringPanel } from '@/components/ArcticMonitoringPanel';
 import { ClimateSecurityNexusPanel } from '@/components/ClimateSecurityNexusPanel';
@@ -1548,7 +1549,7 @@ export class PanelLayoutManager implements AppModule {
  this.ctx.panels['water-security'] = new WaterSecurityPanel();
  this.ctx.panels['energy-security'] = new EnergySecurityPanel();
  this.ctx.panels['arms-proliferation'] = new ArmsProliferationPanel();
- this.ctx.panels['territorial-disputes'] = new TerritorialDisputesPanel(); this.ctx.panels['regime-stability'] = new RegimeStabilityPanel(); this.ctx.panels['coalition-dynamics'] = new CoalitionDynamicsPanel(); this.ctx.panels['transnational-repression'] = new TransnationalRepressionPanel();
+ this.ctx.panels['territorial-disputes'] = new TerritorialDisputesPanel(); this.ctx.panels['regime-stability'] = new RegimeStabilityPanel(); this.ctx.panels['coalition-dynamics'] = new CoalitionDynamicsPanel(); this.ctx.panels['transnational-repression'] = new TransnationalRepressionPanel(); this.ctx.panels['foreign-aid-weaponization'] = new ForeignAidWeaponizationPanel();
  this.ctx.panels['space-militarization'] = new SpaceMilitarizationPanel();
  this.ctx.panels['arctic-monitoring'] = new ArcticMonitoringPanel();
  this.ctx.panels['climate-security-nexus'] = new ClimateSecurityNexusPanel();

--- a/src/components/ForeignAidWeaponizationPanel.ts
+++ b/src/components/ForeignAidWeaponizationPanel.ts
@@ -1,0 +1,144 @@
+import { Panel } from './Panel';
+import { h, replaceChildren } from '@/utils/dom-utils';
+import {
+  buildRenderData,
+  impactClass,
+  eventTypeClass,
+  getImpactCategory,
+} from './foreign-aid-weaponization-helpers';
+
+const REFRESH_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+function safe<T>(fn: () => T): T | null {
+  try { return fn(); } catch { return null; }
+}
+
+export class ForeignAidWeaponizationPanel extends Panel {
+  static readonly panelId = 'foreign-aid-weaponization';
+  static readonly title = 'Foreign Aid Weaponization';
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    super({
+      id: ForeignAidWeaponizationPanel.panelId,
+      title: ForeignAidWeaponizationPanel.title,
+      showCount: true,
+      trackActivity: false,
+      infoTooltip:
+        'Tracks foreign aid as a geopolitical weapon: cuts, conditions, redirections, and weaponization by major donor states. ' +
+        'Covers 12 major events (2021-2025) across USA USAID freeze, China BRI conditionality, ' +
+        'EU migration conditionality, Gulf state leverage, Russia grain weaponization, and more.',
+    });
+    this.start();
+  }
+
+  public override destroy(): void {
+    if (this.refreshTimer !== null) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    super.destroy();
+  }
+
+  private start(): void {
+    this.render();
+    this.refreshTimer = setInterval(() => this.render(), REFRESH_MS);
+  }
+
+  private render(): void {
+    const data = safe(() => buildRenderData());
+    if (!data) {
+      replaceChildren(
+        this.getContentElement(),
+        h('div', { className: 'panel-empty' }, 'Data unavailable'),
+      );
+      return;
+    }
+
+    const {
+      events,
+      donors,
+      weaponizationIndex,
+      highImpactCount,
+      activeConditionCount,
+    } = data;
+
+    this.setCount(highImpactCount);
+
+    let idxClass: string;
+    if (weaponizationIndex >= 80) {
+      idxClass = 'imp-critical';
+    } else if (weaponizationIndex >= 60) {
+      idxClass = 'imp-high';
+    } else if (weaponizationIndex >= 40) {
+      idxClass = 'imp-medium';
+    } else {
+      idxClass = 'imp-low';
+    }
+
+    const header = h('div', { className: 'faw-header' },
+      h('div', { className: 'faw-metric' },
+        h('span', { className: 'faw-label' }, 'Weaponization Index'),
+        h('span', { className: 'faw-value ' + idxClass }, weaponizationIndex + '/100'),
+      ),
+      h('div', { className: 'faw-metric' },
+        h('span', { className: 'faw-label' }, 'High Impact Events'),
+        h('span', { className: 'faw-value imp-high' }, String(highImpactCount)),
+      ),
+      h('div', { className: 'faw-metric' },
+        h('span', { className: 'faw-label' }, 'Active Conditions'),
+        h('span', { className: 'faw-value imp-medium' }, String(activeConditionCount)),
+      ),
+      h('div', { className: 'faw-metric' },
+        h('span', { className: 'faw-label' }, 'Donors Tracked'),
+        h('span', { className: 'faw-value' }, String(donors.length)),
+      ),
+    );
+
+    const donorSection = h('div', { className: 'faw-donors' },
+      h('h3', { className: 'faw-section-title' }, 'Major Donor Profiles'),
+    );
+
+    for (const donor of [...donors].sort((a, b) => b.annualAidBillionUSD - a.annualAidBillionUSD)) {
+      const trendArrow = donor.trend === 'escalating' ? '\u2191' : donor.trend === 'declining' ? '\u2193' : '\u2192';
+      const trendCls = donor.trend === 'escalating' ? 'trend-up' : donor.trend === 'declining' ? 'trend-down' : 'trend-flat';
+
+      const row = h('div', { className: 'faw-donor-row' },
+        h('div', { className: 'faw-donor-header' },
+          h('span', { className: 'faw-donor-name' }, donor.name),
+          h('span', { className: 'faw-category-badge' }, donor.category),
+          h('span', { className: 'faw-trend ' + trendCls }, trendArrow),
+          h('span', { className: 'faw-amount' }, '$' + donor.annualAidBillionUSD + 'B/yr'),
+        ),
+        h('div', { className: 'faw-leverage' }, 'Leverage: ' + donor.leverageTypes.join(', ')),
+        h('div', { className: 'faw-instruments' }, 'Instruments: ' + donor.keyInstruments.join(', ')),
+        h('div', { className: 'faw-conditionality' }, donor.conditionality),
+      );
+      donorSection.append(row);
+    }
+
+    const eventSection = h('div', { className: 'faw-events' },
+      h('h3', { className: 'faw-section-title' }, 'Aid Weaponization Events'),
+    );
+
+    for (const evt of [...events].sort((a, b) => b.impactScore - a.impactScore)) {
+      const row = h('div', { className: 'faw-event-row ' + impactClass(evt.impactScore) },
+        h('div', { className: 'faw-event-header' },
+          h('span', { className: 'faw-donor-tag' }, evt.donor),
+          h('span', { className: 'faw-event-type ' + eventTypeClass(evt.eventType) }, evt.eventType),
+          h('span', { className: 'faw-impact-badge ' + impactClass(evt.impactScore) },
+            getImpactCategory(evt.impactScore),
+          ),
+          h('span', { className: 'faw-date' }, evt.date),
+          evt.active ? h('span', { className: 'faw-active-badge' }, 'ACTIVE') : h('span', {}),
+        ),
+        h('div', { className: 'faw-recipient' }, 'Target: ' + evt.recipient),
+        h('div', { className: 'faw-desc' }, evt.description),
+        h('div', { className: 'faw-geo-effect' }, 'Geopolitical Effect: ' + evt.geopoliticalEffect),
+      );
+      eventSection.append(row);
+    }
+
+    replaceChildren(this.getContentElement(), header, donorSection, eventSection);
+  }
+}

--- a/src/components/__tests__/foreign-aid-weaponization-helpers.test.mts
+++ b/src/components/__tests__/foreign-aid-weaponization-helpers.test.mts
@@ -1,0 +1,702 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import {
+  computeWeaponizationIndex,
+  getByDonor,
+  getHighImpactEvents,
+  getActiveConditionality,
+  donorLeverageClass,
+  impactClass,
+  eventTypeClass,
+  getImpactCategory,
+  buildRenderData,
+  type AidEvent,
+  type DonorProfile,
+  type LeverageType,
+  type AidEventType,
+} from '../foreign-aid-weaponization-helpers.ts';
+
+// ── Mock data ─────────────────────────────────────────────────────────────────
+
+const MOCK_EVENTS: AidEvent[] = [
+  {
+    id: 'M1',
+    date: '2025-01-20',
+    donor: 'Freedonia',
+    recipient: 'Global',
+    eventType: 'freeze',
+    description: 'Froze all aid.',
+    impactScore: 10,
+    active: true,
+    geopoliticalEffect: 'Major vacuum created.',
+    sources: ['EO Jan 2025'],
+  },
+  {
+    id: 'M2',
+    date: '2024-04-24',
+    donor: 'Freedonia',
+    recipient: 'Ruritania',
+    eventType: 'condition',
+    description: 'Military aid conditioned on elections.',
+    amountBillionUSD: 61,
+    impactScore: 9,
+    active: false,
+    geopoliticalEffect: 'NATO allies nervous.',
+    sources: ['HR 815'],
+  },
+  {
+    id: 'M3',
+    date: '2023-07-01',
+    donor: 'Sylvania',
+    recipient: 'Borduria',
+    eventType: 'condition',
+    description: 'Migration control conditionality.',
+    amountBillionUSD: 0.105,
+    impactScore: 7,
+    active: true,
+    geopoliticalEffect: 'Human rights norms weakened.',
+    sources: ['MoU July 2023'],
+  },
+  {
+    id: 'M4',
+    date: '2022-07-22',
+    donor: 'Ruritania',
+    recipient: 'Global',
+    eventType: 'weaponize',
+    description: 'Grain deal used as leverage.',
+    impactScore: 8,
+    active: false,
+    geopoliticalEffect: 'Food price spikes.',
+    sources: ['UN reports'],
+  },
+  {
+    id: 'M5',
+    date: '2021-11-01',
+    donor: 'Freedonia',
+    recipient: 'Global',
+    eventType: 'cut',
+    description: 'ODA cut from 0.7% to 0.5% GDP.',
+    amountBillionUSD: 4,
+    impactScore: 6,
+    active: false,
+    geopoliticalEffect: 'Soft power decline.',
+    sources: ['FCDO stats'],
+  },
+  {
+    id: 'M6',
+    date: '2022-01-01',
+    donor: 'Sylvania',
+    recipient: 'Borduria, Pottsylvania',
+    eventType: 'competition',
+    description: 'Competing aid in Horn region.',
+    amountBillionUSD: 35,
+    impactScore: 7,
+    active: true,
+    geopoliticalEffect: 'Peace process undermined.',
+    sources: ['UN Panel report'],
+  },
+  {
+    id: 'M7',
+    date: '2023-01-01',
+    donor: 'Multilateral Bank',
+    recipient: 'Global South',
+    eventType: 'reform',
+    description: 'Structural adjustment conditionality reform.',
+    amountBillionUSD: 3,
+    impactScore: 5,
+    active: true,
+    geopoliticalEffect: 'Opening for alternative financing.',
+    sources: ['IMF documents'],
+  },
+];
+
+const MOCK_DONORS: DonorProfile[] = [
+  {
+    id: 'D1',
+    name: 'Freedonia',
+    category: 'Western',
+    annualAidBillionUSD: 60,
+    leverageTypes: ['military', 'economic'],
+    conditionality: 'Democracy and human rights, selectively applied.',
+    politicalAlignment: 'NATO allies.',
+    keyInstruments: ['USAID', 'MCC'],
+    incidentCount: 3,
+    trend: 'declining',
+  },
+  {
+    id: 'D2',
+    name: 'Sylvania',
+    category: 'BRICS',
+    annualAidBillionUSD: 85,
+    leverageTypes: ['infrastructure', 'diplomatic'],
+    conditionality: 'Taiwan non-recognition, UN voting alignment.',
+    politicalAlignment: 'Global South.',
+    keyInstruments: ['EXIM Bank', 'Silk Road Fund'],
+    incidentCount: 2,
+    trend: 'escalating',
+  },
+  {
+    id: 'D3',
+    name: 'Ruritania',
+    category: 'Gulf',
+    annualAidBillionUSD: 20,
+    leverageTypes: ['economic', 'military'],
+    conditionality: 'Political silence, anti-Iran positioning.',
+    politicalAlignment: 'Regional proxies.',
+    keyInstruments: ['National Fund', 'Investment Authority'],
+    incidentCount: 1,
+    trend: 'stable',
+  },
+];
+
+// ── computeWeaponizationIndex ──────────────────────────────────────────────────
+
+describe('computeWeaponizationIndex', () => {
+  it('returns 0 for empty array', () => {
+    assert.equal(computeWeaponizationIndex([]), 0);
+  });
+
+  it('returns a number in range 0-100', () => {
+    const idx = computeWeaponizationIndex(MOCK_EVENTS);
+    assert.ok(idx >= 0 && idx <= 100, 'index out of range');
+  });
+
+  it('returns an integer', () => {
+    const idx = computeWeaponizationIndex(MOCK_EVENTS);
+    assert.equal(idx, Math.round(idx));
+  });
+
+  it('more active high-impact events yield higher index', () => {
+    const highActive = Array.from({ length: 8 }, (_, i) => ({
+      ...MOCK_EVENTS[0],
+      id: 'H' + i,
+      active: true,
+      impactScore: 9,
+    }));
+    const lowActive = Array.from({ length: 8 }, (_, i) => ({
+      ...MOCK_EVENTS[0],
+      id: 'L' + i,
+      active: false,
+      impactScore: 3,
+    }));
+    assert.ok(
+      computeWeaponizationIndex(highActive) > computeWeaponizationIndex(lowActive),
+    );
+  });
+
+  it('all inactive events yield lower index than all active', () => {
+    const active = MOCK_EVENTS.map(e => ({ ...e, active: true }));
+    const inactive = MOCK_EVENTS.map(e => ({ ...e, active: false }));
+    assert.ok(computeWeaponizationIndex(active) >= computeWeaponizationIndex(inactive));
+  });
+
+  it('caps at 100 with extreme inputs', () => {
+    const extreme = Array.from({ length: 20 }, (_, i) => ({
+      ...MOCK_EVENTS[0],
+      id: 'X' + i,
+      active: true,
+      impactScore: 10,
+    }));
+    assert.ok(computeWeaponizationIndex(extreme) <= 100);
+  });
+
+  it('single inactive low-impact event yields low index', () => {
+    const single = [{ ...MOCK_EVENTS[4], active: false, impactScore: 2 }];
+    assert.ok(computeWeaponizationIndex(single) < 50);
+  });
+});
+
+// ── getByDonor ────────────────────────────────────────────────────────────────
+
+describe('getByDonor', () => {
+  it('returns only events from matching donor', () => {
+    const result = getByDonor(MOCK_EVENTS, 'Freedonia');
+    assert.ok(result.length >= 1);
+    assert.ok(result.every(e => e.donor === 'Freedonia'));
+  });
+
+  it('returns empty when donor not found', () => {
+    assert.equal(getByDonor(MOCK_EVENTS, 'Nonexistentia').length, 0);
+  });
+
+  it('is case-sensitive', () => {
+    assert.equal(getByDonor(MOCK_EVENTS, 'freedonia').length, 0);
+  });
+
+  it('returns multiple when several match', () => {
+    const result = getByDonor(MOCK_EVENTS, 'Freedonia');
+    assert.ok(result.length >= 2);
+  });
+
+  it('does not mutate the input array', () => {
+    const before = MOCK_EVENTS.length;
+    getByDonor(MOCK_EVENTS, 'Sylvania');
+    assert.equal(MOCK_EVENTS.length, before);
+  });
+
+  it('all returned events have the requested donor', () => {
+    const result = getByDonor(MOCK_EVENTS, 'Sylvania');
+    assert.ok(result.every(e => e.donor === 'Sylvania'));
+  });
+
+  it('returns empty array (not null/undefined) for missing donor', () => {
+    const result = getByDonor(MOCK_EVENTS, 'Nobody');
+    assert.ok(Array.isArray(result));
+    assert.equal(result.length, 0);
+  });
+});
+
+// ── getHighImpactEvents ───────────────────────────────────────────────────────
+
+describe('getHighImpactEvents', () => {
+  it('returns events at or above threshold', () => {
+    const result = getHighImpactEvents(MOCK_EVENTS, 8);
+    assert.ok(result.every(e => e.impactScore >= 8));
+  });
+
+  it('uses default threshold of 7', () => {
+    const result = getHighImpactEvents(MOCK_EVENTS);
+    assert.ok(result.every(e => e.impactScore >= 7));
+  });
+
+  it('includes events exactly at threshold', () => {
+    const result = getHighImpactEvents(MOCK_EVENTS, 10);
+    assert.ok(result.every(e => e.impactScore >= 10));
+    assert.ok(result.length >= 1);
+  });
+
+  it('returns empty when no events meet threshold', () => {
+    const result = getHighImpactEvents(MOCK_EVENTS, 11);
+    assert.equal(result.length, 0);
+  });
+
+  it('returns all when threshold is 1', () => {
+    const result = getHighImpactEvents(MOCK_EVENTS, 1);
+    assert.equal(result.length, MOCK_EVENTS.length);
+  });
+
+  it('does not mutate input array', () => {
+    const before = MOCK_EVENTS.length;
+    getHighImpactEvents(MOCK_EVENTS, 5);
+    assert.equal(MOCK_EVENTS.length, before);
+  });
+
+  it('excludes events below threshold', () => {
+    const result = getHighImpactEvents(MOCK_EVENTS, 9);
+    assert.ok(result.every(e => e.impactScore >= 9));
+    const excluded = MOCK_EVENTS.filter(e => e.impactScore < 9);
+    assert.ok(excluded.length > 0, 'test assumes some events below 9');
+  });
+});
+
+// ── getActiveConditionality ───────────────────────────────────────────────────
+
+describe('getActiveConditionality', () => {
+  it('returns only active condition events', () => {
+    const result = getActiveConditionality(MOCK_EVENTS);
+    assert.ok(result.every(e => e.active && e.eventType === 'condition'));
+  });
+
+  it('excludes inactive condition events', () => {
+    const result = getActiveConditionality(MOCK_EVENTS);
+    const inactiveConditions = MOCK_EVENTS.filter(e => !e.active && e.eventType === 'condition');
+    for (const inact of inactiveConditions) {
+      assert.ok(!result.some(r => r.id === inact.id));
+    }
+  });
+
+  it('excludes active non-condition events', () => {
+    const result = getActiveConditionality(MOCK_EVENTS);
+    const activeNonCondition = MOCK_EVENTS.filter(e => e.active && e.eventType !== 'condition');
+    for (const nonCond of activeNonCondition) {
+      assert.ok(!result.some(r => r.id === nonCond.id));
+    }
+  });
+
+  it('returns empty for empty input', () => {
+    assert.equal(getActiveConditionality([]).length, 0);
+  });
+
+  it('does not mutate input array', () => {
+    const before = MOCK_EVENTS.length;
+    getActiveConditionality(MOCK_EVENTS);
+    assert.equal(MOCK_EVENTS.length, before);
+  });
+});
+
+// ── donorLeverageClass ────────────────────────────────────────────────────────
+
+describe('donorLeverageClass', () => {
+  it('military returns lev-military', () => {
+    assert.equal(donorLeverageClass('military'), 'lev-military');
+  });
+
+  it('economic returns lev-economic', () => {
+    assert.equal(donorLeverageClass('economic'), 'lev-economic');
+  });
+
+  it('diplomatic returns lev-diplomatic', () => {
+    assert.equal(donorLeverageClass('diplomatic'), 'lev-diplomatic');
+  });
+
+  it('infrastructure returns lev-infra', () => {
+    assert.equal(donorLeverageClass('infrastructure'), 'lev-infra');
+  });
+
+  it('food returns lev-food', () => {
+    assert.equal(donorLeverageClass('food'), 'lev-food');
+  });
+
+  it('humanitarian returns lev-humanitarian', () => {
+    assert.equal(donorLeverageClass('humanitarian'), 'lev-humanitarian');
+  });
+
+  it('returns a non-empty string for every valid type', () => {
+    const types: LeverageType[] = ['military', 'economic', 'diplomatic', 'infrastructure', 'food', 'humanitarian'];
+    for (const t of types) {
+      const cls = donorLeverageClass(t);
+      assert.ok(cls.length > 0, 'empty class for ' + t);
+    }
+  });
+});
+
+// ── impactClass ───────────────────────────────────────────────────────────────
+
+describe('impactClass', () => {
+  it('returns imp-critical for score 10', () => {
+    assert.equal(impactClass(10), 'imp-critical');
+  });
+
+  it('returns imp-critical for score 9', () => {
+    assert.equal(impactClass(9), 'imp-critical');
+  });
+
+  it('returns imp-high for score 8', () => {
+    assert.equal(impactClass(8), 'imp-high');
+  });
+
+  it('returns imp-high for score 7', () => {
+    assert.equal(impactClass(7), 'imp-high');
+  });
+
+  it('returns imp-medium for score 6', () => {
+    assert.equal(impactClass(6), 'imp-medium');
+  });
+
+  it('returns imp-medium for score 5', () => {
+    assert.equal(impactClass(5), 'imp-medium');
+  });
+
+  it('returns imp-low for score 4', () => {
+    assert.equal(impactClass(4), 'imp-low');
+  });
+
+  it('returns imp-low for score 1', () => {
+    assert.equal(impactClass(1), 'imp-low');
+  });
+});
+
+// ── eventTypeClass ────────────────────────────────────────────────────────────
+
+describe('eventTypeClass', () => {
+  it('freeze returns et-freeze', () => {
+    assert.equal(eventTypeClass('freeze'), 'et-freeze');
+  });
+
+  it('cut returns et-cut', () => {
+    assert.equal(eventTypeClass('cut'), 'et-cut');
+  });
+
+  it('condition returns et-condition', () => {
+    assert.equal(eventTypeClass('condition'), 'et-condition');
+  });
+
+  it('redirect returns et-redirect', () => {
+    assert.equal(eventTypeClass('redirect'), 'et-redirect');
+  });
+
+  it('weaponize returns et-weaponize', () => {
+    assert.equal(eventTypeClass('weaponize'), 'et-weaponize');
+  });
+
+  it('competition returns et-competition', () => {
+    assert.equal(eventTypeClass('competition'), 'et-competition');
+  });
+
+  it('reform returns et-reform', () => {
+    assert.equal(eventTypeClass('reform'), 'et-reform');
+  });
+
+  it('returns a non-empty string for every valid type', () => {
+    const types: AidEventType[] = ['freeze', 'cut', 'condition', 'redirect', 'weaponize', 'competition', 'reform'];
+    for (const t of types) {
+      const cls = eventTypeClass(t);
+      assert.ok(cls.length > 0, 'empty class for ' + t);
+    }
+  });
+});
+
+// ── getImpactCategory ─────────────────────────────────────────────────────────
+
+describe('getImpactCategory', () => {
+  it('returns Critical for score 10', () => {
+    assert.equal(getImpactCategory(10), 'Critical');
+  });
+
+  it('returns Critical for score 9', () => {
+    assert.equal(getImpactCategory(9), 'Critical');
+  });
+
+  it('returns High for score 8', () => {
+    assert.equal(getImpactCategory(8), 'High');
+  });
+
+  it('returns High for score 7', () => {
+    assert.equal(getImpactCategory(7), 'High');
+  });
+
+  it('returns Medium for score 6', () => {
+    assert.equal(getImpactCategory(6), 'Medium');
+  });
+
+  it('returns Medium for score 5', () => {
+    assert.equal(getImpactCategory(5), 'Medium');
+  });
+
+  it('returns Low for score 4', () => {
+    assert.equal(getImpactCategory(4), 'Low');
+  });
+
+  it('returns Low for score 1', () => {
+    assert.equal(getImpactCategory(1), 'Low');
+  });
+});
+
+// ── buildRenderData ───────────────────────────────────────────────────────────
+
+describe('buildRenderData', () => {
+  it('returns all required fields', () => {
+    const d = buildRenderData();
+    assert.ok(Array.isArray(d.events));
+    assert.ok(Array.isArray(d.donors));
+    assert.equal(typeof d.weaponizationIndex, 'number');
+    assert.equal(typeof d.highImpactCount, 'number');
+    assert.equal(typeof d.activeConditionCount, 'number');
+    assert.ok(Array.isArray(d.topDonors));
+    assert.ok(Array.isArray(d.recentEvents));
+  });
+
+  it('events array is non-empty', () => {
+    assert.ok(buildRenderData().events.length > 0);
+  });
+
+  it('donors array is non-empty', () => {
+    assert.ok(buildRenderData().donors.length > 0);
+  });
+
+  it('weaponizationIndex is in range 0-100', () => {
+    const idx = buildRenderData().weaponizationIndex;
+    assert.ok(idx >= 0 && idx <= 100, 'index out of range: ' + idx);
+  });
+
+  it('weaponizationIndex is an integer', () => {
+    const idx = buildRenderData().weaponizationIndex;
+    assert.equal(idx, Math.round(idx));
+  });
+
+  it('highImpactCount matches events with impactScore >= 7', () => {
+    const d = buildRenderData();
+    const expected = d.events.filter(e => e.impactScore >= 7).length;
+    assert.equal(d.highImpactCount, expected);
+  });
+
+  it('activeConditionCount matches active condition events', () => {
+    const d = buildRenderData();
+    const expected = d.events.filter(e => e.active && e.eventType === 'condition').length;
+    assert.equal(d.activeConditionCount, expected);
+  });
+
+  it('topDonors is sorted by annualAidBillionUSD descending', () => {
+    const td = buildRenderData().topDonors;
+    for (let i = 1; i < td.length; i++) {
+      assert.ok(td[i - 1].annualAidBillionUSD >= td[i].annualAidBillionUSD);
+    }
+  });
+
+  it('topDonors has at most 5 entries', () => {
+    assert.ok(buildRenderData().topDonors.length <= 5);
+  });
+
+  it('recentEvents has at most 5 entries', () => {
+    assert.ok(buildRenderData().recentEvents.length <= 5);
+  });
+
+  it('recentEvents is sorted by date descending', () => {
+    const re = buildRenderData().recentEvents;
+    for (let i = 1; i < re.length; i++) {
+      assert.ok(re[i - 1].date >= re[i].date);
+    }
+  });
+
+  it('all event IDs are unique', () => {
+    const ids = buildRenderData().events.map(e => e.id);
+    assert.equal(new Set(ids).size, ids.length);
+  });
+
+  it('all donor IDs are unique', () => {
+    const ids = buildRenderData().donors.map(d => d.id);
+    assert.equal(new Set(ids).size, ids.length);
+  });
+
+  it('all impact scores are in range 1-10', () => {
+    for (const e of buildRenderData().events) {
+      assert.ok(e.impactScore >= 1 && e.impactScore <= 10,
+        e.id + ' impactScore ' + e.impactScore + ' out of range');
+    }
+  });
+
+  it('all donor annualAidBillionUSD are positive', () => {
+    for (const d of buildRenderData().donors) {
+      assert.ok(d.annualAidBillionUSD > 0, d.name + ' has non-positive aid amount');
+    }
+  });
+
+  it('all donor trends are valid', () => {
+    const valid = new Set(['escalating', 'stable', 'declining']);
+    for (const d of buildRenderData().donors) {
+      assert.ok(valid.has(d.trend), 'invalid trend: ' + d.trend);
+    }
+  });
+
+  it('all donor categories are valid', () => {
+    const valid = new Set(['Western', 'BRICS', 'Gulf', 'Multilateral', 'Emerging']);
+    for (const d of buildRenderData().donors) {
+      assert.ok(valid.has(d.category), 'invalid category: ' + d.category);
+    }
+  });
+
+  it('all event types are valid', () => {
+    const valid = new Set(['freeze', 'cut', 'condition', 'redirect', 'weaponize', 'competition', 'reform']);
+    for (const e of buildRenderData().events) {
+      assert.ok(valid.has(e.eventType), 'invalid eventType: ' + e.eventType);
+    }
+  });
+
+  it('all events have non-empty donor strings', () => {
+    for (const e of buildRenderData().events) {
+      assert.ok(e.donor.trim().length > 0, e.id + ' has empty donor');
+    }
+  });
+
+  it('all events have non-empty recipient strings', () => {
+    for (const e of buildRenderData().events) {
+      assert.ok(e.recipient.trim().length > 0, e.id + ' has empty recipient');
+    }
+  });
+
+  it('all events have at least one source', () => {
+    for (const e of buildRenderData().events) {
+      assert.ok(e.sources.length > 0, e.id + ' has no sources');
+    }
+  });
+
+  it('all donors have at least one leverage type', () => {
+    for (const d of buildRenderData().donors) {
+      assert.ok(d.leverageTypes.length > 0, d.name + ' has no leverage types');
+    }
+  });
+
+  it('all donors have at least one key instrument', () => {
+    for (const d of buildRenderData().donors) {
+      assert.ok(d.keyInstruments.length > 0, d.name + ' has no key instruments');
+    }
+  });
+
+  it('all events have non-empty geopoliticalEffect', () => {
+    for (const e of buildRenderData().events) {
+      assert.ok(e.geopoliticalEffect.trim().length > 0, e.id + ' has empty geopoliticalEffect');
+    }
+  });
+
+  it('has at least 10 events', () => {
+    assert.ok(buildRenderData().events.length >= 10);
+  });
+
+  it('has at least 5 donors', () => {
+    assert.ok(buildRenderData().donors.length >= 5);
+  });
+
+  it('FA001 (USA USAID freeze) is present with impact 10', () => {
+    const d = buildRenderData();
+    const ev = d.events.find(e => e.id === 'FA001');
+    assert.ok(ev, 'FA001 not found');
+    assert.equal(ev!.impactScore, 10);
+    assert.equal(ev!.donor, 'USA');
+    assert.equal(ev!.eventType, 'freeze');
+    assert.equal(ev!.active, true);
+  });
+
+  it('FA004 (China BRI) is present as active condition', () => {
+    const d = buildRenderData();
+    const ev = d.events.find(e => e.id === 'FA004');
+    assert.ok(ev, 'FA004 not found');
+    assert.equal(ev!.donor, 'China');
+    assert.equal(ev!.eventType, 'condition');
+    assert.equal(ev!.active, true);
+  });
+
+  it('FA006 (Russia grain weaponization) is present as weaponize type', () => {
+    const d = buildRenderData();
+    const ev = d.events.find(e => e.id === 'FA006');
+    assert.ok(ev, 'FA006 not found');
+    assert.equal(ev!.eventType, 'weaponize');
+    assert.equal(ev!.donor, 'Russia');
+  });
+
+  it('FA002 (USA Ukraine aid) is inactive (passed)', () => {
+    const d = buildRenderData();
+    const ev = d.events.find(e => e.id === 'FA002');
+    assert.ok(ev, 'FA002 not found');
+    assert.equal(ev!.active, false);
+    assert.ok(ev!.amountBillionUSD !== undefined && ev!.amountBillionUSD >= 61);
+  });
+
+  it('USA donor exists with military leverage', () => {
+    const d = buildRenderData();
+    const usa = d.donors.find(dn => dn.name === 'USA');
+    assert.ok(usa, 'USA donor not found');
+    assert.ok(usa!.leverageTypes.includes('military'));
+  });
+
+  it('China donor exists as BRICS with escalating trend', () => {
+    const d = buildRenderData();
+    const china = d.donors.find(dn => dn.name === 'China');
+    assert.ok(china, 'China donor not found');
+    assert.equal(china!.category, 'BRICS');
+    assert.equal(china!.trend, 'escalating');
+  });
+
+  it('at least 2 donors with escalating trend', () => {
+    const d = buildRenderData();
+    const escalating = d.donors.filter(dn => dn.trend === 'escalating');
+    assert.ok(escalating.length >= 2, 'fewer than 2 escalating donors');
+  });
+
+  it('at least 3 active events', () => {
+    const d = buildRenderData();
+    const activeEvts = d.events.filter(e => e.active);
+    assert.ok(activeEvts.length >= 3, 'fewer than 3 active events');
+  });
+
+  it('at least 1 redirect event', () => {
+    const d = buildRenderData();
+    const redirects = d.events.filter(e => e.eventType === 'redirect');
+    assert.ok(redirects.length >= 1, 'no redirect events');
+  });
+
+  it('at least 1 competition event', () => {
+    const d = buildRenderData();
+    const comp = d.events.filter(e => e.eventType === 'competition');
+    assert.ok(comp.length >= 1, 'no competition events');
+  });
+});

--- a/src/components/foreign-aid-weaponization-helpers.ts
+++ b/src/components/foreign-aid-weaponization-helpers.ts
@@ -1,0 +1,393 @@
+// foreign-aid-weaponization-helpers.ts
+// Pure logic for ForeignAidWeaponizationPanel — no DOM, no Panel imports
+
+export type AidEventType =
+  | "freeze"
+  | "cut"
+  | "condition"
+  | "redirect"
+  | "weaponize"
+  | "competition"
+  | "reform";
+
+export type DonorCategory = "Western" | "BRICS" | "Gulf" | "Multilateral" | "Emerging";
+
+export type LeverageType =
+  | "military"
+  | "economic"
+  | "diplomatic"
+  | "infrastructure"
+  | "food"
+  | "humanitarian";
+
+export interface AidEvent {
+  id: string;
+  date: string;
+  donor: string;
+  recipient: string;
+  eventType: AidEventType;
+  description: string;
+  amountBillionUSD?: number;
+  impactScore: number; // 1-10
+  active: boolean;
+  geopoliticalEffect: string;
+  sources: string[];
+}
+
+export interface DonorProfile {
+  id: string;
+  name: string;
+  category: DonorCategory;
+  annualAidBillionUSD: number;
+  leverageTypes: LeverageType[];
+  conditionality: string;
+  politicalAlignment: string;
+  keyInstruments: string[];
+  incidentCount: number;
+  trend: "escalating" | "stable" | "declining";
+}
+
+export interface ForeignAidWeaponizationRenderData {
+  events: AidEvent[];
+  donors: DonorProfile[];
+  weaponizationIndex: number; // 0-100
+  highImpactCount: number;
+  activeConditionCount: number;
+  topDonors: DonorProfile[];
+  recentEvents: AidEvent[];
+}
+
+// ── Data ──────────────────────────────────────────────────────────────────────
+
+const AID_EVENTS: AidEvent[] = [
+  {
+    id: "FA001",
+    date: "2025-01-20",
+    donor: "USA",
+    recipient: "Global (90+ countries)",
+    eventType: "freeze",
+    description:
+      "Trump administration froze 0B+/year USAID budget via executive order on inauguration day. DOGE deployed to State Dept and USAID; 10,000+ programs paused worldwide. Largest single-event foreign aid disruption in US history. Humanitarian programs, HIV/AIDS treatment, food security, and development projects halted.",
+    amountBillionUSD: 60,
+    impactScore: 10,
+    active: true,
+    geopoliticalEffect:
+      "Massive vacuum in global development finance; China and Gulf states moving to fill gaps; NGO ecosystem facing collapse; US soft power decline accelerating.",
+    sources: ["Executive Order Jan 20 2025", "USAID shutdown notices", "State Dept DOGE memo"],
+  },
+  {
+    id: "FA002",
+    date: "2024-04-24",
+    donor: "USA",
+    recipient: "Ukraine",
+    eventType: "condition",
+    description:
+      "Congress passed 1B Ukraine aid package after six-month Congressional battle. Trump had blocked the package demanding border security legislation. Final package included military hardware, ammunition, and economic support. Trump continued threatening to cut off aid after taking office.",
+    amountBillionUSD: 61,
+    impactScore: 9,
+    active: false,
+    geopoliticalEffect:
+      "NATO cohesion test; Russia emboldened during aid gap; Ukraine forced to ration ammunition; European allies scrambling to fill gaps.",
+    sources: ["HR 815 signed April 24 2024", "Congressional Budget Office", "DoD Ukraine Security Assistance Initiative"],
+  },
+  {
+    id: "FA003",
+    date: "2023-01-01",
+    donor: "USA",
+    recipient: "Egypt",
+    eventType: "condition",
+    description:
+      "US Congress withheld 5M of Egypt annual .3B military aid on human rights grounds: political prisoners, press freedom, due process. Administration repeatedly waived conditions citing national security interests. Ongoing debate between strategic value (Suez Canal, Camp David) vs. human rights conditionality.",
+    amountBillionUSD: 1.3,
+    impactScore: 6,
+    active: true,
+    geopoliticalEffect:
+      "Egypt hedging toward Russia and China; purchased Russian Su-35s; participates in Chinese-led forums while maintaining US military relationship.",
+    sources: ["SFOPS appropriations", "State Dept human rights report", "Cairo Bureau diplomatic cables"],
+  },
+  {
+    id: "FA004",
+    date: "2022-01-01",
+    donor: "China",
+    recipient: "Global South (140+ countries)",
+    eventType: "condition",
+    description:
+      "Belt and Road Initiative infrastructure aid tied to diplomatic recognition of PRC over Taiwan, UN voting alignment, and exclusion of Western telecom infrastructure (Huawei). China provided 43B in BRI commitments 2013-2021. Aid conditioned on non-interference framing that bars human rights conditions.",
+    amountBillionUSD: 843,
+    impactScore: 9,
+    active: true,
+    geopoliticalEffect:
+      "Taiwan recognition down to 12 countries (2024); China controls UN voting blocs on Xinjiang Tibet Hong Kong; debt-trap diplomacy controversy (Hambantota Port, Ethiopia, Zambia).",
+    sources: ["AidData Research Lab BRI study 2021", "OECD DAC", "Global Development Policy Center Boston University"],
+  },
+  {
+    id: "FA005",
+    date: "2023-07-01",
+    donor: "EU",
+    recipient: "Tunisia",
+    eventType: "condition",
+    description:
+      "EU signed 105M EUR Memorandum of Understanding with Tunisia for migration control; aid explicitly conditioned on Tunisia preventing migrants from crossing to Europe. Human rights groups criticized deal as incentivizing pushbacks into Libyan desert. Deal bypassed standard EU democratic conditionality.",
+    amountBillionUSD: 0.105,
+    impactScore: 7,
+    active: true,
+    geopoliticalEffect:
+      "EU democratic conditionality credibility undermined; precedent for security-over-values aid; Morocco deal 2022 (500M EUR) followed same template.",
+    sources: ["EU-Tunisia MoU July 2023", "European Commission press release", "Amnesty International report"],
+  },
+  {
+    id: "FA006",
+    date: "2022-07-22",
+    donor: "Russia",
+    recipient: "Global (Middle East, Africa)",
+    eventType: "weaponize",
+    description:
+      "Russia used Black Sea Grain Initiative as diplomatic leverage. Withdrew from and rejoined the deal multiple times 2022-2023, using access to 45M tonnes/year of Ukrainian grain as geopolitical tool. Provided subsidized grain to African allies (Egypt, Ethiopia). Sabotaged Kakhovka dam 2023 destroying irrigation for 600,000 hectares.",
+    amountBillionUSD: 0,
+    impactScore: 8,
+    active: false,
+    geopoliticalEffect:
+      "Food price spikes hit MENA and Sub-Saharan Africa hardest; increased Russian influence in African Union; grain deal collapse July 2023 led to price surge.",
+    sources: ["UN Black Sea Grain Initiative reports", "USDA global supply forecasts", "WFP emergency assessments"],
+  },
+  {
+    id: "FA007",
+    date: "2023-10-07",
+    donor: "Gulf States",
+    recipient: "Egypt, Jordan, PA",
+    eventType: "condition",
+    description:
+      "Gulf states provided 5B+ in financial support to Egypt, Jordan, and Palestinian Authority with implicit conditions of political silence on Gaza policy. Qatar maintained Hamas political office funding (0M/mo) as mediation tool. Saudi-UAE split on Gaza stance reflected in aid conditionality.",
+    amountBillionUSD: 25,
+    impactScore: 8,
+    active: true,
+    geopoliticalEffect:
+      "Gulf states using financial aid as primary regional stability mechanism; Egypt prevented from publicly criticizing Israel offensive; PA funding tied to security cooperation.",
+    sources: ["IMF Egypt Article IV", "Jordan MOU with Gulf Cooperation Council", "AP Qatar Hamas funding investigation"],
+  },
+  {
+    id: "FA008",
+    date: "2024-02-01",
+    donor: "India",
+    recipient: "Bangladesh, Sri Lanka, Nepal, Maldives",
+    eventType: "competition",
+    description:
+      "India Quad alignment aid strategy: B+ in lines of credit to Sri Lanka (post-IMF crisis), B to Bangladesh, infrastructure grants to Nepal. Counter to Chinese BRI presence. Maldives elected pro-China president (Nov 2023) who expelled Indian military; India cut fuel subsidies in response demonstrating aid leverage.",
+    amountBillionUSD: 12,
+    impactScore: 7,
+    active: true,
+    geopoliticalEffect:
+      "Neighborhood First doctrine vs. China BRI competition in South Asia; Sri Lanka demonstrating willingness to play China vs. India; Nepal hydropower project arena.",
+    sources: ["MEA India development partnership", "Quad Infrastructure Partnership", "RIS New Delhi policy brief"],
+  },
+  {
+    id: "FA009",
+    date: "2022-02-27",
+    donor: "Germany",
+    recipient: "Ukraine (Zeitenwende redirect)",
+    eventType: "redirect",
+    description:
+      "Zeitenwende: Scholz announced 100B EUR special defence fund redirecting Germany from 0.5% to 2% GDP defense. ODA redirected: Ukraine received 8.8B EUR (2022-2024) vs. traditional development partners. German development bank KfW shifted portfolio toward conflict response.",
+    amountBillionUSD: 8.8,
+    impactScore: 7,
+    active: true,
+    geopoliticalEffect:
+      "EU development architecture being reshaped by security priorities; traditional aid recipients (Africa, Latin America) facing reduced German support; NATO reinforcement.",
+    sources: ["Bundestag Sondervermogen legislation", "BMZ development report 2023", "KfW annual report 2023"],
+  },
+  {
+    id: "FA010",
+    date: "2021-11-01",
+    donor: "UK",
+    recipient: "Global",
+    eventType: "cut",
+    description:
+      "UK cut Official Development Assistance from 0.7% to 0.5% GDP (Nov 2020, implemented 2021), citing COVID-19 costs. Cut reduced UK aid by ~4B GBP/year. Labour government reversed to 0.7% commitment in 2024 manifesto though fiscal constraints remain.",
+    amountBillionUSD: 4,
+    impactScore: 6,
+    active: false,
+    geopoliticalEffect:
+      "UK soft power decline in Commonwealth; Global Britain credibility undermined; FCDO capability hollowed out; Africa aid programs cut 30-80%.",
+    sources: ["FCDO ODA statistics 2021-2024", "Overseas Development Institute analysis", "Labour manifesto 2024"],
+  },
+  {
+    id: "FA011",
+    date: "2022-01-01",
+    donor: "Saudi Arabia",
+    recipient: "Yemen, Somalia, Sudan",
+    eventType: "competition",
+    description:
+      "Saudi-UAE aid competition in Horn of Africa and Yemen: Saudi Fund for Development disbursed 5B since 2017. UAE competes with separate Abu Dhabi Fund channels; divergent Yemen war exit strategies reflected in competing aid conditionality. Somalia: UAE-Qatar proxy competition via infrastructure grants tied to political alignment.",
+    amountBillionUSD: 35,
+    impactScore: 7,
+    active: true,
+    geopoliticalEffect:
+      "Divided Gulf aid undermining Yemen peace process; Somalia political fragmentation aided by competing Gulf patrons; Sudan civil war both Saudi and UAE backing different factions.",
+    sources: ["Saudi Fund for Development annual report", "UN Panel of Experts Yemen report", "Crisis Group Horn of Africa analysis"],
+  },
+  {
+    id: "FA012",
+    date: "2023-01-01",
+    donor: "World Bank",
+    recipient: "Global South",
+    eventType: "reform",
+    description:
+      "Developing world pushback on World Bank/IMF structural adjustment conditionality. Zambia, Ghana, Sri Lanka defaults exposed debt architecture failures. G20 Common Framework criticized as too slow. Ghana secured B IMF package with austerity conditions opposed by civil society. Paris Summit 2023 called for conditionality reform.",
+    amountBillionUSD: 3,
+    impactScore: 6,
+    active: true,
+    geopoliticalEffect:
+      "IMF conditionality providing opening for China/Russia alternative financing without conditions; Global South debt architecture reform urgency; SDR reallocation debate ongoing.",
+    sources: ["IMF Ghana program documents", "G20 Common Framework progress report", "Jubilee Debt Campaign analysis"],
+  },
+];
+
+const DONORS: DonorProfile[] = [
+  {
+    id: "D001",
+    name: "USA",
+    category: "Western",
+    annualAidBillionUSD: 60,
+    leverageTypes: ["military", "economic", "humanitarian"],
+    conditionality: "Democracy, human rights, counter-narcotics, counter-terrorism: selectively applied based on strategic interest.",
+    politicalAlignment: "NATO allies, Israel, Egypt, Jordan, Gulf states, Indo-Pacific partners.",
+    keyInstruments: ["USAID", "MCC", "DoD 333 Security Assistance", "ESF", "PEPFAR", "FMF"],
+    incidentCount: 3,
+    trend: "declining",
+  },
+  {
+    id: "D002",
+    name: "China",
+    category: "BRICS",
+    annualAidBillionUSD: 85,
+    leverageTypes: ["infrastructure", "economic", "diplomatic"],
+    conditionality: "Taiwan non-recognition, PRC UN voting alignment, market access, Huawei inclusion; no human rights conditions.",
+    politicalAlignment: "Global South, SCO members, African Union, BRI signatories.",
+    keyInstruments: ["China EXIM Bank", "Silk Road Fund", "AIIB", "South-South Cooperation Fund", "BRI bilateral MOUs"],
+    incidentCount: 1,
+    trend: "escalating",
+  },
+  {
+    id: "D003",
+    name: "EU",
+    category: "Western",
+    annualAidBillionUSD: 72,
+    leverageTypes: ["economic", "humanitarian", "diplomatic"],
+    conditionality: "Rule of law, democratic governance, migration control (increasingly dominant), trade compliance.",
+    politicalAlignment: "EU candidate states, African ACP partners, MENA neighborhood.",
+    keyInstruments: ["NDICI-Global Europe", "EIB", "EBRD", "EU Trust Funds", "EFSD+"],
+    incidentCount: 1,
+    trend: "stable",
+  },
+  {
+    id: "D004",
+    name: "Gulf States",
+    category: "Gulf",
+    annualAidBillionUSD: 20,
+    leverageTypes: ["economic", "military", "diplomatic"],
+    conditionality: "Political silence on human rights, Sunni alignment, anti-Iran positioning, trade and investment reciprocity.",
+    politicalAlignment: "Egypt, Jordan, Pakistan, Yemen government, GCC bloc.",
+    keyInstruments: ["Saudi Fund for Development", "Abu Dhabi Fund", "Qatar Investment Authority", "Kuwait Fund"],
+    incidentCount: 2,
+    trend: "escalating",
+  },
+  {
+    id: "D005",
+    name: "Japan",
+    category: "Western",
+    annualAidBillionUSD: 17,
+    leverageTypes: ["infrastructure", "economic", "diplomatic"],
+    conditionality: "Governance, anti-corruption, climate standards, Free and Open Indo-Pacific alignment.",
+    politicalAlignment: "Southeast Asia, Pacific islands, India, Africa, Ukraine.",
+    keyInstruments: ["JICA", "JBIC", "TICAD framework", "Quad infrastructure"],
+    incidentCount: 0,
+    trend: "stable",
+  },
+  {
+    id: "D006",
+    name: "India",
+    category: "Emerging",
+    annualAidBillionUSD: 5,
+    leverageTypes: ["infrastructure", "diplomatic", "economic"],
+    conditionality: "Neighborhood First alignment, anti-China counterbalancing, non-interference framing, connectivity projects using Indian firms.",
+    politicalAlignment: "South Asian neighbors, Africa (IAFS), Pacific islands, Global South voice.",
+    keyInstruments: ["MEA development partnerships", "EXIM Bank lines of credit", "ITEC technical cooperation", "UPI payment diplomacy"],
+    incidentCount: 1,
+    trend: "escalating",
+  },
+];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+export function computeWeaponizationIndex(events: AidEvent[]): number {
+  if (!events.length) return 0;
+  const activeHigh = events.filter(e => e.active && e.impactScore >= 7);
+  const ratio = activeHigh.length / events.length;
+  const avg = activeHigh.length > 0
+    ? activeHigh.reduce((s, e) => s + e.impactScore, 0) / activeHigh.length
+    : 0;
+  return Math.min(100, Math.round(ratio * 60 + avg * 4));
+}
+
+export function getByDonor(events: AidEvent[], donor: string): AidEvent[] {
+  return events.filter(e => e.donor === donor);
+}
+
+export function getHighImpactEvents(events: AidEvent[], threshold = 7): AidEvent[] {
+  return events.filter(e => e.impactScore >= threshold);
+}
+
+export function getActiveConditionality(events: AidEvent[]): AidEvent[] {
+  return events.filter(e => e.active && e.eventType === "condition");
+}
+
+export function donorLeverageClass(leverageType: LeverageType): string {
+  const map: Record<LeverageType, string> = {
+    military: "lev-military",
+    economic: "lev-economic",
+    diplomatic: "lev-diplomatic",
+    infrastructure: "lev-infra",
+    food: "lev-food",
+    humanitarian: "lev-humanitarian",
+  };
+  return map[leverageType] ?? "lev-economic";
+}
+
+export function impactClass(score: number): string {
+  if (score >= 9) return "imp-critical";
+  if (score >= 7) return "imp-high";
+  if (score >= 5) return "imp-medium";
+  return "imp-low";
+}
+
+export function eventTypeClass(eventType: AidEventType): string {
+  const map: Record<AidEventType, string> = {
+    freeze: "et-freeze",
+    cut: "et-cut",
+    condition: "et-condition",
+    redirect: "et-redirect",
+    weaponize: "et-weaponize",
+    competition: "et-competition",
+    reform: "et-reform",
+  };
+  return map[eventType] ?? "et-condition";
+}
+
+export function getImpactCategory(score: number): string {
+  if (score >= 9) return "Critical";
+  if (score >= 7) return "High";
+  if (score >= 5) return "Medium";
+  return "Low";
+}
+
+export function buildRenderData(): ForeignAidWeaponizationRenderData {
+  return {
+    events: AID_EVENTS,
+    donors: DONORS,
+    weaponizationIndex: computeWeaponizationIndex(AID_EVENTS),
+    highImpactCount: AID_EVENTS.filter(e => e.impactScore >= 7).length,
+    activeConditionCount: getActiveConditionality(AID_EVENTS).length,
+    topDonors: [...DONORS].sort((a, b) => b.annualAidBillionUSD - a.annualAidBillionUSD).slice(0, 5),
+    recentEvents: [...AID_EVENTS].sort((a, b) => b.date.localeCompare(a.date)).slice(0, 5),
+  };
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -329,6 +329,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'regime-stability': { name: 'Regime Stability', enabled: true, priority: 1 },
   'coalition-dynamics': { name: 'Coalition Dynamics', enabled: true, priority: 1 },
   'transnational-repression': { name: 'Transnational Repression', enabled: true, priority: 1 },
+  'foreign-aid-weaponization': { name: 'Foreign Aid Weaponization', enabled: true, priority: 1 },
 };
 
 const FULL_MAP_LAYERS: MapLayers = {


### PR DESCRIPTION
Tracks the use of foreign aid as a geopolitical tool across 12 major events (2021-2025) and 6 major donor profiles.

## Events Covered
- **USA USAID freeze** (Jan 2025, Trump): $60B+/yr frozen, 10,000+ programs paused; DOGE impact
- **USA Ukraine military aid** ($61B, 2022-2024): Congressional battle, Trump threatening cuts
- **USA Egypt military aid conditionality**: human rights conditions vs. strategic value debate
- **China BRI conditionality** ($843B): infrastructure for Taiwan recognition, UN votes alignment
- **EU North Africa migration conditionality**: Tunisia (EUR 105M MoU), Morocco — security over values
- **Russia grain deal weaponization**: Black Sea Grain Initiative as diplomatic lever, Kakhovka dam
- **Gulf states aid to Egypt/Jordan/PA**: $25B+ tied to post-Oct 7 Gaza policy silence
- **India Neighborhood First vs. China**: $12B+ in South Asia, Maldives fuel subsidy leverage
- **Germany Zeitenwende**: ODA redirected to Ukraine from development, 3% GDP defense
- **UK ODA cut** (0.7% to 0.5% GDP 2021, reversed Labour 2024)
- **Saudi-UAE competing aid**: Yemen, Somalia, Sudan divergent conditionality
- **World Bank/IMF conditionality reform**: developing world pushback, G20 Common Framework

## Files
- `src/components/foreign-aid-weaponization-helpers.ts` — pure logic, 8 helper functions
- `src/components/ForeignAidWeaponizationPanel.ts` — extends Panel, 24hr refresh
- `src/components/__tests__/foreign-aid-weaponization-helpers.test.mts` — 93 passing tests
- Registered in `src/config/panels.ts` and `src/app/panel-layout.ts`

## Test Results
```
tests 93
pass  93
fail  0
```

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
