### PR TITLE
feat(panel): surface tuning decision history in AlgorithmDiagnosticPanel

### DIFF
--- a/src/components/AlgorithmDiagnosticPanel.ts
+++ b/src/components/AlgorithmDiagnosticPanel.ts
@@ -21,6 +21,11 @@ import { summarizeCalibration } from '@/services/algorithms/algorithm-evaluation
 import { proposeAdjustments } from '@/services/algorithms/safe-adjustment';
 import { getTunings } from '@/services/algorithms/tunable-params-store';
 import {
+  getTuningDecisions,
+  type TuningDecision,
+  type TuningDecisionKind,
+} from '@/services/algorithms/tuning-decision-log';
+import {
   gateAdjustmentProposal,
   type GatedProposal,
 } from '@/services/governance/policy-gate';
@@ -154,6 +159,10 @@ export class AlgorithmDiagnosticPanel extends Panel {
         ${recHtml}
       </div>
       <div style="display:flex;flex-direction:column;gap:6px;">${rows}</div>
+      <div>
+        <div style="font-size:11px;color:var(--text-secondary,#aaa);text-transform:uppercase;margin-bottom:6px;">Tuning history</div>
+        ${renderTuningHistory(getTuningDecisions())}
+      </div>
     </div>`;
     this.setContent(html);
   }
@@ -211,6 +220,46 @@ function renderProposalHtml(gated: GatedProposal | undefined): string {
     <div style="margin-top:4px;font-size:10px;color:var(--text-secondary,#aaa);font-style:italic;">${escapeHtml(display.helper)}</div>
     ${requiredHtml}
   </div>`;
+}
+
+const TUNING_KIND_DISPLAY: Record<TuningDecisionKind, { label: string; color: string; background: string }> = {
+  applied: { label: 'APPLIED', color: '#4caf50', background: 'rgba(76,175,80,0.10)' },
+  held_for_approval: { label: 'HELD', color: '#ffb74d', background: 'rgba(255,183,77,0.10)' },
+};
+
+function formatTuningWhen(at: number): string {
+  if (!Number.isFinite(at)) return '';
+  try {
+    return new Date(at).toLocaleString();
+  } catch {
+    return '';
+  }
+}
+
+/** Render the most-recent tuning decisions (applied / held) as an audit
+ *  trail. Read-only — the loop writes this log; the panel only displays it. */
+function renderTuningHistory(decisions: readonly TuningDecision[]): string {
+  if (decisions.length === 0) {
+    return `<div style="font-size:12px;color:var(--text-secondary,#aaa);">No tuning decisions recorded yet.</div>`;
+  }
+  const rows = decisions.slice(0, 8).map((d) => {
+    const kind = TUNING_KIND_DISPLAY[d.kind];
+    const when = formatTuningWhen(d.at);
+    const change = `${d.algorithmId}.${d.parameterId}: ${formatTuningValue(d.priorValue)} → ${formatTuningValue(d.nextValue)}`;
+    return `<div style="font-size:11px;border-left:3px solid ${kind.color};background:${kind.background};border-radius:3px;padding:4px 8px;">
+      <div style="display:flex;align-items:center;justify-content:space-between;gap:6px;">
+        <span style="font-family:ui-monospace,monospace;">${escapeHtml(change)}</span>
+        <span style="font-size:9px;color:${kind.color};font-weight:700;letter-spacing:0.05em;">${kind.label}</span>
+      </div>
+      <div style="margin-top:2px;color:var(--text-secondary,#aaa);">${escapeHtml(d.reason)}</div>
+      ${when ? `<div style="margin-top:2px;font-size:9px;color:var(--text-secondary,#777);">${escapeHtml(when)}</div>` : ''}
+    </div>`;
+  }).join('');
+  return `<div style="display:flex;flex-direction:column;gap:4px;">${rows}</div>`;
+}
+
+function formatTuningValue(value: number): string {
+  return Number.isFinite(value) ? String(value) : '?';
 }
 
 function renderCriticalityBadge(criticality: string): string {


### PR DESCRIPTION
## What

B3-UI: render `getTuningDecisions()` as a read-only **Tuning history** section in the Algorithm Diagnostic panel — `applied` vs `held_for_approval` chips, before→after value, the policy-gate reason, and a timestamp. Newest 8 shown; empty-state when the log is empty.

Closes the *observe* half of the self-improvement loop: the panel already rendered live proposals + gating; now it also shows what the runner actually decided over time ("prove it with logs"). The panel only displays — the runner owns the log.

## Verification

- `npm run typecheck:all` → clean
- eslint clean; values escaped via `escapeHtml`; non-finite values render `?`, non-finite timestamps suppress the date — no throw paths.
- Panel smoke harness errors identically for all 239 panels on `@/workers/ml.worker?worker` (pre-existing Vite `?worker` loader gap in the node harness; unrelated to this change).

cross-agent review: codex — LGTM. Confirmed every interpolated field is escaped (no XSS), empty/NaN/bad-timestamp inputs don't throw, and the existing proposal/gating render is unchanged.