### PR TITLE
Update NOTICE.md identifiers to Crystal Ball

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,4 +1,4 @@
-World Monitor macOS
+Crystal Ball
 Copyright (C) 2026 Bradley Bond
 
 This software is based on **World Monitor** by Elie Habib.
@@ -18,10 +18,10 @@ been retained in accordance with the AGPL-3.0 license requirements.
 
 ---
 
-## World Monitor macOS Modifications
+## Crystal Ball Modifications
 
 The following additions and modifications were made by Bradley Bond
-for the World Monitor macOS project (https://github.com/bradleybond512/worldmonitor-macos):
+for the Crystal Ball project (https://github.com/bradleybond512/crystal-ball):
 
 - macOS native Tauri desktop application shell
 - Air Strikes & Drone Monitoring panel (ACLED integration)


### PR DESCRIPTION
Tidies leftover pre-rename identifiers in `NOTICE.md`:

- Title `World Monitor macOS` → `Crystal Ball`
- Modifications section header + repo link → `Crystal Ball` / `bradleybond512/crystal-ball`

Upstream attribution to [koala73/worldmonitor](https://github.com/koala73/worldmonitor) (Elie Habib) and the AGPL-3.0 terms are unchanged. Prompted by provenance/licensing inquiry #675.

cross-agent review: codex — LGTM (docs-only NOTICE.md identifier update, no functional changes).