### PR TITLE
feat(space): near-Earth object tracker (Phase 1.2)

### DIFF
--- a/api/space/neo.js
+++ b/api/space/neo.js
@@ -1,0 +1,171 @@
+/**
+ * Near-Earth Object proxy. Combines two free, no-key JPL CNEOS feeds:
+ *   - CAD    (close-approach data): upcoming flybys within 0.05 AU / 60 days
+ *   - Sentry (impact-risk table):   objects with nonzero impact probability
+ *
+ * The normalizers mirror src/services/space/neo-normalize.ts (the TS
+ * version is the unit-tested source of truth).
+ */
+
+import { getCorsHeaders, isDisallowedOrigin } from '../_cors.js';
+
+export const config = { runtime: 'edge' };
+
+const CACHE_TTL_MS = 30 * 60 * 1000; // NEO data changes slowly
+const AU_PER_LD = 0.002_569_6;
+const ASSUMED_ALBEDO = 0.14;
+const MONTHS = { Jan: 0, Feb: 1, Mar: 2, Apr: 3, May: 4, Jun: 5, Jul: 6, Aug: 7, Sep: 8, Oct: 9, Nov: 10, Dec: 11 };
+const CAD_DATE_RE = /^(\d{4})-([A-Za-z]{3})-(\d{2})\s+(\d{2}):(\d{2})$/;
+
+export const cache = new Map();
+
+const j = (payload, status, cors) =>
+  Response.json(payload, { status, headers: { 'content-type': 'application/json; charset=utf-8', ...cors } });
+
+function finite(v) {
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  if (typeof v === 'string' && v.trim()) {
+    const n = Number(v);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+function estDiameterM(h) {
+  if (h === null || !Number.isFinite(h)) return null;
+  return Math.round((1329 / Math.sqrt(ASSUMED_ALBEDO)) * 10 ** (-0.2 * h) * 1000);
+}
+
+function parseCadDate(cd) {
+  const m = String(cd).trim().match(CAD_DATE_RE);
+  if (!m) return null;
+  const month = MONTHS[m[2]];
+  if (month === undefined) return null;
+  const day = Number(m[3]);
+  const hour = Number(m[4]);
+  const minute = Number(m[5]);
+  if (day < 1 || day > 31 || hour > 23 || minute > 59) return null;
+  return Date.UTC(Number(m[1]), month, day, hour, minute, 0, 0);
+}
+
+function classifyApproach(ld, dM) {
+  const big = (dM ?? 0) >= 140;
+  if (ld <= 1) return 'very_close';
+  if (ld <= 5) return big ? 'very_close' : 'close';
+  if (ld <= 20) return big ? 'close' : 'notable';
+  return big ? 'notable' : 'none';
+}
+
+function normalizeCloseApproaches(payload) {
+  if (!payload || !Array.isArray(payload.fields) || !Array.isArray(payload.data)) return [];
+  const f = payload.fields;
+  const iDes = f.indexOf('des');
+  const iCd = f.indexOf('cd');
+  const iDist = f.indexOf('dist');
+  const iVrel = f.indexOf('v_rel');
+  const iH = f.indexOf('h');
+  if (iDes === -1 || iCd === -1 || iDist === -1) return [];
+  const out = [];
+  for (const row of payload.data) {
+    if (!Array.isArray(row)) continue;
+    const designation = String(row[iDes] ?? '').trim();
+    const approachAt = parseCadDate(row[iCd]);
+    const distanceAu = Number(row[iDist]);
+    if (!designation || approachAt === null || !Number.isFinite(distanceAu)) continue;
+    const h = iH === -1 ? null : finite(row[iH]);
+    const dM = estDiameterM(h);
+    const ld = distanceAu / AU_PER_LD;
+    out.push({
+      designation,
+      approachAt,
+      distanceAu,
+      distanceLd: ld,
+      velocityKms: iVrel === -1 ? null : finite(row[iVrel]),
+      absoluteMagnitude: h,
+      estDiameterM: dM,
+      hazard: classifyApproach(ld, dM),
+    });
+  }
+  out.sort((a, b) => a.approachAt - b.approachAt);
+  return out;
+}
+
+function normalizeImpactRisks(payload) {
+  if (!payload || !Array.isArray(payload.data)) return [];
+  const out = [];
+  for (const r of payload.data) {
+    if (!r || typeof r !== 'object') continue;
+    const designation = String(r.des ?? '').trim();
+    const ip = finite(r.ip);
+    if (!designation || ip === null) continue;
+    const diameterKm = finite(r.diameter);
+    const h = finite(r.h);
+    out.push({
+      designation,
+      fullname: typeof r.fullname === 'string' ? r.fullname.trim() : null,
+      impactProbability: ip,
+      impactCount: Math.trunc(finite(r.n_imp) ?? 0),
+      palermoScaleCum: finite(r.ps_cum),
+      diameterM: diameterKm === null ? estDiameterM(h) : Math.round(diameterKm * 1000),
+      yearRange: typeof r.range === 'string' ? r.range.trim() : null,
+      absoluteMagnitude: h,
+    });
+  }
+  out.sort((a, b) => (b.palermoScaleCum ?? -Infinity) - (a.palermoScaleCum ?? -Infinity));
+  return out;
+}
+
+async function fetchJson(url) {
+  const r = await fetch(url, {
+    headers: { 'User-Agent': 'CrystalBall/2 (neo-tracker)', Accept: 'application/json' },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!r.ok) throw new Error(`HTTP ${r.status}`);
+  return r.json();
+}
+
+async function buildPayload() {
+  const cadUrl = 'https://ssd-api.jpl.nasa.gov/cad.api?date-min=now&date-max=%2B60&dist-max=0.05&sort=date';
+  const sentryUrl = 'https://ssd-api.jpl.nasa.gov/sentry.api';
+  const [cadRes, sentryRes] = await Promise.allSettled([fetchJson(cadUrl), fetchJson(sentryUrl)]);
+
+  const closeApproaches = cadRes.status === 'fulfilled' ? normalizeCloseApproaches(cadRes.value) : [];
+  const impactRisks = sentryRes.status === 'fulfilled' ? normalizeImpactRisks(sentryRes.value).slice(0, 30) : [];
+  const reasons = [];
+  if (cadRes.status === 'rejected') reasons.push(`CAD: ${cadRes.reason?.message ?? cadRes.reason}`);
+  if (sentryRes.status === 'rejected') reasons.push(`Sentry: ${sentryRes.reason?.message ?? sentryRes.reason}`);
+
+  return {
+    closeApproaches,
+    impactRisks,
+    closeApproachCount: closeApproaches.length,
+    impactRiskCount: impactRisks.length,
+    degraded: reasons.length > 0,
+    reason: reasons.length > 0 ? reasons.join('; ') : undefined,
+    source: 'NASA/JPL CNEOS',
+    generatedAt: new Date().toISOString(),
+    cacheTtlSeconds: CACHE_TTL_MS / 1000,
+  };
+}
+
+export default async function handler(req) {
+  const cors = getCorsHeaders(req, 'GET, OPTIONS');
+  if (isDisallowedOrigin(req)) return j({ error: 'Origin not allowed' }, 403, cors);
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
+  if (req.method !== 'GET') return j({ error: 'Method not allowed' }, 405, cors);
+
+  const cached = cache.get('neo');
+  if (cached && Date.now() - cached.at < CACHE_TTL_MS) return j(cached.payload, 200, cors);
+
+  try {
+    const payload = await buildPayload();
+    cache.set('neo', { at: Date.now(), payload });
+    return j(payload, 200, cors);
+  } catch (error) {
+    return j(
+      { closeApproaches: [], impactRisks: [], degraded: true, reason: error?.message ?? String(error), source: 'NASA/JPL CNEOS', generatedAt: new Date().toISOString() },
+      200,
+      cors,
+    );
+  }
+}

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -281,6 +281,7 @@ import type { WeatherRadarPanel } from '@/components/WeatherRadarPanel';
 import type { TidePredictionsPanel } from '@/components/TidePredictionsPanel';
 import type { PollenPanel } from '@/components/PollenPanel';
 import type { GoesSatellitePanel } from '@/components/GoesSatellitePanel';
+import type { NeoTrackerPanel } from '@/components/NeoTrackerPanel';
 import type { FloodMonitorPanel } from '@/components/FloodMonitorPanel';
 import type { IntelligenceFeedPanel } from '@/components/IntelligenceFeedPanel';
 import { ingest } from '@/services/intelligence/observation-store';
@@ -620,6 +621,7 @@ export class DataLoaderManager implements AppModule {
  if (SITE_VARIANT === 'full') tasks.push({ name: 'tidePredictions', task: () => runGuarded('tidePredictions', () => this.loadTidePredictions()) });
  if (SITE_VARIANT === 'full') tasks.push({ name: 'pollenData', task: () => runGuarded('pollenData', () => this.loadPollenData()) });
  if (SITE_VARIANT === 'full') tasks.push({ name: 'goesSatellite', task: () => runGuarded('goesSatellite', () => this.loadGoesSatellite()) });
+ if (SITE_VARIANT === 'full') tasks.push({ name: 'neoTracker', task: () => runGuarded('neoTracker', () => this.loadNeoTracker()) });
  if (SITE_VARIANT === 'full') tasks.push({ name: 'floodMonitor', task: () => runGuarded('floodMonitor', () => this.loadFloodMonitor()) });
  if (SITE_VARIANT === 'full') tasks.push({ name: 'intelligenceFeed', task: () => runGuarded('intelligenceFeed', () => this.loadIntelligenceFeed()) });
  if (SITE_VARIANT === 'full') tasks.push({ name: 'lightning', task: () => runGuarded('lightning', () => this.loadLightning()) });
@@ -3601,6 +3603,11 @@ export class DataLoaderManager implements AppModule {
  } catch (error) {
  console.warn('[pollen] fetch failed', error);
  }
+  }
+
+  async loadNeoTracker(): Promise<void> {
+ // The panel owns its own fetch (/api/space/neo); the tick just refreshes it.
+ await (this.ctx.panels['neo-tracker'] as NeoTrackerPanel | undefined)?.update();
   }
 
   async loadGoesSatellite(): Promise<void> {

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -144,6 +144,7 @@ import { LittleSnitchPanel } from '@/components/LittleSnitchPanel';
 import { AlertCenterPanel } from '@/components/AlertCenterPanel';
 import { SituationPanel } from '@/components/SituationPanel';
 import { SpaceWeatherPanel } from '@/components/SpaceWeatherPanel';
+import { NeoTrackerPanel } from '@/components/NeoTrackerPanel';
 import { SpaceSecurityPanel } from '@/components/SpaceSecurityPanel';
 import { SpaceSuperpowerPanel } from '@/components/SpaceSuperpowerPanel';
 import { WeatherSuperpowerPanel } from '@/components/WeatherSuperpowerPanel';
@@ -1227,6 +1228,7 @@ export class PanelLayoutManager implements AppModule {
 
  const spaceWeatherPanel = new SpaceWeatherPanel();
  this.ctx.panels['space-weather'] = spaceWeatherPanel;
+ this.ctx.panels['neo-tracker'] = new NeoTrackerPanel();
  this.ctx.panels['space-security'] = new SpaceSecurityPanel();
 
  this.ctx.panels['space-superpower'] = new SpaceSuperpowerPanel();

--- a/src/components/NeoTrackerPanel.ts
+++ b/src/components/NeoTrackerPanel.ts
@@ -1,0 +1,117 @@
+import { Panel } from './Panel';
+import { escapeHtml } from '@/utils/sanitize';
+import type { CloseApproach, ImpactRiskObject, NeoHazard } from '@/services/space/neo-normalize';
+import { fetchNeoSnapshot, type NeoSnapshot } from '@/services/space/neo-service';
+
+const HAZARD_COLOR: Record<NeoHazard, string> = {
+  none: '#6b7280',
+  notable: '#eab308',
+  close: '#f97316',
+  very_close: '#dc2626',
+};
+
+export class NeoTrackerPanel extends Panel {
+  private data: NeoSnapshot | null = null;
+  private fetchAbort: AbortController | null = null;
+
+  constructor() {
+    super({
+      id: 'neo-tracker',
+      title: 'Near-Earth Objects',
+      showCount: true,
+      trackActivity: true,
+      infoTooltip:
+        'Upcoming asteroid close approaches (within 0.05 AU / 60 days) and the JPL Sentry impact-risk watchlist. Distances shown in lunar distances (LD). Source: NASA/JPL CNEOS — no API key.',
+    });
+    this.showLoading('Fetching near-Earth objects…');
+  }
+
+  public async update(): Promise<void> {
+    this.fetchAbort?.abort();
+    const controller = new AbortController();
+    this.fetchAbort = controller;
+    try {
+      const data = await fetchNeoSnapshot(controller.signal);
+      this.data = data;
+      this.setCount(data.closeApproachCount);
+      this.render();
+    } catch {
+      if (controller.signal.aborted) return;
+      if (!this.data) this.setContent('<div class="panel-empty">NEO data unavailable.</div>');
+    }
+  }
+
+  public dispose(): void {
+    this.fetchAbort?.abort();
+  }
+
+  private render(): void {
+    if (!this.data) return;
+    const d = this.data;
+    this.setContent(`
+      <div class="neo-panel-content">
+        ${this.renderApproaches(d.closeApproaches)}
+        ${this.renderImpactRisks(d.impactRisks)}
+        ${d.degraded ? `<div class="neo-degraded">⚠ ${escapeHtml(d.reason ?? 'degraded')}</div>` : ''}
+        <div class="fires-footer">
+          <span class="fires-source">${escapeHtml(d.source)} · No API key</span>
+          <span class="fires-updated">${escapeHtml(d.closeApproachCount.toString())} approaches · ${escapeHtml(d.impactRiskCount.toString())} risk objects</span>
+        </div>
+      </div>
+    `);
+  }
+
+  private renderApproaches(rows: readonly CloseApproach[]): string {
+    if (rows.length === 0) {
+      return '<div class="neo-section"><div class="neo-section-title">Close Approaches</div><div class="panel-empty">None within range.</div></div>';
+    }
+    const body = rows.slice(0, 20).map((a) => {
+      const color = HAZARD_COLOR[a.hazard];
+      const ld = a.distanceLd.toFixed(1);
+      const size = a.estDiameterM ? `~${formatMetres(a.estDiameterM)}` : '—';
+      const vel = a.velocityKms === null ? '—' : `${a.velocityKms.toFixed(1)} km/s`;
+      const when = new Date(a.approachAt).toUTCString().replace('GMT', 'UTC');
+      return `
+        <div class="neo-row" style="border-left:3px solid ${color};">
+          <div class="neo-row-main">
+            <span class="neo-des">${escapeHtml(a.designation)}</span>
+            <span class="neo-dist" style="color:${color};">${ld} LD</span>
+          </div>
+          <div class="neo-row-sub">${escapeHtml(size)} · ${escapeHtml(vel)} · ${escapeHtml(when)}</div>
+        </div>`;
+    }).join('');
+    return `<div class="neo-section"><div class="neo-section-title">Close Approaches (next 60 days)</div>${body}</div>`;
+  }
+
+  private renderImpactRisks(rows: readonly ImpactRiskObject[]): string {
+    if (rows.length === 0) return '';
+    const body = rows.slice(0, 10).map((r) => {
+      const prob = formatProbability(r.impactProbability);
+      const size = r.diameterM ? `~${formatMetres(r.diameterM)}` : '—';
+      const ps = r.palermoScaleCum === null ? 'PS —' : `PS ${r.palermoScaleCum.toFixed(2)}`;
+      const years = r.yearRange ? escapeHtml(r.yearRange) : '—';
+      return `
+        <div class="neo-row">
+          <div class="neo-row-main">
+            <span class="neo-des">${escapeHtml(r.designation)}</span>
+            <span class="neo-prob">${escapeHtml(prob)}</span>
+          </div>
+          <div class="neo-row-sub">${escapeHtml(size)} · ${escapeHtml(ps)} · ${years}</div>
+        </div>`;
+    }).join('');
+    return `<div class="neo-section"><div class="neo-section-title">Sentry Impact-Risk Watchlist</div>${body}</div>`;
+  }
+}
+
+function formatMetres(m: number): string {
+  if (m >= 1000) return `${(m / 1000).toFixed(1)} km`;
+  return `${m} m`;
+}
+
+function formatProbability(p: number): string {
+  if (p <= 0) return '0';
+  if (p >= 0.01) return `${(p * 100).toFixed(1)}%`;
+  // e.g. "1 in 12,000"
+  const oneIn = Math.round(1 / p);
+  return `1 in ${oneIn.toLocaleString('en-US')}`;
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -98,6 +98,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'oref-sirens': { name: 'Israel Sirens', enabled: true, priority: 2 },
   'telegram-intel': { name: 'Telegram Intel', enabled: true, priority: 2 },
   'space-weather': { name: 'Space Weather', enabled: true, priority: 1 },
+  'neo-tracker': { name: 'Near-Earth Objects', enabled: true, priority: 1 },
   'space-security': { name: 'Space Security', enabled: true, priority: 1 },
   'space-superpower': { name: 'Space Superpower', enabled: true, priority: 1 },
   'weather-superpower': { name: 'Weather Intelligence', enabled: true, priority: 1 },
@@ -1152,7 +1153,7 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   },
   dataTracking: {
  labelKey: 'header.panelCatDataTracking',
- panelKeys: ['counterterrorism', 'monitors', 'cyber-threats', 'threat-inbox', 'local-ids', 'little-snitch', 'comms-health', 'power-grid', 'grid-intelligence', 'electric-grid-vulnerability', 'cve-tracker', 'vulners-cve', 'hibp-breaches', 'ipinfo-lookup', 'ucdp-events', 'nuclear-risk', 'nuclear-near-miss', 'airstrikes', 'displacement', 'security-advisories', 'bitcoin-abuse', 'reddit-osint', 'network-rules', 's2u-intel', 'oref-sirens', 'space-weather', 'space-security', 'space-superpower', 'spaceflight-news', 'space-launches', 'population-exposure', 'internet-disruptions', 'air-traffic', 'threat-intel-hub', 'phishstats-feed', 'urlscan-threats', 'pulsedive-intel', 'geo-intel', 'dark-web', 'anomaly-detection', 'financial-contagion', 'supply-chain-impact', 'nuclear-monitor', 'sigint-panel', 'dark-vessel', 'ics-ot-dashboard', 'ioc-manager', 'network-topology', 'stix-taxii', 'custom-geofence', 'sanctions-crossref', 'emergency-broadcast', 'satellite-change', 'ripe-ncc', 'ripe-atlas', 'aerospace-reentry', 'satellite-intel', 'cyber-espionage', 'political-violence'], variants: ['full'],  },
+ panelKeys: ['counterterrorism', 'monitors', 'cyber-threats', 'threat-inbox', 'local-ids', 'little-snitch', 'comms-health', 'power-grid', 'grid-intelligence', 'electric-grid-vulnerability', 'cve-tracker', 'vulners-cve', 'hibp-breaches', 'ipinfo-lookup', 'ucdp-events', 'nuclear-risk', 'nuclear-near-miss', 'airstrikes', 'displacement', 'security-advisories', 'bitcoin-abuse', 'reddit-osint', 'network-rules', 's2u-intel', 'oref-sirens', 'space-weather', 'neo-tracker', 'space-security', 'space-superpower', 'spaceflight-news', 'space-launches', 'population-exposure', 'internet-disruptions', 'air-traffic', 'threat-intel-hub', 'phishstats-feed', 'urlscan-threats', 'pulsedive-intel', 'geo-intel', 'dark-web', 'anomaly-detection', 'financial-contagion', 'supply-chain-impact', 'nuclear-monitor', 'sigint-panel', 'dark-vessel', 'ics-ot-dashboard', 'ioc-manager', 'network-topology', 'stix-taxii', 'custom-geofence', 'sanctions-crossref', 'emergency-broadcast', 'satellite-change', 'ripe-ncc', 'ripe-atlas', 'aerospace-reentry', 'satellite-intel', 'cyber-espionage', 'political-violence'], variants: ['full'],  },
   hazards: {
  labelKey: 'header.panelCatHazards',
 

--- a/src/services/space/__tests__/neo-normalize.test.mts
+++ b/src/services/space/__tests__/neo-normalize.test.mts
@@ -1,0 +1,147 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  auToLunarDistances,
+  classifyApproach,
+  estimateDiameterMetres,
+  normalizeCloseApproaches,
+  normalizeImpactRisks,
+  parseCadDate,
+} from '../neo-normalize';
+
+describe('estimateDiameterMetres', () => {
+  it('estimates a larger diameter for a brighter (lower H) object', () => {
+    const bright = estimateDiameterMetres(18)!;
+    const faint = estimateDiameterMetres(28)!;
+    assert.ok(bright > faint);
+  });
+  it('H=18.5 estimates a sub-km diameter in the right ballpark', () => {
+    // ~600-700 m for H=18.5 at albedo 0.14.
+    const d = estimateDiameterMetres(18.5)!;
+    assert.ok(d > 400 && d < 900, `got ${d}`);
+  });
+  it('returns null for null/NaN', () => {
+    assert.equal(estimateDiameterMetres(null), null);
+    assert.equal(estimateDiameterMetres(Number.NaN), null);
+  });
+});
+
+describe('auToLunarDistances', () => {
+  it('converts 0.0025696 AU to ~1 LD', () => {
+    assert.ok(Math.abs(auToLunarDistances(0.0025696) - 1) < 0.01);
+  });
+  it('0.05 AU is ~19.5 LD', () => {
+    const ld = auToLunarDistances(0.05);
+    assert.ok(ld > 19 && ld < 20, `got ${ld}`);
+  });
+});
+
+describe('parseCadDate', () => {
+  it('parses "2026-May-31 00:54" UTC', () => {
+    const ms = parseCadDate('2026-May-31 00:54')!;
+    const d = new Date(ms);
+    assert.equal(d.getUTCFullYear(), 2026);
+    assert.equal(d.getUTCMonth(), 4); // May
+    assert.equal(d.getUTCDate(), 31);
+    assert.equal(d.getUTCHours(), 0);
+    assert.equal(d.getUTCMinutes(), 54);
+  });
+  it('rejects malformed dates', () => {
+    assert.equal(parseCadDate('2026-Foo-31 00:54'), null);
+    assert.equal(parseCadDate('garbage'), null);
+    assert.equal(parseCadDate('2026-May-31 25:00'), null);
+  });
+});
+
+describe('classifyApproach', () => {
+  it('very_close inside 1 LD', () => {
+    assert.equal(classifyApproach(0.5, 10), 'very_close');
+  });
+  it('close for a small rock at 3 LD', () => {
+    assert.equal(classifyApproach(3, 10), 'close');
+  });
+  it('very_close for a big rock at 3 LD (size raises the floor)', () => {
+    assert.equal(classifyApproach(3, 200), 'very_close');
+  });
+  it('none for a tiny rock far out', () => {
+    assert.equal(classifyApproach(50, 5), 'none');
+  });
+  it('notable for a big rock far out', () => {
+    assert.equal(classifyApproach(50, 200), 'notable');
+  });
+});
+
+describe('normalizeCloseApproaches', () => {
+  const payload = {
+    fields: ['des', 'orbit_id', 'jd', 'cd', 'dist', 'dist_min', 'dist_max', 'v_rel', 'v_inf', 't_sigma_f', 'h'],
+    data: [
+      ['2026 KJ2', '6', '2461191.5', '2026-May-31 00:54', '0.0447861', '0.0445', '0.0449', '7.21184', '7.2', '< 00:01', '25.807'],
+      ['2026 KA3', '5', '2461191.5', '2026-May-31 01:31', '0.0247142', '0.0246', '0.0248', '9.33287', '9.3', '< 00:01', '24.0'],
+    ],
+  };
+
+  it('parses fields[]/data[][] into sorted CloseApproach[]', () => {
+    const out = normalizeCloseApproaches(payload);
+    assert.equal(out.length, 2);
+    assert.equal(out[0]!.designation, '2026 KJ2');
+    assert.ok(out[0]!.approachAt < out[1]!.approachAt); // sorted by time
+    assert.ok(Math.abs(out[0]!.distanceAu - 0.0447861) < 1e-6);
+    assert.ok(out[0]!.distanceLd > 17 && out[0]!.distanceLd < 18);
+    assert.equal(out[0]!.velocityKms, 7.21184);
+  });
+
+  it('returns [] for non-CAD payloads', () => {
+    assert.deepEqual(normalizeCloseApproaches(null), []);
+    assert.deepEqual(normalizeCloseApproaches({ data: [] }), []);
+    assert.deepEqual(normalizeCloseApproaches({ fields: ['x'], data: [['y']] }), []);
+  });
+
+  it('skips rows with unparseable dates or distances', () => {
+    const bad = {
+      fields: ['des', 'cd', 'dist'],
+      data: [
+        ['ok', '2026-May-31 00:54', '0.01'],
+        ['baddate', 'nope', '0.01'],
+        ['baddist', '2026-May-31 00:54', 'NaN'],
+      ],
+    };
+    const out = normalizeCloseApproaches(bad);
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.designation, 'ok');
+  });
+});
+
+describe('normalizeImpactRisks', () => {
+  const payload = {
+    data: [
+      { des: '1979 XB', fullname: '(1979 XB)', ip: '8.5e-07', n_imp: 4, ps_cum: '-2.69', diameter: '0.66', h: '18.54', range: '2056-2113' },
+      { des: '2022 KK2', fullname: '(2022 KK2)', ip: '0.00012', n_imp: 33, ps_cum: '-5.58', diameter: '0.0069', h: '28.45', range: '2060-2122' },
+    ],
+  };
+
+  it('parses Sentry objects sorted by Palermo scale (highest first)', () => {
+    const out = normalizeImpactRisks(payload);
+    assert.equal(out.length, 2);
+    assert.equal(out[0]!.designation, '1979 XB'); // ps_cum -2.69 > -5.58
+    assert.equal(out[0]!.impactCount, 4);
+    assert.ok(Math.abs(out[0]!.impactProbability - 8.5e-7) < 1e-9);
+    assert.equal(out[0]!.diameterM, 660); // 0.66 km
+    assert.equal(out[0]!.yearRange, '2056-2113');
+  });
+
+  it('falls back to H-estimated diameter when diameter missing', () => {
+    const out = normalizeImpactRisks({ data: [{ des: 'X', ip: '1e-6', h: '20' }] });
+    assert.ok(out[0]!.diameterM! > 0);
+  });
+
+  it('returns [] for non-Sentry payloads', () => {
+    assert.deepEqual(normalizeImpactRisks(null), []);
+    assert.deepEqual(normalizeImpactRisks({ data: 'nope' }), []);
+  });
+
+  it('skips entries without designation or impact probability', () => {
+    const out = normalizeImpactRisks({ data: [{ des: '', ip: '1e-6' }, { des: 'Y' }] });
+    assert.equal(out.length, 0);
+  });
+});

--- a/src/services/space/neo-normalize.ts
+++ b/src/services/space/neo-normalize.ts
@@ -1,0 +1,191 @@
+/**
+ * Near-Earth Object normalizers — pure-deterministic.
+ *
+ * Sources (both free, no key):
+ *   - JPL CNEOS CAD  (close-approach data)  → upcoming flybys
+ *   - JPL CNEOS Sentry (impact-risk table)  → objects with nonzero
+ *                                             cumulative impact probability
+ *
+ * No I/O. The sidecar fetches; these functions parse + classify.
+ *
+ * Units:
+ *   - Distances arrive in astronomical units (AU); we expose lunar
+ *     distances (LD) as the intuitive scale (1 LD ≈ 0.0025696 AU).
+ *   - Absolute magnitude H → estimated diameter when no measured
+ *     diameter is published.
+ */
+
+export const AU_PER_LUNAR_DISTANCE = 0.002_569_6;
+export const KM_PER_AU = 149_597_870.7;
+
+export type NeoHazard = 'none' | 'notable' | 'close' | 'very_close';
+
+export interface CloseApproach {
+  designation: string;
+  /** Close-approach time, epoch ms (UTC). */
+  approachAt: number;
+  /** Nominal miss distance in AU. */
+  distanceAu: number;
+  /** Nominal miss distance in lunar distances. */
+  distanceLd: number;
+  /** Relative velocity, km/s. */
+  velocityKms: number | null;
+  /** Absolute magnitude H. */
+  absoluteMagnitude: number | null;
+  /** Estimated diameter in metres (from H when not measured). */
+  estDiameterM: number | null;
+  hazard: NeoHazard;
+}
+
+export interface ImpactRiskObject {
+  designation: string;
+  fullname: string | null;
+  /** Cumulative impact probability over all virtual impactors. */
+  impactProbability: number;
+  /** Number of potential impacts. */
+  impactCount: number;
+  /** Cumulative Palermo Technical Scale (higher = more concerning). */
+  palermoScaleCum: number | null;
+  /** Estimated diameter in metres. */
+  diameterM: number | null;
+  /** Window of potential impact years, e.g. "2056-2113". */
+  yearRange: string | null;
+  absoluteMagnitude: number | null;
+}
+
+// Diameter estimate from absolute magnitude H, assuming a typical
+// albedo of 0.14: D(km) = 1329 / sqrt(albedo) * 10^(-0.2 H).
+const ASSUMED_ALBEDO = 0.14;
+
+export function estimateDiameterMetres(h: number | null): number | null {
+  if (h === null || !Number.isFinite(h)) return null;
+  const km = (1329 / Math.sqrt(ASSUMED_ALBEDO)) * 10 ** (-0.2 * h);
+  return Math.round(km * 1000);
+}
+
+export function auToLunarDistances(au: number): number {
+  return au / AU_PER_LUNAR_DISTANCE;
+}
+
+const MONTHS: Record<string, number> = {
+  Jan: 0, Feb: 1, Mar: 2, Apr: 3, May: 4, Jun: 5,
+  Jul: 6, Aug: 7, Sep: 8, Oct: 9, Nov: 10, Dec: 11,
+};
+
+const CAD_DATE_RE = /^(\d{4})-([A-Za-z]{3})-(\d{2})\s+(\d{2}):(\d{2})$/;
+
+/** Parse JPL CAD calendar dates like "2026-May-31 00:54" (UTC) to epoch ms. */
+export function parseCadDate(cd: string): number | null {
+  // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec, sonarjs/prefer-regexp-exec -- RegExp.exec is blocked by the repo security hook
+  const m = cd.trim().match(CAD_DATE_RE);
+  if (!m) return null;
+  const year = Number(m[1]);
+  const month = MONTHS[m[2]!];
+  if (month === undefined) return null;
+  const day = Number(m[3]);
+  const hour = Number(m[4]);
+  const minute = Number(m[5]);
+  if (day < 1 || day > 31 || hour > 23 || minute > 59) return null;
+  return Date.UTC(year, month, day, hour, minute, 0, 0);
+}
+
+export function classifyApproach(distanceLd: number, estDiameterM: number | null): NeoHazard {
+  // Lunar distance is the intuitive yardstick. Size raises the floor:
+  // a big rock at 5 LD is more notable than a pebble at 5 LD.
+  const big = (estDiameterM ?? 0) >= 140; // NASA "potentially hazardous" size floor
+  if (distanceLd <= 1) return 'very_close';
+  if (distanceLd <= 5) return big ? 'very_close' : 'close';
+  if (distanceLd <= 20) return big ? 'close' : 'notable';
+  return big ? 'notable' : 'none';
+}
+
+interface CadPayload {
+  fields?: unknown;
+  data?: unknown;
+}
+
+/** Normalize a JPL CAD response (fields[] + data[][]) to CloseApproach[]. */
+export function normalizeCloseApproaches(payload: unknown): CloseApproach[] {
+  const p = (payload ?? {}) as CadPayload;
+  if (!Array.isArray(p.fields) || !Array.isArray(p.data)) return [];
+  const fields = p.fields as string[];
+  const iDes = fields.indexOf('des');
+  const iCd = fields.indexOf('cd');
+  const iDist = fields.indexOf('dist');
+  const iVrel = fields.indexOf('v_rel');
+  const iH = fields.indexOf('h');
+  if (iDes === -1 || iCd === -1 || iDist === -1) return [];
+
+  const out: CloseApproach[] = [];
+  for (const row of p.data as unknown[]) {
+    if (!Array.isArray(row)) continue;
+    const designation = asString(row[iDes]).trim();
+    const approachAt = parseCadDate(asString(row[iCd]));
+    const distanceAu = Number(row[iDist]);
+    if (!designation || approachAt === null || !Number.isFinite(distanceAu)) continue;
+    const velocityKms = iVrel === -1 ? null : finite(row[iVrel]);
+    const absoluteMagnitude = iH === -1 ? null : finite(row[iH]);
+    const estDiameterM = estimateDiameterMetres(absoluteMagnitude);
+    const distanceLd = auToLunarDistances(distanceAu);
+    out.push({
+      designation,
+      approachAt,
+      distanceAu,
+      distanceLd,
+      velocityKms,
+      absoluteMagnitude,
+      estDiameterM,
+      hazard: classifyApproach(distanceLd, estDiameterM),
+    });
+  }
+  out.sort((a, b) => a.approachAt - b.approachAt);
+  return out;
+}
+
+interface SentryPayload {
+  data?: unknown;
+}
+
+/** Normalize a JPL Sentry response (data[] of objects) to ImpactRiskObject[]. */
+export function normalizeImpactRisks(payload: unknown): ImpactRiskObject[] {
+  const p = (payload ?? {}) as SentryPayload;
+  if (!Array.isArray(p.data)) return [];
+  const out: ImpactRiskObject[] = [];
+  for (const item of p.data as unknown[]) {
+    if (!item || typeof item !== 'object') continue;
+    const r = item as Record<string, unknown>;
+    const designation = asString(r.des).trim();
+    const impactProbability = finite(r.ip);
+    if (!designation || impactProbability === null) continue;
+    const diameterKm = finite(r.diameter);
+    const absoluteMagnitude = finite(r.h);
+    out.push({
+      designation,
+      fullname: typeof r.fullname === 'string' ? r.fullname.trim() : null,
+      impactProbability,
+      impactCount: Math.trunc(finite(r.n_imp) ?? 0),
+      palermoScaleCum: finite(r.ps_cum),
+      diameterM: diameterKm === null ? estimateDiameterMetres(absoluteMagnitude) : Math.round(diameterKm * 1000),
+      yearRange: typeof r.range === 'string' ? r.range.trim() : null,
+      absoluteMagnitude,
+    });
+  }
+  // Highest Palermo scale first (most concerning); nulls last.
+  out.sort((a, b) => (b.palermoScaleCum ?? -Infinity) - (a.palermoScaleCum ?? -Infinity));
+  return out;
+}
+
+function asString(v: unknown): string {
+  if (typeof v === 'string') return v;
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+  return '';
+}
+
+function finite(v: unknown): number | null {
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  if (typeof v === 'string' && v.trim()) {
+    const n = Number(v);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}

--- a/src/services/space/neo-service.ts
+++ b/src/services/space/neo-service.ts
@@ -1,0 +1,24 @@
+/**
+ * NEO service — thin renderer-side fetch over the sidecar `/api/space/neo`
+ * route. Pure parsing/classification lives in neo-normalize.ts.
+ */
+
+import { getApiBaseUrl } from '../runtime';
+import type { CloseApproach, ImpactRiskObject } from './neo-normalize';
+
+export interface NeoSnapshot {
+  closeApproaches: CloseApproach[];
+  impactRisks: ImpactRiskObject[];
+  closeApproachCount: number;
+  impactRiskCount: number;
+  degraded: boolean;
+  reason?: string;
+  source: string;
+  generatedAt: string;
+}
+
+export async function fetchNeoSnapshot(signal?: AbortSignal): Promise<NeoSnapshot> {
+  const res = await fetch(`${getApiBaseUrl()}/api/space/neo`, { signal });
+  if (!res.ok) throw new Error(`neo HTTP ${res.status}`);
+  return (await res.json()) as NeoSnapshot;
+}

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -794,3 +794,15 @@
 .goes-play-btn:disabled { opacity: 0.4; cursor: default; }
 .goes-frame-count { margin-left: auto; }
 .goes-degraded { padding: 4px 8px; font-size: 10px; color: #ffb74d; }
+
+/* Near-Earth Objects panel */
+.neo-panel-content { display: flex; flex-direction: column; gap: 8px; padding: 6px 0; }
+.neo-section { padding: 0 8px; }
+.neo-section-title { font-size: 11px; font-weight: 600; color: var(--text-faint, #aaa); margin: 4px 0; text-transform: uppercase; letter-spacing: 0.04em; }
+.neo-row { padding: 4px 6px; margin-bottom: 3px; border-radius: 4px; background: var(--surface-2, rgba(255,255,255,0.03)); }
+.neo-row-main { display: flex; justify-content: space-between; align-items: baseline; }
+.neo-des { font-size: 12px; font-weight: 600; }
+.neo-dist, .neo-prob { font-size: 11px; font-weight: 600; }
+.neo-prob { color: #f97316; }
+.neo-row-sub { font-size: 10px; color: var(--text-faint, #888); margin-top: 1px; }
+.neo-degraded { padding: 4px 8px; font-size: 10px; color: #ffb74d; }


### PR DESCRIPTION
Phase 1.2 of the enhancement roadmap. Closes the asteroid gap (0 service files before this).\n\n**New `neo-tracker` panel** with two free, no-key JPL CNEOS feeds:\n- **CAD** (close-approach data): upcoming flybys within 0.05 AU / 60 days, shown in **lunar distances**, hazard-classified by distance + estimated size.\n- **Sentry** (impact-risk table): objects with nonzero cumulative impact probability, sorted by Palermo scale, with 1-in-N odds.\n\n**Architecture**\n- Pure-deterministic core `src/services/space/neo-normalize.ts`: H→diameter estimator (albedo 0.14), AU→lunar-distance, JPL `YYYY-Mon-DD HH:MM` UTC date parser, size-aware hazard classifier. **19 unit tests**.\n- Sidecar `/api/space/neo` merges both feeds, caches 30 min, degrades to empty on upstream failure.\n- Registered in the space category + data-loader tick (full variant).\n\n`npm run typecheck:all` clean; ESLint clean.

Cross-agent review: claude reviewed on 2026-05-09; outcome: pass