### PR TITLE
test(panels): recover XSS + data-contract test suites

### DIFF
--- a/tests/panels/panel-data-contracts.mts
+++ b/tests/panels/panel-data-contracts.mts
@@ -1,0 +1,236 @@
+/**
+ * Panel data contracts — per
+ * docs/CLAUDE_REVIEW_FINDINGS_AND_PANEL_DATA_ROADMAP_2026-04-29.md
+ * Priority 4.
+ *
+ * Many smoke "degraded" rows are not proof of broken data — they're
+ * proof that the panel is mounted in isolation without its data
+ * pipeline. The real app uses `DataLoader.loadAllData()` to push data
+ * into panels via `update()` / `setData()` / etc. This registry
+ * classifies each panel by HOW it gets data, so smoke counts are
+ * meaningful instead of misleading.
+ *
+ * Each panel falls into one of seven categories:
+ *
+ *   - self-fetches:                       constructor calls fetch()
+ *   - updated-by-data-loader:             waits for DataLoader.update()
+ *   - requires-user-config:               needs saved place / location click
+ *   - requires-api-key:                   shows degraded until key is set
+ *   - static-local:                       no remote data; renders from
+ *                                         local-only state
+ *   - fixture-only-testable:              has no real backend yet (scaffold)
+ *   - intentionally-degraded-in-isolated-smoke:
+ *                                         alone-in-harness state is degraded
+ *                                         by design; live mounting is fine
+ *
+ * The accompanying test (panel-data-contracts.test.mts) reports
+ * panels missing from this registry as a TODO list. Newly-added panels
+ * must be classified here.
+ */
+
+export type PanelDataContract =
+  | 'self-fetches'
+  | 'updated-by-data-loader'
+  | 'requires-user-config'
+  | 'requires-api-key'
+  | 'static-local'
+  | 'fixture-only-testable'
+  | 'intentionally-degraded-in-isolated-smoke';
+
+export interface PanelContractEntry {
+  contract: PanelDataContract;
+  /** Update method name when contract === 'updated-by-data-loader'. */
+  updateMethod?: string;
+  /** Loader file when contract === 'updated-by-data-loader'. */
+  loaderFile?: string;
+  /** Free-text reason for the classification. */
+  reason?: string;
+}
+
+/**
+ * Initial classification covers the high-value panels (those the
+ * fixture smoke covers) + clear self-fetchers + clear data-loader
+ * receivers. Panels not yet classified will surface as TODOs in the
+ * gate test.
+ */
+export const PANEL_DATA_CONTRACTS: Record<string, PanelContractEntry> = {
+  // ── self-fetches (constructor → void this.fetchData()) ──────────────
+  'national-debt': { contract: 'self-fetches' },
+  'fear-greed': { contract: 'self-fetches' },
+  'fuel-prices': { contract: 'self-fetches' },
+  'faa-weather-cams': { contract: 'self-fetches' },
+  'gdelt-intel': { contract: 'self-fetches' },
+  'live-news': { contract: 'self-fetches' },
+  'service-status': { contract: 'self-fetches' },
+  'internet-disruptions': { contract: 'self-fetches' },
+  'amtrak-alerts': { contract: 'self-fetches' },
+  'pollen': { contract: 'self-fetches' },
+  'weather-radar': { contract: 'self-fetches' },
+  'space-weather': { contract: 'self-fetches' },
+  'air-quality': { contract: 'self-fetches' },
+
+  // ── updated-by-data-loader (DataLoader pushes data via update()) ────
+  'nws-alerts': {
+    contract: 'updated-by-data-loader',
+    updateMethod: 'update',
+    loaderFile: 'src/app/data-loader.ts',
+    reason: 'NWS alerts pushed via DataLoader.loadWeatherAlerts() → setWeatherAlerts on map + update() on panel',
+  },
+  'gdacs-alerts': {
+    contract: 'updated-by-data-loader',
+    updateMethod: 'update',
+    loaderFile: 'src/app/data-loader.ts',
+  },
+  'earthquakes': {
+    contract: 'updated-by-data-loader',
+    updateMethod: 'update',
+    loaderFile: 'src/app/data-loader.ts',
+  },
+  'tsunami-alerts': {
+    contract: 'updated-by-data-loader',
+    updateMethod: 'update',
+    loaderFile: 'src/app/data-loader.ts',
+  },
+  'volcano-alerts': {
+    contract: 'updated-by-data-loader',
+    updateMethod: 'update',
+    loaderFile: 'src/app/data-loader.ts',
+  },
+  'satellite-fires': {
+    contract: 'updated-by-data-loader',
+    updateMethod: 'update',
+    loaderFile: 'src/app/data-loader.ts',
+  },
+  'disease-outbreaks': {
+    contract: 'updated-by-data-loader',
+    updateMethod: 'update',
+    loaderFile: 'src/app/loaders/disease.ts',
+  },
+  'disease-intel': {
+    contract: 'updated-by-data-loader',
+    updateMethod: 'update',
+    loaderFile: 'src/app/loaders/disease.ts',
+  },
+  'humanitarian-crisis': {
+    contract: 'updated-by-data-loader',
+    updateMethod: 'update',
+    loaderFile: 'src/app/loaders/disease.ts',
+  },
+  'extended-forecast': {
+    contract: 'updated-by-data-loader',
+    updateMethod: 'update',
+    loaderFile: 'src/app/data-loader.ts',
+  },
+  'tide-predictions': {
+    contract: 'updated-by-data-loader',
+    updateMethod: 'update',
+    loaderFile: 'src/app/data-loader.ts',
+  },
+  'tropical-cyclones': {
+    contract: 'updated-by-data-loader',
+    updateMethod: 'update',
+    loaderFile: 'src/app/data-loader.ts',
+  },
+  'wildfire-smoke': {
+    contract: 'updated-by-data-loader',
+    updateMethod: 'update',
+    loaderFile: 'src/app/data-loader.ts',
+  },
+  'wildfire-incidents': {
+    contract: 'updated-by-data-loader',
+    updateMethod: 'update',
+    loaderFile: 'src/app/data-loader.ts',
+  },
+  'cyber-threats': {
+    contract: 'updated-by-data-loader',
+    updateMethod: 'update',
+    loaderFile: 'src/app/data-loader.ts',
+  },
+  'markets': {
+    contract: 'updated-by-data-loader',
+    updateMethod: 'update',
+    loaderFile: 'src/app/data-loader.ts',
+  },
+  'commodities': {
+    contract: 'updated-by-data-loader',
+    updateMethod: 'update',
+    loaderFile: 'src/app/data-loader.ts',
+  },
+  'crypto': {
+    contract: 'updated-by-data-loader',
+    updateMethod: 'update',
+    loaderFile: 'src/app/data-loader.ts',
+  },
+  'economic': {
+    contract: 'updated-by-data-loader',
+    updateMethod: 'update',
+    loaderFile: 'src/app/data-loader.ts',
+  },
+  'forex': {
+    contract: 'updated-by-data-loader',
+    updateMethod: 'update',
+    loaderFile: 'src/app/data-loader.ts',
+  },
+
+  // ── intentionally-degraded-in-isolated-smoke ─────────────────────────
+  // Panels fed via direct method calls (setRequests, setData with no
+  // initial fetch). Empty-state in isolation is by design.
+  'shortage-radar': {
+    contract: 'intentionally-degraded-in-isolated-smoke',
+    reason: 'Fed via panel.setRequests([...]) by host, not fetch.',
+  },
+  'command-center': {
+    contract: 'intentionally-degraded-in-isolated-smoke',
+    reason: 'Fed via setActiveSituation() + setSavedPlaces() by host bridge.',
+  },
+  'system-diagnostic': {
+    contract: 'self-fetches',
+    reason: 'Reads diagnostic registries on a 5s tick.',
+  },
+  'algorithm-diagnostic': {
+    contract: 'self-fetches',
+    reason: 'Reads algorithm health registry on a 15s tick.',
+  },
+
+  // ── requires-api-key (degrades visibly until user sets key) ──────────
+  'breakthroughs': {
+    contract: 'requires-api-key',
+    reason: 'Optional ANTHROPIC_API_KEY for breakthroughs synthesis.',
+  },
+  'ask-crystal-ball': {
+    contract: 'requires-api-key',
+    reason: 'Requires ANTHROPIC/GROQ/OPENROUTER for inference.',
+  },
+  'survival-advisor': { contract: 'requires-api-key' },
+
+  // ── static-local (no remote data, renders from saved/static state) ──
+  'saved-places': { contract: 'static-local' },
+  'watchlist': { contract: 'static-local' },
+  'watchlist-locations': { contract: 'static-local' },
+  'family-tracker': { contract: 'requires-user-config' },
+  'evacuation': { contract: 'requires-user-config' },
+  'comms-plan': { contract: 'static-local' },
+  'resource-inventory': { contract: 'static-local' },
+  'after-action-review': { contract: 'static-local' },
+  'alert-rules': { contract: 'static-local' },
+  'offline-maps': { contract: 'static-local' },
+
+};
+
+/** Returns true when the panel id has a recorded contract. */
+export function hasPanelContract(panelId: string): boolean {
+  return panelId in PANEL_DATA_CONTRACTS;
+}
+
+/** Look up a panel's contract entry, or undefined. */
+export function getPanelContract(panelId: string): PanelContractEntry | undefined {
+  return PANEL_DATA_CONTRACTS[panelId];
+}
+
+/** All panel ids classified into a specific contract. */
+export function panelsByContract(contract: PanelDataContract): string[] {
+  return Object.entries(PANEL_DATA_CONTRACTS)
+    .filter(([, e]) => e.contract === contract)
+    .map(([id]) => id)
+    .sort();
+}

--- a/tests/panels/panel-data-contracts.test.mts
+++ b/tests/panels/panel-data-contracts.test.mts
@@ -1,0 +1,72 @@
+/**
+ * Panel data contracts gate test.
+ *
+ * Reports panels in the smoke registry that have not been classified
+ * in `panel-data-contracts.mts`. Currently a TODO surface — newly-added
+ * panels show up as warnings, not failures, so the contract registry
+ * can be filled in incrementally.
+ *
+ * Tightening path: when the registry is complete, flip the TODO check
+ * to a hard `assert.equal(unclassified.length, 0)`.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { PANEL_SMOKE_REGISTRY, PANEL_SMOKE_EXCLUSIONS } from './panel-smoke-registry.mts';
+import {
+  PANEL_DATA_CONTRACTS,
+  hasPanelContract,
+  panelsByContract,
+} from './panel-data-contracts.mts';
+import { PANEL_FIXTURES } from './panel-fixtures.mts';
+
+describe('panel data contracts', () => {
+  it('every classified panel exists in the smoke registry or is excluded', () => {
+    const orphans: string[] = [];
+    for (const id of Object.keys(PANEL_DATA_CONTRACTS)) {
+      const inRegistry = id in PANEL_SMOKE_REGISTRY;
+      const excluded = id in PANEL_SMOKE_EXCLUSIONS;
+      if (!inRegistry && !excluded) orphans.push(id);
+    }
+    assert.deepEqual(
+      orphans,
+      [],
+      `panels listed in PANEL_DATA_CONTRACTS but absent from smoke registry: ${orphans.join(', ')}`,
+    );
+  });
+
+  it('every updated-by-data-loader panel records its update method + loader file', () => {
+    const malformed: string[] = [];
+    for (const id of panelsByContract('updated-by-data-loader')) {
+      const entry = PANEL_DATA_CONTRACTS[id];
+      if (!entry?.updateMethod || !entry?.loaderFile) {
+        malformed.push(`${id} (missing ${!entry?.updateMethod ? 'updateMethod' : 'loaderFile'})`);
+      }
+    }
+    assert.deepEqual(malformed, [], `incomplete data-loader contract entries:\n  ${malformed.join('\n  ')}`);
+  });
+
+  it('reports unclassified panels (TODO surface, currently non-failing)', () => {
+    const unclassified = Object.keys(PANEL_SMOKE_REGISTRY)
+      .filter((id) => !hasPanelContract(id))
+      .sort();
+    if (unclassified.length > 0) {
+      console.log(`\n[panel-contracts] TODO: ${unclassified.length} unclassified panel(s)`);
+      console.log(`  Add each to tests/panels/panel-data-contracts.mts when its data flow is reviewed.`);
+      console.log(`  Sample (first 10): ${unclassified.slice(0, 10).join(', ')}`);
+    }
+    // Bootstrap: do not fail. Tighten to assert.equal(unclassified.length, 0)
+    // once the registry is complete.
+  });
+
+  it('every panel with a fixture entry also has a contract classification', () => {
+    const fixturedWithoutContract = Object.keys(PANEL_FIXTURES)
+      .filter((id) => !hasPanelContract(id));
+    assert.deepEqual(
+      fixturedWithoutContract,
+      [],
+      `panels with fixtures but no contract:\n  ${fixturedWithoutContract.join('\n  ')}`,
+    );
+  });
+});

--- a/tests/panels/panel-fixtures.mts
+++ b/tests/panels/panel-fixtures.mts
@@ -12,8 +12,16 @@
 import { installFixture } from './fixture-store.mts';
 
 export interface PanelFixtureBundle {
-  /** Function that registers all fixtures for this panel via installFixture(). */
+  /** Function that registers all fixtures for this panel via installFixture().
+   *  Use for self-fetch panels whose constructor calls fetch(). */
   install: () => void;
+  /** Optional direct-update path for data-loader-driven panels: the
+   *  test mounts the panel, then calls this with the panel instance
+   *  to push fixture data via update() / setData() / similar. Use
+   *  when the panel's constructor doesn't fetch and waits for the
+   *  data loader. The function is async because some panels expose
+   *  async update methods. */
+  directUpdate?: (panel: unknown) => Promise<void> | void;
 }
 
 const NOW_S = Math.floor(Date.now() / 1000);
@@ -198,12 +206,135 @@ export const PANEL_FIXTURES: Record<string, PanelFixtureBundle> = {
   },
 
   'nws-alerts': {
-    install: () => {
-      // NWSAlertsPanel doesn't fetch — alerts are pushed via update().
-      // Like shortage-radar, the documented contract under the smoke
-      // factory is degraded (loading banner). The fixture entry is
-      // kept here for future integration tests that drive update()
-      // directly. Listed in the SETRESQUEST_ONLY exception set.
+    install: () => { /* fed via update() — see directUpdate */ },
+    directUpdate: async (panel) => {
+      const p = panel as { update: (alerts: unknown[]) => void };
+      p.update([
+        {
+          id: 'NWS.IND.123',
+          event: 'Severe Thunderstorm Watch',
+          severity: 'Severe',
+          urgency: 'Expected',
+          areaDesc: 'La Porte; St. Joseph',
+          headline: 'Severe Thunderstorm Watch in effect',
+          onset: new Date(NOW_MS).toISOString(),
+        },
+      ]);
+    },
+  },
+
+  // ── Data-loader-driven panels: directUpdate drives panel.update(...) ──
+
+  'gdacs-alerts': {
+    install: () => { /* fed via update() */ },
+    directUpdate: async (panel) => {
+      const p = panel as { update: (events: unknown[]) => void };
+      p.update([
+        {
+          id: 'gdacs-EQ-1234',
+          eventType: 'EQ',
+          name: 'Magnitude 6.2 earthquake — northern Honshu',
+          alertLevel: 'Orange',
+          country: 'Japan',
+          coordinates: [141.5, 38.5],
+          fromDate: new Date(NOW_MS - 3_600_000),
+        },
+      ]);
+    },
+  },
+
+  'earthquakes': {
+    install: () => { /* fed via update() */ },
+    directUpdate: async (panel) => {
+      const p = panel as { update: (quakes: unknown[]) => void };
+      p.update([
+        {
+          id: 'us7000abcd',
+          magnitude: 5.4,
+          place: '120 km E of Tokyo, Japan',
+          lat: 35.7,
+          lon: 141.2,
+          depthKm: 35,
+          time: new Date(NOW_MS - 1_800_000).toISOString(),
+          tsunami: false,
+        },
+      ]);
+    },
+  },
+
+  'air-quality': {
+    install: () => { /* fed via update() */ },
+    directUpdate: async (panel) => {
+      const p = panel as { update: (readings: unknown[]) => void };
+      p.update([
+        {
+          city: 'La Porte',
+          country: 'US',
+          aqi: 47,
+          aqiLevel: 'good',
+          pm25: 11.4,
+          pm10: 18.2,
+          o3: null,
+          measuredAt: new Date(NOW_MS).toISOString(),
+        },
+        {
+          city: 'Chicago',
+          country: 'US',
+          aqi: 72,
+          aqiLevel: 'moderate',
+          pm25: 24.6,
+          pm10: 31.0,
+          o3: null,
+          measuredAt: new Date(NOW_MS).toISOString(),
+        },
+      ]);
+    },
+  },
+
+  'space-weather': {
+    install: () => { /* fed via update() */ },
+    directUpdate: async (panel) => {
+      const p = panel as { update: (data: unknown) => void };
+      p.update({
+        kpIndex: 3,
+        kpClass: 'unsettled',
+        solarWindSpeed: 410,
+        solarWindDensity: 5.2,
+        bz: -1.5,
+        xrayClass: 'B5.2',
+        // Include at least one alert so the panel doesn't render the
+        // 'No active alerts' sub-banner (which uses .panel-empty and
+        // would trip the smoke classifier).
+        alertMessages: [
+          {
+            id: 'sw-watch-1',
+            message: 'G1 (Minor) Geomagnetic Storm Watch',
+            issuedAt: new Date(NOW_MS - 30 * 60 * 1000),
+            severity: 'watch',
+          },
+        ],
+        donkiEvents: [],
+        fetchedAt: new Date(NOW_MS),
+      });
+    },
+  },
+
+  'humanitarian-crisis': {
+    install: () => { /* fed via update() */ },
+    directUpdate: async (panel) => {
+      const p = panel as { update: (crises: unknown[]) => void };
+      p.update([
+        {
+          id: 'unhcr-1',
+          country: 'Sudan',
+          countryCode: 'SD',
+          crisisType: 'displacement',
+          severity: 'critical',
+          title: 'Internally displaced population from ongoing conflict',
+          url: 'https://example.test/r/1',
+          updatedAt: new Date(NOW_MS - 86_400_000),
+        },
+      ]);
     },
   },
 };

--- a/tests/panels/panel-fixtures.test.mts
+++ b/tests/panels/panel-fixtures.test.mts
@@ -83,6 +83,14 @@ for (const [id, bundle] of Object.entries(PANEL_FIXTURES)) {
     await Promise.resolve();
     await new Promise<void>((resolve) => setTimeout(resolve, 250));
 
+    // If the panel exposes a direct-update path (data-loader-driven
+    // panels that don't fetch on mount), drive it now and re-wait
+    // for the debounced setContent to flush.
+    if (bundle.directUpdate) {
+      await bundle.directUpdate(panel as unknown);
+      await new Promise<void>((resolve) => setTimeout(resolve, 250));
+    }
+
     const verdict = classify(el, factory.minTextLength ?? 1);
 
     try {
@@ -97,11 +105,12 @@ for (const [id, bundle] of Object.entries(PANEL_FIXTURES)) {
 
     reports.push({ id, ...verdict });
 
-    // Acceptance: with a fixture installed, the panel should reach
-    // `rendered`. Some panels are fed by direct update()/setRequests()
-    // calls (not fetch), so under the smoke factory they stay in a
-    // documented degraded state — those skip the assertion.
-    const SETRESQUEST_ONLY = new Set(['shortage-radar', 'nws-alerts']);
+    // Acceptance: with a fixture installed (URL-based or direct-update),
+    // the panel should reach `rendered`. shortage-radar is the
+    // remaining exception — it uses `panel.setRequests([...])` and
+    // its smoke factory doesn't expose that method without seeding
+    // commodity inputs the harness doesn't have.
+    const SETRESQUEST_ONLY = new Set(['shortage-radar']);
     if (SETRESQUEST_ONLY.has(id)) return;
     assert.equal(
       verdict.state,

--- a/tests/panels/panel-xss.test.mts
+++ b/tests/panels/panel-xss.test.mts
@@ -1,0 +1,253 @@
+/**
+ * Panel HTML/XSS fixture coverage — per
+ * docs/CLAUDE_EXTRA_BUG_SECURITY_CHECKS_2026-04-29.md Priority 1.
+ *
+ * Many panels render remote-sourced strings (news titles, alert
+ * headlines, country names, error messages, feed names) and write
+ * them into the DOM via `setContent(html)` → `innerHTML`. The path
+ * is safe ONLY when each string passes through `escapeHtml()` /
+ * `sanitizeUrl()` first. Manual code review can miss a single
+ * unescaped interpolation.
+ *
+ * This test injects classic XSS payloads into fixture data, mounts
+ * each target panel, and asserts the rendered HTML contains no
+ * executable markup. If a panel renders a remote string without
+ * escaping, this test fails with a clear panel-level pointer.
+ */
+
+import './setup-dom.mts';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { PANEL_SMOKE_REGISTRY } from './panel-smoke-registry.mts';
+import { installFixture, clearFixtures } from './fixture-store.mts';
+
+const XSS_PAYLOADS = {
+  scriptTag: '<script>window.__xss_canary=1;</script>',
+  imgOnError: '<img src=x onerror="window.__xss_canary=1">',
+  svgOnLoad: '<svg onload=window.__xss_canary=1>',
+  jsScheme: 'javascript:window.__xss_canary=1',
+  attrBreak: '" onmouseover="window.__xss_canary=1',
+  textCanary: 'CANARY-PAYLOAD-DO-NOT-EXECUTE',
+};
+
+function assertSafeHtml(html: string, panelId: string): void {
+  // The escaped form (`&lt;script&gt;`) is fine; the raw form is not.
+  assert.doesNotMatch(
+    html,
+    /<script\b/i,
+    `Panel ${panelId} rendered raw <script> tag — escapeHtml() missing somewhere in render path.`,
+  );
+  // <img src=x onerror=...> is a separate vector
+  assert.doesNotMatch(
+    html,
+    /<img[^>]*\bonerror\s*=/i,
+    `Panel ${panelId} rendered raw <img onerror=...> — escapeHtml() missing.`,
+  );
+  // <svg onload=...>
+  assert.doesNotMatch(
+    html,
+    /<svg[^>]*\bonload\s*=/i,
+    `Panel ${panelId} rendered raw <svg onload=...>.`,
+  );
+  // javascript: scheme inside an href / src must not appear unescaped
+  assert.doesNotMatch(
+    html,
+    /(?:href|src)\s*=\s*["']?javascript:/i,
+    `Panel ${panelId} rendered an href/src with javascript: scheme — sanitizeUrl() missing.`,
+  );
+  // Attribute-break injection: " onmouseover= leaks attributes
+  assert.doesNotMatch(
+    html,
+    /\bonmouseover\s*=\s*["'][^"']*window\.__xss_canary/i,
+    `Panel ${panelId} let an attribute-break payload through.`,
+  );
+}
+
+async function mountAndCapture(panelId: string, install: () => void): Promise<{ html: string; cleanup: () => void }> {
+  const factory = PANEL_SMOKE_REGISTRY[panelId];
+  if (!factory) throw new Error(`No factory for panel ${panelId}`);
+  clearFixtures();
+  install();
+  const panel = await factory.create();
+  const el = panel.getElement();
+  const container = document.createElement('div');
+  container.id = `mount-xss-${panelId}`;
+  document.body.append(container);
+  container.append(el);
+  // Allow fetch + render + setContent debounce
+  await new Promise<void>((r) => setTimeout(r, factory.waitMs ?? 100));
+  await new Promise<void>((r) => setTimeout(r, 250));
+  const html = el.innerHTML;
+  return {
+    html,
+    cleanup: () => {
+      try {
+        const d = panel as unknown as { dispose?: () => void; destroy?: () => void };
+        d.dispose?.();
+        d.destroy?.();
+      } catch { /* ignore */ }
+      el.remove();
+      container.remove();
+    },
+  };
+}
+
+test('XSS: GDELT Intel panel escapes title + source from feed', async () => {
+  const { html, cleanup } = await mountAndCapture('gdelt-intel', () => {
+    installFixture('/api/gdelt-intel', {
+      events: [
+        {
+          title: `${XSS_PAYLOADS.scriptTag} ${XSS_PAYLOADS.textCanary}`,
+          url: XSS_PAYLOADS.jsScheme, // sanitizeUrl should reject
+          source: XSS_PAYLOADS.imgOnError,
+          tone: -2.0,
+          country: XSS_PAYLOADS.attrBreak,
+          timestamp: Date.now(),
+        },
+      ],
+      updatedAt: Math.floor(Date.now() / 1000),
+    });
+  });
+  try {
+    assertSafeHtml(html, 'gdelt-intel');
+  } finally {
+    cleanup();
+  }
+});
+
+test('XSS: live-news panel escapes title + source from feed', async () => {
+  const { html, cleanup } = await mountAndCapture('live-news', () => {
+    installFixture('/api/news', {
+      items: [
+        {
+          id: 'n1',
+          title: XSS_PAYLOADS.scriptTag,
+          url: XSS_PAYLOADS.jsScheme,
+          source: XSS_PAYLOADS.imgOnError,
+          publishedAt: Date.now(),
+          summary: XSS_PAYLOADS.svgOnLoad,
+        },
+      ],
+      updatedAt: Date.now(),
+    });
+  });
+  try {
+    assertSafeHtml(html, 'live-news');
+  } finally {
+    cleanup();
+  }
+});
+
+test('XSS: service-status panel escapes service names', async () => {
+  const { html, cleanup } = await mountAndCapture('service-status', () => {
+    installFixture('/api/service-status', {
+      success: true,
+      timestamp: new Date().toISOString(),
+      services: [
+        { name: XSS_PAYLOADS.scriptTag, status: 'operational', category: XSS_PAYLOADS.imgOnError },
+        { name: 'Cloudflare', status: 'operational', category: 'infrastructure' },
+      ],
+      summary: { operational: 2, degraded: 0, outage: 0, unknown: 0 },
+    });
+  });
+  try {
+    assertSafeHtml(html, 'service-status');
+  } finally {
+    cleanup();
+  }
+});
+
+test('XSS: national-debt panel escapes country names', async () => {
+  const { html, cleanup } = await mountAndCapture('national-debt', () => {
+    installFixture('/api/national-debt', {
+      countries: [
+        {
+          code: 'XX',
+          name: XSS_PAYLOADS.scriptTag,
+          debtPctGdp: 999,
+          year: XSS_PAYLOADS.imgOnError,
+        },
+      ],
+      updatedAt: Date.now(),
+    });
+  });
+  try {
+    assertSafeHtml(html, 'national-debt');
+  } finally {
+    cleanup();
+  }
+});
+
+test('XSS: fuel-prices panel escapes region names', async () => {
+  const { html, cleanup } = await mountAndCapture('fuel-prices', () => {
+    installFixture('/api/fuel-prices', {
+      regions: [
+        {
+          name: XSS_PAYLOADS.scriptTag,
+          gasolineUsd: 1,
+          dieselUsd: 1,
+          period: XSS_PAYLOADS.imgOnError,
+        },
+      ],
+      keyMissing: false,
+      updatedAt: Date.now(),
+    });
+  });
+  try {
+    assertSafeHtml(html, 'fuel-prices');
+  } finally {
+    cleanup();
+  }
+});
+
+test('XSS: faa-weather-cams panel escapes camera names + states', async () => {
+  const { html, cleanup } = await mountAndCapture('faa-weather-cams', () => {
+    installFixture('/api/faa-cameras', {
+      cameras: [
+        {
+          id: 'BAD',
+          name: XSS_PAYLOADS.scriptTag,
+          lat: 47,
+          lon: -122,
+          state: XSS_PAYLOADS.imgOnError,
+          category: 'urban',
+          imageUrl: XSS_PAYLOADS.jsScheme,
+          isOnline: true,
+          lastUpdated: new Date().toISOString(),
+        },
+      ],
+    });
+  });
+  try {
+    assertSafeHtml(html, 'faa-weather-cams');
+  } finally {
+    cleanup();
+  }
+});
+
+test('XSS: internet-disruptions panel escapes degraded source names', async () => {
+  const { html, cleanup } = await mountAndCapture('internet-disruptions', () => {
+    installFixture('/api/comms-health', {
+      overall: 'normal',
+      bgp: { hijacks: 0, leaks: 0, severity: 'normal' },
+      ixp: { status: 'operational', degraded: [XSS_PAYLOADS.scriptTag] },
+      ddos: { l7: 'normal', l3: 'normal', cloudflareKeyMissing: false },
+      cables: { degraded: [XSS_PAYLOADS.imgOnError], normal: ['Atlantic-1'] },
+      updatedAt: new Date().toISOString(),
+    });
+  });
+  try {
+    assertSafeHtml(html, 'internet-disruptions');
+  } finally {
+    cleanup();
+  }
+});
+
+test('XSS: window.__xss_canary is never set after mounting any panel', () => {
+  // Catch-all: if any of the previous tests' payloads actually
+  // executed, the global canary would be set on the happy-dom window.
+  const w = globalThis as unknown as { __xss_canary?: number };
+  assert.equal(w.__xss_canary, undefined, 'XSS canary fired — a payload above bypassed escaping');
+});


### PR DESCRIPTION
## What
Recovers two panel test suites authored on `claude/panel-quality-B` (2026-04-28) that were never merged:
- `tests/panels/panel-xss.test.mts` — XSS-escaping verification across the panel smoke registry
- `tests/panels/panel-data-contracts.{mts,test.mts}` — data-contract checks per panel
- `tests/panels/panel-fixtures.mts` — `directUpdate` extension (the contract tests depend on it)

## Why
Part of a feature-loss audit: of 121 unmerged local branches, these were among the few adding files genuinely absent from main. Test-only, no runtime changes.

## Provenance
Cherry-picked cleanly from commit a5294e51 onto current main. Original branch preserved at `origin/recovered/panel-quality-B`.

## Verification
- `npm run typecheck:all` → clean
- Local smoke execution is blocked by the harness's Vite `?worker` import resolution under node/tsx (pre-existing limitation affecting main too); CI runs the real Vite toolchain so these execute there.

🤖 Recovered via automated feature-loss audit