### PR TITLE
feat(algorithms): B1 cont. — instrument 9 more algos into the evaluation ledger (15/21)

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -1480,6 +1480,16 @@ export class DataLoaderManager implements AppModule {
  detail: { domain: 'weather', triggers: bigEventResult.triggers.length, tier: bigEventResult.tier },
  });
  } catch { /* ledger unavailable — skip silently */ }
+ // confidence-urgency-matrix: the tier + deliveryPriority come directly from the matrix
+ // computation inside detectBigEvent — record them as a separate matrix evaluation.
+ try {
+ recordAlgorithmEvaluation('confidence-urgency-matrix', {
+ durationMs: performance.now() - _bedStart, // shares the detectBigEvent bracket (matrix runs inside it)
+ score: bigEventResult.totalScore / 100,
+ label: bigEventResult.tier,
+ detail: { priority: bigEventResult.deliveryPriority, urgency: bigEventResult.urgency },
+ });
+ } catch { /* ledger unavailable — skip silently */ }
  if (!bigEventResult.isBigEvent) continue;
  const decision = routeBigEventToLadder(registry, bigEventResult, ladderInput, {
  domain: 'weather',

--- a/src/services/alert-correlator.ts
+++ b/src/services/alert-correlator.ts
@@ -20,6 +20,7 @@ import { getSourceTrust } from './source-trust';
 import { canonicalEntityKey } from './entity-key';
 import { recordCoOccurrence } from './pair-discovery';
 import { getPairFeedbackMult } from './correlation-feedback';
+import { recordAlgorithmEvaluation } from '@/services/algorithms/record-evaluation';
 import { runIntel } from './intel-provider';
 import { getEnabledCustomRules } from './custom-correlation-rules';
 
@@ -517,7 +518,17 @@ function scan(): void {
     }
     const baseConfidence = computeConfidence(members, rule, maxDist, maxLag);
     const pairKey = `${rule.cause}|${rule.effect}`;
-    const confidence = Math.max(0.1, Math.min(1, baseConfidence * getPairFeedbackMult(pairKey)));
+    const _t0 = Date.now();
+    const feedbackMult = getPairFeedbackMult(pairKey);
+    const confidence = Math.max(0.1, Math.min(1, baseConfidence * feedbackMult));
+    try {
+      recordAlgorithmEvaluation('correlation-feedback', {
+        durationMs: Date.now() - _t0,
+        score: confidence,
+        label: feedbackMult >= 1 ? 'boosted' : 'suppressed',
+        detail: { cause: rule.cause, effect: rule.effect, members: members.length },
+      });
+    } catch { /* ledger unavailable */ }
 
     const sources = [...new Set(members.map(m => m.source))];
     synthesized.set(id, { ts: now, alertId: id, memberIds: members.map(m => m.id) });

--- a/src/services/hypothesis-accuracy.ts
+++ b/src/services/hypothesis-accuracy.ts
@@ -17,6 +17,7 @@ import { unifiedAlertStore } from './unified-alerts';
 import { scoreAlert } from './alert-routing';
 import { signatureFor } from './hypothesis-feedback';
 import { getMemory, putMemory } from './reasoning-memory';
+import { recordAlgorithmEvaluation } from '@/services/algorithms/record-evaluation';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -170,6 +171,7 @@ function bumpStats(stats: AccuracyStats, hit: boolean): void {
 }
 
 function gradeOne(p: PendingHypothesis): void {
+  const _t0 = Date.now();
   const hit = didEvidenceEscalate(p);
   if (hit === null) return; // no evidence left to judge — skip, don't record a miss
 
@@ -180,6 +182,15 @@ function gradeOne(p: PendingHypothesis): void {
   const kindStats = byKind.get(p.kind) ?? { hits: 0, misses: 0, lastGraded: 0 };
   bumpStats(kindStats, hit);
   byKind.set(p.kind, kindStats);
+
+  try {
+    recordAlgorithmEvaluation('hypothesis-accuracy', {
+      durationMs: Date.now() - _t0,
+      score: hit ? 1 : 0,
+      label: hit ? 'hit' : 'miss',
+      detail: { kind: p.kind, situationIds: p.situationIds.length, alertIds: p.alertIds.length },
+    });
+  } catch { /* ledger unavailable */ }
 }
 
 function gradeDue(): void {

--- a/src/services/relevance-learner.ts
+++ b/src/services/relevance-learner.ts
@@ -20,6 +20,7 @@
 import { unifiedAlertStore, type UnifiedAlert } from './unified-alerts';
 import { isGhostMode } from './mode-manager';
 import { getMemory, putMemory } from './reasoning-memory';
+import { recordAlgorithmEvaluation } from '@/services/algorithms/record-evaluation';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -133,13 +134,24 @@ function prune(): void {
 
 function learn(alert: UnifiedAlert, polarity: 'positive' | 'negative'): void {
   if (isGhostMode()) return;
+  const _t0 = Date.now();
   const step = polarity === 'positive' ? POSITIVE_STEP : -NEGATIVE_STEP;
-  for (const term of extractTerms(alert)) bump(term, step);
+  const terms = extractTerms(alert);
+  for (const term of terms) bump(term, step);
 
   state.writeCount += 1;
   if (state.writeCount % 20 === 0) decayAll();
   prune();
   save();
+
+  try {
+    recordAlgorithmEvaluation('relevance-learner', {
+      durationMs: Date.now() - _t0,
+      score: polarity === 'positive' ? 1 : 0,
+      label: polarity,
+      detail: { terms: terms.length, totalWeights: Object.keys(state.weights).length },
+    });
+  } catch { /* ledger unavailable */ }
 }
 
 // ── Boost computation ────────────────────────────────────────────────────────

--- a/src/services/shortage/shortage-fullset.ts
+++ b/src/services/shortage/shortage-fullset.ts
@@ -23,6 +23,7 @@ import {
   computeElectricityShortageRisk,
 } from './energy-fertilizer-models';
 import type { ShortageForecast, ShortageInputBag } from './shortage-types';
+import { recordAlgorithmEvaluation } from '@/services/algorithms/record-evaluation';
 
 // ── Public types ───────────────────────────────────────────────────────────
 
@@ -118,7 +119,20 @@ function runCommodity(
 ): ShortageForecast | undefined {
   const opts = { region, now };
   switch (commodity) {
-    case 'wheat': {       return computeWheatShortageRisk(inputs, opts);
+    case 'wheat': {
+      const _t0 = performance.now();
+      const r = computeWheatShortageRisk(inputs, opts);
+      if (r) {
+        try {
+          recordAlgorithmEvaluation('shortage-wheat', {
+            durationMs: performance.now() - _t0,
+            score: r.riskScore / 100,
+            label: r.confidence,
+            detail: { region, drivers: r.drivers.length, dataGaps: r.dataGaps.length },
+          });
+        } catch { /* ledger unavailable */ }
+      }
+      return r;
     }
     case 'corn': {        return computeCornShortageRisk(inputs, opts);
     }
@@ -126,7 +140,20 @@ function runCommodity(
     }
     case 'soybeans': {    return computeSoybeansShortageRisk(inputs, opts);
     }
-    case 'diesel': {      return computeDieselShortageRisk(inputs, opts);
+    case 'diesel': {
+      const _t0 = performance.now();
+      const r = computeDieselShortageRisk(inputs, opts);
+      if (r) {
+        try {
+          recordAlgorithmEvaluation('shortage-diesel', {
+            durationMs: performance.now() - _t0,
+            score: r.riskScore / 100,
+            label: r.confidence,
+            detail: { region, drivers: r.drivers.length, dataGaps: r.dataGaps.length },
+          });
+        } catch { /* ledger unavailable */ }
+      }
+      return r;
     }
     case 'gasoline': {    return computeGasolineShortageRisk(inputs, opts);
     }

--- a/src/services/source-feedback.ts
+++ b/src/services/source-feedback.ts
@@ -10,6 +10,7 @@
  */
 
 import { unifiedAlertStore, type AlertSource } from './unified-alerts';
+import { recordAlgorithmEvaluation } from '@/services/algorithms/record-evaluation';
 
 const STORAGE_KEY = 'crystalball-source-feedback-v1';
 const FAST_ACK_MS = 10_000;
@@ -43,6 +44,20 @@ function bump(source: AlertSource, field: keyof SourceStats): void {
   cur[field] += 1;
   stats.set(source, cur);
   save();
+  // Record once per user action. A fast-ack bumps both 'ackCount' and
+  // 'fastAckCount'; skip the sub-classification so it isn't double-counted.
+  if (field !== 'fastAckCount') {
+    try {
+      const _t0 = performance.now();
+      const mult = getSourceFeedbackMult(source);
+      recordAlgorithmEvaluation('source-feedback', {
+        durationMs: performance.now() - _t0,
+        score: mult,
+        label: field,
+        detail: { source, ackCount: cur.ackCount, snoozeCount: cur.snoozeCount },
+      });
+    } catch { /* ledger unavailable */ }
+  }
 }
 
 /** 0.5–1.0 multiplier — closer to 0.5 means user treats this source as noise. */

--- a/src/services/weather/weather-warning-router.ts
+++ b/src/services/weather/weather-warning-router.ts
@@ -159,12 +159,23 @@ export function routeWeatherAlert(
     : undefined;
 
   // Step 3: when urgency is at banner+, build the Storm Mode payload.
-  const payload = urgency && shouldBuildPayload(urgency.priority)
-    ? buildStormModePayload(strongest!.match, strongest!.place.label, {
-        now,
-        ...options.stormMode,
-      })
-    : undefined;
+  let payload: StormModePayload | undefined;
+  if (urgency && shouldBuildPayload(urgency.priority)) {
+    const _smStart = Date.now();
+    payload = buildStormModePayload(strongest!.match, strongest!.place.label, {
+      now,
+      ...options.stormMode,
+    });
+    const _smScore = { high: 1, medium: 0.6, low: 0.3 }[payload.confidenceLabel] ?? 0.3;
+    try {
+      recordAlgorithmEvaluation('personal-storm-mode', {
+        durationMs: Date.now() - _smStart,
+        score: _smScore,
+        label: payload.activation,
+        detail: { threatLevel: payload.threatLevel, hazardKind: payload.primaryHazard },
+      });
+    } catch { /* ledger unavailable */ }
+  }
 
   // Step 4: dispatch actions derived from urgency + quiet-hours state.
   const { dispatchActions, suppressed } = deriveDispatchActions(
@@ -206,7 +217,16 @@ function pickStrongestMatch(
   if (places.length === 0) return undefined;
   let best: PlaceAndMatch | undefined;
   for (const place of places) {
+    const _t0 = performance.now();
     const match = matchAlertToPlace(alert, place, { now });
+    try {
+      recordAlgorithmEvaluation('nws-polygon-match', {
+        durationMs: performance.now() - _t0,
+        score: MATCH_KIND_RANK[match.matchKind] / 4, // 0..1 (inside_polygon=1)
+        label: match.matchKind,
+        detail: { threatLevel: match.threatLevel, hazardKind: match.hazardKind },
+      });
+    } catch { /* ledger unavailable */ }
     if (!best) { best = { place, match }; continue; }
     if (matchStrength(match) > matchStrength(best.match)) best = { place, match };
   }


### PR DESCRIPTION
Continues B1 of the self-improvement gameplan. Wires `recordAlgorithmEvaluation` (guarded) at the live call sites of 9 more registered algorithms: confidence-urgency-matrix, correlation-feedback, hypothesis-accuracy, nws-polygon-match, personal-storm-mode, relevance-learner, shortage-wheat, shortage-diesel, source-feedback. **15 of 21 registered algos now feed the ledger.**

Bulk wiring done by a Sonnet sub-agent; reviewed by Codex (CHANGES REQUIRED → fixed → PASS).

**Post-review fixes:**
- `source-feedback` double-counted fast-acks (`bump` fires for `ackCount` AND `fastAckCount`) → now records once per user action + brackets the real `getSourceFeedbackMult` work
- `confidence-urgency-matrix` durationMs now shares the `detectBigEvent` bracket (runs inside it) instead of 0
- removed a redundant duplicate import; de-nested a ternary (lint)

**Finding:** 6 registered algos (baseline-deviation, evidence-graph, forecast-calibration, situation-clustering, watchlist-relevance, what-changed-digest) have **no live call site** — pure modules never invoked. Logged as orphaned-algorithm follow-up.

## Verification
- `tsc --noEmit` (app + api) → 0; ESLint changed files → 0

Cross-agent review: Codex reviewed on 2026-06-06; outcome: pass (re-review after fixing the 3 flagged items; no new issues).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>