### PR TITLE
feat(panels): wire markets/commodities/crypto news panels

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1854,6 +1854,27 @@ export class PanelLayoutManager implements AppModule {
  focusInvestmentOnMap(this.ctx.map, this.ctx.mapLayers, inv.lat, inv.lon);
  });
  this.ctx.panels['gcc-investments'] = investmentsPanel;
+
+ // Finance-only news panels. The markets/commodities/crypto feed
+ // categories live in FINANCE_FEEDS, so loadNews() already fetches
+ // them every cycle — they just lacked a render target. Registering
+ // under ctx.newsPanels[<feed category>] routes the fetched clusters;
+ // ctx.panels[<panel id>] wires the sidebar registry (ids from
+ // FINANCE_PANELS in config/panels.ts).
+ const marketsNewsPanel = new NewsPanel('markets', t('panels.marketsNews'));
+ this.attachRelatedAssetHandlers(marketsNewsPanel);
+ this.ctx.newsPanels.markets = marketsNewsPanel;
+ this.ctx.panels['markets-news'] = marketsNewsPanel;
+
+ const commoditiesNewsPanel = new NewsPanel('commodities', t('panels.commoditiesNews'));
+ this.attachRelatedAssetHandlers(commoditiesNewsPanel);
+ this.ctx.newsPanels.commodities = commoditiesNewsPanel;
+ this.ctx.panels['commodities-news'] = commoditiesNewsPanel;
+
+ const cryptoNewsPanel = new NewsPanel('crypto', t('panels.cryptoNews'));
+ this.attachRelatedAssetHandlers(cryptoNewsPanel);
+ this.ctx.newsPanels.crypto = cryptoNewsPanel;
+ this.ctx.panels['crypto-news'] = cryptoNewsPanel;
  }
 
  if (SITE_VARIANT !== 'happy') {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -151,6 +151,9 @@
   "panels": {
  "liveNews": "Live News",
  "markets": "Markets",
+ "marketsNews": "Markets News",
+ "commoditiesNews": "Commodities News",
+ "cryptoNews": "Crypto News",
  "map": "Global Situation",
  "techMap": "Global Tech",
  "techHubs": "Hot Tech Hubs",


### PR DESCRIPTION
Three FINANCE_PANELS ids (`markets-news`, `commodities-news`, `crypto-news`) were registered in config but never instantiated, so the markets/commodities/crypto feeds — already fetched every cycle by `loadNews()` — had no render target and were silently dropped.

Wired inside the existing `SITE_VARIANT === 'finance'` block (their feeds live in `FINANCE_FEEDS`, so they'd be empty in other variants). Dual-key registration: `ctx.newsPanels[<category>]` routes data, `ctx.panels[<id>]` wires the sidebar. Added 3 i18n title keys.

No sidecar / data-service changes — pure wiring. typecheck + eslint clean.