### PR TITLE
feat: add DroneWarfarePanel

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -390,6 +390,7 @@ import { RegimeStabilityPanel } from '@/components/RegimeStabilityPanel';
 import { ArmsSalesPanel } from '@/components/ArmsSalesPanel';
 import { StateCapitalismPanel } from '@/components/StateCapitalismPanel';
 import { GlobalLogisticsChokepointsPanel } from '@/components/GlobalLogisticsChokepointsPanel';
+import { DroneWarfarePanel } from '@/components/DroneWarfarePanel';
 import { CoalitionDynamicsPanel } from '@/components/CoalitionDynamicsPanel';
 import { TransnationalRepressionPanel } from '@/components/TransnationalRepressionPanel';
 import { CorruptionIndexPanel } from '@/components/CorruptionIndexPanel';
@@ -1551,8 +1552,7 @@ export class PanelLayoutManager implements AppModule {
  this.ctx.panels['terrorism-superpower'] = new TerrorismSuperpowerPanel();
  this.ctx.panels['water-security'] = new WaterSecurityPanel();
  this.ctx.panels['energy-security'] = new EnergySecurityPanel();
- this.ctx.panels['arms-proliferation'] = new ArmsProliferationPanel();
- this.ctx.panels['territorial-disputes'] = new TerritorialDisputesPanel(); this.ctx.panels['regime-stability'] = new RegimeStabilityPanel(); this.ctx.panels['arms-sales'] = new ArmsSalesPanel(); this.ctx.panels['global-logistics-chokepoints'] = new GlobalLogisticsChokepointsPanel(); this.ctx.panels['coalition-dynamics'] = new CoalitionDynamicsPanel(); this.ctx.panels['transnational-repression'] = new TransnationalRepressionPanel();
+ this.ctx.panels['arms-proliferation'] = new ArmsProliferationPanel(); this.ctx.panels['drone-warfare'] = new DroneWarfarePanel(); this.ctx.panels['territorial-disputes'] = new TerritorialDisputesPanel(); this.ctx.panels['regime-stability'] = new RegimeStabilityPanel(); this.ctx.panels['arms-sales'] = new ArmsSalesPanel(); this.ctx.panels['global-logistics-chokepoints'] = new GlobalLogisticsChokepointsPanel(); this.ctx.panels['coalition-dynamics'] = new CoalitionDynamicsPanel(); this.ctx.panels['transnational-repression'] = new TransnationalRepressionPanel();
         this.ctx.panels['corruption-index'] = new CorruptionIndexPanel();
  this.ctx.panels['space-militarization'] = new SpaceMilitarizationPanel();
  this.ctx.panels['arctic-monitoring'] = new ArcticMonitoringPanel();

--- a/src/components/DroneWarfarePanel.ts
+++ b/src/components/DroneWarfarePanel.ts
@@ -1,0 +1,146 @@
+import { Panel } from './Panel';
+import { h, replaceChildren } from '@/utils/dom-utils';
+import {
+  buildRenderData,
+  proliferationClass,
+  maturityClass,
+  incidentTypeClass,
+} from './drone-warfare-helpers';
+
+const REFRESH_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+function safe<T>(fn: () => T): T | null {
+  try { return fn(); } catch { return null; }
+}
+
+export class DroneWarfarePanel extends Panel {
+  static readonly panelId = 'drone-warfare';
+  static readonly title = 'Drone Warfare';
+  private refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    super({
+      id: DroneWarfarePanel.panelId,
+      title: DroneWarfarePanel.title,
+      showCount: true,
+      trackActivity: false,
+      infoTooltip: 'Tracks drone proliferation and combat use across 8 state and non-state actors. Covers key programs, platforms, export networks, and 12 significant drone incidents 2020\u20132024.',
+    });
+    this.start();
+  }
+
+  public override destroy(): void {
+    if (this.refreshTimer !== null) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    super.destroy();
+  }
+
+  private start(): void {
+    this.render();
+    this.refreshTimer = setInterval(() => this.render(), REFRESH_MS);
+  }
+
+  private render(): void {
+    const data = safe(() => buildRenderData());
+    if (!data) {
+      replaceChildren(
+        this.getContentElement(),
+        h('div', { className: 'panel-empty' }, 'Data unavailable'),
+      );
+      return;
+    }
+
+    const {
+      programs,
+      incidents,
+      globalDroneIndex,
+      proliferationScore,
+      combatUsageScore,
+      topActors,
+    } = data;
+
+    this.setCount(incidents.filter(i => i.ongoing).length);
+
+    let idxClass: string;
+    if (globalDroneIndex >= 70) {
+      idxClass = 'drone-advanced';
+    } else if (globalDroneIndex >= 40) {
+      idxClass = 'drone-developing';
+    } else {
+      idxClass = 'drone-nascent';
+    }
+
+    const header = h('div', { className: 'dw-header' },
+      h('div', { className: 'dw-metric' },
+        h('span', { className: 'dw-label' }, 'Drone Index'),
+        h('span', { className: `dw-value ${idxClass}` }, `${globalDroneIndex}/100`),
+      ),
+      h('div', { className: 'dw-metric' },
+        h('span', { className: 'dw-label' }, 'Proliferation'),
+        h('span', { className: 'dw-value drone-advanced' }, `${proliferationScore}%`),
+      ),
+      h('div', { className: 'dw-metric' },
+        h('span', { className: 'dw-label' }, 'Combat Use'),
+        h('span', { className: 'dw-value drone-advanced' }, `${combatUsageScore}%`),
+      ),
+      h('div', { className: 'dw-metric' },
+        h('span', { className: 'dw-label' }, 'Active Actors'),
+        h('span', { className: 'dw-value' }, String(topActors.length)),
+      ),
+    );
+
+    const programSection = h('div', { className: 'dw-programs' },
+      h('h3', { className: 'dw-section-title' }, 'Drone Programs'),
+    );
+
+    const maturityOrder: Record<string, number> = { Advanced: 0, Developing: 1, Nascent: 2 };
+    for (const p of [...programs].sort((a, b) => (maturityOrder[a.maturityLevel] ?? 2) - (maturityOrder[b.maturityLevel] ?? 2))) {
+      const row = h('div', { className: `dw-program-row ${maturityClass(p.maturityLevel)}` },
+        h('div', { className: 'dw-program-header' },
+          h('span', { className: 'dw-country' }, p.country),
+          h('span', { className: `dw-mat-badge ${proliferationClass(p.maturityLevel)}` }, p.maturityLevel),
+          h('span', { className: 'dw-type-badge' }, p.type),
+          p.combatExperience
+            ? h('span', { className: 'dw-combat-badge' }, 'Combat \u2713')
+            : h('span', { className: 'dw-no-combat-badge' }, 'No combat'),
+        ),
+        h('div', { className: 'dw-platforms' }, `Platforms: ${p.keyPlatforms.join(', ')}`),
+        p.exportingTo.length > 0
+          ? h('div', { className: 'dw-exports' },
+              `Exporting to: ${p.exportingTo.slice(0, 5).join(', ')}${p.exportingTo.length > 5 ? ` +${p.exportingTo.length - 5} more` : ''}`,
+            )
+          : h('div', { className: 'dw-exports dw-no-export' }, 'Not exporting'),
+        h('div', { className: 'dw-description' }, p.description),
+      );
+      programSection.append(row);
+    }
+
+    const incidentSection = h('div', { className: 'dw-incidents' },
+      h('h3', { className: 'dw-section-title' }, 'Significant Drone Incidents'),
+    );
+
+    for (const inc of [...incidents].sort((a, b) => b.significance - a.significance)) {
+      const ongoingBadge = inc.ongoing
+        ? h('span', { className: 'dw-ongoing-badge' }, 'Ongoing')
+        : null;
+      const children = [
+        h('div', { className: 'dw-incident-header' },
+          h('span', { className: 'dw-actor' }, inc.actor),
+          h('span', { className: `dw-itype-badge ${incidentTypeClass(inc.type)}` }, inc.type),
+          h('span', { className: 'dw-sig' }, `Sig: ${inc.significance}/10`),
+          h('span', { className: 'dw-inc-date' }, inc.date),
+        ),
+        h('div', { className: 'dw-target' }, `Target: ${inc.target}`),
+        h('div', { className: 'dw-inc-platform' }, `Platform: ${inc.platform}`),
+        h('div', { className: 'dw-inc-desc' }, inc.description),
+      ];
+      if (ongoingBadge) children[0].append(ongoingBadge);
+      const row = h('div', { className: `dw-incident-row ${incidentTypeClass(inc.type)}` }, ...children);
+      incidentSection.append(row);
+    }
+
+    replaceChildren(this.getContentElement(), header, programSection, incidentSection);
+  }
+}

--- a/src/components/__tests__/drone-warfare-helpers.test.mts
+++ b/src/components/__tests__/drone-warfare-helpers.test.mts
@@ -1,0 +1,534 @@
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert/strict';
+import {
+  computeGlobalDroneIndex,
+  getByType,
+  getCombatExperienced,
+  getHighSignificanceIncidents,
+  getOngoingIncidents,
+  proliferationClass,
+  maturityClass,
+  incidentTypeClass,
+  buildRenderData,
+  type DroneProgram,
+  type DroneIncident,
+  type DroneType,
+  type MaturityLevel,
+  type IncidentType,
+} from '../drone-warfare-helpers.ts';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const MOCK_PROGRAMS: DroneProgram[] = [
+  {
+    country: 'Alpha',
+    type: 'Military',
+    maturityLevel: 'Advanced',
+    keyPlatforms: ['X-1'],
+    combatExperience: true,
+    exportingTo: ['Beta', 'Gamma'],
+    description: 'Advanced military program',
+  },
+  {
+    country: 'Beta',
+    type: 'Commercial',
+    maturityLevel: 'Developing',
+    keyPlatforms: ['Y-2'],
+    combatExperience: false,
+    exportingTo: [],
+    description: 'Commercial-only program',
+  },
+  {
+    country: 'Gamma',
+    type: 'Both',
+    maturityLevel: 'Nascent',
+    keyPlatforms: ['Z-3'],
+    combatExperience: true,
+    exportingTo: ['Alpha'],
+    description: 'Dual-use nascent program',
+  },
+  {
+    country: 'Delta',
+    type: 'Military',
+    maturityLevel: 'Developing',
+    keyPlatforms: ['W-4', 'W-5'],
+    combatExperience: false,
+    exportingTo: [],
+    description: 'Developing military program, no combat',
+  },
+];
+
+const MOCK_INCIDENTS: DroneIncident[] = [
+  {
+    id: 'I1', date: '2024-01-01', actor: 'Alpha', target: 'City A',
+    platform: 'X-1', type: 'Strike', region: 'Europe',
+    casualties: 10, significance: 9, description: 'Major strike', ongoing: true,
+  },
+  {
+    id: 'I2', date: '2023-06-15', actor: 'Beta', target: 'Fleet B',
+    platform: 'Y-2', type: 'Surveillance', region: 'Asia',
+    casualties: 0, significance: 6, description: 'Surveillance op', ongoing: false,
+  },
+  {
+    id: 'I3', date: '2023-11-01', actor: 'Gamma', target: 'Convoy C',
+    platform: 'Z-3', type: 'Swarm Attack', region: 'Middle East',
+    casualties: 50, significance: 8, description: 'Swarm attack on convoy', ongoing: true,
+  },
+  {
+    id: 'I4', date: '2022-05-01', actor: 'Delta', target: 'Base D',
+    platform: 'W-4', type: 'Kamikaze', region: 'Europe',
+    casualties: 5, significance: 10, description: 'Kamikaze strike', ongoing: false,
+  },
+  {
+    id: 'I5', date: '2024-03-01', actor: 'Epsilon', target: 'Port E',
+    platform: 'E-1', type: 'Supply', region: 'Africa',
+    casualties: 0, significance: 3, description: 'Supply run', ongoing: false,
+  },
+];
+
+// ── computeGlobalDroneIndex ───────────────────────────────────────────────────
+
+describe('computeGlobalDroneIndex', () => {
+  it('returns 0 for empty programs array', () => {
+    assert.equal(computeGlobalDroneIndex([], MOCK_INCIDENTS), 0);
+  });
+
+  it('returns a number between 0 and 100', () => {
+    const idx = computeGlobalDroneIndex(MOCK_PROGRAMS, MOCK_INCIDENTS);
+    assert.ok(idx >= 0 && idx <= 100, `Index ${idx} out of range`);
+  });
+
+  it('returns an integer', () => {
+    const idx = computeGlobalDroneIndex(MOCK_PROGRAMS, MOCK_INCIDENTS);
+    assert.equal(idx, Math.round(idx));
+  });
+
+  it('all-combat all-advanced programs yield higher index than none', () => {
+    const highPrograms = MOCK_PROGRAMS.map(p => ({ ...p, combatExperience: true, maturityLevel: 'Advanced' as MaturityLevel }));
+    const lowPrograms = MOCK_PROGRAMS.map(p => ({ ...p, combatExperience: false, maturityLevel: 'Nascent' as MaturityLevel }));
+    assert.ok(
+      computeGlobalDroneIndex(highPrograms, MOCK_INCIDENTS) >=
+      computeGlobalDroneIndex(lowPrograms, MOCK_INCIDENTS),
+    );
+  });
+
+  it('handles empty incidents list', () => {
+    const idx = computeGlobalDroneIndex(MOCK_PROGRAMS, []);
+    assert.ok(idx >= 0 && idx <= 100);
+  });
+
+  it('high-significance incidents increase index vs low-significance', () => {
+    const highSig = MOCK_INCIDENTS.map(i => ({ ...i, significance: 10 }));
+    const lowSig = MOCK_INCIDENTS.map(i => ({ ...i, significance: 1 }));
+    assert.ok(
+      computeGlobalDroneIndex(MOCK_PROGRAMS, highSig) >=
+      computeGlobalDroneIndex(MOCK_PROGRAMS, lowSig),
+    );
+  });
+
+  it('caps at 100 for max inputs', () => {
+    const maxPrograms = MOCK_PROGRAMS.map(p => ({ ...p, combatExperience: true, maturityLevel: 'Advanced' as MaturityLevel }));
+    const maxIncidents = MOCK_INCIDENTS.map(i => ({ ...i, significance: 10 }));
+    assert.ok(computeGlobalDroneIndex(maxPrograms, maxIncidents) <= 100);
+  });
+});
+
+// ── getByType ─────────────────────────────────────────────────────────────────
+
+describe('getByType', () => {
+  it('returns only Military programs', () => {
+    const mil = getByType(MOCK_PROGRAMS, 'Military');
+    assert.ok(mil.length > 0);
+    assert.ok(mil.every(p => p.type === 'Military'));
+  });
+
+  it('returns only Commercial programs', () => {
+    const com = getByType(MOCK_PROGRAMS, 'Commercial');
+    assert.equal(com.length, 1);
+    assert.equal(com[0].country, 'Beta');
+  });
+
+  it('returns only Both programs', () => {
+    const both = getByType(MOCK_PROGRAMS, 'Both');
+    assert.equal(both.length, 1);
+    assert.equal(both[0].country, 'Gamma');
+  });
+
+  it('returns empty when no match', () => {
+    const noMil = MOCK_PROGRAMS.map(p => ({ ...p, type: 'Commercial' as DroneType }));
+    assert.equal(getByType(noMil, 'Military').length, 0);
+  });
+
+  it('does not mutate the input array', () => {
+    const before = MOCK_PROGRAMS.length;
+    getByType(MOCK_PROGRAMS, 'Military');
+    assert.equal(MOCK_PROGRAMS.length, before);
+  });
+
+  it('returns all when all match', () => {
+    const allMil = MOCK_PROGRAMS.map(p => ({ ...p, type: 'Military' as DroneType }));
+    assert.equal(getByType(allMil, 'Military').length, allMil.length);
+  });
+});
+
+// ── getCombatExperienced ──────────────────────────────────────────────────────
+
+describe('getCombatExperienced', () => {
+  it('returns only programs with combatExperience=true', () => {
+    const combat = getCombatExperienced(MOCK_PROGRAMS);
+    assert.ok(combat.every(p => p.combatExperience === true));
+  });
+
+  it('correct count of combat-experienced programs', () => {
+    const combat = getCombatExperienced(MOCK_PROGRAMS);
+    assert.equal(combat.length, MOCK_PROGRAMS.filter(p => p.combatExperience).length);
+  });
+
+  it('returns empty when none have combat experience', () => {
+    const none = MOCK_PROGRAMS.map(p => ({ ...p, combatExperience: false }));
+    assert.equal(getCombatExperienced(none).length, 0);
+  });
+
+  it('returns all when all have combat experience', () => {
+    const all = MOCK_PROGRAMS.map(p => ({ ...p, combatExperience: true }));
+    assert.equal(getCombatExperienced(all).length, MOCK_PROGRAMS.length);
+  });
+
+  it('does not mutate the input array', () => {
+    const before = MOCK_PROGRAMS.length;
+    getCombatExperienced(MOCK_PROGRAMS);
+    assert.equal(MOCK_PROGRAMS.length, before);
+  });
+});
+
+// ── getHighSignificanceIncidents ──────────────────────────────────────────────
+
+describe('getHighSignificanceIncidents', () => {
+  it('default threshold of 8 filters correctly', () => {
+    const high = getHighSignificanceIncidents(MOCK_INCIDENTS);
+    assert.ok(high.every(i => i.significance >= 8));
+  });
+
+  it('includes incidents equal to threshold', () => {
+    const high = getHighSignificanceIncidents(MOCK_INCIDENTS, 8);
+    assert.ok(high.some(i => i.significance === 8));
+  });
+
+  it('excludes incidents below threshold', () => {
+    const high = getHighSignificanceIncidents(MOCK_INCIDENTS, 8);
+    assert.ok(high.every(i => i.significance >= 8));
+  });
+
+  it('returns empty when none meet threshold', () => {
+    const low = MOCK_INCIDENTS.map(i => ({ ...i, significance: 1 }));
+    assert.equal(getHighSignificanceIncidents(low, 8).length, 0);
+  });
+
+  it('returns all when all meet threshold', () => {
+    const all = MOCK_INCIDENTS.map(i => ({ ...i, significance: 10 }));
+    assert.equal(getHighSignificanceIncidents(all, 8).length, MOCK_INCIDENTS.length);
+  });
+
+  it('custom threshold works', () => {
+    const high = getHighSignificanceIncidents(MOCK_INCIDENTS, 10);
+    assert.equal(high.length, MOCK_INCIDENTS.filter(i => i.significance >= 10).length);
+  });
+
+  it('significance 7 is excluded at threshold 8', () => {
+    const borderline = [{ ...MOCK_INCIDENTS[0], significance: 7 }];
+    assert.equal(getHighSignificanceIncidents(borderline, 8).length, 0);
+  });
+});
+
+// ── getOngoingIncidents ───────────────────────────────────────────────────────
+
+describe('getOngoingIncidents', () => {
+  it('returns only ongoing incidents', () => {
+    const ongoing = getOngoingIncidents(MOCK_INCIDENTS);
+    assert.ok(ongoing.every(i => i.ongoing === true));
+  });
+
+  it('correct count of ongoing incidents', () => {
+    const ongoing = getOngoingIncidents(MOCK_INCIDENTS);
+    assert.equal(ongoing.length, MOCK_INCIDENTS.filter(i => i.ongoing).length);
+  });
+
+  it('returns empty when none ongoing', () => {
+    const none = MOCK_INCIDENTS.map(i => ({ ...i, ongoing: false }));
+    assert.equal(getOngoingIncidents(none).length, 0);
+  });
+
+  it('returns all when all ongoing', () => {
+    const all = MOCK_INCIDENTS.map(i => ({ ...i, ongoing: true }));
+    assert.equal(getOngoingIncidents(all).length, MOCK_INCIDENTS.length);
+  });
+
+  it('does not mutate input', () => {
+    const before = MOCK_INCIDENTS.length;
+    getOngoingIncidents(MOCK_INCIDENTS);
+    assert.equal(MOCK_INCIDENTS.length, before);
+  });
+});
+
+// ── proliferationClass ────────────────────────────────────────────────────────
+
+describe('proliferationClass', () => {
+  it('Advanced -> drone-advanced', () => {
+    assert.equal(proliferationClass('Advanced'), 'drone-advanced');
+  });
+
+  it('Developing -> drone-developing', () => {
+    assert.equal(proliferationClass('Developing'), 'drone-developing');
+  });
+
+  it('Nascent -> drone-nascent', () => {
+    assert.equal(proliferationClass('Nascent'), 'drone-nascent');
+  });
+
+  it('returns a non-empty string for all valid maturity levels', () => {
+    const levels: MaturityLevel[] = ['Advanced', 'Developing', 'Nascent'];
+    for (const level of levels) {
+      assert.ok(proliferationClass(level).length > 0);
+    }
+  });
+});
+
+// ── maturityClass ─────────────────────────────────────────────────────────────
+
+describe('maturityClass', () => {
+  it('produces same output as proliferationClass for all inputs', () => {
+    const levels: MaturityLevel[] = ['Advanced', 'Developing', 'Nascent'];
+    for (const level of levels) {
+      assert.equal(maturityClass(level), proliferationClass(level));
+    }
+  });
+
+  it('Advanced -> drone-advanced', () => {
+    assert.equal(maturityClass('Advanced'), 'drone-advanced');
+  });
+
+  it('Nascent -> drone-nascent', () => {
+    assert.equal(maturityClass('Nascent'), 'drone-nascent');
+  });
+});
+
+// ── incidentTypeClass ─────────────────────────────────────────────────────────
+
+describe('incidentTypeClass', () => {
+  it('Strike -> itype-strike', () => {
+    assert.equal(incidentTypeClass('Strike'), 'itype-strike');
+  });
+
+  it('Swarm Attack -> itype-swarm', () => {
+    assert.equal(incidentTypeClass('Swarm Attack'), 'itype-swarm');
+  });
+
+  it('Surveillance -> itype-surveillance', () => {
+    assert.equal(incidentTypeClass('Surveillance'), 'itype-surveillance');
+  });
+
+  it('Supply -> itype-supply', () => {
+    assert.equal(incidentTypeClass('Supply'), 'itype-supply');
+  });
+
+  it('Kamikaze -> itype-kamikaze', () => {
+    assert.equal(incidentTypeClass('Kamikaze'), 'itype-kamikaze');
+  });
+
+  it('returns non-empty string for all incident types', () => {
+    const types: IncidentType[] = ['Strike', 'Swarm Attack', 'Surveillance', 'Supply', 'Kamikaze'];
+    for (const t of types) {
+      assert.ok(incidentTypeClass(t).length > 0);
+    }
+  });
+});
+
+// ── buildRenderData ───────────────────────────────────────────────────────────
+
+describe('buildRenderData', () => {
+  it('returns all required fields', () => {
+    const d = buildRenderData();
+    assert.ok(Array.isArray(d.programs));
+    assert.ok(Array.isArray(d.incidents));
+    assert.equal(typeof d.globalDroneIndex, 'number');
+    assert.equal(typeof d.proliferationScore, 'number');
+    assert.equal(typeof d.combatUsageScore, 'number');
+    assert.ok(Array.isArray(d.topActors));
+  });
+
+  it('programs array has 8 entries', () => {
+    assert.equal(buildRenderData().programs.length, 8);
+  });
+
+  it('incidents array has 12 entries', () => {
+    assert.equal(buildRenderData().incidents.length, 12);
+  });
+
+  it('globalDroneIndex is in range 0-100', () => {
+    const idx = buildRenderData().globalDroneIndex;
+    assert.ok(idx >= 0 && idx <= 100);
+  });
+
+  it('proliferationScore is in range 0-100', () => {
+    const s = buildRenderData().proliferationScore;
+    assert.ok(s >= 0 && s <= 100);
+  });
+
+  it('combatUsageScore is in range 0-100', () => {
+    const s = buildRenderData().combatUsageScore;
+    assert.ok(s >= 0 && s <= 100);
+  });
+
+  it('topActors contains only combat-experienced program countries', () => {
+    const d = buildRenderData();
+    const combatCountries = new Set(d.programs.filter(p => p.combatExperience).map(p => p.country));
+    for (const actor of d.topActors) {
+      assert.ok(combatCountries.has(actor), `${actor} not in combat-experienced countries`);
+    }
+  });
+
+  it('topActors length matches combat-experienced programs count', () => {
+    const d = buildRenderData();
+    assert.equal(d.topActors.length, d.programs.filter(p => p.combatExperience).length);
+  });
+
+  it('all program countries are non-empty strings', () => {
+    for (const p of buildRenderData().programs) {
+      assert.ok(p.country.trim().length > 0);
+    }
+  });
+
+  it('all incident IDs are unique', () => {
+    const ids = buildRenderData().incidents.map(i => i.id);
+    assert.equal(new Set(ids).size, ids.length);
+  });
+
+  it('all incident significance values are in range 1-10', () => {
+    for (const i of buildRenderData().incidents) {
+      assert.ok(i.significance >= 1 && i.significance <= 10, `Significance ${i.significance} out of range`);
+    }
+  });
+
+  it('all incident types are valid', () => {
+    const valid = new Set(['Strike', 'Swarm Attack', 'Surveillance', 'Supply', 'Kamikaze']);
+    for (const i of buildRenderData().incidents) {
+      assert.ok(valid.has(i.type), `Invalid type: ${i.type}`);
+    }
+  });
+
+  it('all program maturity levels are valid', () => {
+    const valid = new Set(['Advanced', 'Developing', 'Nascent']);
+    for (const p of buildRenderData().programs) {
+      assert.ok(valid.has(p.maturityLevel), `Invalid maturity: ${p.maturityLevel}`);
+    }
+  });
+
+  it('all program types are valid', () => {
+    const valid = new Set(['Military', 'Commercial', 'Both']);
+    for (const p of buildRenderData().programs) {
+      assert.ok(valid.has(p.type), `Invalid type: ${p.type}`);
+    }
+  });
+
+  it('all programs have non-empty keyPlatforms', () => {
+    for (const p of buildRenderData().programs) {
+      assert.ok(p.keyPlatforms.length > 0, `${p.country} has no key platforms`);
+    }
+  });
+
+  it('USA is present in programs', () => {
+    const d = buildRenderData();
+    assert.ok(d.programs.some(p => p.country === 'USA'));
+  });
+
+  it('USA has combat experience', () => {
+    const usa = buildRenderData().programs.find(p => p.country === 'USA');
+    assert.ok(usa?.combatExperience === true);
+  });
+
+  it('Houthi non-state actor is present', () => {
+    const d = buildRenderData();
+    assert.ok(d.programs.some(p => p.country.includes('Houthi')));
+  });
+
+  it('Houthi has Nascent maturity', () => {
+    const houthi = buildRenderData().programs.find(p => p.country.includes('Houthi'));
+    assert.equal(houthi?.maturityLevel, 'Nascent');
+  });
+
+  it('Russia Shahed incidents are included', () => {
+    const d = buildRenderData();
+    assert.ok(d.incidents.some(i => i.actor === 'Russia' && i.type === 'Kamikaze'));
+  });
+
+  it('at least one ongoing incident exists', () => {
+    assert.ok(buildRenderData().incidents.some(i => i.ongoing));
+  });
+
+  it('at least one high-significance incident (>=8) exists', () => {
+    assert.ok(buildRenderData().incidents.some(i => i.significance >= 8));
+  });
+
+  it('combatUsageScore equals 100 when all programs have combat experience', () => {
+    const d = buildRenderData();
+    if (d.programs.every(p => p.combatExperience)) {
+      assert.equal(d.combatUsageScore, 100);
+    } else {
+      assert.ok(d.combatUsageScore < 100);
+    }
+  });
+
+  it('all incident dates are non-empty strings', () => {
+    for (const i of buildRenderData().incidents) {
+      assert.ok(i.date.trim().length > 0);
+    }
+  });
+
+  it('all incident descriptions are non-empty strings', () => {
+    for (const i of buildRenderData().incidents) {
+      assert.ok(i.description.trim().length > 0);
+    }
+  });
+
+  it('all program descriptions are non-empty strings', () => {
+    for (const p of buildRenderData().programs) {
+      assert.ok(p.description.trim().length > 0);
+    }
+  });
+
+  it('exportingTo is an array for every program', () => {
+    for (const p of buildRenderData().programs) {
+      assert.ok(Array.isArray(p.exportingTo));
+    }
+  });
+
+  it('DI002 (Russia Shahed) has significance 10', () => {
+    const inc = buildRenderData().incidents.find(i => i.id === 'DI002');
+    assert.equal(inc?.significance, 10);
+  });
+
+  it('DI001 (Houthi Red Sea) is ongoing', () => {
+    const inc = buildRenderData().incidents.find(i => i.id === 'DI001');
+    assert.ok(inc?.ongoing === true);
+  });
+
+  it('China exports to more than 5 countries', () => {
+    const china = buildRenderData().programs.find(p => p.country === 'China');
+    assert.ok((china?.exportingTo.length ?? 0) > 5);
+  });
+
+  it('Turkey has combat experience', () => {
+    const turkey = buildRenderData().programs.find(p => p.country === 'Turkey');
+    assert.ok(turkey?.combatExperience === true);
+  });
+
+  it('Iran type is Military', () => {
+    const iran = buildRenderData().programs.find(p => p.country === 'Iran');
+    assert.equal(iran?.type, 'Military');
+  });
+
+  it('Ukraine type is Both', () => {
+    const ukraine = buildRenderData().programs.find(p => p.country === 'Ukraine');
+    assert.equal(ukraine?.type, 'Both');
+  });
+});

--- a/src/components/drone-warfare-helpers.ts
+++ b/src/components/drone-warfare-helpers.ts
@@ -1,0 +1,345 @@
+// drone-warfare-helpers.ts
+// Pure logic for DroneWarfarePanel — no DOM, no Panel imports
+
+export type DroneType = 'Military' | 'Commercial' | 'Both';
+export type MaturityLevel = 'Advanced' | 'Developing' | 'Nascent';
+export type IncidentType = 'Strike' | 'Swarm Attack' | 'Surveillance' | 'Supply' | 'Kamikaze';
+
+export interface DroneProgram {
+  country: string;
+  type: DroneType;
+  maturityLevel: MaturityLevel;
+  keyPlatforms: string[];
+  combatExperience: boolean;
+  exportingTo: string[];
+  description: string;
+}
+
+export interface DroneIncident {
+  id: string;
+  date: string;
+  actor: string;
+  target: string;
+  platform: string;
+  type: IncidentType;
+  region: string;
+  casualties: number;
+  significance: number; // 1-10
+  description: string;
+  ongoing: boolean;
+}
+
+export interface DroneRenderData {
+  programs: DroneProgram[];
+  incidents: DroneIncident[];
+  globalDroneIndex: number;
+  proliferationScore: number;
+  combatUsageScore: number;
+  topActors: string[];
+}
+
+const PROGRAMS: DroneProgram[] = [
+  {
+    country: 'USA',
+    type: 'Military',
+    maturityLevel: 'Advanced',
+    keyPlatforms: ['MQ-9 Reaper', 'RQ-4 Global Hawk', 'Switchblade'],
+    combatExperience: true,
+    exportingTo: ['UK', 'Australia', 'India'],
+    description: 'World leader in military drone development; ISR and strike capabilities across all domains.',
+  },
+  {
+    country: 'China',
+    type: 'Both',
+    maturityLevel: 'Advanced',
+    keyPlatforms: ['Wing Loong', 'CH-4', 'TB001'],
+    combatExperience: true,
+    exportingTo: [
+      'Saudi Arabia', 'UAE', 'Iraq', 'Nigeria', 'Ethiopia', 'Pakistan', 'Jordan', 'Myanmar',
+      'Serbia', 'Egypt', 'Morocco', 'Algeria', 'Turkey', 'Sudan', 'Bangladesh', 'Kenya',
+      'Zambia', 'Cameroon', 'Namibia', 'Senegal',
+    ],
+    description: 'Rapidly expanding military and commercial drone sector; major global exporter to 20+ countries.',
+  },
+  {
+    country: 'Turkey',
+    type: 'Military',
+    maturityLevel: 'Advanced',
+    keyPlatforms: ['Bayraktar TB2', 'Ak\u0131nc\u0131'],
+    combatExperience: true,
+    exportingTo: ['Ukraine', 'Azerbaijan', 'Qatar', 'Morocco', 'Ethiopia', 'Libya', 'Kyrgyzstan', 'Albania', 'Latvia', 'Lithuania', 'Estonia'],
+    description: 'Bayraktar TB2 transformed modern warfare in Ukraine, Libya, and Nagorno-Karabakh; growing export market.',
+  },
+  {
+    country: 'Iran',
+    type: 'Military',
+    maturityLevel: 'Developing',
+    keyPlatforms: ['Shahed-136', 'Mohajer'],
+    combatExperience: true,
+    exportingTo: ['Russia', 'Hamas', 'Hezbollah'],
+    description: 'Loitering munitions exported to Russia for Ukraine war; proxy networks armed with Shahed variants.',
+  },
+  {
+    country: 'Israel',
+    type: 'Military',
+    maturityLevel: 'Advanced',
+    keyPlatforms: ['Harop', 'Hermes 900', 'Heron'],
+    combatExperience: true,
+    exportingTo: ['India', 'Azerbaijan', 'Germany', 'France', 'Brazil', 'Colombia', 'Philippines'],
+    description: 'Pioneer in loitering munitions and ISR drones; extensive combat testing in Gaza and Syria.',
+  },
+  {
+    country: 'Russia',
+    type: 'Military',
+    maturityLevel: 'Developing',
+    keyPlatforms: ['Orlan-10', 'Lancet', 'Shahed variants'],
+    combatExperience: true,
+    exportingTo: [],
+    description: 'Heavy reliance on Iranian-supplied Shaheds; domestic Lancet loitering munition effective against armor.',
+  },
+  {
+    country: 'Ukraine',
+    type: 'Both',
+    maturityLevel: 'Developing',
+    keyPlatforms: ['Magura V5', 'FPV drones', 'custom kamikaze'],
+    combatExperience: true,
+    exportingTo: [],
+    description: 'Pioneering civilian-to-military drone conversion at scale; naval drone attacks on Black Sea fleet.',
+  },
+  {
+    country: 'Houthi (non-state)',
+    type: 'Military',
+    maturityLevel: 'Nascent',
+    keyPlatforms: ['Shahed variants (Iranian-supplied)'],
+    combatExperience: true,
+    exportingTo: [],
+    description: 'Iranian-supplied drones and missiles; Red Sea shipping disruption campaign 2023\u20132024.',
+  },
+];
+
+const INCIDENTS: DroneIncident[] = [
+  {
+    id: 'DI001',
+    date: '2024-01-01',
+    actor: 'Houthis',
+    target: 'Commercial shipping (Red Sea)',
+    platform: 'Shahed variants',
+    type: 'Swarm Attack',
+    region: 'Middle East',
+    casualties: 3,
+    significance: 9,
+    description: 'Houthi drone and missile swarm attacks on international shipping lanes in Red Sea; forced global rerouting.',
+    ongoing: true,
+  },
+  {
+    id: 'DI002',
+    date: '2022-09-12',
+    actor: 'Russia',
+    target: 'Ukrainian cities',
+    platform: 'Shahed-136',
+    type: 'Kamikaze',
+    region: 'Europe',
+    casualties: 500,
+    significance: 10,
+    description: 'Russia launched mass Shahed-136 kamikaze drone attacks on Ukrainian energy infrastructure and cities.',
+    ongoing: true,
+  },
+  {
+    id: 'DI003',
+    date: '2023-07-17',
+    actor: 'Ukraine',
+    target: 'Russian Black Sea Fleet, Sevastopol',
+    platform: 'Sea Baby USV',
+    type: 'Strike',
+    region: 'Europe',
+    casualties: 1,
+    significance: 8,
+    description: 'Ukrainian Sea Baby drone boat attacked Russian fleet in Sevastopol harbor; damaged warships.',
+    ongoing: false,
+  },
+  {
+    id: 'DI004',
+    date: '2020-10-01',
+    actor: 'Azerbaijan',
+    target: 'Armenian military units, Nagorno-Karabakh',
+    platform: 'Bayraktar TB2',
+    type: 'Strike',
+    region: 'Europe',
+    casualties: 2000,
+    significance: 9,
+    description: 'TB2 drones devastated Armenian armor and air defenses; transformed the 44-day war outcome.',
+    ongoing: false,
+  },
+  {
+    id: 'DI005',
+    date: '2024-03-01',
+    actor: 'Houthis',
+    target: 'USA MQ-9 Reaper (international airspace)',
+    platform: 'Surface-to-air missile vs MQ-9',
+    type: 'Surveillance',
+    region: 'Middle East',
+    casualties: 0,
+    significance: 7,
+    description: 'Houthis shot down a US Navy MQ-9 Reaper over the Red Sea, demonstrating IADS capability against ISR drones.',
+    ongoing: false,
+  },
+  {
+    id: 'DI006',
+    date: '2023-10-07',
+    actor: 'Hamas',
+    target: 'Israeli military positions',
+    platform: 'Modified commercial drones',
+    type: 'Strike',
+    region: 'Middle East',
+    casualties: 50,
+    significance: 8,
+    description: 'Hamas used drone-dropped munitions to disable Iron Dome radar systems during Oct 7 attack.',
+    ongoing: false,
+  },
+  {
+    id: 'DI007',
+    date: '2024-01-28',
+    actor: 'Iran-aligned militia',
+    target: 'US base Tower 22, Al-Asad, Jordan',
+    platform: 'Iranian one-way attack drone',
+    type: 'Strike',
+    region: 'Middle East',
+    casualties: 3,
+    significance: 7,
+    description: 'Iran-backed militia drone strike killed 3 US soldiers at Tower 22 base in Jordan; triggered US retaliatory strikes.',
+    ongoing: false,
+  },
+  {
+    id: 'DI008',
+    date: '2023-06-01',
+    actor: 'Ukraine',
+    target: 'Russian armored vehicles',
+    platform: 'FPV kamikaze drones',
+    type: 'Swarm Attack',
+    region: 'Europe',
+    casualties: 100,
+    significance: 8,
+    description: 'Ukrainian FPV drone swarms became primary anti-armor weapon; low-cost consumer drones modified for combat.',
+    ongoing: true,
+  },
+  {
+    id: 'DI009',
+    date: '2023-09-01',
+    actor: 'Russia',
+    target: 'Ukrainian armored vehicles and artillery',
+    platform: 'Lancet loitering munition',
+    type: 'Strike',
+    region: 'Europe',
+    casualties: 0,
+    significance: 7,
+    description: 'Russian Lancet loitering munitions achieved high kill rates against Western-supplied armor in Ukraine.',
+    ongoing: true,
+  },
+  {
+    id: 'DI010',
+    date: '2024-08-01',
+    actor: 'China (PLA)',
+    target: 'Taiwan Strait / Taiwan airspace',
+    platform: 'BZK-005 / TB001',
+    type: 'Surveillance',
+    region: 'Asia',
+    casualties: 0,
+    significance: 7,
+    description: 'PLA drones repeatedly entered Taiwan ADIZ for surveillance; frequency increased through 2024.',
+    ongoing: true,
+  },
+  {
+    id: 'DI011',
+    date: '2024-06-01',
+    actor: 'Hezbollah',
+    target: 'Northern Israel military bases',
+    platform: 'Iranian-supplied Shahed variants',
+    type: 'Strike',
+    region: 'Middle East',
+    casualties: 12,
+    significance: 7,
+    description: 'Hezbollah drone campaign against northern Israel intensified; displaced 100,000 civilians.',
+    ongoing: true,
+  },
+  {
+    id: 'DI012',
+    date: '2024-03-01',
+    actor: 'Ukraine',
+    target: 'Russian warships and oil tankers, Black Sea',
+    platform: 'Magura V5',
+    type: 'Strike',
+    region: 'Europe',
+    casualties: 20,
+    significance: 8,
+    description: 'Magura V5 naval drones sank or damaged Russian warships; forced partial Black Sea Fleet withdrawal.',
+    ongoing: true,
+  },
+];
+
+export function getByType(programs: DroneProgram[], type: DroneType): DroneProgram[] {
+  return programs.filter(p => p.type === type);
+}
+
+export function getCombatExperienced(programs: DroneProgram[]): DroneProgram[] {
+  return programs.filter(p => p.combatExperience);
+}
+
+export function getHighSignificanceIncidents(incidents: DroneIncident[], threshold = 8): DroneIncident[] {
+  return incidents.filter(i => i.significance >= threshold);
+}
+
+export function getOngoingIncidents(incidents: DroneIncident[]): DroneIncident[] {
+  return incidents.filter(i => i.ongoing);
+}
+
+export function computeGlobalDroneIndex(programs: DroneProgram[], incidents: DroneIncident[]): number {
+  if (!programs.length) return 0;
+  const combatPct = programs.filter(p => p.combatExperience).length / programs.length;
+  const advancedPct = programs.filter(p => p.maturityLevel === 'Advanced').length / programs.length;
+  const avgSig = incidents.length
+    ? incidents.reduce((s, i) => s + i.significance, 0) / incidents.length
+    : 0;
+  return Math.min(100, Math.round(combatPct * 30 + advancedPct * 30 + (avgSig / 10) * 40));
+}
+
+export function proliferationClass(maturity: MaturityLevel): string {
+  const map: Record<MaturityLevel, string> = {
+    Advanced: 'drone-advanced',
+    Developing: 'drone-developing',
+    Nascent: 'drone-nascent',
+  };
+  return map[maturity] ?? 'drone-nascent';
+}
+
+export function maturityClass(maturity: MaturityLevel): string {
+  return proliferationClass(maturity);
+}
+
+export function incidentTypeClass(type: IncidentType): string {
+  const map: Record<IncidentType, string> = {
+    Strike: 'itype-strike',
+    'Swarm Attack': 'itype-swarm',
+    Surveillance: 'itype-surveillance',
+    Supply: 'itype-supply',
+    Kamikaze: 'itype-kamikaze',
+  };
+  return map[type] ?? 'itype-strike';
+}
+
+export function buildRenderData(): DroneRenderData {
+  const proliferationScore = Math.round(
+    (PROGRAMS.filter(p => p.exportingTo.length > 0).length / PROGRAMS.length) * 100,
+  );
+  const combatUsageScore = Math.round(
+    (PROGRAMS.filter(p => p.combatExperience).length / PROGRAMS.length) * 100,
+  );
+  const topActors = getCombatExperienced(PROGRAMS).map(p => p.country);
+  return {
+    programs: PROGRAMS,
+    incidents: INCIDENTS,
+    globalDroneIndex: computeGlobalDroneIndex(PROGRAMS, INCIDENTS),
+    proliferationScore,
+    combatUsageScore,
+    topActors,
+  };
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -286,6 +286,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'water-security': { name: 'Water Security Intelligence', enabled: true, priority: 1 },
   'energy-security': { name: 'Energy Security Intelligence', enabled: true, priority: 1 },
   'arms-proliferation': { name: 'Arms Proliferation Monitor', enabled: true, priority: 1 },
+  'drone-warfare': { name: 'Drone Warfare Monitor', enabled: true, priority: 1 },
   'space-militarization': { name: 'Space Militarization Monitor', enabled: true, priority: 1 },
   'arctic-monitoring': { name: 'Arctic Intelligence', enabled: true, priority: 1 },
   'climate-security-nexus': { name: 'Climate-Security Nexus', enabled: true, priority: 1 },


### PR DESCRIPTION
Tracks drone proliferation and combat use as a transformative military technology indicator.

## What

- **`drone-warfare-helpers.ts`** — pure logic: `DroneProgram`, `DroneIncident`, `DroneRenderData` interfaces; 8 programs (USA, China, Turkey, Iran, Israel, Russia, Ukraine, Houthi); 12 incidents 2020–2024; helpers `getByType`, `getCombatExperienced`, `getHighSignificanceIncidents`, `getOngoingIncidents`, `computeGlobalDroneIndex`, `proliferationClass`, `maturityClass`, `incidentTypeClass`, `buildRenderData`
- **`DroneWarfarePanel.ts`** — extends `Panel`, 24-hour refresh, programs table sorted by maturity level, incident log sorted by significance
- **`drone-warfare-helpers.test.mts`** — 76 passing `node:test` assertions
- **`src/config/panels.ts`** — registers `drone-warfare`
- **`src/app/panel-layout.ts`** — imports and instantiates `DroneWarfarePanel`

## Tests

```
ℹ tests 76
ℹ pass  76
ℹ fail  0
```

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>