### PR TITLE
fix: GDACS route alias + FinancialContagionPanel spurious error log

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -949,6 +949,7 @@ const ROUTE_ALIASES = {
   '/api/firms': '/api/nasa-firms',
   '/api/wildfire/hotspots': '/api/nasa-firms',
   '/api/opensanctions': '/api/opensanctions-recent',
+  '/api/gdacs-alerts': '/api/disasters/gdacs',
 };
 
 // ── IP geolocation helpers ────────────────────────────────────────────────

--- a/src/components/FinancialContagionPanel.ts
+++ b/src/components/FinancialContagionPanel.ts
@@ -36,7 +36,12 @@ export class FinancialContagionPanel extends Panel {
  } catch (error) {
  const delay = DELAYS[attempt];
  if (delay === undefined) {
- console.error('[FinancialContagionPanel] load error:', error);
+ const msg = error instanceof Error ? error.message : String(error);
+ if (/unavailable/i.test(msg)) {
+  console.warn(`[FEED] [FinancialContagionPanel] ${msg}`);
+ } else {
+  console.error('[FinancialContagionPanel] load error:', error);
+ }
  this.showError('Contagion data unavailable');
  return;
  }


### PR DESCRIPTION
Two small log-noise fixes found in a log audit of the running app.

**GDACS alias:** `/api/gdacs-alerts → no local handler` was appearing in sidecar logs. The handler exists at `/api/disasters/gdacs`; added the alias to `ROUTE_ALIASES` so the path resolves.

**FinancialContagionPanel:** `loadWithRetry()`'s final failure path used `console.error` unconditionally, logging "Economic stress data unavailable" as an app error. The `load()` method already routes `/unavailable/i` messages to `console.warn([FEED])`; made `loadWithRetry()` consistent.

Cross-agent review: Codex reviewed on 2026-06-04; outcome: pass. Alias rewrite preserves cache/degraded behavior; logging change matches existing load() pattern.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>