### PR TITLE
fix(ui): wire RIPE NCC BGP panel + remove dead globe toggles

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -608,6 +608,7 @@ export class App {
  { name: 'diseaseOutbreaks', fn: () => this.dataLoader.loadDiseaseOutbreaks(), intervalMs: 15 * 60 * 1000, condition: () => SITE_VARIANT === 'full' },
  { name: 'humanitarianCrises', fn: () => this.dataLoader.loadHumanitarianCrises(), intervalMs: 60 * 60 * 1000, condition: () => SITE_VARIANT === 'full' },
  { name: 'ripeAtlas', fn: () => this.dataLoader.loadRipeAtlas(), intervalMs: 10 * 60 * 1000, condition: () => SITE_VARIANT === 'full' },
+ { name: 'ripeNcc', fn: () => this.dataLoader.loadRipeNcc(), intervalMs: 60 * 60 * 1000, condition: () => SITE_VARIANT === 'full' },
  { name: 'federalRegister', fn: () => this.dataLoader.loadFederalRegister(), intervalMs: 60 * 60 * 1000, condition: () => SITE_VARIANT === 'full' },
  { name: 'airQuality', fn: () => this.dataLoader.loadAirQuality(), intervalMs: 30 * 60 * 1000, condition: () => SITE_VARIANT === 'full' },
  { name: 'commsHealth', fn: () => this.dataLoader.loadCommsHealth(), intervalMs: 2 * 60 * 1000, condition: () => SITE_VARIANT === 'full' },

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -162,6 +162,8 @@ import { fetchAdsbSnapshot } from '@/services/adsb';
 import type { AirTrafficPanel } from '@/components/AirTrafficPanel';
 import { fetchRipeAtlasStatus } from '@/services/ripe-atlas';
 import type { RipeAtlasPanel } from '@/components/RipeAtlasPanel';
+import { fetchRipeNccStatus } from '@/services/ripe-ncc';
+import type { RipeNccPanel } from '@/components/RipeNccPanel';
 import { updateRegionCount, getHighRiskRegions } from '@/services/ema-forecast';
 import { GDACSAlertsPanel } from '@/components/GDACSAlertsPanel';
 import { NWSAlertsPanel } from '@/components/NWSAlertsPanel';
@@ -3709,6 +3711,15 @@ export class DataLoaderManager implements AppModule {
  (this.ctx.panels['ripe-atlas'] as RipeAtlasPanel | undefined)?.update(data);
  } catch (error) {
  console.error('[App] RIPE Atlas fetch failed:', error);
+ }
+  }
+
+  async loadRipeNcc(): Promise<void> {
+ try {
+ const data = await fetchRipeNccStatus();
+ (this.ctx.panels['ripe-ncc'] as RipeNccPanel | undefined)?.update(data);
+ } catch (error) {
+ console.error('[App] RIPE NCC fetch failed:', error);
  }
   }
 

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -489,6 +489,7 @@ import { SavedPlaceModal } from '@/components/SavedPlaceModal';
 import type { GeoHubActivity } from '@/services/geo-activity';
 import type { TechHubActivity } from '@/services/tech-activity';
 import { RipeAtlasPanel } from '@/components/RipeAtlasPanel';
+import { RipeNccPanel } from '@/components/RipeNccPanel';
 import { GoesSatellitePanel } from '@/components/GoesSatellitePanel';
 import { FloodMonitorPanel } from '@/components/FloodMonitorPanel';
 // HTML builders (app shell + map + sidebar) live in a sibling module.
@@ -1847,6 +1848,7 @@ export class PanelLayoutManager implements AppModule {
  this.ctx.panels['foreign-mil-news'] = new ForeignMilNewsPanel();
  this.ctx.panels['spc-mesoscale'] = new SpcMesoscalePanel();
  this.ctx.panels['ripe-atlas'] = new RipeAtlasPanel();
+ this.ctx.panels['ripe-ncc'] = new RipeNccPanel();
  }
 
  if (SITE_VARIANT === 'finance') {

--- a/src/components/RipeNccPanel.ts
+++ b/src/components/RipeNccPanel.ts
@@ -1,0 +1,49 @@
+import { Panel } from './Panel';
+import { escapeHtml } from '@/utils/sanitize';
+import type { RipeRoutingStatus } from '@/services/ripe-ncc';
+
+export class RipeNccPanel extends Panel {
+  constructor() {
+    super({ id: 'ripe-ncc', title: 'RIPE NCC BGP', showCount: false, trackActivity: false });
+    this.showLoading('Loading RIPE NCC routing status...');
+  }
+
+  update(data: RipeRoutingStatus | null): void {
+    if (!data) {
+      this.showError('RIPE NCC routing status unavailable');
+      return;
+    }
+
+    const v4Pct = data.v4TotalPeers > 0
+      ? Math.round((data.v4PeersSeeing / data.v4TotalPeers) * 100)
+      : 0;
+    const v6Pct = data.v6TotalPeers > 0
+      ? Math.round((data.v6PeersSeeing / data.v6TotalPeers) * 100)
+      : 0;
+    const originList = data.origins.length > 0
+      ? data.origins.map(a => `AS${a}`).join(', ')
+      : '—';
+
+    const seenRow = (label: string, seen: RipeRoutingStatus['firstSeen']) =>
+      seen
+        ? `<tr><td>${label}</td><td>${escapeHtml(seen.prefix)} · AS${escapeHtml(seen.origin)}</td><td>${escapeHtml((seen.time || '').replace('T', ' '))}</td></tr>`
+        : '';
+
+    this.setContent(`
+      <div class="panel-summary">
+        <span class="stat">${escapeHtml(data.resource)}</span>
+        <span class="stat">IPv4 visibility ${v4Pct}% (${data.v4PeersSeeing}/${data.v4TotalPeers} RIS peers)</span>
+        <span class="stat">IPv6 visibility ${v6Pct}% (${data.v6PeersSeeing}/${data.v6TotalPeers} RIS peers)</span>
+        <span class="stat">Origin: ${escapeHtml(originList)}</span>
+        <span class="stat">${data.lessSpecifics} less-specific · ${data.moreSpecifics} more-specific</span>
+      </div>
+      <table class="panel-table">
+        <thead><tr><th>Event</th><th>Prefix · Origin</th><th>Time (UTC)</th></tr></thead>
+        <tbody>
+          ${seenRow('First seen', data.firstSeen)}
+          ${seenRow('Last seen', data.lastSeen)}
+        </tbody>
+      </table>
+    `);
+  }
+}

--- a/src/config/gods-vision-layers.ts
+++ b/src/config/gods-vision-layers.ts
@@ -209,18 +209,6 @@ export const DEFAULT_GODS_VISION_LAYERS: GodsVisionLayers = {
  enabled: false,
  description: 'Detailed glTF aircraft models at real altitude with heading',
   },
-  rfCoverage: {
- name: 'RF/SIGINT',
- category: 'intelligence',
- enabled: false,
- description: 'GPS jamming domes, radar cones, EW hotspots',
-  },
-  entityGraph: {
- name: 'Entity Graph',
- category: 'analytical',
- enabled: false,
- description: '3D force-directed entity link analysis',
-  },
   timeline: {
  name: 'Timeline',
  category: 'analytical',

--- a/src/services/ripe-ncc.ts
+++ b/src/services/ripe-ncc.ts
@@ -24,3 +24,57 @@ export async function fetchRipeNccRoutingStatus(): Promise<RipeNccData | null> {
  return null;
   }
 }
+
+// ── Typed BGP routing-status view (for RipeNccPanel) ──────────────────────
+// Normalised subset of the RIPE Stat `routing-status` payload proxied by
+// /api/ripe-ncc. The raw API uses snake_case + array specifics; we flatten
+// to the few fields the panel surfaces.
+export interface RipeRoutingSeen {
+  prefix: string;
+  origin: string;
+  time: string;
+}
+
+export interface RipeRoutingStatus {
+  resource: string;
+  v4PeersSeeing: number;
+  v4TotalPeers: number;
+  v6PeersSeeing: number;
+  v6TotalPeers: number;
+  origins: number[];
+  firstSeen: RipeRoutingSeen | null;
+  lastSeen: RipeRoutingSeen | null;
+  lessSpecifics: number;
+  moreSpecifics: number;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+}
+
+function asNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+export async function fetchRipeNccStatus(): Promise<RipeRoutingStatus | null> {
+  const raw = await fetchRipeNccRoutingStatus();
+  if (!raw) return null;
+  const vis = asRecord(raw.visibility);
+  const v4 = asRecord(vis.v4);
+  const v6 = asRecord(vis.v6);
+  const origins = Array.isArray(raw.origins)
+ ? raw.origins.map((o) => asNumber(asRecord(o).origin)).filter((n) => n > 0)
+ : [];
+  return {
+ resource: typeof raw.resource === 'string' ? raw.resource : '—',
+ v4PeersSeeing: asNumber(v4.ris_peers_seeing),
+ v4TotalPeers: asNumber(v4.total_ris_peers),
+ v6PeersSeeing: asNumber(v6.ris_peers_seeing),
+ v6TotalPeers: asNumber(v6.total_ris_peers),
+ origins,
+ firstSeen: (raw.first_seen as RipeRoutingSeen) ?? null,
+ lastSeen: (raw.last_seen as RipeRoutingSeen) ?? null,
+ lessSpecifics: Array.isArray(raw.less_specifics) ? raw.less_specifics.length : 0,
+ moreSpecifics: Array.isArray(raw.more_specifics) ? raw.more_specifics.length : 0,
+  };
+}


### PR DESCRIPTION
Dead-UI cleanup from the full-codebase audit.

**Wired `ripe-ncc`** — it was registered in FULL_PANELS + PANEL_CATEGORY_MAP with a working `/api/ripe-ncc` route + service, but no component ever consumed it (service fns never called). Built `RipeNccPanel` (modeled on the 30-line RipeAtlasPanel) showing prefix, IPv4/IPv6 RIS-peer visibility, origin AS, and first/last-seen BGP events; typed `fetchRipeNccStatus()`; instantiated in the full-variant block; `loadRipeNcc()` in data-loader; 60-min scheduled task in App.ts (matches the route's 1h cache).

**Removed dead globe toggles `rfCoverage` + `entityGraph`** — existed only in gods-vision-layers.ts with no `registerLayer()`/handler, so they rendered HUD buttons that silently no-op'd. (The real entity-graph feature is `EntityLinkGraphPanel`, untouched.)

Verified: typecheck exit 0, eslint clean, 53 globe tests pass.