### PR TITLE
fix(build): stable local signing identity to stop keychain/location re-prompts on rebuild

### DIFF
--- a/scripts/desktop-package.mjs
+++ b/scripts/desktop-package.mjs
@@ -230,9 +230,33 @@ if (targetOs === 'macos') {
   const dmgPath = path.join(dmgDir, `${variantProductName}_${bundleVersion}_${archSuffix}.dmg`);
   ensureModernMacLaunchServicesPlist(appPath, !sign);
 
-  try {
+  // A stable local signing identity (a self-signed code-signing cert the
+  // developer creates once) keeps the app's designated requirement constant
+  // across rebuilds. macOS keys keychain ACLs and Location Services (TCC) grants
+  // off that requirement, so signing every local build with the same identity
+  // means "Always Allow" / location are granted ONCE and persist — instead of
+  // re-prompting after every rebuild like an ad-hoc signature does (each ad-hoc
+  // build gets a new cdhash, which resets both). Applied to ALL local builds
+  // (not just when tauri's signature fails verification) so the identity is
+  // never silently skipped.
+  const stableIdentity = (process.env.CRYSTALBALL_SIGN_IDENTITY || '').trim();
+  if (stableIdentity && !sign) {
+ const entitlementsPath = path.join('src-tauri', 'Entitlements.plist');
+ const hasEntitlements = existsSync(entitlementsPath);
+ console.log(`[desktop-package] Re-signing macOS app bundle with stable identity "${stableIdentity}" (CRYSTALBALL_SIGN_IDENTITY) — keychain/location grants persist across rebuilds`);
+ run('codesign', [
+ '--force',
+ '--deep',
+ '--sign',
+ stableIdentity,
+ ...(hasEntitlements ? ['--entitlements', entitlementsPath] : []),
+ appPath,
+ ]);
  verifyMacCodeSignature(appPath, 'App bundle');
-  } catch (error) {
+  } else {
+ try {
+ verifyMacCodeSignature(appPath, 'App bundle');
+ } catch (error) {
  if (sign) {
  console.error(`[desktop-package] Signed app bundle failed verification: ${error.message}`);
  process.exit(1);
@@ -254,6 +278,7 @@ if (targetOs === 'macos') {
  appPath,
  ]);
  verifyMacCodeSignature(appPath, 'App bundle');
+ }
   }
 
   if (appOnly) {


### PR DESCRIPTION
## Summary
Every local rebuild re-signs the app ad-hoc with a new code signature (cdhash). macOS keys keychain ACLs and Location Services (TCC) grants off the app's designated requirement, so each ad-hoc rebuild **resets both** — forcing the user to re-grant "Always Allow" and location on every build.

This adds support for a **stable self-signed signing identity**: when `CRYSTALBALL_SIGN_IDENTITY` is set, local builds (`sign` off) are signed with that identity instead of ad-hoc. The designated requirement stays constant across rebuilds, so the user grants keychain + location **once** and both persist across all future rebuilds.

- Applied to all local builds (before the verify/catch), so the identity is never silently skipped.
- `--sign` (real Apple signing) path is unchanged (`stableIdentity && !sign`).
- Env var unset → unchanged ad-hoc behavior; the ad-hoc codesign literal is preserved in the fallback (regression test passes).

## Developer setup (one-time)
Create a self-signed **Code Signing** cert named e.g. `Crystal Ball Dev` (Keychain Access → Certificate Assistant → Create a Certificate → Self-Signed Root / Code Signing), then:
```
export CRYSTALBALL_SIGN_IDENTITY="Crystal Ball Dev"
npm run desktop:build:full
```
Grant keychain "Always Allow" + location once on first launch; they persist thereafter.

## Dropped: keychain skip-when-empty (Part 2b)
A second mitigation (skip the keychain vault read when a marker says 0 keys) was prototyped but **dropped** after cross-agent review flagged key-loss-class risks: a timed-out vault read would write a `0` marker and skip the keychain forever (hiding real keys), plus a startup/save race and a restore/vault interaction. Not worth the risk given Part 1 already makes grants persist.

## Verification
- `node --test tests/desktop-package-signing.test.mjs` → pass
- `node --check scripts/desktop-package.mjs` → ok

Cross-agent review: Codex reviewed on 2026-06-02; outcome: pass. Flagged that the identity initially only applied in the verify-failure path (fixed: now applies to all local builds) and that the prototyped keychain marker was unsafe (dropped). Final diff: signing-only change, ad-hoc fallback preserved, real Apple signing unaffected.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>