### PR TITLE
fix(sidecar): update OFAC URL + add missing USNI port coordinates

### DIFF
--- a/server/crystalball/military/v1/get-usni-fleet-report.ts
+++ b/server/crystalball/military/v1/get-usni-fleet-report.ts
@@ -126,11 +126,16 @@ const REGION_COORDS: Record<string, { lat: number; lon: number }> = {
   Bangor: { lat: 47.73, lon: -122.71 },
   // Alternate spelling of Rota
   'Rota Spain': { lat: 36.63, lon: -6.35 },
+  // Ports that appear in USNI articles but were previously unmapped
+  'New Orleans': { lat: 29.95, lon: -90.07 },
+  'Kingston, Jamaica': { lat: 17.99, lon: -76.79 },
+  'Portsmouth, England': { lat: 50.80, lon: -1.09 },
 };
 
 function getRegionCoords(regionText: string): { lat: number; lon: number } | null {
   const normalized = regionText
  .replace(/^(In the|In|The)\s+/i, '')
+ .replace(/\s+,/g, ',')
  .replace(/\s+/g, ' ')
  .trim();
   if (REGION_COORDS[normalized]) return REGION_COORDS[normalized];

--- a/src-tauri/sidecar/ofac-cache.mjs
+++ b/src-tauri/sidecar/ofac-cache.mjs
@@ -3,8 +3,8 @@
  *
  * - Reads the parsed cache from `${dataDir}/data/ofac-cache.json` on
  *   first call.
- * - Refreshes from https://www.treasury.gov/ofac/downloads/sdn.xml when
- *   the cache is missing or older than 7 days.
+ * - Refreshes from https://sanctionslistservice.ofac.treas.gov/api/publicationpreview/exports/sdn.xml
+ *   when the cache is missing or older than 7 days.
  * - Parses the XML in-process (no DOM dependency, just a tag-extraction
  *   walk that mirrors the renderer-side TS in src/services/sanctions/
  *   ofac-parser.ts — kept lean here so the sidecar boot doesn't have to
@@ -21,7 +21,7 @@
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 
-const SDN_XML_URL = 'https://www.treasury.gov/ofac/downloads/sdn.xml';
+const SDN_XML_URL = 'https://sanctionslistservice.ofac.treas.gov/api/publicationpreview/exports/sdn.xml';
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 const CACHE_VERSION = 1;
 


### PR DESCRIPTION
Two bug fixes caught from log analysis.

**1. OFAC sanctions cache never refreshed (175 errors/session)**

`treasury.gov/ofac/downloads/sdn.xml` permanently redirected to `sanctionslistservice.ofac.treas.gov/api/publicationpreview/exports/sdn.xml` at some point. The sidecar's `_downloadSdnXml` treated the 302 as an error (`!r.ok`), so the OFAC cache never refreshed. Fixed by updating `SDN_XML_URL` to the current endpoint.

**2. USNI Fleet 3 ports mapped to (0,0) on every fetch**

`get-usni-fleet-report.ts` was missing New Orleans, Kingston Jamaica, and Portsmouth England from `REGION_COORDS`. Vessels in those ports were placed at lat/lon (0,0) — in the Atlantic off Gabon. Also fixed the space-before-comma normalization bug (`"Portsmouth , England"` from USNI article HTML was not matching `"Portsmouth, England"` after text normalization).

Cross-agent review: claude reviewed on 2026-06-01; outcome: pass