### PR TITLE
test(shortage): fix stale full-set commodity count (8 → 12)

### DIFF
--- a/src/services/shortage/__tests__/shortage-ui.test.mts
+++ b/src/services/shortage/__tests__/shortage-ui.test.mts
@@ -54,13 +54,14 @@ test('riskLevelFor: score 100 → CRITICAL', () => {
 
 // ── ALL_FULLSET_COMMODITIES ───────────────────────────────────────────────
 
-test('ALL_FULLSET_COMMODITIES has exactly 8 entries', () => {
-  assert.equal(ALL_FULLSET_COMMODITIES.length, 8);
+test('ALL_FULLSET_COMMODITIES has exactly 12 entries', () => {
+  assert.equal(ALL_FULLSET_COMMODITIES.length, 12);
 });
 
-test('ALL_FULLSET_COMMODITIES includes all 8 required commodities', () => {
+test('ALL_FULLSET_COMMODITIES includes all 12 required commodities', () => {
   const required: FullSetCommodity[] = [
     'wheat', 'corn', 'rice', 'soybeans', 'diesel', 'gasoline', 'natural-gas', 'jet-fuel',
+    'fertilizer', 'crude', 'propane', 'electricity',
   ];
   for (const c of required) {
     assert.ok(ALL_FULLSET_COMMODITIES.includes(c), `missing: ${c}`);
@@ -69,10 +70,10 @@ test('ALL_FULLSET_COMMODITIES includes all 8 required commodities', () => {
 
 // ── computeShortageFullSet — basic contract ───────────────────────────────
 
-test('computeShortageFullSet returns 8 entries with empty inputs', () => {
+test('computeShortageFullSet returns one entry per commodity with empty inputs', () => {
   _resetTrendMemory();
   const entries = computeShortageFullSet({}, { now: NOW });
-  assert.equal(entries.length, 8);
+  assert.equal(entries.length, ALL_FULLSET_COMMODITIES.length);
 });
 
 test('each entry has commodity, riskScore, riskLevel, primaryDrivers, timeToImpact, trend', () => {


### PR DESCRIPTION
`ALL_FULLSET_COMMODITIES` grew from 8 to 12 (added fertilizer, crude, propane, electricity) but `shortage-ui.test.mts` still asserted exactly 8 — 2 failing tests. Implementation is correct; updated the assertions to 12 and tied the `computeShortageFullSet` count to `ALL_FULLSET_COMMODITIES.length` so it stays in sync.

Verified: `npm run test:shortage` → 175 pass / 0 fail.

Cross-agent review: trivial test-data update, no production code touched.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>