### PR TITLE
feat: StateCapitalismPanel — tracks state-owned enterprises as geopolitical instruments

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -388,6 +388,7 @@ import { ArmsProliferationPanel } from '@/components/ArmsProliferationPanel';
 import { TerritorialDisputesPanel } from '@/components/TerritorialDisputesPanel';
 import { RegimeStabilityPanel } from '@/components/RegimeStabilityPanel';
 import { ArmsSalesPanel } from '@/components/ArmsSalesPanel';
+import { StateCapitalismPanel } from '@/components/StateCapitalismPanel';
 import { CoalitionDynamicsPanel } from '@/components/CoalitionDynamicsPanel';
 import { TransnationalRepressionPanel } from '@/components/TransnationalRepressionPanel';
 import { CorruptionIndexPanel } from '@/components/CorruptionIndexPanel';
@@ -1559,7 +1560,7 @@ export class PanelLayoutManager implements AppModule {
         this.ctx.panels['great-power-competition'] = new GreatPowerCompetitionPanel();
     this.ctx.panels['urban-instability'] = new UrbanInstabilityPanel();
     this.ctx.panels['cyber-espionage'] = new CyberEspionagePanel();
-    this.ctx.panels['political-economy'] = new PoliticalEconomyPanel();
+    this.ctx.panels['political-economy'] = new PoliticalEconomyPanel(); this.ctx.panels['state-capitalism'] = new StateCapitalismPanel();
  this.ctx.panels['election-monitoring'] = new ElectionMonitoringPanel();
  this.ctx.panels['urban-security'] = new UrbanSecurityPanel();
  this.ctx.panels['alliance-cohesion'] = new AllianceCohesionPanel();

--- a/src/components/StateCapitalismPanel.ts
+++ b/src/components/StateCapitalismPanel.ts
@@ -1,0 +1,172 @@
+import { Panel } from './Panel';
+import { h, replaceChildren } from '@/utils/dom-utils';
+import {
+  buildRenderData,
+  functionClass,
+  riskClass,
+  type StrategicSOE,
+  type SOEIncident,
+} from './state-capitalism-helpers';
+
+const REFRESH_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+const RISK_ORDER: Record<string, number> = { Critical: 0, High: 1, Medium: 2, Low: 3 };
+
+const COUNTRY_INDEX: Array<[string, number]> = [
+  ['China', 92], ['Russia', 88], ['Saudi Arabia', 75], ['UAE', 65],
+  ['France', 45], ['South Korea', 35], ['Germany', 25], ['USA', 20],
+];
+
+function safe<T>(fn: () => T): T | null {
+  try { return fn(); } catch { return null; }
+}
+
+function scoreClass(score: number): string {
+  if (score >= 75) return 'risk-critical';
+  if (score >= 50) return 'risk-high';
+  return 'risk-medium';
+}
+
+function severityClass(severity: number): string {
+  if (severity >= 9) return 'risk-critical';
+  if (severity >= 7) return 'risk-high';
+  return 'risk-medium';
+}
+
+function renderIndexSection(): HTMLElement {
+  const section = h('div', { className: 'sc-index-section' },
+    h('h3', { className: 'sc-section-title' }, 'State Capitalism Index by Country'),
+  );
+  for (const [country, score] of COUNTRY_INDEX) {
+    const cls = scoreClass(score);
+    section.append(
+      h('div', { className: 'sc-index-row' },
+        h('span', { className: 'sc-idx-country' }, country),
+        h('div', { className: 'sc-bar-track' },
+          h('div', { className: `sc-bar-fill ${cls}`, style: `width:${score}%` }),
+        ),
+        h('span', { className: `sc-idx-score ${cls}` }, String(score)),
+      ),
+    );
+  }
+  return section;
+}
+
+function renderSoeSection(soes: StrategicSOE[]): HTMLElement {
+  const section = h('div', { className: 'sc-soe-section' },
+    h('h3', { className: 'sc-section-title' }, 'Strategic State-Owned Enterprises'),
+  );
+  for (const soe of [...soes].sort(
+    (a, b) => (RISK_ORDER[a.geopoliticalRiskLevel] ?? 9) - (RISK_ORDER[b.geopoliticalRiskLevel] ?? 9),
+  )) {
+    section.append(
+      h('div', { className: `sc-soe-row ${riskClass(soe.geopoliticalRiskLevel)}` },
+        h('div', { className: 'sc-soe-header' },
+          h('span', { className: 'sc-soe-name' }, soe.name),
+          h('span', { className: `sc-risk-badge ${riskClass(soe.geopoliticalRiskLevel)}` }, soe.geopoliticalRiskLevel),
+          h('span', { className: `sc-fn-badge ${functionClass(soe.strategicFunction)}` }, soe.strategicFunction),
+          h('span', { className: 'sc-country' }, soe.country),
+          h('span', { className: 'sc-sector' }, soe.sector),
+          h('span', { className: 'sc-revenue' }, `$${soe.annualRevenueBn}B`),
+        ),
+        h('div', { className: 'sc-soe-desc' }, soe.description),
+        h('div', { className: 'sc-incident-note' }, soe.recentIncident),
+      ),
+    );
+  }
+  return section;
+}
+
+function renderIncidentSection(incidents: SOEIncident[]): HTMLElement {
+  const section = h('div', { className: 'sc-incident-section' },
+    h('h3', { className: 'sc-section-title' }, 'SOE Incident Log'),
+  );
+  for (const inc of [...incidents].sort((a, b) => b.severity - a.severity)) {
+    const cls = severityClass(inc.severity);
+    section.append(
+      h('div', { className: `sc-inc-row ${cls}` },
+        h('div', { className: 'sc-inc-header' },
+          h('span', { className: 'sc-inc-soe' }, inc.soe),
+          h('span', { className: 'sc-inc-type' }, inc.incidentType),
+          h('span', { className: `sc-sev-badge ${cls}` }, `Sev ${inc.severity}`),
+          h('span', { className: 'sc-inc-date' }, inc.date),
+        ),
+        h('div', { className: 'sc-inc-desc' }, inc.description),
+      ),
+    );
+  }
+  return section;
+}
+
+export class StateCapitalismPanel extends Panel {
+  static readonly panelId = 'state-capitalism';
+  static readonly title = 'State Capitalism';
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    super({
+      id: StateCapitalismPanel.panelId,
+      title: StateCapitalismPanel.title,
+      showCount: true,
+      trackActivity: false,
+      infoTooltip:
+        'Tracks state-owned enterprises as geopolitical instruments across 8 countries. Maps 12 strategic SOEs by function (energy leverage, port access, tech espionage, sanctions evasion, market dominance, defense export), risk level, and recent incidents.',
+    });
+    this.start();
+  }
+
+  public override destroy(): void {
+    if (this.refreshTimer !== null) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    super.destroy();
+  }
+
+  private start(): void {
+    this.render();
+    this.refreshTimer = setInterval(() => this.render(), REFRESH_MS);
+  }
+
+  private render(): void {
+    const data = safe(() => buildRenderData());
+    if (!data) {
+      replaceChildren(
+        this.getContentElement(),
+        h('div', { className: 'panel-empty' }, 'Data unavailable'),
+      );
+      return;
+    }
+
+    const { soes, incidents, stateCapIndex, criticalRiskCount, highRiskCount, topCountryByControl } = data;
+    this.setCount(criticalRiskCount + highRiskCount);
+
+    const idxClass = scoreClass(stateCapIndex);
+    const header = h('div', { className: 'sc-header' },
+      h('div', { className: 'sc-metric' },
+        h('span', { className: 'sc-label' }, 'State Cap Index'),
+        h('span', { className: `sc-value ${idxClass}` }, `${stateCapIndex}/100`),
+      ),
+      h('div', { className: 'sc-metric' },
+        h('span', { className: 'sc-label' }, 'Critical Risk'),
+        h('span', { className: 'sc-value risk-critical' }, String(criticalRiskCount)),
+      ),
+      h('div', { className: 'sc-metric' },
+        h('span', { className: 'sc-label' }, 'High Risk'),
+        h('span', { className: 'sc-value risk-high' }, String(highRiskCount)),
+      ),
+      h('div', { className: 'sc-metric' },
+        h('span', { className: 'sc-label' }, 'Top Actor'),
+        h('span', { className: 'sc-value' }, topCountryByControl),
+      ),
+    );
+
+    replaceChildren(
+      this.getContentElement(),
+      header,
+      renderIndexSection(),
+      renderSoeSection(soes),
+      renderIncidentSection(incidents),
+    );
+  }
+}

--- a/src/components/__tests__/state-capitalism-helpers.test.mts
+++ b/src/components/__tests__/state-capitalism-helpers.test.mts
@@ -1,0 +1,356 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import {
+  getByCountry,
+  getByFunction,
+  getCriticalRisk,
+  computeStateCapIndex,
+  topCountryBySoeCount,
+  functionClass,
+  riskClass,
+  buildRenderData,
+  type StrategicSOE,
+  type StrategicFunction,
+  type GeopoliticalRiskLevel,
+} from '../state-capitalism-helpers.ts';
+
+// ── Mock data ─────────────────────────────────────────────────────────────────
+const MOCK_SOES: StrategicSOE[] = [
+  { id: 'S1', name: 'Alpha Corp', country: 'China', sector: 'Telecom', annualRevenueBn: 100, strategicFunction: 'Tech Espionage', geopoliticalRiskLevel: 'Critical', description: 'Desc A', recentIncident: 'Banned in EU' },
+  { id: 'S2', name: 'Beta Oil', country: 'Russia', sector: 'Oil', annualRevenueBn: 200, strategicFunction: 'Energy Leverage', geopoliticalRiskLevel: 'High', description: 'Desc B', recentIncident: 'Sanctioned' },
+  { id: 'S3', name: 'Gamma Ports', country: 'China', sector: 'Shipping', annualRevenueBn: 50, strategicFunction: 'Port Access', geopoliticalRiskLevel: 'Critical', description: 'Desc C', recentIncident: 'CFIUS blocked' },
+  { id: 'S4', name: 'Delta Investments', country: 'UAE', sector: 'Finance', annualRevenueBn: 20, strategicFunction: 'Market Dominance', geopoliticalRiskLevel: 'Medium', description: 'Desc D', recentIncident: 'Scrutinized' },
+  { id: 'S5', name: 'Epsilon Arms', country: 'Russia', sector: 'Defense', annualRevenueBn: 15, strategicFunction: 'Defense Export', geopoliticalRiskLevel: 'High', description: 'Desc E', recentIncident: 'Arms to Iran' },
+  { id: 'S6', name: 'Zeta Evasion', country: 'Russia', sector: 'Oil', annualRevenueBn: 80, strategicFunction: 'Sanctions Evasion', geopoliticalRiskLevel: 'High', description: 'Desc F', recentIncident: 'Shadow fleet' },
+  { id: 'S7', name: 'Eta Grid', country: 'China', sector: 'Power', annualRevenueBn: 530, strategicFunction: 'Market Dominance', geopoliticalRiskLevel: 'High', description: 'Desc G', recentIncident: 'Blocked in AU' },
+];
+
+// ── getByCountry ──────────────────────────────────────────────────────────────
+describe('getByCountry', () => {
+  it('returns only SOEs matching the given country', () => {
+    const cn = getByCountry(MOCK_SOES, 'China');
+    assert.equal(cn.length, 3);
+    assert.ok(cn.every(s => s.country === 'China'));
+  });
+  it('returns only Russia SOEs', () => {
+    const ru = getByCountry(MOCK_SOES, 'Russia');
+    assert.equal(ru.length, 3);
+  });
+  it('returns empty array for unknown country', () => {
+    assert.equal(getByCountry(MOCK_SOES, 'Atlantis').length, 0);
+  });
+  it('does not mutate the source array', () => {
+    const before = MOCK_SOES.length;
+    getByCountry(MOCK_SOES, 'China');
+    assert.equal(MOCK_SOES.length, before);
+  });
+  it('returns single match for UAE', () => {
+    const uae = getByCountry(MOCK_SOES, 'UAE');
+    assert.equal(uae.length, 1);
+    assert.equal(uae[0].id, 'S4');
+  });
+  it('is case-sensitive (china vs China)', () => {
+    assert.equal(getByCountry(MOCK_SOES, 'china').length, 0);
+  });
+});
+
+// ── getByFunction ─────────────────────────────────────────────────────────────
+describe('getByFunction', () => {
+  it('returns Tech Espionage SOEs', () => {
+    const tech = getByFunction(MOCK_SOES, 'Tech Espionage');
+    assert.equal(tech.length, 1);
+    assert.equal(tech[0].id, 'S1');
+  });
+  it('returns Energy Leverage SOEs', () => {
+    const en = getByFunction(MOCK_SOES, 'Energy Leverage');
+    assert.equal(en.length, 1);
+    assert.equal(en[0].id, 'S2');
+  });
+  it('returns Port Access SOEs', () => {
+    const p = getByFunction(MOCK_SOES, 'Port Access');
+    assert.equal(p.length, 1);
+    assert.equal(p[0].id, 'S3');
+  });
+  it('returns Market Dominance SOEs (2 entries)', () => {
+    const md = getByFunction(MOCK_SOES, 'Market Dominance');
+    assert.equal(md.length, 2);
+    assert.ok(md.every(s => s.strategicFunction === 'Market Dominance'));
+  });
+  it('returns Defense Export SOEs', () => {
+    const de = getByFunction(MOCK_SOES, 'Defense Export');
+    assert.equal(de.length, 1);
+    assert.equal(de[0].id, 'S5');
+  });
+  it('returns Sanctions Evasion SOEs', () => {
+    const se = getByFunction(MOCK_SOES, 'Sanctions Evasion');
+    assert.equal(se.length, 1);
+    assert.equal(se[0].id, 'S6');
+  });
+  it('returns empty array when no match', () => {
+    const allEnergy = MOCK_SOES.map(s => ({ ...s, strategicFunction: 'Energy Leverage' as StrategicFunction }));
+    assert.equal(getByFunction(allEnergy, 'Tech Espionage').length, 0);
+  });
+});
+
+// ── getCriticalRisk ───────────────────────────────────────────────────────────
+describe('getCriticalRisk', () => {
+  it('returns only Critical risk SOEs', () => {
+    const crit = getCriticalRisk(MOCK_SOES);
+    assert.equal(crit.length, 2);
+    assert.ok(crit.every(s => s.geopoliticalRiskLevel === 'Critical'));
+  });
+  it('returns empty array when no Critical SOEs', () => {
+    const low = MOCK_SOES.map(s => ({ ...s, geopoliticalRiskLevel: 'Low' as GeopoliticalRiskLevel }));
+    assert.equal(getCriticalRisk(low).length, 0);
+  });
+  it('does not include High risk SOEs', () => {
+    const crit = getCriticalRisk(MOCK_SOES);
+    assert.ok(crit.every(s => s.geopoliticalRiskLevel !== 'High'));
+  });
+  it('returns all when all are Critical', () => {
+    const all = MOCK_SOES.map(s => ({ ...s, geopoliticalRiskLevel: 'Critical' as GeopoliticalRiskLevel }));
+    assert.equal(getCriticalRisk(all).length, MOCK_SOES.length);
+  });
+  it('handles empty array', () => {
+    assert.equal(getCriticalRisk([]).length, 0);
+  });
+});
+
+// ── computeStateCapIndex ──────────────────────────────────────────────────────
+describe('computeStateCapIndex', () => {
+  it('returns a number', () => {
+    assert.equal(typeof computeStateCapIndex({ China: 92, Russia: 88 }, { China: 18, Russia: 2 }), 'number');
+  });
+  it('returns 0 for empty index', () => {
+    assert.equal(computeStateCapIndex({}, {}), 0);
+  });
+  it('returns the single value for one country', () => {
+    assert.equal(computeStateCapIndex({ China: 90 }, { China: 10 }), 90);
+  });
+  it('higher-weighted countries influence result more', () => {
+    const highChinaWeight = computeStateCapIndex({ China: 92, USA: 20 }, { China: 100, USA: 1 });
+    const equalWeight = computeStateCapIndex({ China: 92, USA: 20 }, { China: 1, USA: 1 });
+    assert.ok(highChinaWeight > equalWeight);
+  });
+  it('result is an integer (rounded)', () => {
+    const idx = computeStateCapIndex({ A: 91, B: 87 }, { A: 3, B: 5 });
+    assert.equal(idx, Math.round(idx));
+  });
+  it('handles missing weight with fallback of 1', () => {
+    const idx = computeStateCapIndex({ X: 50, Y: 50 }, {});
+    assert.equal(idx, 50);
+  });
+  it('returns correct weighted average for equal weights', () => {
+    const idx = computeStateCapIndex({ A: 80, B: 60 }, { A: 1, B: 1 });
+    assert.equal(idx, 70);
+  });
+});
+
+// ── topCountryBySoeCount ──────────────────────────────────────────────────────
+describe('topCountryBySoeCount', () => {
+  it('returns China as top country (3 SOEs in mock)', () => {
+    assert.equal(topCountryBySoeCount(MOCK_SOES), 'China');
+  });
+  it('returns N/A for empty array', () => {
+    assert.equal(topCountryBySoeCount([]), 'N/A');
+  });
+  it('returns the sole country in a single-element array', () => {
+    assert.equal(topCountryBySoeCount([MOCK_SOES[0]]), 'China');
+  });
+  it('returns the country with most SOEs', () => {
+    const soes = [
+      { ...MOCK_SOES[0], country: 'USA' },
+      { ...MOCK_SOES[1], country: 'USA' },
+      { ...MOCK_SOES[2], country: 'USA' },
+      { ...MOCK_SOES[3], country: 'France' },
+    ];
+    assert.equal(topCountryBySoeCount(soes), 'USA');
+  });
+});
+
+// ── functionClass ─────────────────────────────────────────────────────────────
+describe('functionClass', () => {
+  it('returns fn-energy for Energy Leverage', () => {
+    assert.equal(functionClass('Energy Leverage'), 'fn-energy');
+  });
+  it('returns fn-port for Port Access', () => {
+    assert.equal(functionClass('Port Access'), 'fn-port');
+  });
+  it('returns fn-tech for Tech Espionage', () => {
+    assert.equal(functionClass('Tech Espionage'), 'fn-tech');
+  });
+  it('returns fn-sanctions for Sanctions Evasion', () => {
+    assert.equal(functionClass('Sanctions Evasion'), 'fn-sanctions');
+  });
+  it('returns fn-market for Market Dominance', () => {
+    assert.equal(functionClass('Market Dominance'), 'fn-market');
+  });
+  it('returns fn-defense for Defense Export', () => {
+    assert.equal(functionClass('Defense Export'), 'fn-defense');
+  });
+  it('all functions return a string starting with fn-', () => {
+    const all: StrategicFunction[] = [
+      'Energy Leverage', 'Port Access', 'Tech Espionage',
+      'Sanctions Evasion', 'Market Dominance', 'Defense Export',
+    ];
+    for (const fn of all) {
+      assert.ok(functionClass(fn).startsWith('fn-'), `${fn} => ${functionClass(fn)}`);
+    }
+  });
+});
+
+// ── riskClass ─────────────────────────────────────────────────────────────────
+describe('riskClass', () => {
+  it('returns risk-critical for Critical', () => {
+    assert.equal(riskClass('Critical'), 'risk-critical');
+  });
+  it('returns risk-high for High', () => {
+    assert.equal(riskClass('High'), 'risk-high');
+  });
+  it('returns risk-medium for Medium', () => {
+    assert.equal(riskClass('Medium'), 'risk-medium');
+  });
+  it('returns risk-low for Low', () => {
+    assert.equal(riskClass('Low'), 'risk-low');
+  });
+  it('all levels return a string starting with risk-', () => {
+    const levels: GeopoliticalRiskLevel[] = ['Critical', 'High', 'Medium', 'Low'];
+    for (const l of levels) {
+      assert.ok(riskClass(l).startsWith('risk-'), `${l} => ${riskClass(l)}`);
+    }
+  });
+});
+
+// ── buildRenderData ───────────────────────────────────────────────────────────
+describe('buildRenderData', () => {
+  it('returns all required fields', () => {
+    const d = buildRenderData();
+    assert.ok(Array.isArray(d.soes));
+    assert.ok(Array.isArray(d.incidents));
+    assert.equal(typeof d.stateCapIndex, 'number');
+    assert.equal(typeof d.criticalRiskCount, 'number');
+    assert.equal(typeof d.highRiskCount, 'number');
+    assert.equal(typeof d.topCountryByControl, 'string');
+  });
+  it('soes array is non-empty', () => {
+    assert.ok(buildRenderData().soes.length > 0);
+  });
+  it('incidents array is non-empty', () => {
+    assert.ok(buildRenderData().incidents.length > 0);
+  });
+  it('stateCapIndex is between 0 and 100', () => {
+    const idx = buildRenderData().stateCapIndex;
+    assert.ok(idx >= 0 && idx <= 100, `stateCapIndex ${idx} out of range`);
+  });
+  it('criticalRiskCount matches actual Critical SOEs', () => {
+    const d = buildRenderData();
+    assert.equal(d.criticalRiskCount, d.soes.filter(s => s.geopoliticalRiskLevel === 'Critical').length);
+  });
+  it('highRiskCount matches actual High SOEs', () => {
+    const d = buildRenderData();
+    assert.equal(d.highRiskCount, d.soes.filter(s => s.geopoliticalRiskLevel === 'High').length);
+  });
+  it('topCountryByControl is a non-empty string', () => {
+    assert.ok(buildRenderData().topCountryByControl.trim().length > 0);
+  });
+  it('topCountryByControl is China (most SOEs)', () => {
+    assert.equal(buildRenderData().topCountryByControl, 'China');
+  });
+  it('all SOE IDs are unique', () => {
+    const ids = buildRenderData().soes.map(s => s.id);
+    assert.equal(new Set(ids).size, ids.length);
+  });
+  it('all incident IDs are unique', () => {
+    const ids = buildRenderData().incidents.map(i => i.id);
+    assert.equal(new Set(ids).size, ids.length);
+  });
+  it('all annualRevenueBn values are positive', () => {
+    for (const s of buildRenderData().soes) {
+      assert.ok(s.annualRevenueBn > 0, `${s.name} revenue ${s.annualRevenueBn} not positive`);
+    }
+  });
+  it('all SOE risk levels are valid', () => {
+    const valid = new Set(['Low', 'Medium', 'High', 'Critical']);
+    for (const s of buildRenderData().soes) {
+      assert.ok(valid.has(s.geopoliticalRiskLevel), `Invalid risk: ${s.geopoliticalRiskLevel}`);
+    }
+  });
+  it('all SOE strategic functions are valid', () => {
+    const valid = new Set([
+      'Energy Leverage', 'Port Access', 'Tech Espionage',
+      'Sanctions Evasion', 'Market Dominance', 'Defense Export',
+    ]);
+    for (const s of buildRenderData().soes) {
+      assert.ok(valid.has(s.strategicFunction), `Invalid function: ${s.strategicFunction}`);
+    }
+  });
+  it('all incident severities are in range 1-10', () => {
+    for (const inc of buildRenderData().incidents) {
+      assert.ok(inc.severity >= 1 && inc.severity <= 10, `${inc.id} severity ${inc.severity} out of range`);
+    }
+  });
+  it('all SOEs have non-empty names', () => {
+    for (const s of buildRenderData().soes) {
+      assert.ok(s.name.trim().length > 0, `SOE ${s.id} has empty name`);
+    }
+  });
+  it('all SOEs have non-empty descriptions', () => {
+    for (const s of buildRenderData().soes) {
+      assert.ok(s.description.trim().length > 0, `SOE ${s.id} has empty description`);
+    }
+  });
+  it('all SOEs have non-empty recentIncident', () => {
+    for (const s of buildRenderData().soes) {
+      assert.ok(s.recentIncident.trim().length > 0, `SOE ${s.id} has empty recentIncident`);
+    }
+  });
+  it('all incidents have non-empty descriptions', () => {
+    for (const inc of buildRenderData().incidents) {
+      assert.ok(inc.description.trim().length > 0, `Incident ${inc.id} has empty description`);
+    }
+  });
+  it('all incidents have non-empty soe field', () => {
+    for (const inc of buildRenderData().incidents) {
+      assert.ok(inc.soe.trim().length > 0, `Incident ${inc.id} has empty soe`);
+    }
+  });
+  it('all incidents have non-empty date field', () => {
+    for (const inc of buildRenderData().incidents) {
+      assert.ok(inc.date.trim().length > 0, `Incident ${inc.id} has empty date`);
+    }
+  });
+  it('exactly 12 SOEs are defined', () => {
+    assert.equal(buildRenderData().soes.length, 12);
+  });
+  it('exactly 8 incidents are defined', () => {
+    assert.equal(buildRenderData().incidents.length, 8);
+  });
+  it('China has at least 4 SOEs', () => {
+    const d = buildRenderData();
+    assert.ok(getByCountry(d.soes, 'China').length >= 4);
+  });
+  it('Russia has at least 3 SOEs', () => {
+    const d = buildRenderData();
+    assert.ok(getByCountry(d.soes, 'Russia').length >= 3);
+  });
+  it('all SOE countries are non-empty strings', () => {
+    for (const s of buildRenderData().soes) {
+      assert.ok(s.country.trim().length > 0);
+    }
+  });
+  it('all SOE sectors are non-empty strings', () => {
+    for (const s of buildRenderData().soes) {
+      assert.ok(s.sector.trim().length > 0);
+    }
+  });
+  it('stateCapIndex is an integer', () => {
+    const idx = buildRenderData().stateCapIndex;
+    assert.equal(idx, Math.round(idx));
+  });
+  it('criticalRiskCount is non-negative', () => {
+    assert.ok(buildRenderData().criticalRiskCount >= 0);
+  });
+  it('highRiskCount is non-negative', () => {
+    assert.ok(buildRenderData().highRiskCount >= 0);
+  });
+});

--- a/src/components/state-capitalism-helpers.ts
+++ b/src/components/state-capitalism-helpers.ts
@@ -1,0 +1,340 @@
+// state-capitalism-helpers.ts
+// Pure logic for StateCapitalismPanel — no DOM, no Panel imports
+
+export type StrategicFunction =
+  | 'Energy Leverage'
+  | 'Port Access'
+  | 'Tech Espionage'
+  | 'Sanctions Evasion'
+  | 'Market Dominance'
+  | 'Defense Export';
+
+export type GeopoliticalRiskLevel = 'Low' | 'Medium' | 'High' | 'Critical';
+
+export interface StrategicSOE {
+  id: string;
+  name: string;
+  country: string;
+  sector: string;
+  annualRevenueBn: number;
+  strategicFunction: StrategicFunction;
+  geopoliticalRiskLevel: GeopoliticalRiskLevel;
+  description: string;
+  recentIncident: string;
+}
+
+export interface SOEIncident {
+  id: string;
+  date: string;
+  soe: string;
+  incidentType: string;
+  description: string;
+  severity: number; // 1-10
+}
+
+export interface StateCapitalismRenderData {
+  soes: StrategicSOE[];
+  incidents: SOEIncident[];
+  stateCapIndex: number;
+  criticalRiskCount: number;
+  highRiskCount: number;
+  topCountryByControl: string;
+}
+
+const SOES: StrategicSOE[] = [
+  {
+    id: 'SOE001',
+    name: 'COSCO Shipping',
+    country: 'China',
+    sector: 'Shipping / Ports',
+    annualRevenueBn: 47,
+    strategicFunction: 'Port Access',
+    geopoliticalRiskLevel: 'Critical',
+    description: "World's largest shipping company; operates or holds stakes in 50+ ports globally including strategic chokepoints.",
+    recentIncident: 'Long Beach terminal acquisition blocked by CFIUS; global port acquisition strategy scrutinized by Five Eyes',
+  },
+  {
+    id: 'SOE002',
+    name: 'Huawei Technologies',
+    country: 'China',
+    sector: 'Telecommunications',
+    annualRevenueBn: 99,
+    strategicFunction: 'Tech Espionage',
+    geopoliticalRiskLevel: 'Critical',
+    description: 'State-linked telecom giant; 5G infrastructure embedded in 170+ countries; linked to PLA via founder and leadership.',
+    recentIncident: '5G equipment banned across Five Eyes nations and EU; US Entity List since 2019; UK rip-and-replace order',
+  },
+  {
+    id: 'SOE003',
+    name: 'CNOOC',
+    country: 'China',
+    sector: 'Oil & Gas',
+    annualRevenueBn: 55,
+    strategicFunction: 'Market Dominance',
+    geopoliticalRiskLevel: 'High',
+    description: "China's largest offshore oil producer; extensive overseas drilling operations in contested waters.",
+    recentIncident: 'Delisted from NYSE December 2021 on DoD military-company designation; US investment prohibited',
+  },
+  {
+    id: 'SOE004',
+    name: 'CATL',
+    country: 'China',
+    sector: 'Battery Manufacturing',
+    annualRevenueBn: 44,
+    strategicFunction: 'Market Dominance',
+    geopoliticalRiskLevel: 'High',
+    description: "Controls 37% of global EV battery market; near-monopoly on lithium iron phosphate cells; supply-chain leverage over Western automakers.",
+    recentIncident: "Added to US DoD 'Chinese military company' list 2024; Ford licensing deal under congressional scrutiny",
+  },
+  {
+    id: 'SOE005',
+    name: 'Gazprom',
+    country: 'Russia',
+    sector: 'Natural Gas',
+    annualRevenueBn: 120,
+    strategicFunction: 'Energy Leverage',
+    geopoliticalRiskLevel: 'Critical',
+    description: 'State-owned gas monopoly; historically supplied 40% of EU gas; used as geopolitical coercion instrument by Kremlin.',
+    recentIncident: 'Weaponized gas supply to Europe 2022; cut flows via Nord Stream 1; EU emergency energy measures activated',
+  },
+  {
+    id: 'SOE006',
+    name: 'Rosneft',
+    country: 'Russia',
+    sector: 'Oil',
+    annualRevenueBn: 130,
+    strategicFunction: 'Sanctions Evasion',
+    geopoliticalRiskLevel: 'High',
+    description: "Russia's largest oil producer; operates shadow fleet with India/China to circumvent G7 price cap.",
+    recentIncident: 'India shadow fleet operations expanded 2023; G7 price cap routinely breached via ship-to-ship transfers',
+  },
+  {
+    id: 'SOE007',
+    name: 'Rostec',
+    country: 'Russia',
+    sector: 'Defense Manufacturing',
+    annualRevenueBn: 23,
+    strategicFunction: 'Defense Export',
+    geopoliticalRiskLevel: 'High',
+    description: 'State defense-industrial conglomerate; produces 80% of Russian military hardware; arms Iran, Syria, and sanctioned states.',
+    recentIncident: 'OFAC sanctioned 2022; weapons transfers to Iran and DPRK documented; Shahed drone production partnership',
+  },
+  {
+    id: 'SOE008',
+    name: 'Saudi Aramco',
+    country: 'Saudi Arabia',
+    sector: 'Oil',
+    annualRevenueBn: 440,
+    strategicFunction: 'Energy Leverage',
+    geopoliticalRiskLevel: 'High',
+    description: "World's largest oil company; backbone of OPEC+ production coordination; $2T market cap instrument of Saudi Vision 2030.",
+    recentIncident: 'OPEC+ unilateral production cut October 2023 defied Biden administration pressure; used as geopolitical counter-lever',
+  },
+  {
+    id: 'SOE009',
+    name: 'Mubadala Investment',
+    country: 'UAE',
+    sector: 'Sovereign Wealth / Tech',
+    annualRevenueBn: 18,
+    strategicFunction: 'Market Dominance',
+    geopoliticalRiskLevel: 'Medium',
+    description: 'Abu Dhabi SWF with $280B AUM; aggressive AI, semiconductor, and strategic-tech acquisitions globally.',
+    recentIncident: 'Scrutinized for AI chip access deals with US firms amid UAE-China tech transfer concerns 2024',
+  },
+  {
+    id: 'SOE010',
+    name: 'EDF (Electricite de France)',
+    country: 'France',
+    sector: 'Nuclear Energy',
+    annualRevenueBn: 143,
+    strategicFunction: 'Energy Leverage',
+    geopoliticalRiskLevel: 'Medium',
+    description: 'Renationalized French nuclear utility; operates 56 reactors supplying 70% of French electricity; EU energy policy instrument.',
+    recentIncident: 'French government fully renationalized EDF 2023; nuclear alliance used as EU energy sovereignty tool vs. gas dependency',
+  },
+  {
+    id: 'SOE011',
+    name: 'Samsung Electronics',
+    country: 'South Korea',
+    sector: 'Semiconductors / Consumer Tech',
+    annualRevenueBn: 234,
+    strategicFunction: 'Tech Espionage',
+    geopoliticalRiskLevel: 'Medium',
+    description: "South Korea's largest chaebol; dominant in DRAM, NAND, and advanced logic chips; caught between US CHIPS Act and China supply pressures.",
+    recentIncident: 'US pressure to restrict China chip sales under CHIPS Act guardrails 2023; Chinese fab operations under scrutiny',
+  },
+  {
+    id: 'SOE012',
+    name: 'State Grid Corporation',
+    country: 'China',
+    sector: 'Electric Power',
+    annualRevenueBn: 530,
+    strategicFunction: 'Market Dominance',
+    geopoliticalRiskLevel: 'High',
+    description: "Controls 88% of Chinese power transmission; world's largest utility; overseas infrastructure investments in 13 countries.",
+    recentIncident: 'Australian and Canadian overseas grid acquisitions blocked on national security grounds 2020-2021',
+  },
+];
+
+const INCIDENTS: SOEIncident[] = [
+  {
+    id: 'INC001',
+    date: '2021-11',
+    soe: 'COSCO Shipping',
+    incidentType: 'Foreign Investment Block',
+    description: "CFIUS blocked COSCO's bid to acquire a terminal at the Port of Long Beach, citing national security risks from Chinese state control of US port infrastructure.",
+    severity: 8,
+  },
+  {
+    id: 'INC002',
+    date: '2021-06',
+    soe: 'Huawei Technologies',
+    incidentType: 'Infrastructure Ban',
+    description: 'US, UK, Australia, Canada, and Sweden finalized bans on Huawei 5G equipment. UK mandated rip-and-replace of existing Huawei kit by 2027.',
+    severity: 9,
+  },
+  {
+    id: 'INC003',
+    date: '2022-08',
+    soe: 'Gazprom',
+    incidentType: 'Energy Weaponization',
+    description: 'Gazprom halted gas flows through Nord Stream 1 citing turbine maintenance, triggering European energy crisis. Germany declared gas emergency.',
+    severity: 10,
+  },
+  {
+    id: 'INC004',
+    date: '2023-10',
+    soe: 'Saudi Aramco',
+    incidentType: 'OPEC+ Production Cut',
+    description: 'Saudi Arabia extended voluntary 1M bpd production cut through end 2023 despite White House pressure, highlighting Aramco geopolitical pricing power.',
+    severity: 7,
+  },
+  {
+    id: 'INC005',
+    date: '2024-03',
+    soe: 'CATL',
+    incidentType: 'Sanctions / Designations',
+    description: 'US Department of Defense added CATL to Chinese military company list; congressional scrutiny of Ford-CATL licensing deal; EU anti-subsidy investigation launched.',
+    severity: 7,
+  },
+  {
+    id: 'INC006',
+    date: '2023-07',
+    soe: 'Rosneft',
+    incidentType: 'Sanctions Evasion',
+    description: 'OFAC identified expanded Rosneft shadow fleet of 100+ tankers routing Russian oil through UAE and India to circumvent G7 price cap.',
+    severity: 8,
+  },
+  {
+    id: 'INC007',
+    date: '2021-12',
+    soe: 'CNOOC',
+    incidentType: 'Exchange Delisting',
+    description: 'NYSE delisted CNOOC following Biden executive order on military-company investments; cut off access to US capital markets.',
+    severity: 7,
+  },
+  {
+    id: 'INC008',
+    date: '2021-04',
+    soe: 'State Grid Corporation',
+    incidentType: 'Foreign Investment Block',
+    description: 'Australia blocked State Grid bid to acquire Ausgrid electricity network on FIRB national security grounds; Canada similarly blocked a State Grid subsidiary stake.',
+    severity: 8,
+  },
+];
+
+// State Capitalism Index by country (0-100; higher = more state-directed economy)
+const STATE_CAP_INDEX: Record<string, number> = {
+  China: 92,
+  Russia: 88,
+  'Saudi Arabia': 75,
+  UAE: 65,
+  France: 45,
+  'South Korea': 35,
+  USA: 20,
+  Germany: 25,
+};
+
+// Approximate GDP weights in trillions for index weighting
+const GDP_WEIGHTS: Record<string, number> = {
+  China: 18,
+  Russia: 2,
+  'Saudi Arabia': 1,
+  UAE: 0.5,
+  France: 3,
+  'South Korea': 2,
+  USA: 27,
+  Germany: 4,
+};
+
+export function getByCountry(soes: StrategicSOE[], country: string): StrategicSOE[] {
+  return soes.filter((s) => s.country === country);
+}
+
+export function getByFunction(soes: StrategicSOE[], fn: StrategicFunction): StrategicSOE[] {
+  return soes.filter((s) => s.strategicFunction === fn);
+}
+
+export function getCriticalRisk(soes: StrategicSOE[]): StrategicSOE[] {
+  return soes.filter((s) => s.geopoliticalRiskLevel === 'Critical');
+}
+
+export function computeStateCapIndex(
+  index: Record<string, number>,
+  weights: Record<string, number>,
+): number {
+  const countries = Object.keys(index);
+  if (!countries.length) return 0;
+  let weightedSum = 0;
+  let totalWeight = 0;
+  for (const c of countries) {
+    const val = index[c];
+    if (val === undefined) continue;
+    const w = weights[c] ?? 1;
+    weightedSum += val * w;
+    totalWeight += w;
+  }
+  return totalWeight > 0 ? Math.round(weightedSum / totalWeight) : 0;
+}
+
+export function topCountryBySoeCount(soes: StrategicSOE[]): string {
+  if (!soes.length) return 'N/A';
+  const counts: Record<string, number> = {};
+  for (const s of soes) {
+    counts[s.country] = (counts[s.country] ?? 0) + 1;
+  }
+  const top = Object.entries(counts).sort((a, b) => b[1] - a[1])[0];
+  return top ? top[0] : 'N/A';
+}
+
+export function functionClass(fn: StrategicFunction): string {
+  switch (fn) {
+    case 'Energy Leverage': { return 'fn-energy'; }
+    case 'Port Access':     { return 'fn-port'; }
+    case 'Tech Espionage':  { return 'fn-tech'; }
+    case 'Sanctions Evasion': { return 'fn-sanctions'; }
+    case 'Market Dominance': { return 'fn-market'; }
+    case 'Defense Export':  { return 'fn-defense'; }
+    default:                { return 'fn-unknown'; }
+  }
+}
+
+export function riskClass(level: GeopoliticalRiskLevel): string {
+  switch (level) {
+    case 'Critical': { return 'risk-critical'; }
+    case 'High':     { return 'risk-high'; }
+    case 'Medium':   { return 'risk-medium'; }
+    case 'Low':      { return 'risk-low'; }
+    default:         { return 'risk-unknown'; }
+  }
+}
+
+export function buildRenderData(): StateCapitalismRenderData {
+  const soes = SOES;
+  const incidents = INCIDENTS;
+  const stateCapIndex = computeStateCapIndex(STATE_CAP_INDEX, GDP_WEIGHTS);
+  const criticalRiskCount = soes.filter((s) => s.geopoliticalRiskLevel === 'Critical').length;
+  const highRiskCount = soes.filter((s) => s.geopoliticalRiskLevel === 'High').length;
+  const topCountryByControl = topCountryBySoeCount(soes);
+  return { soes, incidents, stateCapIndex, criticalRiskCount, highRiskCount, topCountryByControl };
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -294,6 +294,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'cyber-espionage': { name: 'Cyber Espionage Tracker', enabled: true, priority: 1 },
   'urban-instability': { name: 'Urban Instability Monitor', enabled: true, priority: 1 },
   'political-economy': { name: 'Political Economy Risk', enabled: true, priority: 1 },
+  'state-capitalism': { name: 'State Capitalism', enabled: true, priority: 1 },
   'election-monitoring': { name: 'Election Monitoring', enabled: true, priority: 1 },
   'urban-security': { name: 'Urban Security', enabled: true, priority: 1 },
   'signal-noise-filter': { name: 'Signal Quality', enabled: true, priority: 1 },


### PR DESCRIPTION
Adds **StateCapitalismPanel** to Crystal Ball, tracking 12 strategic state-owned enterprises (SOEs) as geopolitical instruments across 8 countries.

## What this adds

### `state-capitalism-helpers.ts` (pure logic)
- **Interfaces:** `StrategicSOE`, `SOEIncident`, `StateCapitalismRenderData`
- **12 strategic SOEs:** COSCO, Huawei, CNOOC, CATL, Gazprom, Rosneft, Rostec, Saudi Aramco, Mubadala, EDF, Samsung, State Grid Corporation
- **8 incidents 2021-2024:** Long Beach block, Huawei 5G bans, Gazprom weaponization, Aramco OPEC+ cut, CATL designation, Rosneft shadow fleet, CNOOC delisting, State Grid AU/CA block
- **Helper functions:** `getByCountry`, `getByFunction`, `getCriticalRisk`, `computeStateCapIndex` (GDP-weighted), `topCountryBySoeCount`, `functionClass`, `riskClass`, `buildRenderData`
- **State capitalism index:** China 92 · Russia 88 · Saudi Arabia 75 · UAE 65 · France 45 · South Korea 35 · Germany 25 · USA 20

### `StateCapitalismPanel.ts`
- Extends `Panel`; 24-hour refresh cycle
- **Country index bar** — horizontal bars color-coded by score (Critical/High/Medium)
- **SOE table** — sorted by risk level (Critical → High → Medium), shows name, risk badge, function badge, country, sector, revenue, description, recent incident note
- **Incident log** — sorted by severity, shows SOE, incident type, severity badge, date, description

### Tests — 70 passing
Full `node:test` suite covering all helpers and `buildRenderData` data-integrity invariants.

### Registration
- `src/config/panels.ts` — `state-capitalism` key (economy group, priority 1)
- `src/app/panel-layout.ts` — import + instantiation alongside `PoliticalEconomyPanel`

---

Cross-agent review: Codex reviewed on 2026-05-30; outcome: pass

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>