### PR TITLE
tune(algos): tighten alert-burst scoring, fix source weights, ISW REST migration

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -9992,34 +9992,28 @@ async function dispatch(requestUrl, req, routes, context) {
   }
 
   // ── ISW (Institute for the Study of War) daily situation reports ─────────
+  // RSS feed (understandingwar.org/feed) 301s to homepage as of 2026-06.
+  // Use the WordPress REST API instead — same data, no redirect.
   if (requestUrl.pathname === '/api/isw-reports') {
  const cached = getCached('isw-reports');
  if (cached) return json(cached);
  try {
  const r = await fetchWithTimeout(
- 'https://www.understandingwar.org/feed',
+ 'https://understandingwar.org/wp-json/wp/v2/posts?per_page=10&_fields=id,date,title,link,excerpt,categories',
  { headers: { 'User-Agent': 'CrystalBall/1.0 (conflict intelligence aggregation)' } },
  12000,
  );
- if (!r.ok) throw new Error(`ISW RSS ${r.status}`);
- const xml = await r.text();
- function parseRssField(block, tag) {
- const cdataMatch = block.match(new RegExp(String.raw`<${tag}><\!\[CDATA\[([\s\S]*?)\]\]><\/${tag}>`));
- if (cdataMatch) return cdataMatch[1].trim();
- const plainMatch = block.match(new RegExp(String.raw`<${tag}>([\s\S]*?)<\/${tag}>`));
- return plainMatch?.[1]?.trim() ?? null;
- }
- const items = [];
- for (const m of xml.matchAll(/<item>([\s\S]*?)<\/item>/g)) {
- const block = m[1];
- const title = parseRssField(block, 'title');
- const link = block.match(/<link>(.*?)<\/link>/)?.[1]?.trim() ?? null;
- const pubDate = block.match(/<pubDate>(.*?)<\/pubDate>/)?.[1]?.trim() ?? null;
- const rawDesc = parseRssField(block, 'description');
- const description = rawDesc ? rawDesc.replace(RE_HTML_TAGS, '').trim().slice(0, 500) : null;
- const category = parseRssField(block, 'category');
- if (title) items.push({ title, link, pubDate, description, category });
- }
+ if (!r.ok) throw new Error(`ISW API ${r.status}`);
+ const posts = await r.json();
+ const items = Array.isArray(posts) ? posts.map(p => ({
+ title: p.title?.rendered ? p.title.rendered.replace(RE_HTML_TAGS, '').trim() : null,
+ link: p.link ?? null,
+ pubDate: p.date ?? null,
+ description: p.excerpt?.rendered
+ ? p.excerpt.rendered.replace(RE_HTML_TAGS, '').trim().slice(0, 500)
+ : null,
+ category: null,
+ })).filter(i => i.title) : [];
  setCached('isw-reports', items, 30 * 60 * 1000);
  return json(items);
  } catch (error) {

--- a/src/services/alert-routing.ts
+++ b/src/services/alert-routing.ts
@@ -25,6 +25,14 @@ const SEVERITY_WEIGHT: Record<AlertSeverity, number> = {
  * Per-source severity multiplier. Lets us calibrate noisy sources without
  * changing their raw classification (e.g. dial down IDS chatter, boost OREF).
  * 1.0 = neutral.
+ *
+ * Tuning notes (2026-06-02):
+ *   air-quality 0.7→0.5: highest false-positive rate in burst detection;
+ *     NWS/EPA air quality fires constantly in many regions without escalation.
+ *   fire 0.8→0.9: satellite fire detections (FIRMS) are more reliable than
+ *     the old text-advisory approach; slight boost warranted.
+ *   RECENCY_HALFLIFE_MIN 20→30: 20m was too aggressive — a genuine event
+ *     that started 35m ago was at <30% score and couldn't contribute to bursts.
  */
 const SOURCE_MULT: Record<UnifiedAlert['source'], number> = {
   'breaking-news': 1,
@@ -39,7 +47,7 @@ const SOURCE_MULT: Record<UnifiedAlert['source'], number> = {
   'resource': 0.8,
   'local-ids': 0.5,
   'earthquake': 1,
-  'fire': 0.8,
+  'fire': 0.9,
   'cyclone': 1.1,
   'power-grid': 1.2,
   'comms-health': 1.1,
@@ -49,12 +57,12 @@ const SOURCE_MULT: Record<UnifiedAlert['source'], number> = {
   'maritime': 0.9,
   'travel-advisory': 0.8,
   'radiation': 1.3,
-  'air-quality': 0.7,
+  'air-quality': 0.5,
   'aviation-hazard': 0.9,
 };
 
 /** Half-life for recency decay, in minutes. After this many minutes, score halves. */
-const RECENCY_HALFLIFE_MIN = 20;
+const RECENCY_HALFLIFE_MIN = 30;
 
 /** Multiplier when alert is within PROXIMITY_KM of the user. */
 const PROXIMITY_MULT = 1.5;

--- a/src/services/analyst-loop.ts
+++ b/src/services/analyst-loop.ts
@@ -79,9 +79,9 @@ export interface AnalystSnapshot {
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 const BASE_INTERVAL_MS = 5 * 60 * 1000;   // 5 minutes
-const HOT_ALERT_SCORE = 50;
+const HOT_ALERT_SCORE = 55;               // raised 50→55; tighter entry to burst pool
 const BURST_WINDOW_MS = 15 * 60 * 1000;    // 15 minutes
-const BURST_THRESHOLD = 6;                 // alerts in window to count as a burst
+const BURST_THRESHOLD = 10;                // raised 6→10; reduces false-positive hypotheses
 const STORAGE_KEY = 'crystalball-analyst-snapshot-v1';
 const EVENT_NAME = 'cb:analyst-hypotheses';
 const MAX_HYPOTHESES = 12;
@@ -178,6 +178,25 @@ function fromAnomalies(anomalies: Anomaly[]): Hypothesis[] {
   return out;
 }
 
+/**
+ * Deduplicate burst alerts by title prefix so that 20 NWS "Flood Warning"
+ * alerts for the same watershed don't each count as a separate burst signal.
+ * Groups whose prefix (first 30 chars, lowercased) collide keep only the
+ * highest-severity representative. Returns deduplicated list.
+ */
+function dedupeByTitlePrefix(alerts: UnifiedAlert[]): UnifiedAlert[] {
+  const SEVERITY_RANK: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1, info: 0 };
+  const best = new Map<string, UnifiedAlert>();
+  for (const a of alerts) {
+    const key = a.title.toLowerCase().slice(0, 30);
+    const prev = best.get(key);
+    if (!prev || (SEVERITY_RANK[a.severity] ?? 0) > (SEVERITY_RANK[prev.severity] ?? 0)) {
+      best.set(key, a);
+    }
+  }
+  return [...best.values()];
+}
+
 /** Detect geographic bursts: many hot alerts in a short window sharing a panel. */
 function fromAlertBurst(alerts: UnifiedAlert[]): Hypothesis[] {
   const now = Date.now();
@@ -199,17 +218,36 @@ function fromAlertBurst(alerts: UnifiedAlert[]): Hypothesis[] {
   const out: Hypothesis[] = [];
   for (const [panelId, group] of byPanel) {
     if (group.length < BURST_THRESHOLD) continue;
-    const confidence = Math.min(0.9, 0.5 + group.length * 0.04);
-    const title = group[0]?.title ?? 'alerts';
+
+    // Deduplicate same-type alerts (e.g. 20 "Flood Warning" zones → 1 representative)
+    const unique = dedupeByTitlePrefix(group);
+    if (unique.length < BURST_THRESHOLD) continue;
+
+    // Severity-weighted confidence: a burst of critical/high alerts earns more
+    // confidence than the same count of low/info alerts.
+    const SWEIGHT: Record<string, number> = { critical: 4, high: 2.5, medium: 1.5, low: 0.5, info: 0.1 };
+    const severitySum = unique.reduce((s, a) => s + (SWEIGHT[a.severity] ?? 1), 0);
+    const rawConf = Math.min(0.85, 0.35 + severitySum / (unique.length * 4));
+
+    // Source quality floor: cap confidence if the burst is dominated by
+    // low-signal sources (e.g. air-quality or travel-advisory noise).
+    const SOURCE_CAP: Partial<Record<UnifiedAlert['source'], number>> = {
+      'air-quality': 0.6, 'travel-advisory': 0.65, 'local-ids': 0.55,
+    };
+    const dominantSource = unique[0]?.source;
+    const cap = (dominantSource && SOURCE_CAP[dominantSource]) ?? 0.85;
+    const confidence = Math.min(rawConf, cap);
+
+    const title = unique[0]?.title ?? 'alerts';
     out.push({
       id: genId(),
       kind: 'alert-burst',
       statement:
-        `Alert burst in ${panelId}: ${group.length} hot alerts within ${Math.round(BURST_WINDOW_MS / 60_000)}m, led by "${title.slice(0, 80)}".`,
+        `Alert burst in ${panelId}: ${unique.length} distinct hot alerts within ${Math.round(BURST_WINDOW_MS / 60_000)}m, led by "${title.slice(0, 80)}".`,
       confidence,
       risk: confidenceToRisk(confidence),
       timestamp: now,
-      evidence: group.slice(0, 8).map((a): HypothesisEvidence => ({
+      evidence: unique.slice(0, 8).map((a): HypothesisEvidence => ({
         source: 'unified-alerts',
         id: a.id,
         label: a.title.slice(0, 80),


### PR DESCRIPTION
Three targeted tuning changes based on live accuracy data (alert-burst at 65%, 516 samples).

**alert-burst: 65% → target ~75%**

Root cause of the 35% miss rate: the algorithm was firing on count alone with no quality gates.

- `HOT_ALERT_SCORE` 50→55 and `BURST_THRESHOLD` 6→10: fewer, better-qualified bursts
- `dedupeByTitlePrefix()`: NWS/EPA issue per-zone alerts — 20 identical "Flood Warning" entries each counted separately, inflating burst counts artificially. Now collapses same-type alerts to the highest-severity representative before counting
- Severity-weighted confidence: replaces `0.5 + n×0.04` (pure count) with a sum over per-severity weights — critical alerts earn more than info/low of the same count
- Source quality cap on confidence: air-quality bursts → max 0.60, travel-advisory → 0.65, local-ids → 0.55. Prevents the noisiest sources from generating `critical` hypotheses on count alone

**Source weight rebalancing (`alert-routing.ts`)**

- `air-quality` 0.7→0.5: highest false-positive rate; the only active hypothesis right now is led by a Riyadh air quality burst
- `fire` 0.8→0.9: FIRMS satellite detections are more reliable than text advisories
- `RECENCY_HALFLIFE_MIN` 20→30: 20m was too aggressive — genuine events 35m old were at <30% score and couldn't contribute to burst detection

**ISW feed migration (`local-api-server.mjs`)**

`understandingwar.org/feed` 301s to the ISW homepage as of 2026-06. WordPress REST API (`/wp-json/wp/v2/posts`) serves identical content with no redirect. Same 30m cache, same output shape.

Cross-agent review: claude reviewed on 2026-06-02; outcome: pass