### PR TITLE
fix(sidecar): follow redirects (OFAC sanctions), load XMPP bundle, quiet boot-handshake noise

### DIFF
--- a/scripts/build-sidecar-xmpp.mjs
+++ b/scripts/build-sidecar-xmpp.mjs
@@ -31,6 +31,22 @@ try {
  // @xmpp/client uses dynamic import for transport selection; mark
  // the legacy ws-only browser transport as external so esbuild
  // doesn't choke when Node 22 has WebSocket builtin.
+ // @xmpp/client (and its deps) call require('events') etc. In an ESM
+ // bundle esbuild rewrites those to a __require shim that throws
+ // "Dynamic require of \"events\" is not supported" at runtime. Inject a
+ // real createRequire so node-builtin requires resolve, otherwise the
+ // bundle imports but throws on first use and the S2U XMPP feed silently
+ // stays disabled in the packaged app.
+ banner: {
+   js: [
+     "import { createRequire as __xmppCreateRequire } from 'node:module';",
+     "import { fileURLToPath as __xmppFileURLToPath } from 'node:url';",
+     "import { dirname as __xmppDirname } from 'node:path';",
+     'const require = __xmppCreateRequire(import.meta.url);',
+     'const __filename = __xmppFileURLToPath(import.meta.url);',
+     'const __dirname = __xmppDirname(__filename);',
+   ].join('\n'),
+ },
  external: [],
  logLevel: 'warning',
   });

--- a/src-tauri/sidecar/__tests__/ipv4-fetch-redirect.test.mjs
+++ b/src-tauri/sidecar/__tests__/ipv4-fetch-redirect.test.mjs
@@ -1,0 +1,96 @@
+// Regression tests for the IPv4-pinned fetch monkeypatch's redirect handling.
+// Before the fix it issued a single request and returned the raw 3xx, so any
+// upstream that began redirecting (OFAC's sdn.xml -> presigned S3) failed with
+// "upstream HTTP 302". These tests stand up local HTTP servers and assert the
+// patched fetch follows redirects per the fetch contract.
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+import http from 'node:http';
+import { ipv4Fetch } from '../local-api-server.mjs';
+
+function startServer(handler) {
+  return new Promise((resolve) => {
+    const srv = http.createServer(handler);
+    srv.listen(0, '127.0.0.1', () => resolve(srv));
+  });
+}
+const addr = (srv) => `http://127.0.0.1:${srv.address().port}`;
+
+test('follows a 302 to a different origin and returns the final 200 body', async () => {
+  const target = await startServer((req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain' });
+    res.end('FINAL-BODY');
+  });
+  const redirector = await startServer((req, res) => {
+    res.writeHead(302, { Location: `${addr(target)}/final` });
+    res.end();
+  });
+  try {
+    const r = await ipv4Fetch(`${addr(redirector)}/start`);
+    assert.equal(r.status, 200);
+    assert.equal(r.ok, true);
+    assert.equal(await r.text(), 'FINAL-BODY');
+  } finally {
+    target.close();
+    redirector.close();
+  }
+});
+
+test('honors redirect:"manual" by returning the raw 3xx', async () => {
+  const redirector = await startServer((req, res) => {
+    res.writeHead(302, { Location: 'http://127.0.0.1:9/none' });
+    res.end();
+  });
+  try {
+    const r = await ipv4Fetch(`${addr(redirector)}/x`, { redirect: 'manual' });
+    assert.equal(r.status, 302);
+  } finally {
+    redirector.close();
+  }
+});
+
+test('throws on redirect:"error"', async () => {
+  const redirector = await startServer((req, res) => {
+    res.writeHead(302, { Location: 'http://127.0.0.1:9/none' });
+    res.end();
+  });
+  try {
+    await assert.rejects(() => ipv4Fetch(`${addr(redirector)}/x`, { redirect: 'error' }), /redirect: "error"/);
+  } finally {
+    redirector.close();
+  }
+});
+
+test('follows a relative Location and downgrades POST->GET on 303', async () => {
+  let secondMethod = null;
+  const srv = await startServer((req, res) => {
+    if (req.url === '/post') {
+      res.writeHead(303, { Location: '/result' });
+      res.end();
+      return;
+    }
+    secondMethod = req.method;
+    res.writeHead(200);
+    res.end('done');
+  });
+  try {
+    const r = await ipv4Fetch(`${addr(srv)}/post`, { method: 'POST', body: 'payload' });
+    assert.equal(r.status, 200);
+    assert.equal(secondMethod, 'GET');
+  } finally {
+    srv.close();
+  }
+});
+
+test('throws on a redirect loop exceeding the hop cap', async () => {
+  const srv = await startServer((req, res) => {
+    // Relative Location resolves against the current origin -> same server -> loops.
+    res.writeHead(302, { Location: '/loop' });
+    res.end();
+  });
+  try {
+    await assert.rejects(() => ipv4Fetch(`${addr(srv)}/loop`), /Too many redirects/);
+  } finally {
+    srv.close();
+  }
+});

--- a/src-tauri/sidecar/__tests__/ipv4-fetch-redirect.test.mjs
+++ b/src-tauri/sidecar/__tests__/ipv4-fetch-redirect.test.mjs
@@ -82,6 +82,26 @@ test('follows a relative Location and downgrades POST->GET on 303', async () => 
   }
 });
 
+test('rejects without sending a request when the signal is already aborted', async () => {
+  const ac = new AbortController();
+  ac.abort();
+  let hits = 0;
+  const srv = await startServer((req, res) => {
+    hits += 1;
+    res.writeHead(200);
+    res.end('x');
+  });
+  try {
+    await assert.rejects(
+      () => ipv4Fetch(`${addr(srv)}/`, { signal: ac.signal }),
+      (e) => e.name === 'AbortError' || /abort/i.test(e.message),
+    );
+    assert.equal(hits, 0, 'no request should be sent when pre-aborted');
+  } finally {
+    srv.close();
+  }
+});
+
 test('throws on a redirect loop exceeding the hop cap', async () => {
   const srv = await startServer((req, res) => {
     // Relative Location resolves against the current origin -> same server -> loops.

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -738,45 +738,98 @@ function isTransientVerificationError(error) {
   return /timed out|timeout|network|fetch failed|failed to fetch|socket hang up/i.test(error.message);
 }
 
-globalThis.fetch = async function ipv4Fetch(input, init) {
+// 3xx statuses that trigger a redirect when the response carries a Location.
+const IPV4_REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const IPV4_MAX_REDIRECTS = 20;
+
+function deleteHeaderCI(headers, name) {
+  const lower = name.toLowerCase();
+  for (const k of Object.keys(headers)) {
+    if (k.toLowerCase() === lower) delete headers[k];
+  }
+}
+
+// IPv4-pinned fetch that ALSO follows 3xx redirects, re-resolving each hop to
+// IPv4. The previous implementation issued a single request and returned the
+// raw 3xx, so any upstream that began redirecting (e.g. OFAC's sdn.xml, which
+// now 302s to a presigned S3 URL) silently failed with "upstream HTTP 302".
+// Honors init.redirect ('follow' default, 'manual', 'error') per the fetch contract.
+export const ipv4Fetch = async function ipv4Fetch(input, init) {
   const isRequest = input && typeof input === 'object' && 'url' in input;
-  let url;
-  try { url = new URL(typeof input === 'string' ? input : input.url); } catch { return _originalFetch(input, init); }
-  if (url.protocol !== 'https:' && url.protocol !== 'http:') return _originalFetch(input, init);
-  const mod = url.protocol === 'https:' ? https : http;
-  const method = init?.method || (isRequest ? input.method : 'GET');
-  const body = await resolveRequestBody(input, init, method, isRequest);
+  let startUrl;
+  try { startUrl = new URL(typeof input === 'string' ? input : input.url); } catch { return _originalFetch(input, init); }
+  if (startUrl.protocol !== 'https:' && startUrl.protocol !== 'http:') return _originalFetch(input, init);
+
+  let method = init?.method || (isRequest ? input.method : 'GET');
+  let body = await resolveRequestBody(input, init, method, isRequest);
   const headers = {};
   const rawHeaders = init?.headers || (isRequest ? input.headers : null);
   if (rawHeaders) {
- const h = rawHeaders instanceof Headers ? Object.fromEntries(rawHeaders.entries())
- : (Array.isArray(rawHeaders) ? Object.fromEntries(rawHeaders) : rawHeaders);
- Object.assign(headers, h);
+    const h = rawHeaders instanceof Headers ? Object.fromEntries(rawHeaders.entries())
+      : (Array.isArray(rawHeaders) ? Object.fromEntries(rawHeaders) : rawHeaders);
+    Object.assign(headers, h);
   }
-  return new Promise((resolve, reject) => {
- const req = mod.request({ hostname: url.hostname, port: url.port || (url.protocol === 'https:' ? 443 : 80), path: url.pathname + url.search, method, headers, family: 4, agent: mod === https ? httpsAgent : httpAgent }, (res) => {
- const chunks = [];
- res.on('data', (c) => chunks.push(c));
- res.on('end', () => {
- const buf = Buffer.concat(chunks);
- const responseHeaders = new Headers();
- for (const [k, v] of Object.entries(res.headers)) {
- if (v) responseHeaders.set(k, Array.isArray(v) ? v.join(', ') : v);
- }
- try {
- resolve(buildSafeResponse(res.statusCode, res.statusMessage, responseHeaders, buf));
- } catch (error) {
- reject(error);
- }
- });
- });
- req.on('error', reject);
- if (init?.signal) { init.signal.addEventListener('abort', () => req.destroy()); }
- if (body != undefined) req.write(body);
- req.end();
-  });
-};
+  const redirectMode = init?.redirect || (isRequest ? input.redirect : null) || 'follow';
+  const signal = init?.signal || (isRequest && input.signal) || null;
 
+  const sendOnce = (target) => new Promise((resolve, reject) => {
+    const mod = target.protocol === 'https:' ? https : http;
+    const req = mod.request({
+      hostname: target.hostname,
+      port: target.port || (target.protocol === 'https:' ? 443 : 80),
+      path: target.pathname + target.search,
+      method, headers, family: 4,
+      agent: mod === https ? httpsAgent : httpAgent,
+    }, (res) => {
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => resolve({ statusCode: res.statusCode, statusMessage: res.statusMessage, headers: res.headers, buf: Buffer.concat(chunks) }));
+    });
+    req.on('error', reject);
+    if (signal) { signal.addEventListener('abort', () => req.destroy(), { once: true }); }
+    if (body != undefined) req.write(body);
+    req.end();
+  });
+
+  let current = startUrl;
+  for (let hop = 0; ; hop++) {
+    const res = await sendOnce(current);
+    const location = res.headers.location;
+    const isRedirect = IPV4_REDIRECT_STATUSES.has(res.statusCode) && Boolean(location);
+
+    if (!isRedirect || redirectMode !== 'follow') {
+      if (isRedirect && redirectMode === 'error') {
+        throw new TypeError(`Redirect not followed (redirect: "error"): ${res.statusCode}`);
+      }
+      const responseHeaders = new Headers();
+      for (const [k, v] of Object.entries(res.headers)) {
+        if (v) responseHeaders.set(k, Array.isArray(v) ? v.join(', ') : v);
+      }
+      return buildSafeResponse(res.statusCode, res.statusMessage, responseHeaders, res.buf);
+    }
+
+    if (hop >= IPV4_MAX_REDIRECTS) throw new TypeError('Too many redirects');
+
+    const next = new URL(location, current);
+    // Per the fetch spec: 303 (and 301/302 on a non-GET/HEAD method) downgrade
+    // to GET and drop the request body.
+    if (res.statusCode === 303 || ((res.statusCode === 301 || res.statusCode === 302) && method !== 'GET' && method !== 'HEAD')) {
+      method = 'GET';
+      body = null;
+      deleteHeaderCI(headers, 'content-length');
+      deleteHeaderCI(headers, 'content-type');
+    }
+    // Drop credentials + Host when the origin changes (browser behavior). The
+    // OFAC -> presigned-S3 hop is cross-origin and self-authenticates via query.
+    if (next.origin !== current.origin) {
+      deleteHeaderCI(headers, 'authorization');
+      deleteHeaderCI(headers, 'cookie');
+      deleteHeaderCI(headers, 'host');
+    }
+    current = next;
+  }
+};
+globalThis.fetch = ipv4Fetch;
 // Wrap fetch AFTER the ipv4Fetch patch so we instrument its entry point.
 // Skips loopback (sidecar-internal) calls since those would drown the real signal.
 const wmUpstreamFetch = globalThis.fetch;

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -772,15 +772,24 @@ export const ipv4Fetch = async function ipv4Fetch(input, init) {
   const redirectMode = init?.redirect || (isRequest ? input.redirect : null) || 'follow';
   const signal = init?.signal || (isRequest && input.signal) || null;
 
-  const sendOnce = (target) => new Promise((resolve, reject) => {
-    const mod = target.protocol === 'https:' ? https : http;
-    const req = mod.request({
-      hostname: target.hostname,
-      port: target.port || (target.protocol === 'https:' ? 443 : 80),
+  const sendOnce = (target, pinnedIp = null) => new Promise((resolve, reject) => {
+    const isHttps = target.protocol === 'https:';
+    const mod = isHttps ? https : http;
+    // When a redirect target was validated by isSafeUrl, connect to the exact
+    // IP it resolved (closing the DNS-rebinding TOCTOU) while preserving SNI +
+    // Host so TLS and virtual-hosting still target the real hostname.
+    const reqHeaders = pinnedIp ? { ...headers, host: target.host } : headers;
+    const options = {
+      hostname: pinnedIp || target.hostname,
+      port: target.port || (isHttps ? 443 : 80),
       path: target.pathname + target.search,
-      method, headers, family: 4,
-      agent: mod === https ? httpsAgent : httpAgent,
-    }, (res) => {
+      method,
+      headers: reqHeaders,
+      family: pinnedIp ? (pinnedIp.includes(':') ? 6 : 4) : 4,
+      agent: isHttps ? httpsAgent : httpAgent,
+    };
+    if (pinnedIp && isHttps) options.servername = target.hostname;
+    const req = mod.request(options, (res) => {
       const chunks = [];
       res.on('data', (c) => chunks.push(c));
       res.on('end', () => resolve({ statusCode: res.statusCode, statusMessage: res.statusMessage, headers: res.headers, buf: Buffer.concat(chunks) }));
@@ -798,11 +807,12 @@ export const ipv4Fetch = async function ipv4Fetch(input, init) {
   const startIsInternal = startUrl.hostname === 'localhost' || isPrivateIP(startHost);
 
   let current = startUrl;
+  let pinnedIp = null;
   for (let hop = 0; ; hop++) {
     if (signal?.aborted) {
       throw signal.reason ?? Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
     }
-    const res = await sendOnce(current);
+    const res = await sendOnce(current, pinnedIp);
     const location = res.headers.location;
     const isRedirect = IPV4_REDIRECT_STATUSES.has(res.statusCode) && Boolean(location);
 
@@ -838,11 +848,17 @@ export const ipv4Fetch = async function ipv4Fetch(input, init) {
     // Block a public->private redirect escalation (DNS-rebinding aware via
     // isSafeUrl). Skipped when the request started internal so loopback and
     // sidecar-internal redirects still work. Only runs on an actual redirect.
-    if (!startIsInternal) {
+    if (startIsInternal) {
+      pinnedIp = null;
+    } else {
       const verdict = await isSafeUrl(next.href);
       if (!verdict.safe) {
         throw new TypeError(`Refusing unsafe redirect target: ${verdict.reason}`);
       }
+      // Pin the validated IP for the next hop (prefer IPv4 to keep the
+      // IPv4-forcing contract). All returned addresses already passed isPrivateIP.
+      const addrs = verdict.resolvedAddresses ?? [];
+      pinnedIp = addrs.find((a) => !a.includes(':')) ?? addrs[0] ?? null;
     }
     current = next;
   }

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -791,8 +791,17 @@ export const ipv4Fetch = async function ipv4Fetch(input, init) {
     req.end();
   });
 
+  // SSRF policy: an internal/loopback origin may redirect freely, but a public
+  // origin must not be redirected to a private/internal target (cloud metadata,
+  // loopback, RFC-1918) — that escalation is the SSRF vector.
+  const startHost = startUrl.hostname.replace(/^\[|\]$/g, '');
+  const startIsInternal = startUrl.hostname === 'localhost' || isPrivateIP(startHost);
+
   let current = startUrl;
   for (let hop = 0; ; hop++) {
+    if (signal?.aborted) {
+      throw signal.reason ?? Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+    }
     const res = await sendOnce(current);
     const location = res.headers.location;
     const isRedirect = IPV4_REDIRECT_STATUSES.has(res.statusCode) && Boolean(location);
@@ -825,6 +834,15 @@ export const ipv4Fetch = async function ipv4Fetch(input, init) {
       deleteHeaderCI(headers, 'authorization');
       deleteHeaderCI(headers, 'cookie');
       deleteHeaderCI(headers, 'host');
+    }
+    // Block a public->private redirect escalation (DNS-rebinding aware via
+    // isSafeUrl). Skipped when the request started internal so loopback and
+    // sidecar-internal redirects still work. Only runs on an actual redirect.
+    if (!startIsInternal) {
+      const verdict = await isSafeUrl(next.href);
+      if (!verdict.safe) {
+        throw new TypeError(`Refusing unsafe redirect target: ${verdict.reason}`);
+      }
     }
     current = next;
   }

--- a/src/services/tauri-bridge.ts
+++ b/src/services/tauri-bridge.ts
@@ -33,6 +33,12 @@ export async function invokeTauri<T>(
   return invoke<T>(command, payload);
 }
 
+// Commands that legitimately fail for the first few seconds of boot while the
+// Rust side spawns the sidecar and assigns its port/token. Callers poll these
+// and handle a null result, so logging each failure as an error is misleading
+// noise — a stalled sidecar is caught separately by the heartbeat watchdog.
+const TRANSIENT_BOOT_COMMANDS = new Set(['get_local_api_port', 'get_local_api_token']);
+
 export async function tryInvokeTauri<T>(
   command: string,
   payload?: Record<string, unknown>,
@@ -40,7 +46,10 @@ export async function tryInvokeTauri<T>(
   try {
  return await invokeTauri<T>(command, payload);
   } catch (error) {
- console.warn(`[tauri-bridge] Command failed: ${command}`, error);
+ if (!TRANSIENT_BOOT_COMMANDS.has(command)) {
+ 	// eslint-disable-next-line no-console -- bridged to the desktop log
+ 	console.warn(`[tauri-bridge] Command failed: ${command}`, error);
+ }
  return null;
   }
 }

--- a/src/services/tauri-bridge.ts
+++ b/src/services/tauri-bridge.ts
@@ -33,11 +33,20 @@ export async function invokeTauri<T>(
   return invoke<T>(command, payload);
 }
 
-// Commands that legitimately fail for the first few seconds of boot while the
-// Rust side spawns the sidecar and assigns its port/token. Callers poll these
-// and handle a null result, so logging each failure as an error is misleading
-// noise — a stalled sidecar is caught separately by the heartbeat watchdog.
+// During the first seconds of boot the renderer polls get_local_api_port /
+// get_local_api_token before the Rust side has spawned the sidecar and assigned
+// them. Those specific "not ready yet" failures are expected — callers poll and
+// handle the null result, and a genuinely stalled sidecar is caught by the
+// heartbeat watchdog. Match the message narrowly so a real failure of these
+// commands (anything other than the handshake-not-ready states) still logs.
 const TRANSIENT_BOOT_COMMANDS = new Set(['get_local_api_port', 'get_local_api_token']);
+const TRANSIENT_BOOT_REASONS = /not yet assigned|not generated|bridge unavailable/i;
+
+function isExpectedBootFailure(command: string, error: unknown): boolean {
+  if (!TRANSIENT_BOOT_COMMANDS.has(command)) return false;
+  const message = error instanceof Error ? error.message : String(error);
+  return TRANSIENT_BOOT_REASONS.test(message);
+}
 
 export async function tryInvokeTauri<T>(
   command: string,
@@ -46,9 +55,9 @@ export async function tryInvokeTauri<T>(
   try {
  return await invokeTauri<T>(command, payload);
   } catch (error) {
- if (!TRANSIENT_BOOT_COMMANDS.has(command)) {
- 	// eslint-disable-next-line no-console -- bridged to the desktop log
- 	console.warn(`[tauri-bridge] Command failed: ${command}`, error);
+ if (!isExpectedBootFailure(command, error)) {
+   // eslint-disable-next-line no-console -- bridged to the desktop log
+   console.warn(`[tauri-bridge] Command failed: ${command}`, error);
  }
  return null;
   }


### PR DESCRIPTION
## Summary
Three Mac-app-only failures found by auditing the **running app's** logs (web dev mode can't surface them — no sidecar, no IPv4 fetch monkeypatch, no Tauri bridge):

### A. Sidecar fetch didn't follow 3xx redirects (sanctions broken)
The IPv4-forcing `fetch` monkeypatch (`ipv4Fetch`) issued a single request and returned the raw 3xx. OFAC's `sdn.xml` now **302s to a presigned AWS GovCloud S3 URL**, so the sanctions cache failed every few minutes with `upstream HTTP 302`. Now follows redirects (re-resolving each hop to IPv4), honoring `redirect: follow|manual|error`, downgrading method per spec, and dropping credentials cross-origin.

**Security (per cross-agent review):**
- Per-hop `isSafeUrl()` revalidation blocks a **public→private redirect escalation** (cloud-metadata/loopback/RFC-1918); internal-origin requests redirect freely.
- The validated IP is **pinned** for the next hop (SNI + Host preserved) to close a DNS-rebinding TOCTOU.
- `signal.aborted` checked before each hop.

Verified live: OFAC now returns **200 / 28.5 MB** of SDN XML through the guarded follower. New test: `__tests__/ipv4-fetch-redirect.test.mjs` (6 cases).

### B(i). S2U XMPP bundle threw on load
`build-sidecar-xmpp.mjs` emitted ESM but bundled CJS deps call `require('events')`, which esbuild turned into a throwing `__require` shim (`Dynamic require of "events" is not supported`) — the bundle imported but threw on use, silently disabling the S2U XMPP feed. Added a `createRequire` banner; the regenerated bundle imports and exposes its API.

### B(ii). Boot-handshake noise logged as errors
The renderer polls `get_local_api_port`/`get_local_api_token` before the Rust side assigns them, producing ~9 false `[tauri-bridge] Command failed` warnings per launch. Now suppressed **only** for those commands' known "not ready" messages — real failures still log.

## Verification
- `npm run typecheck:all` → 0 errors
- ESLint (changed files) → 0; `git diff --check` clean
- `node --test ipv4-fetch-redirect.test.mjs` → 6 pass; `s2u-xmpp.test.mjs` → 12 pass
- Live OFAC fetch through patched `ipv4Fetch` → 200

## Cross-agent review
Codex reviewed iteratively (3 rounds): flagged the SSRF revalidation + abort gaps, then the rebinding TOCTOU; all fixed and re-confirmed.

Cross-agent review: Codex reviewed on 2026-06-02; outcome: pass. Closed two blocking findings (redirect SSRF revalidation + abort-per-hop) and a follow-up DNS-rebinding TOCTOU (validated-IP pinning with SNI/Host preserved); final verdict PASS, no remaining bypass.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>