### PR TITLE
fix(intel-generate): zero-config local LLM (auto-probe Ollama + resolve model)

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -4610,20 +4610,36 @@ async function handleIntelGenerate(req, res, context) {
   // honor it; otherwise auto-probe the two common local backends — Ollama
   // (11434) first per the analyst layer's "prefers Ollama" default, then LM
   // Studio (1234). Both expose an OpenAI-compatible /v1/chat/completions.
-  const rawModel = process.env.OLLAMA_MODEL || 'local-model';
-  const localModel = /^[a-zA-Z0-9._:/-]{1,80}$/.test(rawModel) ? rawModel : 'local-model';
+  const rawModel = process.env.OLLAMA_MODEL || '';
+  const configuredModel = /^[a-zA-Z0-9._:/-]{1,80}$/.test(rawModel) ? rawModel : '';
   const localBases = process.env.OLLAMA_API_URL
     ? [process.env.OLLAMA_API_URL]
     : ['http://127.0.0.1:11434', 'http://127.0.0.1:1234'];
-  const localUrls = localBases
-    .map((base) => { try { return new URL('/v1/chat/completions', base).toString(); } catch { return null; } })
-    .filter(Boolean);
+
+  // Resolve a usable model id for a backend. Ollama rejects unknown names
+  // (e.g. the LM Studio placeholder), so when OLLAMA_MODEL is unset we ask the
+  // backend which models it actually has via the OpenAI-compatible /v1/models.
+  const resolveLocalModel = async (base) => {
+    if (configuredModel) return configuredModel;
+    try {
+      const r = await fetch(new URL('/v1/models', base).toString(), { signal: AbortSignal.timeout(5000) });
+      if (r.ok) {
+        const j = await r.json();
+        const id = Array.isArray(j?.data) && j.data[0] && typeof j.data[0].id === 'string' ? j.data[0].id : '';
+        if (id) return id;
+      }
+    } catch { /* fall through */ }
+    return 'local-model';
+  };
 
   let response, model;
-  for (const localUrl of localUrls) {
+  for (const base of localBases) {
+    let localUrl;
+    try { localUrl = new URL('/v1/chat/completions', base).toString(); } catch { continue; }
     try {
-      response = await callChatCompletion(localUrl, localModel, messages, maxTokens, temperature, null, 60_000);
-      model = localModel;
+      const m = await resolveLocalModel(base);
+      response = await callChatCompletion(localUrl, m, messages, maxTokens, temperature, null, 60_000);
+      model = m;
       break;
     } catch (localError) {
       context.logger.warn(`[intel-generate] local failed (${localUrl}):`, localError.message);

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -4626,7 +4626,8 @@ async function handleIntelGenerate(req, res, context) {
       if (r.ok) {
         const j = await r.json();
         const id = Array.isArray(j?.data) && j.data[0] && typeof j.data[0].id === 'string' ? j.data[0].id : '';
-        if (id) return id;
+        // Apply the same sanitizer as OLLAMA_MODEL before trusting a backend-supplied id.
+        if (id && /^[a-zA-Z0-9._:/-]{1,80}$/.test(id)) return id;
       }
     } catch { /* fall through */ }
     return 'local-model';

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -4606,20 +4606,27 @@ async function handleIntelGenerate(req, res, context) {
 
   const messages = [{ role: 'system', content: system }, { role: 'user', content: prompt }];
 
-  // Try local Ollama first, fall back to Groq
-  const baseUrl = process.env.OLLAMA_API_URL || 'http://localhost:1234';
+  // Try local LLM first, fall back to Groq. When OLLAMA_API_URL is configured we
+  // honor it; otherwise auto-probe the two common local backends — Ollama
+  // (11434) first per the analyst layer's "prefers Ollama" default, then LM
+  // Studio (1234). Both expose an OpenAI-compatible /v1/chat/completions.
   const rawModel = process.env.OLLAMA_MODEL || 'local-model';
   const localModel = /^[a-zA-Z0-9._:/-]{1,80}$/.test(rawModel) ? rawModel : 'local-model';
-  let localUrl;
-  try { localUrl = new URL('/v1/chat/completions', baseUrl).toString(); } catch { /* invalid URL */ }
+  const localBases = process.env.OLLAMA_API_URL
+    ? [process.env.OLLAMA_API_URL]
+    : ['http://127.0.0.1:11434', 'http://127.0.0.1:1234'];
+  const localUrls = localBases
+    .map((base) => { try { return new URL('/v1/chat/completions', base).toString(); } catch { return null; } })
+    .filter(Boolean);
 
   let response, model;
-  if (localUrl) {
+  for (const localUrl of localUrls) {
     try {
       response = await callChatCompletion(localUrl, localModel, messages, maxTokens, temperature, null, 60_000);
       model = localModel;
+      break;
     } catch (localError) {
-      context.logger.warn('[intel-generate] local failed:', localError.message);
+      context.logger.warn(`[intel-generate] local failed (${localUrl}):`, localError.message);
     }
   }
 


### PR DESCRIPTION
## Problem
Local LLM enrichment was dead for Ollama users: the sidecar's `intel-generate` defaulted to `http://localhost:1234` (LM Studio) and the model to `local-model`. With Ollama running on :11434, every call got `ECONNREFUSED` (wrong port) — and once the port was right, Ollama `404`d the `local-model` placeholder. Net effect: `aiEnriched: false`, `hypotheses: 0`, summarization "all providers failed".

## Fix (zero-config)
- When `OLLAMA_API_URL` is unset, auto-probe `http://127.0.0.1:11434` (Ollama, the documented-preferred backend) then `:1234` (LM Studio). Both expose OpenAI-compatible `/v1/chat/completions`.
- When `OLLAMA_MODEL` is unset, resolve the real model id from the backend's `/v1/models` (Ollama rejects unknown names; LM Studio is lenient). Falls back to the prior placeholder.
- Honors explicit `OLLAMA_API_URL` / `OLLAMA_MODEL` when set.

## Verified live
Built, installed, and POSTed to the running sidecar:
`{"response":"PIPELINE OK","model":"llama3.2:3b"}` — auto-resolved the model and reached Ollama with no config.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---
Cross-agent review: codex reviewed on 2026-06-02; outcome: pass (one nit — sanitize /v1/models-resolved model id — fixed in 37d39dfc). SSRF posture clean, fallback logic correct, no regressions. Live-verified: {"response":"PIPELINE OK","model":"llama3.2:3b"}.