### PR TITLE
fix(keychain): widen vault-read timeout 15s → 120s for the ACL prompt

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -176,14 +176,14 @@ struct PersistentCache {
 /// timeout lets the sidecar boot anyway.
 const KEYCHAIN_PER_CALL_TIMEOUT: Duration = Duration::from_secs(3);
 
-/// The consolidated `secrets-vault` read can surface a one-time macOS "Always
-/// Allow" ACL dialog after a re-signed build (the signature changes, so the
-/// keychain no longer trusts the app). 3s is too short for a human to answer
-/// that dialog — the read times out, every API key is dropped, and the app
-/// boots with no data. This load runs async on a worker thread (the UI window
-/// is already up), so a longer wait is safe. The per-key fallback below keeps
-/// the short timeout so a genuinely-failed vault doesn't stack 40+ prompts.
-const KEYCHAIN_VAULT_TIMEOUT: Duration = Duration::from_secs(15);
+/// The consolidated `secrets-vault` read surfaces a macOS "Always Allow" ACL
+/// dialog after every re-signed build. macOS Keychain ACL tracks applications
+/// by CDHash (per-binary), so each new build requires one "Always Allow" click.
+/// The previous 15s window was too narrow — the user often missed it, timing
+/// out every API key. 120s gives a full 2-minute window to click the prompt.
+/// The per-key fallback keeps its short timeout so a failed vault doesn't
+/// stack 40+ prompts. The load runs on a worker thread (UI is already up).
+const KEYCHAIN_VAULT_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Run a single keychain `get_password()` call on a worker thread
 /// and wait at most `timeout` for the answer. Returns:


### PR DESCRIPTION
## Root cause (finally confirmed)

macOS Keychain ACL tracks apps by **CDHash** (per-binary), not by certificate or designated requirement. Every local rebuild produces a new CDHash, so macOS re-prompts on the first read after each rebuild. The \"stable signing identity\" approach (PR #977) correctly fixes Location TCC (which uses the DR) but **cannot** fix keychain ACL (which uses CDHash) — those are two different subsystems.

## Fix

Widen `KEYCHAIN_VAULT_TIMEOUT` from 15s → **120s**. 15s was too narrow: the keychain prompt appears at startup, the user may not see it immediately, and by the time they click \"Always Allow\" the read had already timed out, dropping all API keys. 120s gives a 2-minute window — enough time to notice and click the prompt.

`KEYCHAIN_PER_CALL_TIMEOUT` stays at 3s so a genuinely missing vault doesn't stack 40+ prompts.

## Behaviour after this fix
- First launch after a new build: macOS prompts once. User has 2 minutes to click \"Always Allow\".
- All subsequent launches of the **same build**: no prompt, keys load silently.
- Next rebuild: one more \"Always Allow\" click, then silent again.

This is the correct behaviour given macOS's CDHash-based keychain ACL design without a Developer ID or App Store signing identity.

Cross-agent review: Codex reviewed on 2026-06-03; outcome: pass. Constant+comment-only Rust change; per-key timeout unaffected; no API or type-shape impact.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>