### PR TITLE
chore(sidecar): throttle expected unauthorized-request log noise

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -119,13 +119,26 @@ const SIDECAR_BUILD_TAG = process.env.WM_BUILD_TAG || `node-${process.versions.n
 // relaunch) produce expected unauthorized bursts: the long-lived renderer sends
 // one request with a stale/absent token, gets 401, then retries with a fresh
 // token. The 401 response is the enforcement; logging every racing request at
-// WARN floods the log and buries real signals. Log each pathname once so a
-// genuinely new unauthorized path still surfaces, then suppress repeats.
-const _seenUnauthPaths = new Set();
+// WARN floods the log and buries real signals.
+//
+// Throttle on a fixed time window (not per-pathname): the pathname is
+// client-controlled, so keying suppression on it would let an unauthenticated
+// caller grow unbounded state and bypass the throttle with unique paths. A
+// single global window keeps bounded state and collapses bursts; the
+// suppressed-count preserves visibility into volume.
+const UNAUTH_WARN_WINDOW_MS = 60_000;
+let _lastUnauthWarnAt = 0;
+let _suppressedUnauthCount = 0;
 function warnUnauthorizedOnce(context, pathname) {
-  if (_seenUnauthPaths.has(pathname)) return;
-  _seenUnauthPaths.add(pathname);
-  context.logger.warn(`[local-api] unauthorized request to ${pathname} (token race at startup/rotation; repeats for this path suppressed)`);
+  const now = Date.now();
+  if (now - _lastUnauthWarnAt < UNAUTH_WARN_WINDOW_MS) {
+    _suppressedUnauthCount++;
+    return;
+  }
+  const extra = _suppressedUnauthCount > 0 ? ` (+${_suppressedUnauthCount} more suppressed in last window)` : '';
+  _suppressedUnauthCount = 0;
+  _lastUnauthWarnAt = now;
+  context.logger.warn(`[local-api] unauthorized request to ${pathname} (token race at startup/rotation)${extra}`);
 }
 const SIDECAR_START_MS = Date.now();
 const wmHostStats = new Map(); // host → { ok, fail, lastStatus, lastOkAt, lastFailAt, lastError }

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -114,6 +114,19 @@ const AisWebSocket = WebSocket;
 // when anything happened or which stream produced it.
 const SIDECAR_TRACE = process.env.WM_TRACE === '1';
 const SIDECAR_BUILD_TAG = process.env.WM_BUILD_TAG || `node-${process.versions.node}`;
+
+// Token races at startup and after the sidecar rotates its token (e.g. a rebuild
+// relaunch) produce expected unauthorized bursts: the long-lived renderer sends
+// one request with a stale/absent token, gets 401, then retries with a fresh
+// token. The 401 response is the enforcement; logging every racing request at
+// WARN floods the log and buries real signals. Log each pathname once so a
+// genuinely new unauthorized path still surfaces, then suppress repeats.
+const _seenUnauthPaths = new Set();
+function warnUnauthorizedOnce(context, pathname) {
+  if (_seenUnauthPaths.has(pathname)) return;
+  _seenUnauthPaths.add(pathname);
+  context.logger.warn(`[local-api] unauthorized request to ${pathname} (token race at startup/rotation; repeats for this path suppressed)`);
+}
 const SIDECAR_START_MS = Date.now();
 const wmHostStats = new Map(); // host → { ok, fail, lastStatus, lastOkAt, lastFailAt, lastError }
 const WM_HOST_STATS_CAP = 100;
@@ -4923,7 +4936,7 @@ async function dispatch(requestUrl, req, routes, context) {
   {
  const authHeader = req.headers.authorization || '';
  if (!isValidToken(authHeader)) {
- context.logger.warn(`[local-api] unauthorized request to ${requestUrl.pathname}`);
+ warnUnauthorizedOnce(context, requestUrl.pathname);
  return json({ error: 'Unauthorized' }, 401);
  }
   }
@@ -15461,7 +15474,7 @@ export async function createLocalApiServer(options = {}) {
  {
  const authHeader = req.headers['authorization'] || '';
  if (!isValidToken(authHeader)) {
- context.logger.warn(`[local-api] unauthorized request to ${requestUrl.pathname}`);
+ warnUnauthorizedOnce(context, requestUrl.pathname);
  res.writeHead(401, { 'content-type': 'application/json' });
  res.end(JSON.stringify({ error: 'Unauthorized' }));
  return;


### PR DESCRIPTION
The sidecar logged a WARN for every unauthorized `/api/*` request. In practice these are **expected token races** — at startup (token not generated yet) and after the sidecar rotates its token on a rebuild-relaunch, the long-lived renderer sends one request with a stale/absent token, gets 401, then retries with a fresh token (the interceptor's built-in retry). The 401 *response* is the enforcement; the log just floods (observed ~hundreds/session in synchronized bursts) and buries real signals.

Fix: log each unauthorized pathname **once**, then suppress repeats — a genuinely new unauthorized path still surfaces, the burst noise is gone. No change to auth enforcement (still 401s).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---
Cross-agent review: codex reviewed on 2026-06-03; outcome: pass (initial FAIL — per-pathname Set was attacker-growable — fixed via bounded 60s time-window throttle; re-reviewed PASS). 401 enforcement unchanged.