### PR TITLE
fix: wire 5 orphaned panels into sidebar (counterterrorism + 4 more)

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -403,6 +403,7 @@ import { ArcticCompetitionPanel } from '@/components/ArcticCompetitionPanel';
 import { GreatPowerCompetitionPanel } from '@/components/GreatPowerCompetitionPanel';
 import { UrbanInstabilityPanel } from '@/components/UrbanInstabilityPanel';
 import { CyberEspionagePanel } from '@/components/CyberEspionagePanel';
+import { CounterterrorismPanel } from '@/components/CounterterrorismPanel';
 import { PoliticalEconomyPanel } from '@/components/PoliticalEconomyPanel';
 import { RegulatoryArbitragePanel } from '@/components/RegulatoryArbitragePanel';
 import { ElectionMonitoringPanel } from '@/components/ElectionMonitoringPanel';
@@ -1636,6 +1637,7 @@ export class PanelLayoutManager implements AppModule {
         this.ctx.panels['great-power-competition'] = new GreatPowerCompetitionPanel();
     this.ctx.panels['urban-instability'] = new UrbanInstabilityPanel();
     this.ctx.panels['cyber-espionage'] = new CyberEspionagePanel();
+    this.ctx.panels['counterterrorism'] = new CounterterrorismPanel();
     this.ctx.panels['political-economy'] = new PoliticalEconomyPanel(); this.ctx.panels['state-capitalism'] = new StateCapitalismPanel();
     this.ctx.panels['political-violence'] = new PoliticalViolencePanel();
  this.ctx.panels['election-monitoring'] = new ElectionMonitoringPanel();

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -404,6 +404,10 @@ import { GreatPowerCompetitionPanel } from '@/components/GreatPowerCompetitionPa
 import { UrbanInstabilityPanel } from '@/components/UrbanInstabilityPanel';
 import { CyberEspionagePanel } from '@/components/CyberEspionagePanel';
 import { CounterterrorismPanel } from '@/components/CounterterrorismPanel';
+import { ThreatInboxPanel } from '@/components/ThreatInboxPanel';
+import { FaaTfrsPanel } from '@/components/FaaTfrsPanel';
+import { InfrastructureSuperpowerPanel } from '@/components/InfrastructureSuperpowerPanel';
+import { DiseaseIntelPanel } from '@/components/DiseaseIntelPanel';
 import { PoliticalEconomyPanel } from '@/components/PoliticalEconomyPanel';
 import { RegulatoryArbitragePanel } from '@/components/RegulatoryArbitragePanel';
 import { ElectionMonitoringPanel } from '@/components/ElectionMonitoringPanel';
@@ -1638,6 +1642,10 @@ export class PanelLayoutManager implements AppModule {
     this.ctx.panels['urban-instability'] = new UrbanInstabilityPanel();
     this.ctx.panels['cyber-espionage'] = new CyberEspionagePanel();
     this.ctx.panels['counterterrorism'] = new CounterterrorismPanel();
+    this.ctx.panels['threat-inbox'] = new ThreatInboxPanel();
+    this.ctx.panels['faa-tfrs'] = new FaaTfrsPanel();
+    this.ctx.panels['infrastructure-superpower'] = new InfrastructureSuperpowerPanel();
+    this.ctx.panels['disease-intel'] = new DiseaseIntelPanel();
     this.ctx.panels['political-economy'] = new PoliticalEconomyPanel(); this.ctx.panels['state-capitalism'] = new StateCapitalismPanel();
     this.ctx.panels['political-violence'] = new PoliticalViolencePanel();
  this.ctx.panels['election-monitoring'] = new ElectionMonitoringPanel();


### PR DESCRIPTION
## Summary
Five panels were registered + `enabled: true` in `src/config/panels.ts` and listed in `PANEL_CATEGORY_MAP`, but were **never instantiated** in `src/app/panel-layout.ts` — so they silently never appeared in the sidebar.

| Panel key | Component | Note |
|-----------|-----------|------|
| `counterterrorism` | CounterterrorismPanel | priority 1, dataTracking category |
| `threat-inbox` | ThreatInboxPanel | |
| `faa-tfrs` | FaaTfrsPanel | added 2026-05-11, never wired |
| `infrastructure-superpower` | InfrastructureSuperpowerPanel | added 2026-05-25, never wired |
| `disease-intel` | DiseaseIntelPanel | `loaders/disease.ts` already called `ctx.panels['disease-intel']?.update(data)`, which silently no-op'd |

All five have no-arg constructors; wired with the standard `this.ctx.panels['key'] = new XPanel()` pattern matching adjacent panels.

## How they were found
Systematic audit: every `enabled: true` key in `panels.ts` compared against all three wiring forms in `panel-layout.ts` (direct assignment, dot-notation, lazy-import registry) plus `src/app` loaders. After the fix, a re-run reports **0 orphans**. (`economic-news` is the only other unwired enabled key — it has no Panel component; it's a finance-variant feed key, not a sidebar panel.)

## Verification
- `npx tsc --noEmit` → 0 errors
- `npx eslint src/app/panel-layout.ts` → 0 errors
- Comprehensive orphan re-audit → 0 remaining

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---
Cross-agent review: Codex reviewed on 2026-06-02; outcome: pass. No blocking findings, no nits. Verified all 5 component paths/exports exist, keys match FULL_PANELS + each panel's super({id}), constructors take no required args, and each ctx.panels assignment is unique (no clobber).
