### PR TITLE
fix(keychain): log the actual timeout (15s vault / 3s per-key), not a hardcoded 3s

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -273,7 +273,7 @@ impl SecretsCache {
  // No vault entry yet — fall through to migration.
  }
  Err(()) => {
- log_keychain_timeout(app, "secrets-vault");
+ log_keychain_timeout(app, "secrets-vault", KEYCHAIN_VAULT_TIMEOUT);
  // Vault unreachable → still try migration; if every per-key
  // read also times out, we end up with an empty map and the
  // sidecar boots without secrets. Caller logs the count.
@@ -297,7 +297,7 @@ impl SecretsCache {
  }
  Ok(None) => { /* not present; skip silently */ }
  Err(()) => {
- log_keychain_timeout(app, key);
+ log_keychain_timeout(app, key, KEYCHAIN_PER_CALL_TIMEOUT);
  // continue — other keys may still respond
  }
  }
@@ -343,8 +343,8 @@ impl SecretsCache {
 /// Standalone helper so callers can log keychain timeouts without
 /// needing access to `SecretsCache` internals (the desktop-log
 /// helper requires an `AppHandle`, which tests don't have).
-fn log_keychain_timeout(app: Option<&AppHandle>, key: &str) {
- let secs = KEYCHAIN_PER_CALL_TIMEOUT.as_secs();
+fn log_keychain_timeout(app: Option<&AppHandle>, key: &str, timeout: Duration) {
+ let secs = timeout.as_secs();
  let msg = format!("Keychain entry '{key}' timed out after {secs}s — skipping");
  match app {
  Some(handle) => append_desktop_log(handle, "WARN", &msg),


### PR DESCRIPTION
## Summary
`log_keychain_timeout` hardcoded `KEYCHAIN_PER_CALL_TIMEOUT` (3s) in its message, so a `secrets-vault` read that actually waited `KEYCHAIN_VAULT_TIMEOUT` (15s) still logged "timed out after 3s". This is cosmetic but actively misled a live log audit (made the 15s vault fix look unapplied). Now the function takes the timeout and reports it: vault → 15s, per-key → 3s.

## Verification
- `cargo check` → 0 errors
- Both call sites updated; no other callers (rg-confirmed)

Cross-agent review: Codex reviewed on 2026-06-02; outcome: pass. No findings; 4-line change, behavior otherwise unchanged.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>