### PR TITLE
feat: BorderIncidentsPanel — MID escalation tracking

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -385,6 +385,7 @@ import { TerrorismSuperpowerPanel } from '@/components/TerrorismSuperpowerPanel'
 import { WaterSecurityPanel } from '@/components/WaterSecurityPanel';
 import { EnergySecurityPanel } from '@/components/EnergySecurityPanel';
 import { ArmsProliferationPanel } from '@/components/ArmsProliferationPanel';
+import { BorderIncidentsPanel } from '@/components/BorderIncidentsPanel';
 import { TerritorialDisputesPanel } from '@/components/TerritorialDisputesPanel';
 import { RegimeStabilityPanel } from '@/components/RegimeStabilityPanel';
 import { CoalitionDynamicsPanel } from '@/components/CoalitionDynamicsPanel';
@@ -1549,6 +1550,7 @@ export class PanelLayoutManager implements AppModule {
  this.ctx.panels['water-security'] = new WaterSecurityPanel();
  this.ctx.panels['energy-security'] = new EnergySecurityPanel();
  this.ctx.panels['arms-proliferation'] = new ArmsProliferationPanel();
+    this.ctx.panels['border-incidents'] = new BorderIncidentsPanel();
  this.ctx.panels['territorial-disputes'] = new TerritorialDisputesPanel(); this.ctx.panels['regime-stability'] = new RegimeStabilityPanel(); this.ctx.panels['coalition-dynamics'] = new CoalitionDynamicsPanel(); this.ctx.panels['transnational-repression'] = new TransnationalRepressionPanel();
         this.ctx.panels['corruption-index'] = new CorruptionIndexPanel();
  this.ctx.panels['space-militarization'] = new SpaceMilitarizationPanel();

--- a/src/components/BorderIncidentsPanel.ts
+++ b/src/components/BorderIncidentsPanel.ts
@@ -1,0 +1,206 @@
+/**
+ * BorderIncidentsPanel (panel id: `border-incidents`)
+ *
+ * Tracks militarized interstate disputes (MIDs) across 12 active friction
+ * zones as early-warning escalation signals. Refreshes every 30 minutes.
+ *
+ * Pure rendering logic — data and helpers live in border-incidents-helpers.ts.
+ */
+
+import { Panel } from './Panel';
+import { h, replaceChildren } from '@/utils/dom-utils';
+import {
+  buildRenderData,
+  incidentTypeClass,
+  intensityClass,
+  type BorderFrictionZone,
+  type IncidentType,
+} from './border-incidents-helpers';
+
+const REFRESH_MS = 30 * 60 * 1000; // 30 minutes
+
+function safe<T>(fn: () => T): T | null {
+  try { return fn(); } catch { return null; }
+}
+
+function trendArrow(trend: 'escalating' | 'stable' | 'de-escalating'): string {
+  switch (trend) {
+    case 'escalating':    return '↑';
+    case 'de-escalating': return '↓';
+    default:              return '→';
+  }
+}
+
+function trendColor(trend: 'escalating' | 'stable' | 'de-escalating'): string {
+  switch (trend) {
+    case 'escalating':    return 'var(--severity-critical, #ef4444)';
+    case 'de-escalating': return 'var(--severity-low, #4caf50)';
+    default:              return 'var(--severity-medium, #f59e0b)';
+  }
+}
+
+function indexColor(score: number): string {
+  if (score >= 75) return 'var(--severity-critical, #ef4444)';
+  if (score >= 55) return 'var(--severity-high, #f97316)';
+  if (score >= 35) return 'var(--severity-medium, #f59e0b)';
+  return 'var(--severity-low, #4caf50)';
+}
+
+function potentialColor(potential: number): string {
+  if (potential >= 8) return 'var(--severity-critical, #ef4444)';
+  if (potential >= 6) return 'var(--severity-high, #f97316)';
+  if (potential >= 4) return 'var(--severity-medium, #f59e0b)';
+  return 'var(--severity-low, #4caf50)';
+}
+
+function incidentTypeBadge(type: IncidentType): HTMLElement {
+  return h('span', {
+    className: incidentTypeClass(type),
+    style: 'font-size:9px;padding:1px 4px;border-radius:3px;background:#1e293b;color:#cbd5e1;margin-right:2px',
+  }, type.toUpperCase());
+}
+
+function statTile(value: string | number, label: string, color: string): HTMLElement {
+  return h('div', { style: 'text-align:center;min-width:64px' },
+    h('div', { style: `font-size:20px;font-weight:700;color:${color};line-height:1` }, String(value)),
+    h('div', { style: 'font-size:10px;color:#9e9e9e;margin-top:2px' }, label),
+  );
+}
+
+export class BorderIncidentsPanel extends Panel {
+  static readonly panelId = 'border-incidents';
+  static readonly title = 'Border Incidents';
+
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    super({
+      id: BorderIncidentsPanel.panelId,
+      title: BorderIncidentsPanel.title,
+      showCount: true,
+      trackActivity: false,
+      infoTooltip:
+        'Tracks militarized interstate disputes (MIDs) across 12 active friction zones. Signals escalation potential, incident frequency, nuclear risk, and trend direction. Refreshes every 30 minutes.',
+    });
+    this.start();
+  }
+
+  public override destroy(): void {
+    if (this.refreshTimer !== null) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    super.destroy();
+  }
+
+  private start(): void {
+    this.render();
+    this.refreshTimer = setInterval(() => this.render(), REFRESH_MS);
+  }
+
+  private render(): void {
+    const data = safe(() => buildRenderData());
+    if (!data) {
+      replaceChildren(
+        this.getContentElement(),
+        h('div', { className: 'panel-empty' }, 'Data unavailable'),
+      );
+      return;
+    }
+
+    const { zones, globalMIDIndex, highIntensityCount, escalatingCount, nuclearRiskCount } = data;
+    this.setCount(highIntensityCount + escalatingCount);
+
+    replaceChildren(
+      this.getContentElement(),
+      h('div', { className: 'app-root' },
+        this.buildHeader(globalMIDIndex, highIntensityCount, escalatingCount, nuclearRiskCount),
+        this.buildZoneList(zones),
+      ),
+    );
+  }
+
+  // ── Header — MID Index + aggregate stats ─────────────────────────────────
+
+  private buildHeader(
+    globalMIDIndex: number,
+    highIntensityCount: number,
+    escalatingCount: number,
+    nuclearRiskCount: number,
+  ): HTMLElement {
+    const iColor = indexColor(globalMIDIndex);
+    return h('div', { className: 'app-section' },
+      h('div', { className: 'app-section-header' }, 'MID Global Index'),
+      h('div', { style: 'display:flex;align-items:baseline;gap:4px;margin-bottom:10px' },
+        h('div', { style: `font-size:36px;font-weight:700;color:${iColor};line-height:1` },
+          String(globalMIDIndex)),
+        h('div', { style: 'font-size:11px;color:#9e9e9e' }, '/ 100'),
+      ),
+      h('div', { style: 'display:flex;gap:16px;padding-top:6px;border-top:1px solid #2a2a2a' },
+        statTile(highIntensityCount, 'High Intensity', 'var(--severity-high, #f97316)'),
+        statTile(escalatingCount,    'Escalating',    'var(--severity-critical, #ef4444)'),
+        statTile(nuclearRiskCount,   'Nuclear Risk',  '#a78bfa'),
+      ),
+    );
+  }
+
+  // ── Zone list ─────────────────────────────────────────────────────────────
+
+  private buildZoneList(zones: BorderFrictionZone[]): HTMLElement {
+    const section = h('div', { className: 'app-section' },
+      h('div', { className: 'app-section-header' }, `Friction Zones (${zones.length})`),
+    );
+    for (const zone of zones) {
+      section.append(this.buildZoneRow(zone));
+    }
+    return section;
+  }
+
+  private buildZoneRow(zone: BorderFrictionZone): HTMLElement {
+    const trendCol   = trendColor(zone.trend);
+    const intClass   = intensityClass(zone);
+    const pColor     = potentialColor(zone.escalationPotential);
+    const pct        = (zone.escalationPotential / 10) * 100;
+
+    const typesDiv = h('div', { style: 'display:flex;align-items:center;gap:4px;margin-bottom:3px' });
+    typesDiv.append(
+      h('span', { style: 'font-size:10px;color:#6b7280;margin-right:2px' }, zone.region),
+    );
+    for (const t of zone.incidentType) {
+      typesDiv.append(incidentTypeBadge(t));
+    }
+
+    return h('div', {
+      className: `mid-zone ${intClass}`,
+      style: 'padding:8px 0;border-bottom:1px solid #1e1e1e',
+    },
+      // Title row
+      h('div', { style: 'display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:3px' },
+        h('div', { style: 'font-size:12px;font-weight:600;color:#e5e7eb' },
+          zone.parties.join(' / ')),
+        h('div', { style: 'display:flex;align-items:center;gap:5px' },
+          h('span', { style: `font-size:11px;font-weight:700;color:${trendCol}` },
+            `${trendArrow(zone.trend)} ${zone.trend}`),
+          zone.nuclearRisk
+            ? h('span', { style: 'font-size:9px;background:#4c1d95;color:#c4b5fd;border-radius:3px;padding:1px 4px' }, '☢ NUC')
+            : h('span'),
+        ),
+      ),
+      // Region + incident-type badges
+      typesDiv,
+      // Frequency + escalation-potential bar
+      h('div', { style: 'display:flex;align-items:center;gap:8px;margin-bottom:4px' },
+        h('span', { style: 'font-size:10px;color:#9e9e9e;width:72px;flex-shrink:0' },
+          `${zone.monthlyFrequency}/mo`),
+        h('div', { style: 'flex:1;height:4px;background:#1e293b;border-radius:2px;overflow:hidden' },
+          h('div', { style: `height:100%;width:${pct}%;background:${pColor};border-radius:2px` }),
+        ),
+        h('span', { style: `font-size:10px;font-weight:600;color:${pColor}` },
+          `P${zone.escalationPotential}`),
+      ),
+      // Description
+      h('div', { style: 'font-size:11px;color:#6b7280;line-height:1.4' },
+        zone.description),
+    );
+  }
+}

--- a/src/components/__tests__/border-incidents-helpers.test.mts
+++ b/src/components/__tests__/border-incidents-helpers.test.mts
@@ -1,0 +1,448 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import {
+  BORDER_FRICTION_ZONES,
+  getHighIntensity,
+  getEscalating,
+  getByRegion,
+  getNuclearRisk,
+  computeGlobalMIDIndex,
+  incidentTypeClass,
+  intensityClass,
+  buildRenderData,
+  type BorderFrictionZone,
+} from '../border-incidents-helpers.ts';
+
+// ── BORDER_FRICTION_ZONES data integrity ─────────────────────────────────────
+
+describe('BORDER_FRICTION_ZONES', () => {
+  it('contains exactly 12 zones', () => {
+    assert.equal(BORDER_FRICTION_ZONES.length, 12);
+  });
+
+  it('every zone has a non-empty id string', () => {
+    for (const z of BORDER_FRICTION_ZONES) {
+      assert.ok(typeof z.id === 'string' && z.id.length > 0, `Empty id on zone`);
+    }
+  });
+
+  it('every zone has at least 2 parties', () => {
+    for (const z of BORDER_FRICTION_ZONES) {
+      assert.ok(z.parties.length >= 2, `${z.id} has fewer than 2 parties`);
+    }
+  });
+
+  it('escalationPotential is in [1, 10] for all zones', () => {
+    for (const z of BORDER_FRICTION_ZONES) {
+      assert.ok(
+        z.escalationPotential >= 1 && z.escalationPotential <= 10,
+        `${z.id} potential out of range: ${z.escalationPotential}`,
+      );
+    }
+  });
+
+  it('monthlyFrequency is a positive number for all zones', () => {
+    for (const z of BORDER_FRICTION_ZONES) {
+      assert.ok(z.monthlyFrequency > 0, `${z.id} has non-positive monthlyFrequency`);
+    }
+  });
+
+  it('trend is one of the valid union values', () => {
+    const valid = new Set(['escalating', 'stable', 'de-escalating']);
+    for (const z of BORDER_FRICTION_ZONES) {
+      assert.ok(valid.has(z.trend), `${z.id} invalid trend: ${z.trend}`);
+    }
+  });
+
+  it('incidentType is a non-empty array for all zones', () => {
+    for (const z of BORDER_FRICTION_ZONES) {
+      assert.ok(Array.isArray(z.incidentType) && z.incidentType.length > 0,
+        `${z.id} has empty incidentType`);
+    }
+  });
+
+  it('all incidentType values are valid', () => {
+    const valid = new Set(['Fire', 'Maneuver', 'Display', 'Blockade', 'Seizure']);
+    for (const z of BORDER_FRICTION_ZONES) {
+      for (const t of z.incidentType) {
+        assert.ok(valid.has(t), `${z.id} invalid incidentType: ${t}`);
+      }
+    }
+  });
+
+  it('nuclearRisk is a boolean on all zones', () => {
+    for (const z of BORDER_FRICTION_ZONES) {
+      assert.equal(typeof z.nuclearRisk, 'boolean');
+    }
+  });
+
+  it('china-taiwan-adiz has escalationPotential 9', () => {
+    const z = BORDER_FRICTION_ZONES.find((x) => x.id === 'china-taiwan-adiz');
+    assert.ok(z);
+    assert.equal(z!.escalationPotential, 9);
+  });
+
+  it('russia-ukraine-frontline has monthlyFrequency 300', () => {
+    const z = BORDER_FRICTION_ZONES.find((x) => x.id === 'russia-ukraine-frontline');
+    assert.ok(z);
+    assert.equal(z!.monthlyFrequency, 300);
+  });
+});
+
+// ── getHighIntensity ──────────────────────────────────────────────────────────
+
+describe('getHighIntensity', () => {
+  it('returns an array', () => {
+    assert.ok(Array.isArray(getHighIntensity(BORDER_FRICTION_ZONES)));
+  });
+
+  it('returns empty for empty input', () => {
+    assert.equal(getHighIntensity([]).length, 0);
+  });
+
+  it('every returned zone satisfies monthly>10 or potential>=8', () => {
+    for (const z of getHighIntensity(BORDER_FRICTION_ZONES)) {
+      assert.ok(
+        z.monthlyFrequency > 10 || z.escalationPotential >= 8,
+        `${z.id} should not be high-intensity`,
+      );
+    }
+  });
+
+  it('china-taiwan-adiz is high intensity (45/mo and P9)', () => {
+    const result = getHighIntensity(BORDER_FRICTION_ZONES);
+    assert.ok(result.some((z) => z.id === 'china-taiwan-adiz'));
+  });
+
+  it('russia-ukraine-frontline is high intensity (300/mo)', () => {
+    const result = getHighIntensity(BORDER_FRICTION_ZONES);
+    assert.ok(result.some((z) => z.id === 'russia-ukraine-frontline'));
+  });
+
+  it('ecuador-colombia is NOT high intensity (2/mo, P4)', () => {
+    const result = getHighIntensity(BORDER_FRICTION_ZONES);
+    assert.ok(!result.some((z) => z.id === 'ecuador-colombia'));
+  });
+
+  it('a zone with exactly monthly=11 qualifies', () => {
+    const zone: BorderFrictionZone = {
+      id: 'test', parties: ['A', 'B'], region: 'X',
+      incidentType: ['Fire'], monthlyFrequency: 11, trend: 'stable',
+      nuclearRisk: false, escalationPotential: 3,
+      description: '', lastIncident: '',
+    };
+    assert.equal(getHighIntensity([zone]).length, 1);
+  });
+
+  it('a zone with monthly=10 and potential=7 does NOT qualify', () => {
+    const zone: BorderFrictionZone = {
+      id: 'test', parties: ['A', 'B'], region: 'X',
+      incidentType: ['Display'], monthlyFrequency: 10, trend: 'stable',
+      nuclearRisk: false, escalationPotential: 7,
+      description: '', lastIncident: '',
+    };
+    assert.equal(getHighIntensity([zone]).length, 0);
+  });
+});
+
+// ── getEscalating ─────────────────────────────────────────────────────────────
+
+describe('getEscalating', () => {
+  it('returns empty for empty input', () => {
+    assert.equal(getEscalating([]).length, 0);
+  });
+
+  it('all returned zones have trend === "escalating"', () => {
+    for (const z of getEscalating(BORDER_FRICTION_ZONES)) {
+      assert.equal(z.trend, 'escalating');
+    }
+  });
+
+  it('india-pakistan-loc is escalating', () => {
+    assert.ok(getEscalating(BORDER_FRICTION_ZONES).some((z) => z.id === 'india-pakistan-loc'));
+  });
+
+  it('armenia-azerbaijan is NOT escalating (de-escalating)', () => {
+    assert.ok(!getEscalating(BORDER_FRICTION_ZONES).some((z) => z.id === 'armenia-azerbaijan'));
+  });
+
+  it('russia-ukraine-frontline is NOT escalating (stable)', () => {
+    assert.ok(!getEscalating(BORDER_FRICTION_ZONES).some((z) => z.id === 'russia-ukraine-frontline'));
+  });
+
+  it('result is a subset of input', () => {
+    const ids = new Set(BORDER_FRICTION_ZONES.map((z) => z.id));
+    for (const z of getEscalating(BORDER_FRICTION_ZONES)) {
+      assert.ok(ids.has(z.id));
+    }
+  });
+});
+
+// ── getByRegion ───────────────────────────────────────────────────────────────
+
+describe('getByRegion', () => {
+  it('returns empty for unknown region', () => {
+    assert.equal(getByRegion(BORDER_FRICTION_ZONES, 'Narnia').length, 0);
+  });
+
+  it('returns empty for empty input', () => {
+    assert.equal(getByRegion([], 'Europe').length, 0);
+  });
+
+  it('all returned zones have the requested region', () => {
+    for (const z of getByRegion(BORDER_FRICTION_ZONES, 'Europe')) {
+      assert.equal(z.region, 'Europe');
+    }
+  });
+
+  it('Europe has at least 2 zones (Russia-Ukraine, Serbia-Kosovo, Russia-Finland)', () => {
+    assert.ok(getByRegion(BORDER_FRICTION_ZONES, 'Europe').length >= 2);
+  });
+
+  it('South Asia zone count is 2 (China-India, India-Pakistan)', () => {
+    assert.equal(getByRegion(BORDER_FRICTION_ZONES, 'South Asia').length, 2);
+  });
+
+  it('Latin America has exactly 1 zone', () => {
+    assert.equal(getByRegion(BORDER_FRICTION_ZONES, 'Latin America').length, 1);
+  });
+});
+
+// ── getNuclearRisk ────────────────────────────────────────────────────────────
+
+describe('getNuclearRisk', () => {
+  it('returns empty for empty input', () => {
+    assert.equal(getNuclearRisk([]).length, 0);
+  });
+
+  it('all returned zones have nuclearRisk true', () => {
+    for (const z of getNuclearRisk(BORDER_FRICTION_ZONES)) {
+      assert.equal(z.nuclearRisk, true);
+    }
+  });
+
+  it('china-taiwan-adiz is a nuclear-risk zone', () => {
+    assert.ok(getNuclearRisk(BORDER_FRICTION_ZONES).some((z) => z.id === 'china-taiwan-adiz'));
+  });
+
+  it('ecuador-colombia is NOT a nuclear-risk zone', () => {
+    assert.ok(!getNuclearRisk(BORDER_FRICTION_ZONES).some((z) => z.id === 'ecuador-colombia'));
+  });
+
+  it('nuclear-risk count is 5', () => {
+    assert.equal(getNuclearRisk(BORDER_FRICTION_ZONES).length, 5);
+  });
+});
+
+// ── computeGlobalMIDIndex ─────────────────────────────────────────────────────
+
+describe('computeGlobalMIDIndex', () => {
+  it('returns 0 for empty array', () => {
+    assert.equal(computeGlobalMIDIndex([]), 0);
+  });
+
+  it('returns a number in [0, 100]', () => {
+    const idx = computeGlobalMIDIndex(BORDER_FRICTION_ZONES);
+    assert.ok(idx >= 0 && idx <= 100, `Index out of range: ${idx}`);
+  });
+
+  it('single zone with potential 10, escalating, nuclear yields near-100', () => {
+    const zone: BorderFrictionZone = {
+      id: 'x', parties: ['A', 'B'], region: 'X', incidentType: ['Fire'],
+      monthlyFrequency: 1, trend: 'escalating', nuclearRisk: true,
+      escalationPotential: 10, description: '', lastIncident: '',
+    };
+    const idx = computeGlobalMIDIndex([zone]);
+    assert.ok(idx >= 90, `Expected near-100, got ${idx}`);
+  });
+
+  it('single zone with potential 1, stable, no nuclear yields low index', () => {
+    const zone: BorderFrictionZone = {
+      id: 'x', parties: ['A', 'B'], region: 'X', incidentType: ['Display'],
+      monthlyFrequency: 1, trend: 'stable', nuclearRisk: false,
+      escalationPotential: 1, description: '', lastIncident: '',
+    };
+    const idx = computeGlobalMIDIndex([zone]);
+    assert.ok(idx < 20, `Expected low index, got ${idx}`);
+  });
+
+  it('more nuclear zones yields higher index (same potential, same trend)', () => {
+    const base: BorderFrictionZone = {
+      id: 'x', parties: ['A', 'B'], region: 'X', incidentType: ['Fire'],
+      monthlyFrequency: 1, trend: 'stable', nuclearRisk: false,
+      escalationPotential: 5, description: '', lastIncident: '',
+    };
+    const nuclear: BorderFrictionZone = { ...base, nuclearRisk: true };
+    const withNuclear = computeGlobalMIDIndex([nuclear, base]);
+    const withoutNuclear = computeGlobalMIDIndex([base, base]);
+    assert.ok(withNuclear > withoutNuclear);
+  });
+
+  it('more escalating zones yields higher index (same potential, no nuclear)', () => {
+    const stable: BorderFrictionZone = {
+      id: 'x', parties: ['A', 'B'], region: 'X', incidentType: ['Fire'],
+      monthlyFrequency: 1, trend: 'stable', nuclearRisk: false,
+      escalationPotential: 5, description: '', lastIncident: '',
+    };
+    const esc: BorderFrictionZone = { ...stable, trend: 'escalating' };
+    const withEsc    = computeGlobalMIDIndex([esc, stable]);
+    const withoutEsc = computeGlobalMIDIndex([stable, stable]);
+    assert.ok(withEsc > withoutEsc);
+  });
+
+  it('clamps at 100 for extreme inputs', () => {
+    const maxZone: BorderFrictionZone = {
+      id: 'x', parties: ['A', 'B'], region: 'X', incidentType: ['Fire'],
+      monthlyFrequency: 9999, trend: 'escalating', nuclearRisk: true,
+      escalationPotential: 10, description: '', lastIncident: '',
+    };
+    assert.equal(computeGlobalMIDIndex([maxZone]), 100);
+  });
+});
+
+// ── incidentTypeClass ─────────────────────────────────────────────────────────
+
+describe('incidentTypeClass', () => {
+  it('Fire returns "mid-type--fire"', () => {
+    assert.equal(incidentTypeClass('Fire'), 'mid-type--fire');
+  });
+
+  it('Maneuver returns "mid-type--maneuver"', () => {
+    assert.equal(incidentTypeClass('Maneuver'), 'mid-type--maneuver');
+  });
+
+  it('Display returns "mid-type--display"', () => {
+    assert.equal(incidentTypeClass('Display'), 'mid-type--display');
+  });
+
+  it('Blockade returns "mid-type--blockade"', () => {
+    assert.equal(incidentTypeClass('Blockade'), 'mid-type--blockade');
+  });
+
+  it('Seizure returns "mid-type--seizure"', () => {
+    assert.equal(incidentTypeClass('Seizure'), 'mid-type--seizure');
+  });
+
+  it('all 5 types return distinct class strings', () => {
+    const classes = ['Fire', 'Maneuver', 'Display', 'Blockade', 'Seizure']
+      .map((t) => incidentTypeClass(t as any));
+    assert.equal(new Set(classes).size, 5);
+  });
+
+  it('all returned strings start with "mid-type--"', () => {
+    for (const t of ['Fire', 'Maneuver', 'Display', 'Blockade', 'Seizure'] as const) {
+      assert.ok(incidentTypeClass(t).startsWith('mid-type--'));
+    }
+  });
+});
+
+// ── intensityClass ────────────────────────────────────────────────────────────
+
+describe('intensityClass', () => {
+  function zone(pot: number, freq: number): BorderFrictionZone {
+    return {
+      id: 'test', parties: ['A', 'B'], region: 'X', incidentType: ['Fire'],
+      monthlyFrequency: freq, trend: 'stable', nuclearRisk: false,
+      escalationPotential: pot, description: '', lastIncident: '',
+    };
+  }
+
+  it('potential 8 returns "mid-intensity--critical"', () => {
+    assert.equal(intensityClass(zone(8, 1)), 'mid-intensity--critical');
+  });
+
+  it('monthlyFrequency 51 returns "mid-intensity--critical"', () => {
+    assert.equal(intensityClass(zone(3, 51)), 'mid-intensity--critical');
+  });
+
+  it('potential 6, freq 1 returns "mid-intensity--high"', () => {
+    assert.equal(intensityClass(zone(6, 1)), 'mid-intensity--high');
+  });
+
+  it('monthlyFrequency 11, potential 3 returns "mid-intensity--high"', () => {
+    assert.equal(intensityClass(zone(3, 11)), 'mid-intensity--high');
+  });
+
+  it('potential 4, freq 1 returns "mid-intensity--medium"', () => {
+    assert.equal(intensityClass(zone(4, 1)), 'mid-intensity--medium');
+  });
+
+  it('potential 2, freq 1 returns "mid-intensity--low"', () => {
+    assert.equal(intensityClass(zone(2, 1)), 'mid-intensity--low');
+  });
+
+  it('all BORDER_FRICTION_ZONES return a valid intensity class', () => {
+    const valid = new Set(['mid-intensity--critical', 'mid-intensity--high', 'mid-intensity--medium', 'mid-intensity--low']);
+    for (const z of BORDER_FRICTION_ZONES) {
+      assert.ok(valid.has(intensityClass(z)), `${z.id} returned invalid class: ${intensityClass(z)}`);
+    }
+  });
+});
+
+// ── buildRenderData ───────────────────────────────────────────────────────────
+
+describe('buildRenderData', () => {
+  it('returns an object with zones, globalMIDIndex, highIntensityCount, escalatingCount, nuclearRiskCount', () => {
+    const d = buildRenderData();
+    assert.ok('zones' in d);
+    assert.ok('globalMIDIndex' in d);
+    assert.ok('highIntensityCount' in d);
+    assert.ok('escalatingCount' in d);
+    assert.ok('nuclearRiskCount' in d);
+  });
+
+  it('zones.length equals 12 for default input', () => {
+    assert.equal(buildRenderData().zones.length, 12);
+  });
+
+  it('zones are sorted by escalationPotential descending', () => {
+    const zones = buildRenderData().zones;
+    for (let i = 0; i < zones.length - 1; i++) {
+      assert.ok(
+        zones[i].escalationPotential >= zones[i + 1].escalationPotential,
+        `Sort broken at index ${i}: ${zones[i].escalationPotential} < ${zones[i + 1].escalationPotential}`,
+      );
+    }
+  });
+
+  it('globalMIDIndex is in [0, 100]', () => {
+    const idx = buildRenderData().globalMIDIndex;
+    assert.ok(idx >= 0 && idx <= 100);
+  });
+
+  it('highIntensityCount matches getHighIntensity().length', () => {
+    const d = buildRenderData();
+    assert.equal(d.highIntensityCount, getHighIntensity(BORDER_FRICTION_ZONES).length);
+  });
+
+  it('escalatingCount matches getEscalating().length', () => {
+    const d = buildRenderData();
+    assert.equal(d.escalatingCount, getEscalating(BORDER_FRICTION_ZONES).length);
+  });
+
+  it('nuclearRiskCount matches getNuclearRisk().length', () => {
+    const d = buildRenderData();
+    assert.equal(d.nuclearRiskCount, getNuclearRisk(BORDER_FRICTION_ZONES).length);
+  });
+
+  it('accepts a custom zones array', () => {
+    const custom: BorderFrictionZone[] = [
+      {
+        id: 'a', parties: ['X', 'Y'], region: 'Test', incidentType: ['Fire'],
+        monthlyFrequency: 5, trend: 'stable', nuclearRisk: false,
+        escalationPotential: 3, description: '', lastIncident: '',
+      },
+    ];
+    const d = buildRenderData(custom);
+    assert.equal(d.zones.length, 1);
+    assert.equal(d.highIntensityCount, 0);
+    assert.equal(d.nuclearRiskCount, 0);
+  });
+
+  it('does not mutate the original BORDER_FRICTION_ZONES array order', () => {
+    const before = BORDER_FRICTION_ZONES.map((z) => z.id);
+    buildRenderData();
+    const after = BORDER_FRICTION_ZONES.map((z) => z.id);
+    assert.deepEqual(before, after);
+  });
+});

--- a/src/components/border-incidents-helpers.ts
+++ b/src/components/border-incidents-helpers.ts
@@ -1,0 +1,277 @@
+/**
+ * Pure helpers for BorderIncidentsPanel.
+ *
+ * Tracks militarized interstate disputes (MIDs) across active friction
+ * zones as early-warning escalation signals. All static data is a
+ * synthetic illustrative seed for deterministic rendering and testing.
+ *
+ * No DOM, no fetch — safe to import in Node.js tests.
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type IncidentType = 'Fire' | 'Maneuver' | 'Display' | 'Blockade' | 'Seizure';
+export type TrendType = 'escalating' | 'stable' | 'de-escalating';
+
+export interface BorderFrictionZone {
+  id: string;
+  parties: string[];
+  region: string;
+  incidentType: IncidentType[];
+  /** Approximate monthly incident count (300 = continuous/active-war). */
+  monthlyFrequency: number;
+  trend: TrendType;
+  nuclearRisk: boolean;
+  /** 1 (negligible) – 10 (imminent conflict). */
+  escalationPotential: number;
+  description: string;
+  lastIncident: string;
+}
+
+export interface MIDRenderData {
+  zones: BorderFrictionZone[];
+  globalMIDIndex: number;
+  highIntensityCount: number;
+  escalatingCount: number;
+  nuclearRiskCount: number;
+}
+
+// ── Static data ───────────────────────────────────────────────────────────────
+
+export const BORDER_FRICTION_ZONES: BorderFrictionZone[] = [
+  {
+    id: 'china-taiwan-adiz',
+    parties: ['China', 'Taiwan'],
+    region: 'Asia-Pacific',
+    incidentType: ['Display', 'Maneuver'],
+    monthlyFrequency: 45,
+    trend: 'escalating',
+    nuclearRisk: true,
+    escalationPotential: 9,
+    description:
+      'PLA Air Force sorties into Taiwan ADIZ; record 153 aircraft October 2024. Frequency accelerating post-elections.',
+    lastIncident: '2024-10',
+  },
+  {
+    id: 'china-india-lac',
+    parties: ['China', 'India'],
+    region: 'South Asia',
+    incidentType: ['Maneuver'],
+    monthlyFrequency: 8,
+    trend: 'stable',
+    nuclearRisk: true,
+    escalationPotential: 7,
+    description:
+      'Post-Galwan patrol standoffs along Line of Actual Control; buffer zones holding under 2021 disengagement agreement.',
+    lastIncident: '2024-09',
+  },
+  {
+    id: 'india-pakistan-loc',
+    parties: ['India', 'Pakistan'],
+    region: 'South Asia',
+    incidentType: ['Fire', 'Display'],
+    monthlyFrequency: 15,
+    trend: 'escalating',
+    nuclearRisk: true,
+    escalationPotential: 8,
+    description:
+      'Post-Pahalgam 2025 mobilization elevated cross-LoC firing incidents and fighter deployments to crisis levels.',
+    lastIncident: '2025-05',
+  },
+  {
+    id: 'china-philippines-scs',
+    parties: ['China', 'Philippines'],
+    region: 'Asia-Pacific',
+    incidentType: ['Seizure', 'Blockade'],
+    monthlyFrequency: 12,
+    trend: 'escalating',
+    nuclearRisk: false,
+    escalationPotential: 7,
+    description:
+      'Water-cannon attacks on Philippine resupply missions to Second Thomas Shoal; harassment of BRP Sierra Madre ongoing.',
+    lastIncident: '2025-04',
+  },
+  {
+    id: 'russia-ukraine-frontline',
+    parties: ['Russia', 'Ukraine'],
+    region: 'Europe',
+    incidentType: ['Fire'],
+    monthlyFrequency: 300,
+    trend: 'stable',
+    nuclearRisk: true,
+    escalationPotential: 8,
+    description:
+      'Active war; continuous artillery exchanges along ~1,000 km front. Nuclear risk indirect — escalatory rhetoric from Kremlin.',
+    lastIncident: '2025-05',
+  },
+  {
+    id: 'north-korea-south-korea-dmz',
+    parties: ['North Korea', 'South Korea'],
+    region: 'Asia-Pacific',
+    incidentType: ['Display', 'Fire'],
+    monthlyFrequency: 6,
+    trend: 'escalating',
+    nuclearRisk: true,
+    escalationPotential: 7,
+    description:
+      'GPS jamming, propaganda balloon campaigns, and brief small-arms exchanges along DMZ throughout 2024.',
+    lastIncident: '2024-10',
+  },
+  {
+    id: 'russia-finland-baltic',
+    parties: ['Russia', 'Finland'],
+    region: 'Europe',
+    incidentType: ['Maneuver'],
+    monthlyFrequency: 3,
+    trend: 'escalating',
+    nuclearRisk: false,
+    escalationPotential: 5,
+    description:
+      'Post-NATO accession air and naval maneuvers near Finnish border and Baltic airspace; undersea infrastructure incidents.',
+    lastIncident: '2025-03',
+  },
+  {
+    id: 'armenia-azerbaijan',
+    parties: ['Armenia', 'Azerbaijan'],
+    region: 'Eurasia',
+    incidentType: ['Display'],
+    monthlyFrequency: 2,
+    trend: 'de-escalating',
+    nuclearRisk: false,
+    escalationPotential: 5,
+    description:
+      'Ongoing border demarcation disputes following 2023 Karabakh resolution; tension reduced but legal status unresolved.',
+    lastIncident: '2025-02',
+  },
+  {
+    id: 'serbia-kosovo',
+    parties: ['Serbia', 'Kosovo'],
+    region: 'Europe',
+    incidentType: ['Display'],
+    monthlyFrequency: 3,
+    trend: 'stable',
+    nuclearRisk: false,
+    escalationPotential: 6,
+    description:
+      'Recurring border standoffs; NATO KFOR maintains stabilizing presence along administrative boundary line.',
+    lastIncident: '2025-01',
+  },
+  {
+    id: 'saudi-arabia-yemen',
+    parties: ['Saudi Arabia', 'Yemen (Houthi)'],
+    region: 'Middle East',
+    incidentType: ['Fire'],
+    monthlyFrequency: 20,
+    trend: 'stable',
+    nuclearRisk: false,
+    escalationPotential: 6,
+    description:
+      'Ongoing cross-border exchanges; Houthi drone and ballistic missile fire persists despite intermittent ceasefire efforts.',
+    lastIncident: '2025-05',
+  },
+  {
+    id: 'ethiopia-eritrea',
+    parties: ['Ethiopia', 'Eritrea'],
+    region: 'Africa',
+    incidentType: ['Maneuver'],
+    monthlyFrequency: 4,
+    trend: 'escalating',
+    nuclearRisk: false,
+    escalationPotential: 6,
+    description:
+      'Renewed 2024 troop build-ups along shared border; post-Tigray tensions re-emerging with land-access disputes.',
+    lastIncident: '2024-12',
+  },
+  {
+    id: 'ecuador-colombia',
+    parties: ['Ecuador', 'Colombia'],
+    region: 'Latin America',
+    incidentType: ['Fire'],
+    monthlyFrequency: 2,
+    trend: 'stable',
+    nuclearRisk: false,
+    escalationPotential: 4,
+    description:
+      'FARC dissident cross-border incursions; low-level fire exchanges in Putumayo and Esmeraldas border zones.',
+    lastIncident: '2025-01',
+  },
+];
+
+// ── Helper functions ──────────────────────────────────────────────────────────
+
+/**
+ * Returns zones with monthlyFrequency > 10 OR escalationPotential >= 8.
+ * Represents the most acute near-term risks in the MID dataset.
+ */
+export function getHighIntensity(zones: BorderFrictionZone[]): BorderFrictionZone[] {
+  return zones.filter((z) => z.monthlyFrequency > 10 || z.escalationPotential >= 8);
+}
+
+/** Returns zones currently on an escalating trend. */
+export function getEscalating(zones: BorderFrictionZone[]): BorderFrictionZone[] {
+  return zones.filter((z) => z.trend === 'escalating');
+}
+
+/** Returns zones filtered to a specific region string. */
+export function getByRegion(zones: BorderFrictionZone[], region: string): BorderFrictionZone[] {
+  return zones.filter((z) => z.region === region);
+}
+
+/** Returns zones with the nuclear-risk flag set. */
+export function getNuclearRisk(zones: BorderFrictionZone[]): BorderFrictionZone[] {
+  return zones.filter((z) => z.nuclearRisk);
+}
+
+/**
+ * Computes a composite Global MID Index on a 0–100 scale.
+ *
+ * Formula:
+ *   baseScore       = mean(escalationPotential) × 10
+ *   nuclearBonus    = (nuclearRiskCount / n) × 10
+ *   escalatingBonus = (escalatingCount / n) × 10
+ *   result          = clamp(round(base + nuclearBonus + escalatingBonus), 0, 100)
+ */
+export function computeGlobalMIDIndex(zones: BorderFrictionZone[]): number {
+  if (zones.length === 0) return 0;
+  const n = zones.length;
+  const meanPotential = zones.reduce((s, z) => s + z.escalationPotential, 0) / n;
+  const nuclearBonus = (zones.filter((z) => z.nuclearRisk).length / n) * 10;
+  const escalatingBonus = (zones.filter((z) => z.trend === 'escalating').length / n) * 10;
+  return Math.min(100, Math.round(meanPotential * 10 + nuclearBonus + escalatingBonus));
+}
+
+/** CSS class token for an incident type (used for colour-coding badges). */
+export function incidentTypeClass(type: IncidentType): string {
+  switch (type) {
+    case 'Fire':     return 'mid-type--fire';
+    case 'Maneuver': return 'mid-type--maneuver';
+    case 'Display':  return 'mid-type--display';
+    case 'Blockade': return 'mid-type--blockade';
+    case 'Seizure':  return 'mid-type--seizure';
+  }
+}
+
+/** CSS class token for a zone's intensity level. */
+export function intensityClass(zone: BorderFrictionZone): string {
+  if (zone.escalationPotential >= 8 || zone.monthlyFrequency > 50) return 'mid-intensity--critical';
+  if (zone.escalationPotential >= 6 || zone.monthlyFrequency > 10)  return 'mid-intensity--high';
+  if (zone.escalationPotential >= 4 || zone.monthlyFrequency > 3)   return 'mid-intensity--medium';
+  return 'mid-intensity--low';
+}
+
+/**
+ * Assembles the full render payload for BorderIncidentsPanel.
+ * Zones are sorted by escalationPotential descending.
+ */
+export function buildRenderData(
+  zones: BorderFrictionZone[] = BORDER_FRICTION_ZONES,
+): MIDRenderData {
+  const sorted = [...zones].sort((a, b) => b.escalationPotential - a.escalationPotential);
+  return {
+    zones: sorted,
+    globalMIDIndex: computeGlobalMIDIndex(zones),
+    highIntensityCount: getHighIntensity(zones).length,
+    escalatingCount: getEscalating(zones).length,
+    nuclearRiskCount: getNuclearRisk(zones).length,
+  };
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -286,6 +286,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'water-security': { name: 'Water Security Intelligence', enabled: true, priority: 1 },
   'energy-security': { name: 'Energy Security Intelligence', enabled: true, priority: 1 },
   'arms-proliferation': { name: 'Arms Proliferation Monitor', enabled: true, priority: 1 },
+  'border-incidents': { name: 'Border Incidents', enabled: true, priority: 1 },
   'space-militarization': { name: 'Space Militarization Monitor', enabled: true, priority: 1 },
   'arctic-monitoring': { name: 'Arctic Intelligence', enabled: true, priority: 1 },
   'climate-security-nexus': { name: 'Climate-Security Nexus', enabled: true, priority: 1 },


### PR DESCRIPTION
Tracks militarized interstate disputes (MIDs) across 12 active border friction zones as early-warning escalation signals.

## What
- `border-incidents-helpers.ts` — pure data + helpers (no DOM/fetch)
- `BorderIncidentsPanel.ts` — panel with 30-min refresh, MID Index header, sortedzones with escalation bars and nuclear-risk badges
- `border-incidents-helpers.test.mts` — 66 node:test assertions (all passing)
- Registered in `src/config/panels.ts` and `src/app/panel-layout.ts`

## Zones (sorted by escalation potential)
| Zone | Potential | Trend | Nuclear |
|------|-----------|-------|---------|
| China–Taiwan ADIZ | P9 | escalating | ☢ |
| India–Pakistan LoC | P8 | escalating | ☢ |
| Russia–Ukraine frontline | P8 | stable | ☢ |
| China–India LAC | P7 | stable | ☢ |
| China–Philippines SCS | P7 | escalating | — |
| N. Korea–S. Korea DMZ | P7 | escalating | ☢ |
| Saudi Arabia–Yemen | P6 | stable | — |
| Serbia–Kosovo | P6 | stable | — |
| Ethiopia–Eritrea | P6 | escalating | — |
| Russia–Finland Baltic | P5 | escalating | — |
| Armenia–Azerbaijan | P5 | de-escalating | — |
| Ecuador–Colombia | P4 | stable | — |

## Tests
```
tests 66  pass 66  fail 0
```

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>