### PR TITLE
feat(imagery): GOES live multi-band imagery + animation (Phase 1.1)

### DIFF
--- a/api/satellite/goes-imagery.js
+++ b/api/satellite/goes-imagery.js
@@ -1,0 +1,137 @@
+/**
+ * GOES imagery — animation-frame proxy.
+ *
+ * Given sat / sector / product query params, fetches the NESDIS
+ * directory listing and returns the most recent timestamped frames (so
+ * the panel can play a live loop) plus the latest still URL + freshness.
+ *
+ * Free, no key. East = GOES-19 (GOES-16 retired 2025-04-04), West = GOES-18.
+ *
+ * The frame parser mirrors src/services/imagery/goes-catalog.ts; keep
+ * the two in sync (the TS version is the source of truth + is unit-tested).
+ */
+
+import { getCorsHeaders, isDisallowedOrigin } from '../_cors.js';
+
+export const config = { runtime: 'edge' };
+
+const CDN = 'https://cdn.star.nesdis.noaa.gov';
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const MAX_FRAMES = 24;
+
+const SATELLITES = new Set(['GOES19', 'GOES18']);
+const SECTORS = {
+  CONUS: { animationSize: '1250x750', stillSize: '2500x1500' },
+  FD: { animationSize: '1808x1808', stillSize: '1808x1808' },
+};
+const PRODUCTS = new Set(['GEOCOLOR', '13', '07', '08', '09']);
+
+export const cache = new Map();
+
+const j = (payload, status, cors) =>
+  Response.json(payload, {
+    status,
+    headers: { 'content-type': 'application/json; charset=utf-8', ...cors },
+  });
+
+function dirUrl(sat, sector, product) {
+  return `${CDN}/${sat}/ABI/${sector}/${product}/`;
+}
+
+function goesTimestampToEpoch(stamp) {
+  if (!/^\d{11}$/.test(stamp)) return null;
+  const year = Number(stamp.slice(0, 4));
+  const doy = Number(stamp.slice(4, 7));
+  const hour = Number(stamp.slice(7, 9));
+  const minute = Number(stamp.slice(9, 11));
+  if (doy < 1 || doy > 366 || hour > 23 || minute > 59) return null;
+  const ms = Date.UTC(year, 0, 1, hour, minute, 0, 0) + (doy - 1) * 86_400_000;
+  if (new Date(ms).getUTCFullYear() !== year) return null;
+  return ms;
+}
+
+function parseFrames(html, sat, sector, product, size) {
+  const dir = dirUrl(sat, sector, product);
+  const re = new RegExp(String.raw`(\d{11})_${sat}-ABI-${sector}-${product}-${size}\.jpg`, 'g');
+  const seen = new Set();
+  const frames = [];
+  for (const m of html.matchAll(re)) {
+    const ts = m[1];
+    if (seen.has(ts)) continue;
+    const epochMs = goesTimestampToEpoch(ts);
+    if (epochMs === null) continue;
+    seen.add(ts);
+    frames.push({
+      timestamp: ts,
+      epochMs,
+      url: `${dir}${ts}_${sat}-ABI-${sector}-${product}-${size}.jpg`,
+    });
+  }
+  frames.sort((a, b) => a.epochMs - b.epochMs);
+  return frames.slice(-MAX_FRAMES);
+}
+
+async function buildPayload(sat, sector, product) {
+  const sec = SECTORS[sector];
+  const dir = dirUrl(sat, sector, product);
+  let frames = [];
+  let degraded = false;
+  let reason;
+  try {
+    const r = await fetch(dir, {
+      headers: { 'User-Agent': 'CrystalBall/2 (goes-imagery)' },
+      signal: AbortSignal.timeout(12_000),
+    });
+    if (r.ok) {
+      const html = await r.text();
+      frames = parseFrames(html, sat, sector, product, sec.animationSize);
+    } else {
+      degraded = true;
+      reason = `NESDIS listing HTTP ${r.status}`;
+    }
+  } catch (error) {
+    degraded = true;
+    reason = error?.message ?? String(error);
+  }
+  const latestFrame = frames.length > 0 ? frames.at(-1) : null;
+  return {
+    satellite: sat,
+    sector,
+    product,
+    latestUrl: `${dir}latest.jpg`,
+    stillUrl: `${dir}latest.jpg`,
+    animationSize: sec.animationSize,
+    stillSize: sec.stillSize,
+    frames,
+    frameCount: frames.length,
+    latestFrameAt: latestFrame ? new Date(latestFrame.epochMs).toISOString() : null,
+    degraded,
+    reason,
+    generatedAt: new Date().toISOString(),
+    cacheTtlSeconds: CACHE_TTL_MS / 1000,
+  };
+}
+
+export default async function handler(req) {
+  const cors = getCorsHeaders(req, 'GET, OPTIONS');
+  if (isDisallowedOrigin(req)) return j({ error: 'Origin not allowed' }, 403, cors);
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
+  if (req.method !== 'GET') return j({ error: 'Method not allowed' }, 405, cors);
+
+  const url = new URL(req.url);
+  const sat = (url.searchParams.get('sat') || 'GOES19').toUpperCase();
+  const sector = (url.searchParams.get('sector') || 'CONUS').toUpperCase();
+  const product = (url.searchParams.get('product') || 'GEOCOLOR').toUpperCase();
+
+  if (!SATELLITES.has(sat) || !SECTORS[sector] || !PRODUCTS.has(product)) {
+    return j({ error: 'Invalid sat/sector/product', sat, sector, product }, 400, cors);
+  }
+
+  const key = `${sat}:${sector}:${product}`;
+  const cached = cache.get(key);
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) return j(cached.payload, 200, cors);
+
+  const payload = await buildPayload(sat, sector, product);
+  cache.set(key, { at: Date.now(), payload });
+  return j(payload, 200, cors);
+}

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -3604,14 +3604,9 @@ export class DataLoaderManager implements AppModule {
   }
 
   async loadGoesSatellite(): Promise<void> {
- try {
- const r = await fetch('/api/satellite/goes');
- if (!r.ok) return;
- const data = await r.json();
- (this.ctx.panels['goes-satellite'] as GoesSatellitePanel | undefined)?.update(data);
- } catch (error) {
- console.warn('[goes-satellite] fetch failed', error);
- }
+ // The panel owns its own fetch (it refetches on band/sector switch via
+ // /api/satellite/goes-imagery). The loader tick just asks it to refresh.
+ (this.ctx.panels['goes-satellite'] as GoesSatellitePanel | undefined)?.update();
   }
 
   async loadFloodMonitor(): Promise<void> {

--- a/src/components/GoesSatellitePanel.ts
+++ b/src/components/GoesSatellitePanel.ts
@@ -1,26 +1,30 @@
 import { Panel } from './Panel';
 import { escapeHtml } from '@/utils/sanitize';
+import {
+  GOES_PRODUCTS,
+  GOES_SATELLITES,
+  GOES_SECTORS,
+  getProduct,
+  type GoesSatelliteId,
+  type GoesSectorId,
+} from '@/services/imagery/goes-catalog';
+import {
+  fetchGoesImagery,
+  type GoesImageryResponse,
+} from '@/services/imagery/goes-imagery-service';
 
-interface GoesImageInfo {
-  label: string;
-  region: string;
-  product: string;
-  url: string;
-  available: boolean;
-  lastModified: string | null;
-  contentLength: number | null;
-}
-
-interface GoesSatelliteData {
-  goesEast: GoesImageInfo;
-  goesWest: GoesImageInfo;
-  generatedAt: string;
-  cacheTtlSeconds: number;
-}
+const FRAME_INTERVAL_MS = 350;
 
 export class GoesSatellitePanel extends Panel {
-  private data: GoesSatelliteData | null = null;
+  private satellite: GoesSatelliteId = 'GOES19';
+  private sector: GoesSectorId = 'CONUS';
+  private product = 'GEOCOLOR';
+  private data: GoesImageryResponse | null = null;
   private lastUpdated: Date | null = null;
+  private playing = false;
+  private frameIndex = 0;
+  private animTimer: ReturnType<typeof setInterval> | null = null;
+  private fetchAbort: AbortController | null = null;
 
   constructor() {
     super({
@@ -28,70 +32,173 @@ export class GoesSatellitePanel extends Panel {
       title: 'GOES Satellite',
       showCount: false,
       trackActivity: true,
-      infoTooltip: 'NOAA GOES-East (GOES-16) and GOES-West (GOES-18) GeoColor imagery — updated every 5 minutes.',
+      infoTooltip:
+        'NOAA GOES-East (GOES-19) / GOES-West (GOES-18) live imagery. Switch band (GeoColor / IR / water vapor / fire) and sector (CONUS / Full Disk); press Play for a loop. Updated ~every 5 min.',
     });
-    this.showLoading('Fetching satellite imagery...');
+    this.showLoading('Fetching satellite imagery…');
+    // Defer the first fetch out of the constructor call stack.
+    setTimeout(() => void this.reload(), 0);
   }
 
-  public update(data: GoesSatelliteData): void {
-    this.data = data;
-    this.lastUpdated = new Date();
+  /** Back-compat entry point still called by data-loader on its tick. */
+  public update(): void {
+    void this.reload();
+  }
+
+  public dispose(): void {
+    this.stopAnimation();
+    this.fetchAbort?.abort();
+  }
+
+  private async reload(): Promise<void> {
+    this.fetchAbort?.abort();
+    const controller = new AbortController();
+    this.fetchAbort = controller;
+    try {
+      const data = await fetchGoesImagery(
+        this.satellite,
+        this.sector,
+        this.product,
+        controller.signal,
+      );
+      this.data = data;
+      this.lastUpdated = new Date();
+      this.frameIndex = Math.max(0, data.frames.length - 1);
+      this.render();
+    } catch {
+      if (controller.signal.aborted) return;
+      if (!this.data) {
+        this.setContent('<div class="panel-empty">Satellite imagery unavailable.</div>');
+      }
+    }
+  }
+
+  private stopAnimation(): void {
+    if (this.animTimer !== null) {
+      clearInterval(this.animTimer);
+      this.animTimer = null;
+    }
+    this.playing = false;
+  }
+
+  private toggleAnimation(): void {
+    if (this.playing) {
+      this.stopAnimation();
+      this.render();
+      return;
+    }
+    if (!this.data || this.data.frames.length < 2) return;
+    this.playing = true;
+    this.animTimer = setInterval(() => {
+      if (!this.data || this.data.frames.length === 0) return;
+      this.frameIndex = (this.frameIndex + 1) % this.data.frames.length;
+      this.updateHeroFrame();
+    }, FRAME_INTERVAL_MS);
     this.render();
   }
 
-  private render(): void {
-    if (!this.data) {
-      this.setContent('<div class="panel-empty">No satellite data available.</div>');
-      return;
-    }
+  private updateHeroFrame(): void {
+    const root = this.getContentElement();
+    const img = root.querySelector<HTMLImageElement>('.goes-hero-img');
+    const stamp = root.querySelector<HTMLElement>('.goes-frame-stamp');
+    const frame = this.data?.frames[this.frameIndex];
+    if (img && frame) img.src = frame.url;
+    if (stamp && frame) stamp.textContent = new Date(frame.epochMs).toUTCString().replace('GMT', 'UTC');
+  }
 
-    const { goesEast, goesWest } = this.data;
+  private render(): void {
+    if (!this.data) return;
+    const d = this.data;
+    const frame = d.frames[this.frameIndex];
+    const heroUrl = frame ? frame.url : d.stillUrl;
+    const stampText = frame
+      ? new Date(frame.epochMs).toUTCString().replace('GMT', 'UTC')
+      : '—';
     const updatedStr = this.lastUpdated ? timeAgo(this.lastUpdated) : 'never';
+    const canPlay = d.frames.length >= 2;
 
     this.setContent(`
       <div class="goes-panel-content">
-        <div class="goes-images-row">
-          ${renderGoesImage(goesEast)}
-          ${renderGoesImage(goesWest)}
+        ${this.renderSwitchers()}
+        <div class="goes-hero">
+          <a href="${escapeHtml(d.latestUrl)}" target="_blank" rel="noopener noreferrer">
+            <img class="goes-hero-img" src="${escapeHtml(heroUrl)}"
+                 alt="GOES ${escapeHtml(this.product)} ${escapeHtml(this.sector)}" loading="lazy" />
+          </a>
+          <div class="goes-hero-bar">
+            <button class="goes-play-btn" data-goes-action="toggle" ${canPlay ? '' : 'disabled'}>
+              ${this.playing ? '⏸ Pause' : '▶ Play'}
+            </button>
+            <span class="goes-frame-stamp">${escapeHtml(stampText)}</span>
+            <span class="goes-frame-count">${d.frameCount} frames</span>
+          </div>
         </div>
+        ${d.degraded ? `<div class="goes-degraded">⚠ ${escapeHtml(d.reason ?? 'degraded')}</div>` : ''}
         <div class="fires-footer">
           <span class="fires-source">NOAA NESDIS · No API key</span>
-          <span class="fires-updated">Updated ${updatedStr}</span>
+          <span class="fires-updated">Updated ${escapeHtml(updatedStr)}</span>
         </div>
       </div>
     `);
+    this.wireControls();
   }
-}
 
-function renderGoesImage(info: GoesImageInfo): string {
-  const label = escapeHtml(info.label);
-  const region = escapeHtml(info.region);
-  const product = escapeHtml(info.product);
-  const modifiedStr = info.lastModified ? new Date(info.lastModified).toLocaleTimeString() : '—';
-
-  if (!info.available) {
+  private renderSwitchers(): string {
+    const satBtns = GOES_SATELLITES.map((s) =>
+      chip(s.label, s.id === this.satellite, 'sat', s.id),
+    ).join('');
+    const sectorBtns = GOES_SECTORS.map((s) =>
+      chip(s.label, s.id === this.sector, 'sector', s.id),
+    ).join('');
+    const productBtns = GOES_PRODUCTS.map((p) =>
+      chip(p.label, p.id === this.product, 'product', p.id, p.description),
+    ).join('');
     return `
-      <div class="goes-image-card goes-unavailable">
-        <div class="goes-image-label">${label}</div>
-        <div class="goes-image-placeholder">Imagery unavailable</div>
-        <div class="goes-image-meta">${region} · ${product}</div>
+      <div class="goes-switchers">
+        <div class="goes-switch-row">${satBtns}</div>
+        <div class="goes-switch-row">${sectorBtns}</div>
+        <div class="goes-switch-row">${productBtns}</div>
       </div>`;
   }
 
-  return `
-    <div class="goes-image-card">
-      <div class="goes-image-label">${label}</div>
-      <a href="${escapeHtml(info.url)}" target="_blank" rel="noopener noreferrer" class="goes-image-link">
-        <img
-          class="goes-image"
-          src="${escapeHtml(info.url)}"
-          alt="${label} GeoColor"
-          loading="lazy"
-          onerror="this.parentElement.parentElement.classList.add('goes-unavailable'); this.style.display='none'"
-        />
-      </a>
-      <div class="goes-image-meta">${region} · ${product} · ${modifiedStr}</div>
-    </div>`;
+  private wireControls(): void {
+    const root = this.getContentElement();
+    for (const el of root.querySelectorAll<HTMLElement>('[data-goes-kind]')) {
+      el.addEventListener('click', () => {
+        const kind = el.dataset.goesKind;
+        const value = el.dataset.goesValue;
+        if (!kind || !value) return;
+        this.applySelection(kind, value);
+      });
+    }
+    const toggle = root.querySelector<HTMLElement>('[data-goes-action="toggle"]');
+    toggle?.addEventListener('click', () => this.toggleAnimation());
+  }
+
+  private applySelection(kind: string, value: string): void {
+    if (kind === 'sat' && (value === 'GOES19' || value === 'GOES18')) {
+      this.satellite = value;
+    } else if (kind === 'sector' && (value === 'CONUS' || value === 'FD')) {
+      this.sector = value;
+    } else if (kind === 'product' && getProduct(value)) {
+      this.product = value;
+    } else {
+      return;
+    }
+    this.stopAnimation();
+    void this.reload();
+  }
+}
+
+function chip(
+  label: string,
+  active: boolean,
+  kind: string,
+  value: string,
+  title?: string,
+): string {
+  const titleAttr = title ? ` title="${escapeHtml(title)}"` : '';
+  return `<button class="goes-chip${active ? ' goes-chip-active' : ''}" data-goes-kind="${escapeHtml(kind)}" data-goes-value="${escapeHtml(value)}"${titleAttr}>${escapeHtml(label)}</button>`;
 }
 
 function timeAgo(date: Date): string {

--- a/src/services/imagery/__tests__/goes-catalog.test.mts
+++ b/src/services/imagery/__tests__/goes-catalog.test.mts
@@ -1,0 +1,177 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  GOES_PRODUCTS,
+  GOES_SATELLITES,
+  GOES_SECTORS,
+  frameUrl,
+  goesTimestampToEpoch,
+  isValidSelection,
+  latestUrl,
+  parseFrameListing,
+  productDirUrl,
+  recentFrames,
+  thumbnailUrl,
+} from '../goes-catalog';
+
+describe('catalog', () => {
+  it('uses GOES-19 for East (GOES-16 was retired)', () => {
+    const east = GOES_SATELLITES.find((s) => s.position === 'east');
+    assert.equal(east?.id, 'GOES19');
+  });
+
+  it('uses GOES-18 for West', () => {
+    const west = GOES_SATELLITES.find((s) => s.position === 'west');
+    assert.equal(west?.id, 'GOES18');
+  });
+
+  it('includes fire-detection and water-vapor bands', () => {
+    const ids = GOES_PRODUCTS.map((p) => p.id);
+    assert.ok(ids.includes('07')); // shortwave IR / fire
+    assert.ok(ids.includes('08')); // upper WV
+    assert.ok(ids.includes('13')); // clean IR
+    assert.ok(ids.includes('GEOCOLOR'));
+  });
+
+  it('has CONUS and Full Disk sectors', () => {
+    const ids = GOES_SECTORS.map((s) => s.id);
+    assert.deepEqual(ids, ['CONUS', 'FD']);
+  });
+});
+
+describe('isValidSelection', () => {
+  it('accepts a real combination', () => {
+    assert.equal(isValidSelection('GOES19', 'CONUS', 'GEOCOLOR'), true);
+  });
+  it('rejects unknown satellite / sector / product', () => {
+    assert.equal(isValidSelection('GOES99', 'CONUS', 'GEOCOLOR'), false);
+    assert.equal(isValidSelection('GOES19', 'MESO', 'GEOCOLOR'), false);
+    assert.equal(isValidSelection('GOES19', 'CONUS', 'BOGUS'), false);
+  });
+});
+
+describe('URL builders', () => {
+  it('builds the product directory URL', () => {
+    assert.equal(
+      productDirUrl('GOES19', 'CONUS', 'GEOCOLOR'),
+      'https://cdn.star.nesdis.noaa.gov/GOES19/ABI/CONUS/GEOCOLOR/',
+    );
+  });
+  it('builds the latest + thumbnail URLs', () => {
+    assert.equal(
+      latestUrl('GOES19', 'FD', '13'),
+      'https://cdn.star.nesdis.noaa.gov/GOES19/ABI/FD/13/latest.jpg',
+    );
+    assert.equal(
+      thumbnailUrl('GOES18', 'CONUS', '07'),
+      'https://cdn.star.nesdis.noaa.gov/GOES18/ABI/CONUS/07/thumbnail.jpg',
+    );
+  });
+  it('builds a timestamped frame URL', () => {
+    assert.equal(
+      frameUrl('GOES19', 'CONUS', 'GEOCOLOR', '20261511631', '1250x750'),
+      'https://cdn.star.nesdis.noaa.gov/GOES19/ABI/CONUS/GEOCOLOR/20261511631_GOES19-ABI-CONUS-GEOCOLOR-1250x750.jpg',
+    );
+  });
+});
+
+describe('goesTimestampToEpoch', () => {
+  it('parses a valid YYYYDDDHHMM stamp (UTC)', () => {
+    // 2026, day-of-year 151 = May 31 2026, 16:31 UTC.
+    const ms = goesTimestampToEpoch('20261511631');
+    assert.ok(ms !== null);
+    const d = new Date(ms!);
+    assert.equal(d.getUTCFullYear(), 2026);
+    assert.equal(d.getUTCMonth(), 4); // May (0-indexed)
+    assert.equal(d.getUTCDate(), 31);
+    assert.equal(d.getUTCHours(), 16);
+    assert.equal(d.getUTCMinutes(), 31);
+  });
+
+  it('parses day 1 as Jan 1', () => {
+    const ms = goesTimestampToEpoch('20260010000');
+    const d = new Date(ms!);
+    assert.equal(d.getUTCMonth(), 0);
+    assert.equal(d.getUTCDate(), 1);
+  });
+
+  it('handles leap-year day 366', () => {
+    // 2024 is a leap year — day 366 = Dec 31.
+    const ms = goesTimestampToEpoch('20243661200');
+    assert.ok(ms !== null);
+    const d = new Date(ms!);
+    assert.equal(d.getUTCFullYear(), 2024);
+    assert.equal(d.getUTCMonth(), 11);
+    assert.equal(d.getUTCDate(), 31);
+  });
+
+  it('rejects day 366 in a non-leap year (overflow)', () => {
+    // 2026 is not a leap year — day 366 would roll into next year.
+    assert.equal(goesTimestampToEpoch('20263661200'), null);
+  });
+
+  it('rejects malformed stamps', () => {
+    assert.equal(goesTimestampToEpoch('123'), null);
+    assert.equal(goesTimestampToEpoch('2026151163X'), null);
+    assert.equal(goesTimestampToEpoch('20260001200'), null); // day 0
+    assert.equal(goesTimestampToEpoch('20261512599'), null); // hour 25
+  });
+});
+
+describe('parseFrameListing', () => {
+  const html = `
+    <a href="latest.jpg">latest.jpg</a>
+    <a href="20261511626_GOES19-ABI-CONUS-GEOCOLOR-1250x750.jpg">a</a>
+    <a href="20261511631_GOES19-ABI-CONUS-GEOCOLOR-1250x750.jpg">b</a>
+    <a href="20261511621_GOES19-ABI-CONUS-GEOCOLOR-1250x750.jpg">c</a>
+    <a href="20261511631_GOES19-ABI-CONUS-GEOCOLOR-5000x3000.jpg">wrong size</a>
+    <a href="20261511631_GOES18-ABI-CONUS-GEOCOLOR-1250x750.jpg">wrong sat</a>
+  `;
+
+  it('extracts frames of the requested size, sorted oldest-first', () => {
+    const frames = parseFrameListing(html, 'GOES19', 'CONUS', 'GEOCOLOR', '1250x750');
+    assert.equal(frames.length, 3);
+    assert.deepEqual(
+      frames.map((f) => f.timestamp),
+      ['20261511621', '20261511626', '20261511631'],
+    );
+    assert.ok(frames[0]!.url.endsWith('20261511621_GOES19-ABI-CONUS-GEOCOLOR-1250x750.jpg'));
+  });
+
+  it('ignores other sizes and other satellites', () => {
+    const frames = parseFrameListing(html, 'GOES19', 'CONUS', 'GEOCOLOR', '1250x750');
+    assert.ok(frames.every((f) => f.size === '1250x750'));
+    assert.ok(frames.every((f) => f.url.includes('GOES19')));
+  });
+
+  it('returns [] when nothing matches', () => {
+    assert.deepEqual(parseFrameListing(html, 'GOES19', 'FD', '13', '1808x1808'), []);
+  });
+
+  it('dedupes repeated timestamps', () => {
+    const dup = `${html}\n<a href="20261511631_GOES19-ABI-CONUS-GEOCOLOR-1250x750.jpg">dup</a>`;
+    const frames = parseFrameListing(dup, 'GOES19', 'CONUS', 'GEOCOLOR', '1250x750');
+    assert.equal(frames.length, 3);
+  });
+});
+
+describe('recentFrames', () => {
+  const frames = parseFrameListing(
+    `<a href="20261511621_GOES19-ABI-CONUS-GEOCOLOR-1250x750.jpg">a</a>
+     <a href="20261511626_GOES19-ABI-CONUS-GEOCOLOR-1250x750.jpg">b</a>
+     <a href="20261511631_GOES19-ABI-CONUS-GEOCOLOR-1250x750.jpg">c</a>`,
+    'GOES19', 'CONUS', 'GEOCOLOR', '1250x750',
+  );
+
+  it('keeps the most recent n', () => {
+    const recent = recentFrames(frames, 2);
+    assert.deepEqual(recent.map((f) => f.timestamp), ['20261511626', '20261511631']);
+  });
+  it('returns [] for n <= 0', () => {
+    assert.deepEqual(recentFrames(frames, 0), []);
+  });
+  it('returns all when n exceeds length', () => {
+    assert.equal(recentFrames(frames, 99).length, 3);
+  });
+});

--- a/src/services/imagery/goes-catalog.ts
+++ b/src/services/imagery/goes-catalog.ts
@@ -1,0 +1,189 @@
+/**
+ * GOES imagery catalog — pure-deterministic URL building + frame parsing.
+ *
+ * Replaces the old hardcoded "2 GeoColor CONUS views" with a full
+ * satellite × sector × product catalog, correct GOES-19 East paths
+ * (GOES-16 was retired as East on 2025-04-04), and animation-frame
+ * parsing so the panel can play a live loop.
+ *
+ * No I/O. The sidecar route fetches the NESDIS directory listing and
+ * feeds the HTML to `parseFrameListing`; unit tests feed it static
+ * fixtures.
+ *
+ * NESDIS CDN layout:
+ *   https://cdn.star.nesdis.noaa.gov/{SAT}/ABI/{SECTOR}/{PRODUCT}/
+ *     latest.jpg                              full-res latest
+ *     thumbnail.jpg                           small latest
+ *     {YYYYDDDHHMM}_{SAT}-ABI-{SECTOR}-{PRODUCT}-{WxH}.jpg   timestamped frames
+ *
+ * Frame timestamps are UTC, encoded as 4-digit year + 3-digit
+ * day-of-year + 2-digit hour + 2-digit minute (e.g. 20261511631).
+ */
+
+export const NESDIS_CDN_BASE = 'https://cdn.star.nesdis.noaa.gov';
+
+export type GoesSatelliteId = 'GOES19' | 'GOES18';
+export type GoesSectorId = 'CONUS' | 'FD';
+
+export interface GoesSatellite {
+  id: GoesSatelliteId;
+  label: string;
+  position: 'east' | 'west';
+}
+
+export interface GoesSector {
+  id: GoesSectorId;
+  label: string;
+  /** Sized frame to embed for animation (keeps payload small vs full-res). */
+  animationSize: string;
+  /** Larger size for the still hero image. */
+  stillSize: string;
+}
+
+export interface GoesProduct {
+  /** NESDIS product directory name. */
+  id: string;
+  label: string;
+  description: string;
+}
+
+export const GOES_SATELLITES: readonly GoesSatellite[] = [
+  { id: 'GOES19', label: 'GOES-East (GOES-19)', position: 'east' },
+  { id: 'GOES18', label: 'GOES-West (GOES-18)', position: 'west' },
+];
+
+export const GOES_SECTORS: readonly GoesSector[] = [
+  { id: 'CONUS', label: 'CONUS', animationSize: '1250x750', stillSize: '2500x1500' },
+  { id: 'FD', label: 'Full Disk', animationSize: '1808x1808', stillSize: '1808x1808' },
+];
+
+export const GOES_PRODUCTS: readonly GoesProduct[] = [
+  { id: 'GEOCOLOR', label: 'GeoColor', description: 'True color by day, IR clouds by night' },
+  { id: '13', label: 'Clean IR', description: 'Band 13 longwave IR — cloud-top temps, night storms' },
+  { id: '07', label: 'Shortwave IR', description: 'Band 7 — fire / hot-spot detection' },
+  { id: '08', label: 'Upper Water Vapor', description: 'Band 8 — upper-level moisture & jet dynamics' },
+  { id: '09', label: 'Mid Water Vapor', description: 'Band 9 — mid-level moisture' },
+];
+
+export function getSatellite(id: string): GoesSatellite | undefined {
+  return GOES_SATELLITES.find((s) => s.id === id);
+}
+export function getSector(id: string): GoesSector | undefined {
+  return GOES_SECTORS.find((s) => s.id === id);
+}
+export function getProduct(id: string): GoesProduct | undefined {
+  return GOES_PRODUCTS.find((p) => p.id === id);
+}
+
+export function isValidSelection(sat: string, sector: string, product: string): boolean {
+  return Boolean(getSatellite(sat) && getSector(sector) && getProduct(product));
+}
+
+// URL builders
+
+export function productDirUrl(
+  sat: GoesSatelliteId,
+  sector: GoesSectorId,
+  product: string,
+): string {
+  return `${NESDIS_CDN_BASE}/${sat}/ABI/${sector}/${product}/`;
+}
+
+export function latestUrl(
+  sat: GoesSatelliteId,
+  sector: GoesSectorId,
+  product: string,
+): string {
+  return `${productDirUrl(sat, sector, product)}latest.jpg`;
+}
+
+export function thumbnailUrl(
+  sat: GoesSatelliteId,
+  sector: GoesSectorId,
+  product: string,
+): string {
+  return `${productDirUrl(sat, sector, product)}thumbnail.jpg`;
+}
+
+export function frameUrl(
+  sat: GoesSatelliteId,
+  sector: GoesSectorId,
+  product: string,
+  timestamp: string,
+  size: string,
+): string {
+  return `${productDirUrl(sat, sector, product)}${timestamp}_${sat}-ABI-${sector}-${product}-${size}.jpg`;
+}
+
+// Timestamp parsing
+
+/**
+ * Convert a NESDIS `YYYYDDDHHMM` UTC stamp to epoch ms.
+ * Returns null for malformed input (wrong length, out-of-range fields).
+ */
+export function goesTimestampToEpoch(stamp: string): number | null {
+  if (!/^\d{11}$/.test(stamp)) return null;
+  const year = Number(stamp.slice(0, 4));
+  const dayOfYear = Number(stamp.slice(4, 7));
+  const hour = Number(stamp.slice(7, 9));
+  const minute = Number(stamp.slice(9, 11));
+  if (dayOfYear < 1 || dayOfYear > 366) return null;
+  if (hour > 23 || minute > 59) return null;
+  // Jan 1 00:00 UTC of `year`, plus (dayOfYear - 1) days + hours + minutes.
+  const base = Date.UTC(year, 0, 1, hour, minute, 0, 0);
+  const withDays = base + (dayOfYear - 1) * 86_400_000;
+  // Reject a day-of-year that overflowed into the next year (e.g. 366 in a
+  // non-leap year lands in January — that's a malformed stamp for our use).
+  if (new Date(withDays).getUTCFullYear() !== year) return null;
+  return withDays;
+}
+
+// Frame-listing parser
+
+export interface GoesFrame {
+  timestamp: string;
+  epochMs: number;
+  size: string;
+  url: string;
+}
+
+/**
+ * Parse a NESDIS directory-listing HTML page into sorted frames (oldest
+ * first) matching the requested size. Pure — the caller fetches the HTML.
+ */
+export function parseFrameListing(
+  html: string,
+  sat: GoesSatelliteId,
+  sector: GoesSectorId,
+  product: string,
+  size: string,
+): GoesFrame[] {
+  const dir = productDirUrl(sat, sector, product);
+  const fileRe = new RegExp(
+    String.raw`(\d{11})_${sat}-ABI-${sector}-${product}-${size}\.jpg`,
+    'g',
+  );
+  const seen = new Set<string>();
+  const frames: GoesFrame[] = [];
+  for (const m of html.matchAll(fileRe)) {
+    const timestamp = m[1]!;
+    if (seen.has(timestamp)) continue;
+    const epochMs = goesTimestampToEpoch(timestamp);
+    if (epochMs === null) continue;
+    seen.add(timestamp);
+    frames.push({
+      timestamp,
+      epochMs,
+      size,
+      url: `${dir}${timestamp}_${sat}-ABI-${sector}-${product}-${size}.jpg`,
+    });
+  }
+  frames.sort((a, b) => a.epochMs - b.epochMs);
+  return frames;
+}
+
+/** Keep the most recent `n` frames (for a bounded animation loop). */
+export function recentFrames(frames: readonly GoesFrame[], n: number): GoesFrame[] {
+  if (n <= 0) return [];
+  return frames.slice(-n);
+}

--- a/src/services/imagery/goes-imagery-service.ts
+++ b/src/services/imagery/goes-imagery-service.ts
@@ -1,0 +1,55 @@
+/**
+ * GOES imagery service — thin renderer-side fetch wrapper over the
+ * sidecar `/api/satellite/goes-imagery` route. Pure catalog logic lives
+ * in goes-catalog.ts; this module is the I/O edge.
+ */
+
+import { getApiBaseUrl } from '../runtime';
+import {
+  isValidSelection,
+  type GoesSatelliteId,
+  type GoesSectorId,
+} from './goes-catalog';
+
+export interface GoesImageryFrame {
+  timestamp: string;
+  epochMs: number;
+  url: string;
+}
+
+export interface GoesImageryResponse {
+  satellite: GoesSatelliteId;
+  sector: GoesSectorId;
+  product: string;
+  latestUrl: string;
+  stillUrl: string;
+  animationSize: string;
+  stillSize: string;
+  frames: GoesImageryFrame[];
+  frameCount: number;
+  latestFrameAt: string | null;
+  degraded: boolean;
+  reason?: string;
+  generatedAt: string;
+}
+
+export async function fetchGoesImagery(
+  sat: GoesSatelliteId,
+  sector: GoesSectorId,
+  product: string,
+  signal?: AbortSignal,
+): Promise<GoesImageryResponse> {
+  if (!isValidSelection(sat, sector, product)) {
+    throw new Error(`Invalid GOES selection: ${sat}/${sector}/${product}`);
+  }
+  const url =
+    `${getApiBaseUrl()}/api/satellite/goes-imagery` +
+    `?sat=${encodeURIComponent(sat)}` +
+    `&sector=${encodeURIComponent(sector)}` +
+    `&product=${encodeURIComponent(product)}`;
+  const res = await fetch(url, { signal });
+  if (!res.ok) {
+    throw new Error(`goes-imagery HTTP ${res.status}`);
+  }
+  return (await res.json()) as GoesImageryResponse;
+}

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -769,3 +769,28 @@
     animation: none !important;
   }
 }
+
+/* GOES Satellite panel — band/sector switchers + animation hero */
+.goes-switchers { display: flex; flex-direction: column; gap: 4px; padding: 6px 8px; }
+.goes-switch-row { display: flex; flex-wrap: wrap; gap: 4px; }
+.goes-chip {
+  font-size: 10px; padding: 2px 8px; border-radius: 10px; cursor: pointer;
+  border: 1px solid var(--border, rgba(255,255,255,0.2));
+  background: transparent; color: var(--text-faint, #aaa);
+}
+.goes-chip-active {
+  background: var(--accent, #4a9eff); color: #fff; border-color: var(--accent, #4a9eff);
+}
+.goes-hero { position: relative; padding: 6px 8px 0; }
+.goes-hero-img { width: 100%; border-radius: 6px; display: block; }
+.goes-hero-bar {
+  display: flex; align-items: center; gap: 8px; margin-top: 4px;
+  font-size: 10px; color: var(--text-faint, #aaa);
+}
+.goes-play-btn {
+  font-size: 10px; padding: 2px 10px; border-radius: 4px; cursor: pointer;
+  border: 1px solid var(--accent, #4a9eff); background: transparent; color: var(--accent, #4a9eff);
+}
+.goes-play-btn:disabled { opacity: 0.4; cursor: default; }
+.goes-frame-count { margin-left: auto; }
+.goes-degraded { padding: 4px 8px; font-size: 10px; color: #ffb74d; }


### PR DESCRIPTION
Phase 1.1 of the enhancement roadmap. Upgrades the GOES Satellite panel from 2 hardcoded GeoColor CONUS stills (on the **retired GOES-16 path**) to a full live-imagery surface.\n\n**What changed**\n- Correct **GOES-19** East path (GOES-16 retired as East 2025-04-04), GOES-18 West.\n- **Band switcher**: GeoColor / Clean IR (band 13) / Shortwave-IR fire detection (band 07) / upper + mid water vapor (08/09).\n- **Sector switcher**: CONUS / Full Disk.\n- **Animation**: scrapes the NESDIS directory listing for recent timestamped frames and plays a live loop (play/pause) with UTC frame stamp + frame count.\n- Freshness + degraded states surfaced.\n\n**Architecture**\n- Pure-deterministic core `src/services/imagery/goes-catalog.ts`: URL builders + leap-year-aware `YYYYDDDHHMM` UTC parser + frame-listing parser. **21 unit tests**.\n- Sidecar `/api/satellite/goes-imagery` mirrors the parser, caches 5 min. Old `/api/satellite/goes` kept for back-compat.\n\n`npm run typecheck:all` clean; ESLint clean.

Cross-agent review: claude reviewed on 2026-05-09; outcome: pass