### PR TITLE
fix(drag): register EEW status bar as a window drag zone

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -2387,6 +2387,13 @@ export class PanelLayoutManager implements AppModule {
  // Content toolbar — skip interactive children (region select, search btn)
  attachDrag(document.querySelector('.mac-content-toolbar'));
 
+ // EEW Status Bar — position:fixed; top:0; z-index:9000 sits on top of the
+ // content toolbar and intercepts all mousedown events, blocking drag when a
+ // flare/seismic alert is active. Add the same handler so dragging from the
+ // bar still works (interactive children like expand/dismiss are still excluded
+ // via NO_DRAG_SELECTOR).
+ attachDrag(document.querySelector('.eew-status-bar'));
+
  // Sidebar drag zone — empty div, all clicks are drag
  attachDrag(document.querySelector('.mac-sidebar-drag'), true);
   }


### PR DESCRIPTION
**Bug:** When a space weather or seismic alert is active (e.g. the X-Class flare banner currently showing), the app window becomes undraggable.

**Root cause:** `EEWStatusBar` is `position: fixed; top: 0; z-index: 9000` — when it's showing an alert, it visually occupies the entire top strip of the window. Because it's a fixed overlay (not a child of `.mac-content-toolbar`), mousedown events on it don't bubble to the `.mac-content-toolbar` drag handler. The drag handler never fires; the window is stuck.

**Fix:** One call to `attachDrag('.eew-status-bar')` in `_setupWindowDragRegions()`. The same interactive-child exclusion (`button, select, input, a, label, [role='button/option']`) applies, so clicking 'expand' or 'dismiss' on the banner still works normally — only mousedown on the non-interactive portions of the bar initiates a drag.

Cross-agent review: claude reviewed on 2026-06-03; outcome: pass