### PR TITLE
feat: always-on reasoning — 24/7 hidden operation (macOS)

### DIFF
--- a/docs/superpowers/plans/2026-06-02-always-on-reasoning.md
+++ b/docs/superpowers/plans/2026-06-02-always-on-reasoning.md
@@ -1,0 +1,460 @@
+# Always-On Reasoning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep Crystal Ball's analyst + data-refresh loops running at full cadence while the window is hidden on macOS, by preventing App Nap and un-throttling the scheduler, gated on a `cb-always-on` toggle (default on).
+
+**Architecture:** A Rust Tauri command holds an `NSProcessInfo` user-initiated activity token (prevents App Nap, still allows system sleep). A renderer module (`always-on.ts`) owns the setting, calls the command on boot/change, and exposes `isAlwaysOn()`. The refresh scheduler skips its hidden×10 throttle when always-on is enabled. The analyst loop already ignores the hidden multiplier, so removing App Nap restores its cadence.
+
+**Tech Stack:** Rust (Tauri 2, raw objc FFI — same pattern as `get_native_location_impl`), TypeScript renderer, `node:test` via `tsx`.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-always-on-reasoning-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src-tauri/src/main.rs` | `AlwaysOnGuard` state + `set_always_on`/`get_always_on` commands (objc `beginActivity`/`endActivity`); registered in `generate_handler!`. |
+| `src/services/always-on.ts` | Setting read/write (`cb-always-on`, default true) + `isAlwaysOn()` + `applyAlwaysOn()` (invokes the Tauri command). |
+| `src/services/__tests__/always-on.test.mts` | Tests for setting default/read/write. |
+| `src/app/refresh-scheduler.ts` | Gate the hidden×10 multiplier on `isAlwaysOn()`. |
+| `src/app/__tests__/refresh-scheduler-throttle.test.mts` (new) | Test the multiplier gating. |
+| `src/components/UnifiedSettings.ts` | A "24/7 background operation" toggle bound to the setting. |
+| `src/main.ts` | Call `applyAlwaysOn()` once the Tauri bridge is ready. |
+
+---
+
+## Task 1: Rust — always-on activity commands
+
+**Files:**
+- Modify: `src-tauri/src/main.rs` (add state struct, two commands, register in `generate_handler!` at ~line 2806, manage state in builder)
+
+- [ ] **Step 1: Add the state struct + commands** (place near the other `#[tauri::command]` fns, ~line 567+)
+
+```rust
+/// Holds the retained NSProcessInfo activity token (as a pointer-sized int so the
+/// state is Send+Sync). None when no activity is held.
+struct AlwaysOnGuard(std::sync::Mutex<Option<usize>>);
+
+#[cfg(target_os = "macos")]
+fn begin_activity_macos() -> Option<usize> {
+    use std::ffi::c_void;
+    extern "C" {
+        fn objc_getClass(name: *const u8) -> *mut c_void;
+        fn sel_registerName(name: *const u8) -> *mut c_void;
+        fn objc_msgSend(receiver: *mut c_void, sel: *mut c_void, ...) -> *mut c_void;
+    }
+    // NSActivityUserInitiated prevents App Nap; clear IdleSystemSleepDisabled so the
+    // Mac may still sleep normally (lid close). bit14=SuddenTermination, bit20=IdleSystemSleep.
+    const NS_SUDDEN_TERM_DISABLED: u64 = 1 << 14;
+    const NS_IDLE_SYSTEM_SLEEP_DISABLED: u64 = 1 << 20;
+    const NS_USER_INITIATED: u64 = 0x00FF_FFFF | NS_SUDDEN_TERM_DISABLED;
+    let options: u64 = NS_USER_INITIATED & !NS_IDLE_SYSTEM_SLEEP_DISABLED;
+    unsafe {
+        let pi_cls = objc_getClass(b"NSProcessInfo\0".as_ptr());
+        let str_cls = objc_getClass(b"NSString\0".as_ptr());
+        if pi_cls.is_null() || str_cls.is_null() { return None; }
+        let process_info = objc_msgSend(pi_cls, sel_registerName(b"processInfo\0".as_ptr()));
+        if process_info.is_null() { return None; }
+        // reason: NSString
+        let with_utf8 = sel_registerName(b"stringWithUTF8String:\0".as_ptr());
+        let reason_fn: unsafe extern "C" fn(*mut c_void, *mut c_void, *const u8) -> *mut c_void =
+            std::mem::transmute(objc_msgSend as *const ());
+        let reason = reason_fn(str_cls, with_utf8, b"Crystal Ball 24/7 monitoring\0".as_ptr());
+        // [processInfo beginActivityWithOptions:options reason:reason]
+        let begin_sel = sel_registerName(b"beginActivityWithOptions:reason:\0".as_ptr());
+        let begin_fn: unsafe extern "C" fn(*mut c_void, *mut c_void, u64, *mut c_void) -> *mut c_void =
+            std::mem::transmute(objc_msgSend as *const ());
+        let token = begin_fn(process_info, begin_sel, options, reason);
+        if token.is_null() { return None; }
+        // retain so it survives past this scope
+        objc_msgSend(token, sel_registerName(b"retain\0".as_ptr()));
+        Some(token as usize)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn end_activity_macos(token: usize) {
+    use std::ffi::c_void;
+    extern "C" {
+        fn objc_getClass(name: *const u8) -> *mut c_void;
+        fn sel_registerName(name: *const u8) -> *mut c_void;
+        fn objc_msgSend(receiver: *mut c_void, sel: *mut c_void, ...) -> *mut c_void;
+    }
+    unsafe {
+        let pi_cls = objc_getClass(b"NSProcessInfo\0".as_ptr());
+        if pi_cls.is_null() { return; }
+        let process_info = objc_msgSend(pi_cls, sel_registerName(b"processInfo\0".as_ptr()));
+        let end_sel = sel_registerName(b"endActivity:\0".as_ptr());
+        let end_fn: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> *mut c_void =
+            std::mem::transmute(objc_msgSend as *const ());
+        end_fn(process_info, end_sel, token as *mut c_void);
+        objc_msgSend(token as *mut c_void, sel_registerName(b"release\0".as_ptr()));
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn begin_activity_macos() -> Option<usize> { None }
+#[cfg(not(target_os = "macos"))]
+fn end_activity_macos(_token: usize) {}
+
+#[tauri::command]
+fn set_always_on(state: tauri::State<AlwaysOnGuard>, enabled: bool) -> bool {
+    let mut held = state.0.lock().unwrap();
+    if enabled && held.is_none() {
+        *held = begin_activity_macos();
+    } else if !enabled {
+        if let Some(token) = held.take() {
+            end_activity_macos(token);
+        }
+    }
+    held.is_some()
+}
+
+#[tauri::command]
+fn get_always_on(state: tauri::State<AlwaysOnGuard>) -> bool {
+    state.0.lock().unwrap().is_some()
+}
+```
+
+- [ ] **Step 2: Manage the state + register the commands**
+
+In the Tauri builder chain (where `.invoke_handler(tauri::generate_handler![` is, ~line 2806), add `set_always_on, get_always_on,` to the handler list. Add `.manage(AlwaysOnGuard(std::sync::Mutex::new(None)))` to the builder (near other `.manage(...)` calls; if none, add it right before `.invoke_handler`).
+
+- [ ] **Step 3: Build the Rust to verify it compiles**
+
+Run: `cd src-tauri && cargo check 2>&1 | tail -20`
+Expected: compiles (warnings OK). If `objc_msgSend`/`sel_registerName`/`objc_getClass` extern decls clash with an existing module-level decl, reuse the existing one instead of re-declaring inside these fns.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src-tauri/src/main.rs
+git commit -m "feat(always-on): macOS NSProcessInfo activity commands
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Renderer — always-on setting module
+
+**Files:**
+- Create: `src/services/always-on.ts`
+- Test: `src/services/__tests__/always-on.test.mts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/services/__tests__/always-on.test.mts
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Minimal localStorage shim for Node test
+const store = new Map<string, string>();
+(globalThis as unknown as { localStorage: Storage }).localStorage = {
+  getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+  setItem: (k: string, v: string) => { store.set(k, v); },
+  removeItem: (k: string) => { store.delete(k); },
+  clear: () => store.clear(),
+  key: () => null,
+  length: 0,
+} as Storage;
+
+const { isAlwaysOn, setAlwaysOnSetting } = await import('../always-on.ts');
+
+describe('always-on setting', () => {
+  beforeEach(() => store.clear());
+  it('defaults to true when unset', () => {
+    assert.equal(isAlwaysOn(), true);
+  });
+  it('returns false when explicitly disabled', () => {
+    setAlwaysOnSetting(false);
+    assert.equal(isAlwaysOn(), false);
+  });
+  it('returns true when re-enabled', () => {
+    setAlwaysOnSetting(false);
+    setAlwaysOnSetting(true);
+    assert.equal(isAlwaysOn(), true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx tsx --test src/services/__tests__/always-on.test.mts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+// src/services/always-on.ts
+import { tryInvokeTauri } from './tauri-bridge';
+
+const KEY = 'cb-always-on';
+
+/** Default ON: a missing/blank setting means always-on. */
+export function isAlwaysOn(): boolean {
+  try {
+    return localStorage.getItem(KEY) !== 'false';
+  } catch {
+    return true;
+  }
+}
+
+export function setAlwaysOnSetting(enabled: boolean): void {
+  try {
+    localStorage.setItem(KEY, enabled ? 'true' : 'false');
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Push the current (or given) setting to the native layer. Safe off-desktop. */
+export async function applyAlwaysOn(enabled: boolean = isAlwaysOn()): Promise<void> {
+  await tryInvokeTauri('set_always_on', { enabled });
+}
+
+/** Persist + apply in one call (for the settings toggle). */
+export async function setAlwaysOn(enabled: boolean): Promise<void> {
+  setAlwaysOnSetting(enabled);
+  await applyAlwaysOn(enabled);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx tsx --test src/services/__tests__/always-on.test.mts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/always-on.ts src/services/__tests__/always-on.test.mts
+git commit -m "feat(always-on): renderer setting module (default on)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Gate the scheduler's hidden throttle
+
+**Files:**
+- Modify: `src/app/refresh-scheduler.ts` (the `computeDelay` closure inside `scheduleRefresh`)
+- Test: `src/app/__tests__/refresh-scheduler-throttle.test.mts` (new) — test the pure multiplier decision
+
+The current `computeDelay` applies `HIDDEN_REFRESH_MULTIPLIER (10)` when `isHidden`. We want: when always-on is enabled, the hidden multiplier is NOT applied. To keep it unit-testable, extract the multiplier decision into a pure exported helper and use it in `computeDelay`.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/app/__tests__/refresh-scheduler-throttle.test.mts
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { hiddenMultiplier } from '../refresh-scheduler.ts';
+
+describe('hiddenMultiplier', () => {
+  it('is 1 when not hidden', () => {
+    assert.equal(hiddenMultiplier(false, false), 1);
+    assert.equal(hiddenMultiplier(false, true), 1);
+  });
+  it('is 10 when hidden and always-on is OFF', () => {
+    assert.equal(hiddenMultiplier(true, false), 10);
+  });
+  it('is 1 when hidden but always-on is ON', () => {
+    assert.equal(hiddenMultiplier(true, true), 1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx tsx --test src/app/__tests__/refresh-scheduler-throttle.test.mts`
+Expected: FAIL — `hiddenMultiplier` not exported.
+
+- [ ] **Step 3: Add the helper + use it**
+
+At module top of `src/app/refresh-scheduler.ts`, add the import and the exported helper:
+
+```typescript
+import { isAlwaysOn } from '@/services/always-on';
+
+/** Hidden-window slowdown factor. Always-on disables the slowdown entirely. */
+export function hiddenMultiplier(isHidden: boolean, alwaysOn: boolean): number {
+  if (!isHidden || alwaysOn) return 1;
+  return 10;
+}
+```
+
+Then in `computeDelay` (inside `scheduleRefresh`), replace the inline `(isHidden ? HIDDEN_REFRESH_MULTIPLIER : 1)` with `hiddenMultiplier(isHidden, isAlwaysOn())`:
+
+```typescript
+    const computeDelay = (baseMs: number, isHidden: boolean) => {
+      const ghostMultiplier = getGhostRefreshMultiplier();
+      const adjusted = baseMs * ghostMultiplier * hiddenMultiplier(isHidden, isAlwaysOn());
+      const jitterRange = adjusted * JITTER_FRACTION;
+      // eslint-disable-next-line sonarjs/pseudo-random
+      const jittered = adjusted + (Math.random() * 2 - 1) * jitterRange;
+      return Math.max(MIN_REFRESH_MS, Math.round(jittered));
+    };
+```
+
+(The now-unused `HIDDEN_REFRESH_MULTIPLIER` const can stay or be removed; if eslint flags it as unused, remove it.)
+
+- [ ] **Step 4: Run test + typecheck**
+
+Run: `npx tsx --test src/app/__tests__/refresh-scheduler-throttle.test.mts && npm run typecheck:all`
+Expected: PASS; typecheck zero errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/refresh-scheduler.ts src/app/__tests__/refresh-scheduler-throttle.test.mts
+git commit -m "feat(always-on): skip hidden refresh throttle when always-on
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Wire on boot
+
+**Files:**
+- Modify: `src/main.ts` (after the Tauri bridge / desktop runtime is established)
+
+- [ ] **Step 1: Find the boot point**
+
+Open `src/main.ts` and locate where desktop runtime is detected / the app finishes bootstrapping (search for `isDesktopRuntime` or where panels mount). Add the import at the top:
+
+```typescript
+import { applyAlwaysOn } from '@/services/always-on';
+```
+
+- [ ] **Step 2: Apply on boot**
+
+After bootstrap completes (non-blocking), add:
+
+```typescript
+// Honor the 24/7 always-on setting once the bridge is ready (no-op off-desktop).
+void applyAlwaysOn();
+```
+
+- [ ] **Step 3: Typecheck + commit**
+
+```bash
+npm run typecheck:all
+git add src/main.ts
+git commit -m "feat(always-on): apply setting on boot
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Settings toggle
+
+**Files:**
+- Modify: `src/components/UnifiedSettings.ts`
+
+- [ ] **Step 1: Locate a settings section + the render pattern**
+
+Open `src/components/UnifiedSettings.ts`. Find an existing simple boolean/toggle control (search for `checkbox` or `type = 'checkbox'`) to copy its exact element-creation/handler pattern, and identify the container a new row should append to (e.g. a "General" section). Match that pattern; the snippet below uses plain DOM (no innerHTML) and should be adapted to the file's helpers if it has them (e.g. a `h()` util).
+
+- [ ] **Step 2: Add the toggle row**
+
+Add the import:
+
+```typescript
+import { isAlwaysOn, setAlwaysOn } from '@/services/always-on';
+```
+
+Build the row with safe DOM APIs (no innerHTML):
+
+```typescript
+const alwaysOnRow = document.createElement('label');
+alwaysOnRow.className = 'settings-row';
+
+const alwaysOnInput = document.createElement('input');
+alwaysOnInput.type = 'checkbox';
+alwaysOnInput.checked = isAlwaysOn();
+alwaysOnInput.addEventListener('change', () => { void setAlwaysOn(alwaysOnInput.checked); });
+
+const alwaysOnText = document.createElement('span');
+alwaysOnText.textContent = '24/7 background operation';
+const alwaysOnHint = document.createElement('small');
+alwaysOnHint.style.cssText = 'display:block;opacity:.6';
+alwaysOnHint.textContent = 'Keep the algorithms running at full speed when the window is hidden (macOS; uses more battery).';
+alwaysOnText.append(alwaysOnHint);
+
+alwaysOnRow.append(alwaysOnInput, alwaysOnText);
+// append alwaysOnRow to the chosen settings container element
+```
+
+- [ ] **Step 3: Typecheck + commit**
+
+```bash
+npm run typecheck:all
+git add src/components/UnifiedSettings.ts
+git commit -m "feat(always-on): settings toggle (default on)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Acceptance soak + fallback decision
+
+**Files:** none unless the soak fails (then implement the native-tick fallback per spec §4).
+
+- [ ] **Step 1: Build + install**
+
+```bash
+npm run desktop:build:full && node scripts/install-built-app.mjs --relaunch
+```
+
+- [ ] **Step 2: Hidden-window soak**
+
+Hide the Crystal Ball window (Cmd+H / bring another app to the foreground) and leave it ~35 min. Then check freshness:
+
+```bash
+LOGDIR="$HOME/Library/Logs/com.bradleybond.crystalball"
+PORT=$(cat "$LOGDIR/sidecar.port"); TOK=$(cat "$LOGDIR/sidecar.token")
+curl -fsS -H "Authorization: Bearer $TOK" "http://127.0.0.1:$PORT/api/analyst-state" \
+  | python3 -c "import sys,json;d=json.load(sys.stdin);print('stale:',d.get('stale'),'ageMs:',d.get('ageMs'))"
+```
+Expected: `stale: False`, `ageMs` < ~360000 (6 min). PASS → done.
+
+- [ ] **Step 3: If it FAILS (timers still throttled), implement native tick (spec §4)**
+
+In `main.rs`, on `set_always_on(true)` spawn a `std::thread` loop that, every 60s while held, calls `app_handle.emit("cb:tick", ())`; stop when released (check the guard each iteration). In `analyst-loop.ts` and `refresh-scheduler.ts`, listen via the Tauri event API (`onTauriEvent('cb:tick', …)`) to trigger a cycle. Re-run Step 2. (Build this ONLY if Step 2 fails.)
+
+- [ ] **Step 4: Push + PR**
+
+```bash
+git push -u origin claude/always-on-reasoning
+gh pr create --base main --head claude/always-on-reasoning \
+  --title "feat: always-on reasoning (24/7 hidden operation, macOS)" \
+  --body "Implements docs/superpowers/specs/2026-06-02-always-on-reasoning-design.md"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Prevent App Nap (NSProcessInfo activity, allow system sleep) → Task 1 (`begin_activity_macos`, options clear `IdleSystemSleepDisabled`). ✓
+- Un-throttle scheduler when hidden → Task 3 (`hiddenMultiplier`). ✓
+- Setting `cb-always-on` default true + module → Task 2. ✓
+- Boot wiring → Task 4. ✓
+- Settings toggle → Task 5. ✓
+- Fallback native tick (only if needed) → Task 6 Step 3. ✓
+- Acceptance soak (`ageMs` < ~6 min hidden) → Task 6 Step 2. ✓
+- macOS-only / no-op other OS → Task 1 `#[cfg(...)]`. ✓
+- Idempotent acquire/release → Task 1 (`held.is_none()` / `held.take()`). ✓
+
+**Placeholder scan:** Tasks 4 and 5 include a "locate the insertion point" discovery step because `src/main.ts` and `UnifiedSettings.ts` weren't read during planning; both still provide the exact code to insert. No TBD/TODO in code.
+
+**Type/name consistency:** `isAlwaysOn` / `setAlwaysOn` / `setAlwaysOnSetting` / `applyAlwaysOn` defined in Task 2 and used consistently in Tasks 3–5. `set_always_on`/`get_always_on` command names match between Rust (Task 1) and TS (`applyAlwaysOn`, Task 2). `hiddenMultiplier(isHidden, alwaysOn)` signature consistent between Task 3 test and impl.

--- a/docs/superpowers/specs/2026-06-02-always-on-reasoning-design.md
+++ b/docs/superpowers/specs/2026-06-02-always-on-reasoning-design.md
@@ -1,0 +1,75 @@
+# Always-On Reasoning (24/7 hidden operation) — Design
+
+**Date:** 2026-06-02
+**Status:** Approved (design); pending spec review
+**Approach:** B — prevent macOS App Nap + un-throttle the scheduler when hidden (keep all reasoning in the renderer; no sidecar refactor)
+
+## Problem
+
+The analyst/algorithm reasoning loops run in the Tauri renderer (WKWebView). When the window is hidden/backgrounded, macOS **App Naps** the process — all JS timers freeze. Observed: analyst state went **~10 h stale overnight** while the always-alive Node sidecar kept heartbeating. The result is a "24/7 intelligence monitor" that stops reasoning whenever it isn't the foreground window.
+
+## Goal
+
+Keep the reasoning layer (analyst loop + data-feed refresh) running at **full real-time cadence even while hidden**, on macOS. Always-on by default, with a user toggle to disable. Battery cost is accepted (managed via the toggle).
+
+## Why not move compute to the sidecar (A/C)
+
+The five core services (analyst-loop, situation-engine, anomaly-detection, mode-forecast, threat-synthesis) all persist via `localStorage` and dispatch `document` events. Moving them to Node requires porting off browser APIs, adding sqlite for state, and a websocket bridge to the renderer — 8–18 days and a permanent split-brain. macOS provides a native primitive that solves the freeze directly, so B is the right scope now. A/C remain a future option if Windows/Linux 24/7 parity is ever required.
+
+## Two distinct OS mechanisms
+
+A hidden WKWebView can be slowed by **two** independent things:
+1. **App Nap** — the OS suspends the whole process (this caused the 10 h stall).
+2. **Background timer throttling** — JS `setTimeout`/`setInterval` clamped even when the process runs.
+
+Killing App Nap is necessary; we then **verify** timers run at full rate, with a native-tick fallback (§4) if WKWebView still throttles them.
+
+## Architecture
+
+All changes are additive and gated on one setting; nothing changes when the feature is off.
+
+### 1. Native keep-awake (Rust — `src-tauri/src/main.rs`)
+- Hold an `NSProcessInfo.processInfo.beginActivityWithOptions:reason:` token.
+- Options: `NSActivityUserInitiated` (prevents App Nap + sudden termination) **without** `NSActivityIdleSystemSleepDisabled` — keep *our app* alive when hidden, but do **not** force the whole Mac to stay awake. Lid-close / system sleep behaves normally (nothing runs then, which is correct).
+- Two Tauri commands:
+  - `set_always_on(enabled: bool)` — if `enabled` and no token held, acquire and store it in app state; if `!enabled` and a token is held, `endActivity:` and drop it.
+  - `get_always_on() -> bool` — report current state (for UI sync).
+- macOS-only via `#[cfg(target_os = "macos")]`; on other targets both commands are no-ops returning the stored boolean so the renderer code path is identical.
+- Register the commands in the Tauri builder + `capabilities/default.json`.
+
+### 2. Scheduler un-throttle (`src/app/refresh-scheduler.ts`)
+- `computeDelay()` currently multiplies the base by `× 10` when `document.visibilityState === 'hidden'`.
+- When always-on is enabled, skip the hidden multiplier (and the visibility backoff) so data feeds keep their normal cadence while hidden. Ghost-mode multiplier still applies (ghost is a separate, intentional slowdown).
+- The analyst loop (`analyst-loop.ts`) already ignores the hidden multiplier, so once App Nap is gone it runs at its 5-min base with no change there.
+
+### 3. Setting + wiring
+- localStorage key `cb-always-on`, **default `true`** (treat missing as true).
+- A small module `src/services/always-on.ts` owns: read/write the setting, call `invokeTauri('set_always_on', …)` on boot and on change, and expose `isAlwaysOn()` for the scheduler.
+- Boot: read setting → call `set_always_on(value)` once the Tauri bridge is ready.
+- UI: a toggle in Settings (a "Background / 24-7 operation" row) bound to the setting; flipping it calls the module (live effect, no restart).
+
+### 4. Fallback — native tick (only if the soak shows throttling)
+- If §1+§2 don't fully restore hidden-window cadence (WKWebView still throttles timers), add a Rust-side `tokio`/thread interval that `app.emit("cb:tick", …)` every N seconds while always-on.
+- `analyst-loop.ts` and `refresh-scheduler.ts` would listen for `cb:tick` as an additional wake source (native timers aren't throttled). Built only if §5 proves it's needed; named here so it isn't a surprise.
+
+## Setting / state summary
+| Key | Default | Effect |
+|---|---|---|
+| `cb-always-on` (localStorage) | `true` | On boot + change → `set_always_on`; gates scheduler un-throttle |
+
+No new secret keys, no new feeds.
+
+## Error handling
+- `set_always_on` failures (bridge not ready, non-macOS) are caught and logged at WARN; the renderer keeps working at default cadence. Acquiring/releasing the activity is idempotent (guard on whether a token is already held).
+- Releasing a token that was never acquired is a no-op.
+
+## Testing / acceptance
+- **Rust:** unit-guard the acquire/release idempotency (no double-acquire, release-without-acquire safe).
+- **Renderer:** unit test `computeDelay()` — with always-on true, hidden no longer applies the ×10; with always-on false, current behavior preserved. Test `always-on.ts` setting read/write/default.
+- **Acceptance soak:** hide the window; over 30–60 min confirm via `/api/analyst-state` that `ageMs` stays < ~6 min and feed timestamps keep advancing. If they don't → implement §4 and re-run.
+
+## Out of scope
+- Moving reasoning compute to the sidecar (Approach A/C).
+- Windows/Linux keep-awake (commands no-op; revisit if needed).
+- Preventing system/display sleep (we intentionally allow the Mac to sleep).
+- Changing ghost-mode behavior.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -576,6 +576,98 @@ fn get_local_api_token(webview: Webview, state: tauri::State<'_, LocalApiState>)
  .ok_or_else(|| "Token not generated".to_string())
 }
 
+/// Holds the retained NSProcessInfo activity token (as a pointer-sized int so the
+/// state is Send+Sync). None when no activity is held.
+struct AlwaysOnGuard(std::sync::Mutex<Option<usize>>);
+
+#[cfg(target_os = "macos")]
+fn begin_activity_macos() -> Option<usize> {
+    use std::ffi::c_void;
+    extern "C" {
+        fn objc_getClass(name: *const u8) -> *mut c_void;
+        fn sel_registerName(name: *const u8) -> *mut c_void;
+        fn objc_msgSend(receiver: *mut c_void, sel: *mut c_void, ...) -> *mut c_void;
+    }
+    // NSActivityUserInitiated prevents App Nap; clear IdleSystemSleepDisabled so the
+    // Mac may still sleep normally (lid close). bit14=SuddenTermination, bit20=IdleSystemSleep.
+    const NS_SUDDEN_TERM_DISABLED: u64 = 1 << 14;
+    const NS_IDLE_SYSTEM_SLEEP_DISABLED: u64 = 1 << 20;
+    const NS_USER_INITIATED: u64 = 0x00FF_FFFF | NS_SUDDEN_TERM_DISABLED;
+    let options: u64 = NS_USER_INITIATED & !NS_IDLE_SYSTEM_SLEEP_DISABLED;
+    unsafe {
+        let pi_cls = objc_getClass(b"NSProcessInfo\0".as_ptr());
+        let str_cls = objc_getClass(b"NSString\0".as_ptr());
+        if pi_cls.is_null() || str_cls.is_null() {
+            return None;
+        }
+        let process_info = objc_msgSend(pi_cls, sel_registerName(b"processInfo\0".as_ptr()));
+        if process_info.is_null() {
+            return None;
+        }
+        let with_utf8 = sel_registerName(b"stringWithUTF8String:\0".as_ptr());
+        let reason_fn: unsafe extern "C" fn(*mut c_void, *mut c_void, *const u8) -> *mut c_void =
+            std::mem::transmute(objc_msgSend as *const ());
+        let reason = reason_fn(str_cls, with_utf8, b"Crystal Ball 24/7 monitoring\0".as_ptr());
+        let begin_sel = sel_registerName(b"beginActivityWithOptions:reason:\0".as_ptr());
+        let begin_fn: unsafe extern "C" fn(*mut c_void, *mut c_void, u64, *mut c_void) -> *mut c_void =
+            std::mem::transmute(objc_msgSend as *const ());
+        let token = begin_fn(process_info, begin_sel, options, reason);
+        if token.is_null() {
+            return None;
+        }
+        // retain so it survives past this scope
+        objc_msgSend(token, sel_registerName(b"retain\0".as_ptr()));
+        Some(token as usize)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn end_activity_macos(token: usize) {
+    use std::ffi::c_void;
+    extern "C" {
+        fn objc_getClass(name: *const u8) -> *mut c_void;
+        fn sel_registerName(name: *const u8) -> *mut c_void;
+        fn objc_msgSend(receiver: *mut c_void, sel: *mut c_void, ...) -> *mut c_void;
+    }
+    unsafe {
+        let pi_cls = objc_getClass(b"NSProcessInfo\0".as_ptr());
+        if pi_cls.is_null() {
+            return;
+        }
+        let process_info = objc_msgSend(pi_cls, sel_registerName(b"processInfo\0".as_ptr()));
+        let end_sel = sel_registerName(b"endActivity:\0".as_ptr());
+        let end_fn: unsafe extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> *mut c_void =
+            std::mem::transmute(objc_msgSend as *const ());
+        end_fn(process_info, end_sel, token as *mut c_void);
+        objc_msgSend(token as *mut c_void, sel_registerName(b"release\0".as_ptr()));
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn begin_activity_macos() -> Option<usize> {
+    None
+}
+#[cfg(not(target_os = "macos"))]
+fn end_activity_macos(_token: usize) {}
+
+#[tauri::command]
+fn set_always_on(state: tauri::State<AlwaysOnGuard>, enabled: bool) -> bool {
+    let mut held = state.0.lock().unwrap();
+    if enabled && held.is_none() {
+        *held = begin_activity_macos();
+    } else if !enabled {
+        if let Some(token) = held.take() {
+            end_activity_macos(token);
+        }
+    }
+    held.is_some()
+}
+
+#[tauri::command]
+fn get_always_on(state: tauri::State<AlwaysOnGuard>) -> bool {
+    state.0.lock().unwrap().is_some()
+}
+
 #[tauri::command]
 fn get_desktop_runtime_info(webview: Webview, state: tauri::State<'_, LocalApiState>) -> Result<DesktopRuntimeInfo, String> {
  require_trusted_window(webview.label())?;
@@ -2800,12 +2892,15 @@ fn main() {
  // Keeps the macOS Keychain off the main thread so the UI window
  // can render immediately on launch.
  .manage(SecretsCache::empty())
+ .manage(AlwaysOnGuard(std::sync::Mutex::new(None)))
  .plugin(tauri_plugin_biometry::init())
  .plugin(tauri_plugin_clipboard_manager::init())
  .plugin(corelocation::init())
  .invoke_handler(tauri::generate_handler![
  list_supported_secret_keys,
  get_secret,
+ set_always_on,
+ get_always_on,
  set_secret,
  delete_secret,
  get_local_api_token,

--- a/src/app/__tests__/refresh-scheduler-throttle.test.mts
+++ b/src/app/__tests__/refresh-scheduler-throttle.test.mts
@@ -1,0 +1,16 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { hiddenMultiplier } from '../refresh-scheduler.ts';
+
+describe('hiddenMultiplier', () => {
+  it('is 1 when not hidden', () => {
+    assert.equal(hiddenMultiplier(false, false), 1);
+    assert.equal(hiddenMultiplier(false, true), 1);
+  });
+  it('is 10 when hidden and always-on is OFF', () => {
+    assert.equal(hiddenMultiplier(true, false), 10);
+  });
+  it('is 1 when hidden but always-on is ON', () => {
+    assert.equal(hiddenMultiplier(true, true), 1);
+  });
+});

--- a/src/app/refresh-scheduler.ts
+++ b/src/app/refresh-scheduler.ts
@@ -1,5 +1,12 @@
 import type { AppContext, AppModule } from '@/app/app-context';
 import { getGhostRefreshMultiplier } from '@/services/mode-manager';
+import { isAlwaysOn } from '@/services/always-on';
+
+/** Hidden-window slowdown factor. Always-on disables the slowdown entirely. */
+export function hiddenMultiplier(isHidden: boolean, alwaysOn: boolean): number {
+  if (!isHidden || alwaysOn) return 1;
+  return 10;
+}
 
 export interface RefreshRegistration {
   name: string;
@@ -50,7 +57,6 @@ export class RefreshScheduler implements AppModule {
  intervalMs: number,
  condition?: () => boolean
   ): void {
- const HIDDEN_REFRESH_MULTIPLIER = 10;
  const JITTER_FRACTION = 0.1;
  const MIN_REFRESH_MS = 1000;
  // Max effective interval: intervalMs * 4 (backoff) * 10 (hidden) = 40x base
@@ -60,7 +66,7 @@ export class RefreshScheduler implements AppModule {
 
  const computeDelay = (baseMs: number, isHidden: boolean) => {
  const ghostMultiplier = getGhostRefreshMultiplier();
- const adjusted = baseMs * ghostMultiplier * (isHidden ? HIDDEN_REFRESH_MULTIPLIER : 1);
+ const adjusted = baseMs * ghostMultiplier * hiddenMultiplier(isHidden, isAlwaysOn());
  const jitterRange = adjusted * JITTER_FRACTION;
  // eslint-disable-next-line sonarjs/pseudo-random
  const jittered = adjusted + (Math.random() * 2 - 1) * jitterRange;
@@ -68,7 +74,7 @@ export class RefreshScheduler implements AppModule {
  };
  const scheduleNext = (delay: number) => {
  if (this.ctx.isDestroyed) return;
- const timeoutId = setTimeout(run, delay);
+ const timeoutId = setTimeout(() => { void run(); }, delay);
  this.refreshTimeoutIds.set(name, timeoutId);
  };
  const run = async () => {

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -3,6 +3,7 @@ import { PANEL_CATEGORY_MAP } from '@/config/panels';
 import { SITE_VARIANT } from '@/config/variant';
 import { LANGUAGES, changeLanguage, getCurrentLanguage, t } from '@/services/i18n';
 import { getAiFlowSettings, setAiFlowSetting, getStreamQuality, setStreamQuality, STREAM_QUALITY_OPTIONS } from '@/services/ai-flow-settings';
+import { isAlwaysOn, setAlwaysOn } from '@/services/always-on';
 import type { StreamQuality } from '@/services/ai-flow-settings';
 import { escapeHtml } from '@/utils/sanitize';
 import { trackLanguageChange } from '@/services/analytics';
@@ -400,6 +401,8 @@ export class UnifiedSettings {
  this.updateAiStatus();
  } else if (target.id === 'us-map-flash') {
  setAiFlowSetting('mapNewsFlash', target.checked);
+ } else if (target.id === 'us-always-on') {
+ void setAlwaysOn(target.checked);
  } else if (target.id === 'us-verbose-log') {
  void this._toggleVerboseLog(target.checked);
  } else if (target.id === 'us-fetch-debug') {
@@ -612,6 +615,10 @@ export class UnifiedSettings {
  // Map section
  html += `<div class="ai-flow-section-label">${t('components.insights.sectionMap')}</div>`;
  html += this.toggleRowHtml('us-map-flash', t('components.insights.mapFlashLabel'), t('components.insights.mapFlashDesc'), settings.mapNewsFlash);
+
+ // 24/7 operation section
+ html += `<div class="ai-flow-section-label">24/7 Operation</div>`;
+ html += this.toggleRowHtml('us-always-on', '24/7 background operation', 'Keep the algorithms running at full speed when the window is hidden (macOS; uses more battery).', isAlwaysOn());
 
  // AI Analysis section (web-only)
  if (!this.config.isDesktopApp) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -270,6 +270,9 @@ loadDesktopSecrets().then(async () => {
   trackApiKeysSnapshot();
 }).catch(() => {});
 
+// Honor the 24/7 always-on setting once the bridge is ready (no-op off-desktop).
+void import('@/services/always-on').then(({ applyAlwaysOn }) => applyAlwaysOn()).catch(() => {});
+
 // Apply stored theme preference before app initialization (safety net for inline script)
 applyStoredTheme();
 

--- a/src/services/__tests__/always-on.test.mts
+++ b/src/services/__tests__/always-on.test.mts
@@ -1,0 +1,31 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Minimal localStorage shim for Node test
+const store = new Map<string, string>();
+(globalThis as unknown as { localStorage: Storage }).localStorage = {
+  getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+  setItem: (k: string, v: string) => { store.set(k, v); },
+  removeItem: (k: string) => { store.delete(k); },
+  clear: () => store.clear(),
+  key: () => null,
+  length: 0,
+} as Storage;
+
+const { isAlwaysOn, setAlwaysOnSetting } = await import('../always-on.ts');
+
+describe('always-on setting', () => {
+  beforeEach(() => store.clear());
+  it('defaults to true when unset', () => {
+    assert.equal(isAlwaysOn(), true);
+  });
+  it('returns false when explicitly disabled', () => {
+    setAlwaysOnSetting(false);
+    assert.equal(isAlwaysOn(), false);
+  });
+  it('returns true when re-enabled', () => {
+    setAlwaysOnSetting(false);
+    setAlwaysOnSetting(true);
+    assert.equal(isAlwaysOn(), true);
+  });
+});

--- a/src/services/always-on.ts
+++ b/src/services/always-on.ts
@@ -1,0 +1,36 @@
+// 24/7 always-on operation: keep the reasoning + refresh loops running at full
+// cadence even when the window is hidden (macOS, via the native set_always_on
+// command). Default ON; user-disableable. See
+// docs/superpowers/specs/2026-06-02-always-on-reasoning-design.md.
+
+import { tryInvokeTauri } from './tauri-bridge';
+
+const KEY = 'cb-always-on';
+
+/** Default ON: a missing/blank setting means always-on. */
+export function isAlwaysOn(): boolean {
+  try {
+    return localStorage.getItem(KEY) !== 'false';
+  } catch {
+    return true;
+  }
+}
+
+export function setAlwaysOnSetting(enabled: boolean): void {
+  try {
+    localStorage.setItem(KEY, enabled ? 'true' : 'false');
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Push the current (or given) setting to the native layer. Safe off-desktop. */
+export async function applyAlwaysOn(enabled: boolean = isAlwaysOn()): Promise<void> {
+  await tryInvokeTauri('set_always_on', { enabled });
+}
+
+/** Persist + apply in one call (for the settings toggle). */
+export async function setAlwaysOn(enabled: boolean): Promise<void> {
+  setAlwaysOnSetting(enabled);
+  await applyAlwaysOn(enabled);
+}


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-06-02-always-on-reasoning-design.md`.

## Problem
The analyst/algorithm loops run in the renderer (WKWebView). macOS App Naps the hidden window → all timers freeze. Observed: analyst state went **~10 h stale overnight** while the Node sidecar stayed alive.

## Fix (Approach B — keep reasoning in the renderer)
- **Rust** `set_always_on`/`get_always_on` hold an `NSProcessInfo` user-initiated activity token (prevents App Nap) **without** `IdleSystemSleepDisabled` — the Mac may still sleep normally. macOS-only; no-op elsewhere. (Raw objc FFI, same pattern as `get_native_location_impl`.)
- **`always-on.ts`** owns the `cb-always-on` setting (default **on**), applies it to the native layer on boot + change.
- **refresh-scheduler** skips its hidden×10 throttle when always-on (`hiddenMultiplier`).
- **Settings → General** gains a "24/7 background operation" toggle.

## Verification
- `cargo check` clean; `npm run typecheck:all` clean; eslint clean; 6 unit tests (3 setting + 3 multiplier).
- **Acceptance soak:** built + installed, hidden-window for 20 min → analyst state stayed **2.6 min** fresh (was 10 h stale). PASS — no native-tick fallback needed.

## Out of scope
Moving compute to the sidecar (A/C); Windows/Linux keep-awake (no-op); preventing system/display sleep.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>