### PR TITLE
feat: self-improvement gameplan + B1 (wire big-event-detector into evaluation ledger)

### DIFF
--- a/docs/superpowers/plans/2026-06-06-self-improvement-and-data-expansion.md
+++ b/docs/superpowers/plans/2026-06-06-self-improvement-and-data-expansion.md
@@ -6,10 +6,12 @@
 
 ## CURRENT STATE / NEXT STEP  *(update this every session)*
 
-- **Status:** Workstream B started.
-- **Last landed:** Gameplan committed (2026-06-06).
-- **Next step:** **B1** — wire `recordAlgorithmEvaluation` / `recordAlgorithmOutcome` into the existing grading paths so the evaluation ledger starts filling.
-- **Blocked on:** nothing.
+- **Status:** Workstream B in progress — B1 pattern proven.
+- **Last landed:** B1 canonical wiring — `big-event-detector` instrumented at `data-loader.ts:1468` with `recordAlgorithmEvaluation` (guarded; records score/label/latency to the ledger). typecheck 0.
+- **Next step:** **B1 (continue)** — replicate the same guarded `recordAlgorithmEvaluation(<id>, {durationMs, score, label, detail})` pattern at the live call sites of the other registered algorithms to reach ≥3 (target: all 21). Then **B1b**.
+- **Recipe (mechanical — fine on Sonnet):** for each registered algo id (see `algorithm-registry.ts`, 21 ids), find its live call site, time it, and call `recordAlgorithmEvaluation(id, {...})` in a `try/catch`. Pattern reference: `data-loader.ts` big-event-detector block.
+- **B1b (outcome path):** the outcome side already exists — `outcome-resolver.ts` exports `resolvePendingViaLlm(...)` + `pickEligibleForLlmGrading(...)`, and `llm-grader.ts` is real. They are NOT invoked anywhere. Wire `resolvePendingViaLlm` into the scheduler (B2) using `llm-adapter.generateText` as the injected LLM fn so pending evals get graded into fixtures.
+- **Blocked on:** nothing. B2 (run tuner) requires B1 + B1b first (tuner needs *graded* fixtures, not just evals).
 
 ---
 
@@ -78,4 +80,5 @@ The tuner auto-applies any parameter adjustment that clears all safety gates, an
 
 ## Progress log
 
-- 2026-06-06 — Gameplan created and committed. Discovered the tuning loop is fully built but unwired; locked auto-apply-safe autonomy. Starting B1.
+- 2026-06-06 — Gameplan created and committed. Discovered the tuning loop is fully built but unwired; locked auto-apply-safe autonomy.
+- 2026-06-06 — B1 pattern landed: big-event-detector instrumented (data-loader.ts:1468 → evaluation ledger), guarded, typecheck 0. Discovered the outcome path (resolvePendingViaLlm + llm-grader) exists but is unwired — folded into B1b. Remaining B1 work is mechanical replication across 20 more registered algos.

--- a/docs/superpowers/plans/2026-06-06-self-improvement-and-data-expansion.md
+++ b/docs/superpowers/plans/2026-06-06-self-improvement-and-data-expansion.md
@@ -1,0 +1,81 @@
+# Gameplan: Self-Improvement Loop + Data Expansion
+
+> **Cross-session plan.** Any session picks this up by reading the "Current State / Next Step" block below first, then continuing the unchecked steps in order. Update the block + check boxes as you go.
+
+---
+
+## CURRENT STATE / NEXT STEP  *(update this every session)*
+
+- **Status:** Workstream B started.
+- **Last landed:** Gameplan committed (2026-06-06).
+- **Next step:** **B1** — wire `recordAlgorithmEvaluation` / `recordAlgorithmOutcome` into the existing grading paths so the evaluation ledger starts filling.
+- **Blocked on:** nothing.
+
+---
+
+## Why this exists
+
+Crystal Ball already contains a complete, well-tested **closed-loop algorithm self-improvement system** under `src/services/algorithms/` — but it is **100% unwired** (the orphaned-panels pattern). The loop is broken at the first link: nothing calls `record-evaluation`, so the evaluation ledger never fills, so `adaptive-tuner` (a TPE hyperparameter optimizer) never has data to optimize against, so `self-improvement-scheduler` never fires. This gameplan operationalizes that loop, adds a recurring health-check tool, and raises the data ceiling the whole system runs under.
+
+## Design decision (locked)
+
+**Tuner autonomy: AUTO-APPLY SAFE + LOG EVERYTHING.**
+The tuner auto-applies any parameter adjustment that clears all safety gates, and records every change with rollback metadata. Gates (already implemented in `adaptive-tuner.ts` / `safe-adjustment.ts`):
+- ≥5% F1 improvement on the last 100 graded fixtures before accepting a config
+- ≤20% change to any single parameter per cycle
+- minimum new-grade count before acting
+- `policy-gate` veto + per-param bounds (`at_bound` → no-op)
+- every applied change logged with before/after + a revert path
+
+---
+
+## Workstream B — Operationalize the tuning loop  *(foundation, build first)*
+
+**Goal:** a self-improving loop that runs in production: grade outcomes → fill ledger → detect drift → tune params → auto-apply safe changes → log.
+
+- [ ] **B1 — Fill the ledger.** Call `recordAlgorithmEvaluation` / `recordAlgorithmOutcome` from the existing grading paths so the evaluation ledger accumulates real data.
+  - Call sites: `src/services/analyst-loop.ts`, `src/services/hypothesis-accuracy.ts`, `src/services/alert-correlator.ts`, `src/services/severity-recalibration.ts`
+  - Recorders: `src/services/algorithms/record-evaluation.ts` (`recordAlgorithmEvaluation`, `recordAlgorithmOutcome`, `timeAndRecord`)
+  - Persistence: `algorithm-ledger-persistence.ts` (verify it flushes to IDB so the ledger survives restarts)
+  - Done when: after a keyed session, `getAlgorithmEvaluationLedger()` returns non-empty entries for ≥3 tracked algorithms.
+- [ ] **B2 — Run the scheduler.** Wire `self-improvement-scheduler` into the app bootstrap (`panel-layout.ts` boot or a dedicated init) on its cadences (DAILY_AUDIT_MS / WEEKLY_BACKTEST_MS / MONTHLY_REVIEW_MS). Each cycle runs `drift-detector` → `adaptive-tuner` → `safe-adjustment` → apply (auto), gated by `policy-gate`.
+  - Done when: a forced cycle (test hook) produces a proposal, applies it through the gates, and logs the before/after.
+- [ ] **B3 — Drive + observe.** Add `npm run tune` (CLI that runs one cycle against the persisted ledger and prints proposals/applies) and surface applied adjustments + drift in the already-wired `AlgorithmDiagnosticPanel`.
+  - Done when: `npm run tune` runs end-to-end and the panel shows the last applied adjustment.
+
+**Risk note:** B1 is additive wiring of tested pure functions (low risk). B2 changes runtime behavior (auto-apply) — keep it behind a default-on-but-revertible flag and verify the gates fire before trusting it.
+
+---
+
+## Workstream A — Recurring checkups  *(fast, ship early)*
+
+**Goal:** "run tests like this more often" as one command.
+
+- [ ] **A1 — `npm run checkup`.** A script that runs: typecheck:all, core test suites, log audit (latest desktop.log session + sidecar health), analyst-state freshness probe → prints a GREEN / YELLOW / RED report with the actionable items only.
+  - Reuse: `src/services/diagnostics/self-test.ts`, the npm `test:*` scripts, the bash log-audit patterns from this session.
+  - Done when: `npm run checkup` exits 0/1 with a one-screen summary.
+- [ ] **A2 — Optional schedule.** A `/checkup` skill or cron entry for a daily run.
+
+---
+
+## Workstream C — Data gathering / insight  *(raises the ceiling)*
+
+**Goal:** the algos are input-bound; raise feed coverage and resilience so they have more to reason about, even with few/no keys.
+
+- [ ] **C1 — Coverage audit.** Map live feeds in `data-loader.ts` against `docs/API_SOURCE_EXPANSION_FREE_OPTIONS.md`; list highest-value free/no-key sources not yet wired.
+- [ ] **C2 — Provider redundancy.** For each critical domain, wire a backup source so one key/outage doesn't starve the domain (extend the existing `provider-redundancy.ts` health model).
+- [ ] **C3 — Keyless resilience.** Ensure no-key feeds (USGS, NWS, GDACS, EONET, etc.) reliably produce signal so the app reasons even at 0 keys loaded — directly addresses the recurring "0 keys → starved algos" condition.
+
+---
+
+## Success criteria (whole gameplan)
+
+1. After a normal keyed session, the evaluation ledger is non-empty and the scheduler has run ≥1 cycle.
+2. At least one safe parameter adjustment has been auto-applied and logged with a revert path.
+3. `npm run checkup` gives a one-command health verdict.
+4. Measurable increase in active feed coverage and per-domain redundancy.
+5. No regressions: typecheck 0, all test suites green, no new `[ERROR]` classes in logs.
+
+## Progress log
+
+- 2026-06-06 — Gameplan created and committed. Discovered the tuning loop is fully built but unwired; locked auto-apply-safe autonomy. Starting B1.

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -1434,10 +1434,12 @@ export class DataLoaderManager implements AppModule {
  { detectBigEvent },
  { routeBigEventToLadder },
  { getNotificationTraceRegistry },
+ { recordAlgorithmEvaluation },
  ] = await Promise.all([
  import('@/services/insights/big-event-detector'),
  import('@/services/insights/notification-ladder'),
  import('@/services/diagnostics/diagnostics-state'),
+ import('@/services/algorithms/record-evaluation'),
  ]);
  const SEVERITY_SCORE: Record<string, number> = { Extreme: 95, Severe: 80, Moderate: 55, Minor: 30, Unknown: 20 };
  const RUNG_ACTION: Record<string, 'sound+banner' | 'banner' | null> = {
@@ -1465,7 +1467,19 @@ export class DataLoaderManager implements AppModule {
  userExposure: 50, // conservative default; polygon match refines this
  potentialImpact: severityScore,
  };
+ const _bedStart = performance.now();
  const bigEventResult = detectBigEvent(ladderInput);
+ // B1 (self-improvement gameplan): feed the evaluation ledger so the
+ // adaptive-tuner has data. Guarded — instrumentation must never break
+ // the notification data path.
+ try {
+ recordAlgorithmEvaluation('big-event-detector', {
+ durationMs: performance.now() - _bedStart,
+ score: bigEventResult.totalScore / 100,
+ label: bigEventResult.isBigEvent ? 'big-event' : 'quiet',
+ detail: { domain: 'weather', triggers: bigEventResult.triggers.length, tier: bigEventResult.tier },
+ });
+ } catch { /* ledger unavailable — skip silently */ }
  if (!bigEventResult.isBigEvent) continue;
  const decision = routeBigEventToLadder(registry, bigEventResult, ladderInput, {
  domain: 'weather',


### PR DESCRIPTION
## Cross-session gameplan + first build step

Adds a persistent gameplan (`docs/superpowers/plans/2026-06-06-self-improvement-and-data-expansion.md`) to operationalize the **dormant** algorithm self-improvement loop, plus an `npm run checkup` health tool and data-feed expansion. The `src/services/algorithms/` loop (TPE `adaptive-tuner`, `drift-detector`, `safe-adjustment`, evaluation ledger, `outcome-resolver` + `llm-grader`) is fully built and tested but **100% unwired** — nothing calls `record-evaluation`, so the ledger never fills and the tuner never runs.

**Decision locked:** tuner auto-applies safe adjustments (gated: ≥5% F1, ≤20%/param, min grades, policy-gate) and logs every change with a revert path.

**B1 (this PR):** instruments `big-event-detector` at `data-loader.ts:1468` — each run records score/label/latency into the evaluation ledger, guarded by try/catch so instrumentation can never break the notification path. This proves the wiring pattern; the remaining 20 registered algos follow the same recipe (documented in the plan's Current State block).

## Verification
- `npx tsc --noEmit` → 0 errors
- Codex confirmed: guard correct, `big-event-detector` registered, `totalScore` is the right field

Cross-agent review: Codex reviewed on 2026-06-06; outcome: pass.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>