### PR TITLE
fix(celestrak): route TLE fetches through sidecar to bypass Origin 403

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -5897,13 +5897,16 @@ async function dispatch(requestUrl, req, routes, context) {
   }
 
   if (requestUrl.pathname === '/api/tle') {
+ const cacheKey = 'celestrak-stations-tle';
+ const cached = getCached(cacheKey);
+ if (cached) return new Response(cached, { status: 200, headers: { 'content-type': 'text/plain; charset=utf-8', 'cache-control': 'public, max-age=3600', ...makeCorsHeaders(req) } });
  try {
- const tleRes = await fetch('https://celestrak.org/SOCRATES/stations-tle.txt', {
+ const tleRes = await fetch('https://celestrak.org/NORAD/elements/gp.php?GROUP=stations&FORMAT=tle', {
  signal: AbortSignal.timeout(8000),
- headers: { 'User-Agent': 'CrystalBall/2.x (educational use)' },
  });
  if (!tleRes.ok) return json({ error: `CelesTrak ${tleRes.status}` }, 502, makeCorsHeaders(req));
  const text = await tleRes.text();
+ setCached(cacheKey, text, 60 * 60 * 1000);
  return new Response(text, {
  status: 200,
  headers: { 'content-type': 'text/plain; charset=utf-8', 'cache-control': 'public, max-age=3600', ...makeCorsHeaders(req) },
@@ -5911,6 +5914,34 @@ async function dispatch(requestUrl, req, routes, context) {
  } catch (error) {
  return json({ error: String(error) }, 503, makeCorsHeaders(req));
  }
+  }
+
+  // CelesTrak GP satellite catalog — fetched server-side to avoid the
+  // Origin-header 403 that WKWebView triggers on direct browser fetches.
+  // Combines multiple targeted groups since GROUP=active is now blocked.
+  // Cached 4 hours to match the frontend circuit-breaker TTL.
+  if (requestUrl.pathname === '/api/celestrak-gp') {
+ const cacheKey = 'celestrak-gp-combined';
+ const cached = getCached(cacheKey);
+ if (cached) return json(cached, 200, makeCorsHeaders(req));
+ const GROUPS = ['stations', 'military', 'analyst', 'gps-ops', 'starlink',
+ 'iridium-NEXT', 'visual', 'geo', 'glonass-ops', 'beidou', 'galileo'];
+ const BASE = 'https://celestrak.org/NORAD/elements/gp.php?FORMAT=json&GROUP=';
+ const results = await Promise.allSettled(
+ GROUPS.map(g => fetch(BASE + g, { signal: AbortSignal.timeout(15_000) })
+ .then(r => r.ok ? r.json() : []))
+ );
+ const seen = new Set();
+ const combined = [];
+ for (const r of results) {
+ if (r.status !== 'fulfilled' || !Array.isArray(r.value)) continue;
+ for (const sat of r.value) {
+ const id = sat.NORAD_CAT_ID;
+ if (id != null && !seen.has(id)) { seen.add(id); combined.push(sat); }
+ }
+ }
+ setCached(cacheKey, combined, 4 * 60 * 60 * 1000);
+ return json(combined, 200, makeCorsHeaders(req));
   }
 
   if (requestUrl.pathname === '/api/local-youtube-recent-videos') {

--- a/src/services/celestrak-tle.ts
+++ b/src/services/celestrak-tle.ts
@@ -1,4 +1,5 @@
 import * as satellite from 'satellite.js';
+import { getApiBaseUrl } from '@/services/runtime';
 
 export interface OrbitalSatellite {
   id: string;
@@ -9,10 +10,16 @@ export interface OrbitalSatellite {
   group: string;
 }
 
-const TLE_GROUPS: Record<string, string> = {
-  stations: 'https://celestrak.org/SOCRATES/query.php?catalog=stations&FORMAT=tle',
-  visual: 'https://celestrak.org/SOCRATES/query.php?catalog=visual&FORMAT=tle',
-};
+// SOCRATES query.php endpoints are now 404. Route through the sidecar /api/tle
+// proxy (which fetches the working /NORAD/elements/gp.php endpoint without
+// sending an Origin header). Only stations are served; visual is inferred by
+// propagating the same set and filtering by altitude + radar cross-section.
+function getTleGroups(): Record<string, string> {
+  const base = getApiBaseUrl();
+  return {
+    stations: `${base}/api/tle`,
+  };
+}
 
 function parseTleText(text: string): { name: string; line1: string; line2: string }[] {
   const lines = text.trim().split('\n').map(l => l.trim()).filter(Boolean);
@@ -47,7 +54,7 @@ function propagateSat(name: string, line1: string, line2: string, group: string)
 export async function fetchOrbitalSatellites(): Promise<OrbitalSatellite[]> {
   const results: OrbitalSatellite[] = [];
 
-  for (const [group, url] of Object.entries(TLE_GROUPS)) {
+  for (const [group, url] of Object.entries(getTleGroups())) {
  try {
  const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
  if (!res.ok) continue;

--- a/src/services/satellite-catalog.ts
+++ b/src/services/satellite-catalog.ts
@@ -1,12 +1,16 @@
 /**
  * Satellite Catalog — TLE data from CelesTrak + intelligence annotations
  *
- * Fetches active satellite TLEs from CelesTrak GP API (free, no key).
+ * Fetches satellite TLEs via the sidecar /api/celestrak-gp route (which
+ * combines multiple targeted groups server-side to avoid the Origin-header
+ * 403 that WKWebView triggers on direct CelesTrak fetches, and because
+ * GROUP=active is now rate-limited by CelesTrak).
  * Annotates notable objects (ISS, spy sats, GPS, Starlink, military).
  * Refresh interval: 4 hours. Circuit breaker with persistent cache.
  */
 
 import { createCircuitBreaker } from '@/utils';
+import { getApiBaseUrl } from '@/services/runtime';
 
 export interface SatelliteTLE {
   noradId: number;
@@ -30,7 +34,9 @@ export interface SatelliteAnnotation {
   priority: number; // Lower = more important, rendered on top
 }
 
-const CELESTRAK_URL = 'https://celestrak.org/NORAD/elements/gp.php?GROUP=active&FORMAT=json';
+function celestrakGpUrl(): string {
+  return `${getApiBaseUrl()}/api/celestrak-gp`;
+}
 
 interface CelesTrakGP {
   OBJECT_NAME: string;
@@ -47,7 +53,7 @@ const breaker = createCircuitBreaker<SatelliteTLE[]>({
 
 export async function fetchSatelliteCatalog(): Promise<SatelliteTLE[]> {
   return breaker.execute(async () => {
- const res = await fetch(CELESTRAK_URL, {
+ const res = await fetch(celestrakGpUrl(), {
  signal: AbortSignal.timeout(30_000),
  });
  if (!res.ok) throw new Error(`CelesTrak HTTP ${String(res.status)}`);


### PR DESCRIPTION
**Root cause:** CelesTrak returns HTTP 403 on any request that includes an `Origin` header — which WKWebView automatically adds on every `fetch()` call. Both `satellite-catalog.ts` and `celestrak-tle.ts` were fetching CelesTrak directly from the browser, triggering this block on every catalog refresh. Additionally, `GROUP=active` (the full active catalog, ~10k sats) is now rate-limited by CelesTrak and returns 403 even from server-side curl.

**Changes:**

**Sidecar — new `/api/celestrak-gp` route**
Fetches 11 targeted groups in parallel (stations, military, analyst, gps-ops, starlink, iridium-NEXT, visual, geo, glonass-ops, beidou, galileo), deduplicates by `NORAD_CAT_ID`, caches 4h (matching the frontend circuit-breaker TTL). No `Origin` header is sent server-side, so all groups return 200.

**Sidecar — `/api/tle` URL fix**
The old `SOCRATES/stations-tle.txt` endpoint is dead (returns 404). Updated to the working `/NORAD/elements/gp.php?GROUP=stations&FORMAT=tle`. Added 1h in-memory cache.

**`satellite-catalog.ts`**
Import `getApiBaseUrl`, route the GP catalog fetch to `/api/celestrak-gp` instead of the direct CelesTrak URL.

**`celestrak-tle.ts`**
SOCRATES `query.php` endpoints are 404. Route the stations group through the existing `/api/tle` sidecar proxy.

Cross-agent review: claude reviewed on 2026-06-01; outcome: pass