### PR TITLE
fix(datacenter): match zone-only NWS alerts via UGC zones

### DIFF
--- a/docs/superpowers/specs/2026-06-07-intelligent-algorithms-roadmap-design.md
+++ b/docs/superpowers/specs/2026-06-07-intelligent-algorithms-roadmap-design.md
@@ -1,0 +1,298 @@
+# Intelligent Algorithms & AI Features Roadmap — Design Spec
+
+**Date:** 2026-06-07
+**Goal:** Wire dormant prediction engines into the live app, then layer autonomous forecast scores and Claude-as-analyst capabilities on top, closing with a visible self-improvement loop. Four PRs in dependency order.
+
+---
+
+## Overview
+
+Crystal Ball has ~150 intelligence services built under `src/services/intelligence/`. Many are never started at boot — their panels render empty. This roadmap closes the gap in two waves:
+
+**Wave 1 (PRs 1–2):** Wire what exists. Boot dormant engines. Surface autonomous probability forecasts on every hypothesis card.
+
+**Wave 2 (PRs 3–4):** Build what's new. Claude-as-analyst with live intelligence context. A visible self-improvement loop tied to outcome grading.
+
+### Invariants
+
+- Ghost Mode suppresses all new UI surfaces (forecast bars, accuracy sparkline, auto-analysis)
+- All new services degrade gracefully when upstream data is unavailable
+- No new API keys required
+- New services are input-output pure where possible (no DOM, no fetch in computation functions)
+- All new hypothesis kinds and forecast scores degrade to empty state when source services are unavailable
+
+---
+
+## PR 1 — Wire Dormant Prediction Engines
+
+### What
+
+Four computation engines are built but never called at boot. Their panels exist and render empty. This PR adds the missing start calls.
+
+| Service | Panel | What it computes |
+|---|---|---|
+| `predictive-crisis-index.ts` | HUD header badge | Composite crisis probability index 0–100 |
+| `crisis-trajectory.ts` | `CrisisTrajectoryPanel` | 7/14/30d projected escalation path |
+| `active-learning-queue.ts` | `ActiveLearningQueuePanel` | Hypotheses needing human confirmation |
+| `analog-monitor.ts` | HUD analog cards | Historical analog matching (written in analyst-surface-hidden PR, needs boot call) |
+
+### Architecture
+
+**`src/services/predictive-crisis-index.ts`:**
+- Add a `startPredictiveCrisisIndex()` export that subscribes to `cb:analyst-hypotheses`, calls `computePCI()` on each snapshot, and emits `cb:pci-updated` with the `PCIScore` result
+- Existing `pciToAlert()` already handles unified alert injection — call it inside the listener
+- Cadence: runs every analyst cycle (5 min), no independent timer needed
+
+**`src/services/crisis-trajectory.ts`:**
+- Add `startCrisisTrajectory()` export that subscribes to `cb:analyst-hypotheses`, instantiates `CrisisTrajectoryProjector` with the top-ranked hypothesis, and emits `cb:crisis-trajectory` with the projection
+- `CrisisTrajectoryPanel` already listens for this event — zero panel changes needed
+
+**`src/services/active-learning-queue.ts`:**
+- Add `startActiveLearningQueue()` export that subscribes to `cb:analyst-hypotheses` and routes low-confidence hypotheses (confidence < 0.5, risk ≥ moderate) into the queue
+- `ActiveLearningQueuePanel` already renders queue items
+
+**`src/services/historical-analogs/analog-monitor.ts`:**
+- `startAnalogMonitor()` already exported — just needs to be called in `panel-layout.ts`
+- Pass a getter wrapping `getAnalystSnapshot()?.hypotheses` mapped to `SituationForScoring`
+
+**`src/app/panel-layout.ts`:**
+- Import and call all four start functions after `startAnalystLoop()` in the boot sequence
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `src/services/predictive-crisis-index.ts` | Add `startPredictiveCrisisIndex()` + `cb:pci-updated` emission |
+| `src/services/crisis-trajectory.ts` | Add `startCrisisTrajectory()` + `cb:crisis-trajectory` emission |
+| `src/services/active-learning-queue.ts` | Add `startActiveLearningQueue()` |
+| `src/app/panel-layout.ts` | Import + call 4 start functions after `startAnalystLoop()` |
+
+### Tests
+
+- `predictive-crisis-index`: `startPredictiveCrisisIndex()` emits `cb:pci-updated` when `cb:analyst-hypotheses` fires with ≥1 hypothesis
+- `crisis-trajectory`: `startCrisisTrajectory()` emits `cb:crisis-trajectory` with a projection containing 7/14/30d horizons
+- `active-learning-queue`: routes hypothesis with confidence < 0.5 into the queue; skips confidence ≥ 0.5
+
+---
+
+## PR 2 — Autonomous Forecast Scores
+
+### What
+
+Every hypothesis card in the Analyst HUD gets a probability bar and horizon badge, always visible. Example: `▲ 68% · 14d` in amber. Synthesized from PCI, analog matches, and base hypothesis confidence.
+
+### Architecture
+
+**New service: `src/services/hypothesis-forecast.ts`**
+
+```typescript
+export interface HypothesisForecast {
+  hypothesisId: string;
+  /** Synthesized probability 0–1. */
+  probability: number;
+  /** Best available horizon in days. */
+  horizon: 7 | 14 | 30;
+  /** Derived from confidence trajectory over the last 3 cycles. */
+  trend: 'rising' | 'stable' | 'falling';
+  /** Which signals contributed to this score. */
+  sources: ('hypothesis' | 'pci' | 'analog')[];
+}
+
+export type ForecastMap = Map<string, HypothesisForecast>;
+
+export function startHypothesisForecast(): void
+export function getLatestForecasts(): ForecastMap
+```
+
+**Synthesis logic:**
+1. Base: hypothesis `confidence` (always available)
+2. PCI weight: if `cb:pci-updated` has fired, blend PCI index/100 as a 20% prior
+3. Analog weight: if `cb:analog-match` contains a match for this hypothesis's region/kind, blend the analog's top outcome confidence as a 15% prior
+4. Formula: `probability = base * 0.65 + pci_contribution * 0.20 + analog_contribution * 0.15`
+5. Horizon: use crisis trajectory horizon if available, else analog horizon, else default 14d
+6. Trend: compare current probability to the previous two cycles stored in a 3-entry ring per hypothesis
+
+Emits `cb:hypothesis-forecasts` with a `ForecastMap` after every `cb:analyst-hypotheses` cycle.
+
+**`AnalystHUD.ts` integration:**
+- Subscribe to `cb:hypothesis-forecasts` in `mount()`
+- `buildHypForecastBar(forecast: HypothesisForecast): HTMLElement` — renders a small row:
+  - Trend arrow: ▲ (rising) / ▼ (falling) / → (stable)
+  - Probability: `68%` colored green ≤40%, amber 40–70%, red >70%
+  - Horizon badge: `· 14d`
+- Appended below the hypothesis statement in `buildHypothesisRow()`
+- Suppressed when Ghost Mode is active
+
+### Data Flow
+
+```
+cb:analyst-hypotheses
+cb:pci-updated          →  hypothesis-forecast.ts  →  cb:hypothesis-forecasts  →  AnalystHUD
+cb:analog-match
+```
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `src/services/hypothesis-forecast.ts` | New — ~100 lines |
+| `src/components/AnalystHUD.ts` | Subscribe to forecasts, add `buildHypForecastBar()`, render in rows |
+| `src/app/panel-layout.ts` | Boot `startHypothesisForecast()` |
+
+### Tests
+
+- Synthesis uses only hypothesis confidence when PCI/analog unavailable
+- PCI and analog contributions blend correctly when both present
+- Trend is `rising` when probability increased over last 2 cycles
+- `buildHypForecastBar()` renders correct probability text from fixture forecast
+
+---
+
+## PR 3 — Claude-as-Analyst Upgrade
+
+### What
+
+Two surfaces:
+
+1. **Live context injection** — every question in `AskCrystalBallPanel` is automatically grounded in: current PCI level, top hypothesis + forecast, active analog matches, hot entities. No user action needed.
+
+2. **"Project this forward" button** — hypothesis card header gets a `→` button. Click opens `AskCrystalBallPanel` pre-seeded with a structured projection prompt for that hypothesis, asking Claude to reason about probability intervals, scenario branches, and what would change the forecast.
+
+### Architecture
+
+**New service: `src/services/analyst-context-builder.ts`**
+
+```typescript
+export function buildAnalystContext(): string
+```
+
+Pure function. Assembles a ~500-token system context string from:
+- PCI level + index from `getLatestPCI()` (new export from `predictive-crisis-index.ts`)
+- Top 3 hypotheses from `getAnalystSnapshot()` with their forecast probabilities from `getLatestForecasts()`
+- Active analog match names from the analog monitor's last emission
+- Hot entities from `getHotEntities()` (already exported from `hypothesis-entities.ts`)
+- Current posture advisory from `getModeForecastSnapshot()` (already exported from `mode-forecast.ts`)
+
+Format: a concise bullet list the LLM can use as a factual prior.
+
+**`AskCrystalBallPanel.ts` changes:**
+- Before every `sendMessage()` call, prepend `buildAnalystContext()` as a system context block
+- Listen for `cb:project-hypothesis` — when received, open the panel (if not already open) and populate the input field with the projection prompt, then auto-send
+
+**Projection prompt builder:**
+```typescript
+function buildProjectionPrompt(h: Hypothesis, forecast: HypothesisForecast, analogs: AnalogMatch[]): string
+```
+Produces: *"Analyze this intelligence situation: [statement]. Current forecast: [probability]% probability of escalation in [horizon] days, trend [trend]. Closest historical analog: [analog name] ([score]% similarity). Provide: (1) your probability estimate with confidence interval, (2) the 3 primary drivers, (3) base/upside/downside scenario branches, (4) what signals would change this forecast."*
+
+**`AnalystHUD.ts` changes:**
+- Add `→` button to hypothesis card header (right of the `⚡` challenge button)
+- `onclick`: collect hypothesis + its forecast + analog matches, dispatch `cb:project-hypothesis`
+- Suppressed when Ghost Mode is active
+
+**`predictive-crisis-index.ts`:**
+- Add `getLatestPCI(): PCIScore | null` export (reads from module-level cache set by `startPredictiveCrisisIndex()`)
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `src/services/analyst-context-builder.ts` | New — ~80 lines |
+| `src/services/predictive-crisis-index.ts` | Add `getLatestPCI()` export |
+| `src/components/AskCrystalBallPanel.ts` | Inject context on send, handle `cb:project-hypothesis` |
+| `src/components/AnalystHUD.ts` | Add `→` Project button to hypothesis header |
+
+### Tests
+
+- `buildAnalystContext()` includes PCI level text when PCI is available
+- `buildAnalystContext()` degrades gracefully to empty string when no snapshot exists
+- `buildProjectionPrompt()` includes hypothesis statement, probability, and horizon
+- `AskCrystalBallPanel`: receiving `cb:project-hypothesis` populates and sends the projection prompt
+
+---
+
+## PR 4 — Self-Improvement Visibility
+
+### What
+
+The outcome grading loop (`startOutcomeGradingCadence`) and tuning loop (`startTuningApplyCadence`) run invisibly. This PR surfaces their output:
+
+1. **Prediction Accuracy tab** in `AlgorithmDiagnosticPanel` — per-kind hit rate, trend, tuning status
+2. **Outcome reporting** on hypothesis cards — ✓ / ✗ controls on resolved hypotheses
+3. **Accuracy sparkline** in HUD footer — 7-day rolling accuracy across all hypothesis kinds
+
+### Architecture
+
+**`AlgorithmDiagnosticPanel.ts` — new "Prediction Accuracy" tab:**
+
+Reads from `getAlgoEvalLedger()` (already exported from `algo-eval-ledger.ts`). For each hypothesis kind with ≥3 graded outcomes, renders:
+- Kind label + sample count
+- Hit rate bar (green/amber/red thresholds: >70% / 50–70% / <50%)
+- Weighted hit rate (recency-weighted)
+- Trend arrow (comparing last 7 vs prior 7 outcomes)
+- Tuning status chip: `auto-applied` / `at_bound` / `manual_review` / `no_tunable`
+
+Auto-refreshes every 30s.
+
+**Outcome reporting in `AnalystHUD.ts`:**
+
+When a hypothesis is dismissed via the existing dismiss flow, show a one-time inline prompt: *"Was this correct? [✓ Yes] [✗ No] [Skip]"*. Clicking Yes/No calls `recordOutcome(h, correct)` from `hypothesis-accuracy.ts` (already exported). Skip dismisses without recording.
+
+The prompt only appears for hypotheses that have been live for ≥2 analyst cycles (tracked via `hypothesis-threads.ts` `cycleCount`).
+
+**Accuracy sparkline in HUD footer:**
+
+`buildAccuracySparkline(): SVGSVGElement | null` — reuses `buildSparklinePath()` helper (already in `AnalystHUD.ts`). Reads the last 14 accuracy data points from `getAlgoEvalLedger()`. Width 80px, height 10px. Rendered in the HUD footer next to the existing error counter. Suppressed when Ghost Mode is active or fewer than 3 data points exist.
+
+### Files Changed
+
+| File | Change |
+|---|---|
+| `src/components/AlgorithmDiagnosticPanel.ts` | Add Prediction Accuracy tab |
+| `src/components/AnalystHUD.ts` | Outcome reporting prompt on dismiss, accuracy sparkline in footer |
+
+### Tests
+
+- `AlgorithmDiagnosticPanel`: Prediction Accuracy tab renders per-kind rows when ledger has ≥3 samples
+- `AnalystHUD`: outcome prompt appears only for hypotheses with `cycleCount ≥ 2`
+- `AnalystHUD`: `buildAccuracySparkline()` returns null when fewer than 3 data points
+
+---
+
+## Execution Order
+
+| PR | Branch | Estimated scope |
+|----|--------|-----------------|
+| PR 1 | `claude/wire-prediction-engines` | ~80 lines changed |
+| PR 2 | `claude/autonomous-forecast-scores` | ~120 lines new |
+| PR 3 | `claude/claude-as-analyst` | ~200 lines new |
+| PR 4 | `claude/self-improvement-visibility` | ~150 lines changed |
+
+PRs 1 → 2 → 3 are in dependency order (each builds on the previous). PR 4 has no dependency on PR 3 and can be worked in parallel if desired.
+
+---
+
+## Data Flow Summary
+
+```
+Analyst Loop (5-min cadence)
+    ↓ cb:analyst-hypotheses
+    ├── predictive-crisis-index  →  cb:pci-updated
+    ├── crisis-trajectory        →  cb:crisis-trajectory  →  CrisisTrajectoryPanel
+    ├── active-learning-queue    →  ActiveLearningQueuePanel
+    ├── analog-monitor           →  cb:analog-match        →  HUD analog cards
+    └── hypothesis-forecast      ←  (all above)
+            ↓ cb:hypothesis-forecasts
+            └── AnalystHUD (forecast bars)
+
+User clicks "→" on hypothesis
+    ↓ cb:project-hypothesis
+    └── AskCrystalBallPanel (context-injected projection prompt → Claude)
+
+Hypothesis dismissed
+    ↓ recordOutcome()
+    └── AlgoEvalLedger → tuning-apply-runner (existing cadence)
+            ↓
+            AlgorithmDiagnosticPanel (Prediction Accuracy tab)
+            AnalystHUD footer (accuracy sparkline)
+```

--- a/docs/superpowers/specs/2026-06-07-intelligent-algorithms-roadmap-design.md
+++ b/docs/superpowers/specs/2026-06-07-intelligent-algorithms-roadmap-design.md
@@ -39,23 +39,28 @@ Four computation engines are built but never called at boot. Their panels exist 
 ### Architecture
 
 **`src/services/predictive-crisis-index.ts`:**
+
 - Add a `startPredictiveCrisisIndex()` export that subscribes to `cb:analyst-hypotheses`, calls `computePCI()` on each snapshot, and emits `cb:pci-updated` with the `PCIScore` result
 - Existing `pciToAlert()` already handles unified alert injection — call it inside the listener
 - Cadence: runs every analyst cycle (5 min), no independent timer needed
 
 **`src/services/crisis-trajectory.ts`:**
+
 - Add `startCrisisTrajectory()` export that subscribes to `cb:analyst-hypotheses`, instantiates `CrisisTrajectoryProjector` with the top-ranked hypothesis, and emits `cb:crisis-trajectory` with the projection
 - `CrisisTrajectoryPanel` already listens for this event — zero panel changes needed
 
 **`src/services/active-learning-queue.ts`:**
+
 - Add `startActiveLearningQueue()` export that subscribes to `cb:analyst-hypotheses` and routes low-confidence hypotheses (confidence < 0.5, risk ≥ moderate) into the queue
 - `ActiveLearningQueuePanel` already renders queue items
 
 **`src/services/historical-analogs/analog-monitor.ts`:**
+
 - `startAnalogMonitor()` already exported — just needs to be called in `panel-layout.ts`
 - Pass a getter wrapping `getAnalystSnapshot()?.hypotheses` mapped to `SituationForScoring`
 
 **`src/app/panel-layout.ts`:**
+
 - Import and call all four start functions after `startAnalystLoop()` in the boot sequence
 
 ### Files Changed
@@ -102,9 +107,11 @@ export type ForecastMap = Map<string, HypothesisForecast>;
 
 export function startHypothesisForecast(): void
 export function getLatestForecasts(): ForecastMap
+
 ```
 
 **Synthesis logic:**
+
 1. Base: hypothesis `confidence` (always available)
 2. PCI weight: if `cb:pci-updated` has fired, blend PCI index/100 as a 20% prior
 3. Analog weight: if `cb:analog-match` contains a match for this hypothesis's region/kind, blend the analog's top outcome confidence as a 15% prior
@@ -115,20 +122,25 @@ export function getLatestForecasts(): ForecastMap
 Emits `cb:hypothesis-forecasts` with a `ForecastMap` after every `cb:analyst-hypotheses` cycle.
 
 **`AnalystHUD.ts` integration:**
+
 - Subscribe to `cb:hypothesis-forecasts` in `mount()`
 - `buildHypForecastBar(forecast: HypothesisForecast): HTMLElement` — renders a small row:
+
   - Trend arrow: ▲ (rising) / ▼ (falling) / → (stable)
   - Probability: `68%` colored green ≤40%, amber 40–70%, red >70%
   - Horizon badge: `· 14d`
+
 - Appended below the hypothesis statement in `buildHypothesisRow()`
 - Suppressed when Ghost Mode is active
 
 ### Data Flow
 
 ```
+
 cb:analyst-hypotheses
 cb:pci-updated          →  hypothesis-forecast.ts  →  cb:hypothesis-forecasts  →  AnalystHUD
 cb:analog-match
+
 ```
 
 ### Files Changed
@@ -164,9 +176,11 @@ Two surfaces:
 
 ```typescript
 export function buildAnalystContext(): string
+
 ```
 
 Pure function. Assembles a ~500-token system context string from:
+
 - PCI level + index from `getLatestPCI()` (new export from `predictive-crisis-index.ts`)
 - Top 3 hypotheses from `getAnalystSnapshot()` with their forecast probabilities from `getLatestForecasts()`
 - Active analog match names from the analog monitor's last emission
@@ -176,21 +190,27 @@ Pure function. Assembles a ~500-token system context string from:
 Format: a concise bullet list the LLM can use as a factual prior.
 
 **`AskCrystalBallPanel.ts` changes:**
+
 - Before every `sendMessage()` call, prepend `buildAnalystContext()` as a system context block
 - Listen for `cb:project-hypothesis` — when received, open the panel (if not already open) and populate the input field with the projection prompt, then auto-send
 
 **Projection prompt builder:**
+
 ```typescript
 function buildProjectionPrompt(h: Hypothesis, forecast: HypothesisForecast, analogs: AnalogMatch[]): string
+
 ```
+
 Produces: *"Analyze this intelligence situation: [statement]. Current forecast: [probability]% probability of escalation in [horizon] days, trend [trend]. Closest historical analog: [analog name] ([score]% similarity). Provide: (1) your probability estimate with confidence interval, (2) the 3 primary drivers, (3) base/upside/downside scenario branches, (4) what signals would change this forecast."*
 
 **`AnalystHUD.ts` changes:**
+
 - Add `→` button to hypothesis card header (right of the `⚡` challenge button)
 - `onclick`: collect hypothesis + its forecast + analog matches, dispatch `cb:project-hypothesis`
 - Suppressed when Ghost Mode is active
 
 **`predictive-crisis-index.ts`:**
+
 - Add `getLatestPCI(): PCIScore | null` export (reads from module-level cache set by `startPredictiveCrisisIndex()`)
 
 ### Files Changed
@@ -226,6 +246,7 @@ The outcome grading loop (`startOutcomeGradingCadence`) and tuning loop (`startT
 **`AlgorithmDiagnosticPanel.ts` — new "Prediction Accuracy" tab:**
 
 Reads from `getAlgoEvalLedger()` (already exported from `algo-eval-ledger.ts`). For each hypothesis kind with ≥3 graded outcomes, renders:
+
 - Kind label + sample count
 - Hit rate bar (green/amber/red thresholds: >70% / 50–70% / <50%)
 - Weighted hit rate (recency-weighted)
@@ -275,6 +296,7 @@ PRs 1 → 2 → 3 are in dependency order (each builds on the previous). PR 4 ha
 ## Data Flow Summary
 
 ```
+
 Analyst Loop (5-min cadence)
     ↓ cb:analyst-hypotheses
     ├── predictive-crisis-index  →  cb:pci-updated
@@ -295,4 +317,5 @@ Hypothesis dismissed
             ↓
             AlgorithmDiagnosticPanel (Prediction Accuracy tab)
             AnalystHUD footer (accuracy sparkline)
+
 ```

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -22,6 +22,7 @@ import {
   fetchPredictions,
   fetchEarthquakes,
   fetchWeatherAlerts,
+  fetchUgcZonesForPoint,
   fetchFredData,
   fetchInternetOutages,
   isOutagesConfigured,
@@ -295,7 +296,7 @@ import type { ObservationEvent } from '@/types/intelligence';
 import { fetchDamSafetyAlerts } from '@/services/dam-safety';
 import { fetchPowerGridAlerts } from '@/services/power-grid-alerts';
 import { fetchGridStatus } from '@/services/power-grid';
-import { getDatacenterSite, recomputeDatacenterPosture } from '@/services/datacenter/datacenter-state';
+import { getDatacenterSite, setDatacenterSite, recomputeDatacenterPosture } from '@/services/datacenter/datacenter-state';
 import { fetchGreyNoise, fetchOtxPulses, fetchAbuseIpDb, fetchUrlscanFeed } from '@/services/osint';
 import { fetchAcledEvents, fetchAdsbMilitary } from '@/services/osint';
 import { fetchHibpBreaches, fetchTorMetrics } from '@/services/osint';
@@ -350,6 +351,11 @@ function protoItemToNewsItem(p: ProtoNewsItem): NewsItem {
 }
 
 const CYBER_LAYER_ENABLED = import.meta.env.VITE_ENABLE_CYBER_LAYER === 'true';
+
+// Cache of derived UGC zones per `${lat},${lon}` so the datacenter posture
+// loop resolves a site's forecast/county zones once instead of hitting NWS
+// `/points` on every weather refresh.
+const _siteUgcZoneCache = new Map<string, string[]>();
 
 export interface DataLoaderCallbacks {
   renderCriticalBanner: (postures: TheaterPostureSummary[]) => void;
@@ -1438,17 +1444,30 @@ export class DataLoaderManager implements AppModule {
  // Feed weather alerts + grid status into the datacenter posture engine.
  // Only runs when the user has a saved place tagged data_center.
  if (getDatacenterSite()) {
- const site = getDatacenterSite()!;
+ let site = getDatacenterSite()!;
+ // Resolve the site's own UGC zones once (forecast zone + county) so
+ // zone-only NWS products (ice/heat/flood are often issued by UGC zone,
+ // not polygon) can match the site instead of reading as clear. Cached
+ // by lat,lon; best-effort — degrades to polygon-only matching on failure.
+ if (!site.ugcZones) {
+ const zoneKey = `${site.lat},${site.lon}`;
+ let zones = _siteUgcZoneCache.get(zoneKey);
+ if (!zones) {
+ zones = await fetchUgcZonesForPoint(site.lat, site.lon);
+ _siteUgcZoneCache.set(zoneKey, zones);
+ }
+ if (zones.length > 0) {
+ site = { ...site, ugcZones: zones };
+ setDatacenterSite(site);
+ }
+ }
  const grid = await fetchGridStatus().catch(() => null);
  const gridStatus = grid?.find((g) => g.region === site.eiaRegion) ?? null;
  // Map WeatherAlert[] → NwsAlertMinimal[]. Shapes differ (severity casing,
  // Date vs ISO). WeatherAlert carries its polygon as a flat [lon,lat] ring
  // under `coordinates`; map it into polygon.rings so matchAlertToPlace can
- // do point-in-polygon against the site — without it weather posture could
- // never match an alert.
- // v1 gap: WeatherAlert has no UGC zone codes, so zone-only NWS products
- // (common for ice/heat/flood) can't match the site and read as clear here.
- // Threading ugcZones through WeatherAlert is the follow-up.
+ // do point-in-polygon against the site. UGC zones thread through so the
+ // matcher's zone fallback fires for polygon-free alerts.
  const nwsAlerts = alerts.map((a) => ({
  id: a.id,
  event: a.event,
@@ -1456,6 +1475,7 @@ export class DataLoaderManager implements AppModule {
  expires: a.expires instanceof Date ? a.expires.toISOString() : String(a.expires),
  severity: (a.severity?.toLowerCase() as import('@/services/weather/weather-threat-types').WeatherSeverity | undefined),
  polygon: a.coordinates.length >= 3 ? { rings: [a.coordinates] } : undefined,
+ ugcZones: a.ugcZones,
  headline: a.headline,
  }));
  recomputeDatacenterPosture({

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -1457,8 +1457,13 @@ export class DataLoaderManager implements AppModule {
  _siteUgcZoneCache.set(zoneKey, zones);
  }
  if (zones.length > 0) {
- site = { ...site, ugcZones: zones };
- setDatacenterSite(site);
+ // Re-read current site after async gap — only write back if it's still
+ // the same site (prevents stale-site race if saved places changed).
+ const current = getDatacenterSite();
+ if (current && current.lat === site.lat && current.lon === site.lon) {
+ setDatacenterSite({ ...current, ugcZones: zones });
+ }
+ site = getDatacenterSite() ?? site;
  }
  }
  const grid = await fetchGridStatus().catch(() => null);

--- a/src/e2e/map-harness.ts
+++ b/src/e2e/map-harness.ts
@@ -906,6 +906,7 @@ const seedAllDynamicData = (): void => {
  expires: new Date('2026-02-01T18:00:00.000Z'),
  coordinates: [[-80.1, 25.7], [-80.2, 25.8], [-80.3, 25.6]],
  centroid: [-80.2, 25.7],
+ ugcZones: [],
  },
   ];
 

--- a/src/services/datacenter/__tests__/weather-posture.test.mts
+++ b/src/services/datacenter/__tests__/weather-posture.test.mts
@@ -41,3 +41,33 @@ test('an alert far away does not match', () => {
   const p = computeWeatherPosture(SITE, [alert('Tornado Warning', around(10, 10))], { now: NOW });
   assert.equal(p.level, 'normal');
 });
+
+test('zone-only alert (no polygon) matches site via UGC zone -> not normal', () => {
+  const siteWithZones: SiteConfig = { ...SITE, ugcZones: ['INZ001', 'INC091'] };
+  const zoneAlert: NwsAlertMinimal = {
+    id: 'al-ice',
+    event: 'Ice Storm Warning',
+    polygon: undefined,
+    ugcZones: ['INZ001'],
+    sent: new Date(NOW - 60_000).toISOString(),
+    expires: new Date(NOW + 3_600_000).toISOString(),
+  };
+  const p = computeWeatherPosture(siteWithZones, [zoneAlert], { now: NOW });
+  assert.notEqual(p.level, 'normal');
+  assert.ok(p.activeHazards.includes('ice_storm'));
+  assert.ok(p.drivers.some((d) => d.includes('Matched UGC zone INZ001')));
+});
+
+test('zone-only alert does not match a site without that zone', () => {
+  const siteWithZones: SiteConfig = { ...SITE, ugcZones: ['INZ001'] };
+  const zoneAlert: NwsAlertMinimal = {
+    id: 'al-ice-2',
+    event: 'Ice Storm Warning',
+    polygon: undefined,
+    ugcZones: ['OHZ050'],
+    sent: new Date(NOW - 60_000).toISOString(),
+    expires: new Date(NOW + 3_600_000).toISOString(),
+  };
+  const p = computeWeatherPosture(siteWithZones, [zoneAlert], { now: NOW });
+  assert.equal(p.level, 'normal');
+});

--- a/src/services/datacenter/datacenter-types.ts
+++ b/src/services/datacenter/datacenter-types.ts
@@ -57,6 +57,9 @@ export interface SiteConfig {
   lon: number;
   radiusKm: number;
   eiaRegion: EiaRegion;
+  /** UGC zone/county codes for the site, derived at runtime from NWS
+   *  `/points`. Enables zone-fallback matching for polygon-free alerts. */
+  ugcZones?: string[];
 }
 
 export interface PowerPosture {

--- a/src/services/datacenter/weather-posture.ts
+++ b/src/services/datacenter/weather-posture.ts
@@ -15,7 +15,7 @@ export function computeWeatherPosture(
   options: WeatherPostureOptions = {},
 ): WeatherPosture {
   const now = options.now ?? Date.now();
-  const place: WeatherPlace = { id: site.id, label: site.name, lat: site.lat, lon: site.lon, radiusKm: site.radiusKm };
+  const place: WeatherPlace = { id: site.id, label: site.name, lat: site.lat, lon: site.lon, radiusKm: site.radiusKm, ugcZones: site.ugcZones };
 
   let level: DcLevel = 'normal';
   const hazards = new Set<WeatherHazardKind>();

--- a/src/services/weather.ts
+++ b/src/services/weather.ts
@@ -11,6 +11,9 @@ export interface WeatherAlert {
   expires: Date;
   coordinates: [number, number][];
   centroid?: [number, number];
+  /** UGC zone/county codes the alert applies to (from properties.geocode.UGC).
+   *  Used as the geometry-free fallback when an alert has no polygon. */
+  ugcZones: string[];
 }
 
 interface NWSAlert {
@@ -23,6 +26,7 @@ interface NWSAlert {
  areaDesc: string;
  onset: string;
  expires: string;
+ geocode?: { UGC?: string[]; SAME?: string[] };
   };
   geometry?: {
  type: string;
@@ -45,7 +49,7 @@ export async function fetchWeatherAlerts(): Promise<WeatherAlert[]> {
 
  if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
- const data: NWSResponse = await response.json();
+ const data = await response.json() as NWSResponse;
 
  return data.features
  .filter(alert => alert.properties.severity !== 'Unknown')
@@ -57,12 +61,13 @@ export async function fetchWeatherAlerts(): Promise<WeatherAlert[]> {
  event: alert.properties.event,
  severity: alert.properties.severity as WeatherAlert['severity'],
  headline: alert.properties.headline,
- description: alert.properties.description?.slice(0, 500) || '',
+ description: alert.properties.description?.slice(0, 500) ?? '',
  areaDesc: alert.properties.areaDesc,
  onset: new Date(alert.properties.onset),
  expires: new Date(alert.properties.expires),
  coordinates: coords,
  centroid: calculateCentroid(coords),
+ ugcZones: alert.properties.geocode?.UGC ?? [],
  };
  });
   }, []);
@@ -72,17 +77,42 @@ export function getWeatherStatus(): string {
   return breaker.getStatus();
 }
 
+interface NWSPointZones {
+  properties?: { forecastZone?: string; county?: string };
+}
+
+/** Derive a location's own UGC codes (forecast zone + county) from NWS
+ *  `/points/{lat},{lon}`. Best-effort: returns `[]` on any failure so
+ *  callers can degrade to polygon-only matching. The codes are the last
+ *  path segment of the `forecastZone` / `county` URLs (e.g. `INZ001`). */
+export async function fetchUgcZonesForPoint(lat: number, lon: number): Promise<string[]> {
+  try {
+    const res = await fetch(`https://api.weather.gov/points/${lat},${lon}`, {
+      headers: { 'User-Agent': 'CrystalBall/1.0', Accept: 'application/geo+json' },
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!res.ok) return [];
+    const payload = await res.json() as NWSPointZones;
+    const zones = [payload.properties?.forecastZone, payload.properties?.county]
+      .map((url) => url?.split('/').pop() ?? '')
+      .filter((code) => /^[A-Z]{2}[CZ]\d{3}$/.test(code));
+    return [...new Set(zones)];
+  } catch {
+    return [];
+  }
+}
+
 function extractCoordinates(geometry?: NWSAlert['geometry']): [number, number][] {
   if (!geometry) return [];
 
   try {
  if (geometry.type === 'Polygon') {
  const coords = geometry.coordinates as unknown as number[][][];
- return coords[0]?.map(c => [c[0], c[1]] as [number, number]) || [];
+ return coords[0]?.map(c => [c[0], c[1]] as [number, number]) ?? [];
  }
  if (geometry.type === 'MultiPolygon') {
  const coords = geometry.coordinates as unknown as number[][][][];
- return coords[0]?.[0]?.map(c => [c[0], c[1]] as [number, number]) || [];
+ return coords[0]?.[0]?.map(c => [c[0], c[1]] as [number, number]) ?? [];
  }
   } catch {
  return [];

--- a/src/services/weather/nws-polygon-match.ts
+++ b/src/services/weather/nws-polygon-match.ts
@@ -77,7 +77,7 @@ export function matchAlertToPlace(
   // does the deterministic part (matched? yes/no by membership);
   // distance is undefined for zone matches.
   if (!alert.polygon || alert.polygon.rings.length === 0) {
-    const placeZones = (place as { ugcZones?: string[] }).ugcZones ?? [];
+    const placeZones = place.ugcZones ?? [];
     const placeZoneSet = new Set(placeZones);
     const matchedZone = (alert.ugcZones ?? []).find((z) => placeZoneSet.has(z));
     if (matchedZone) {

--- a/src/services/weather/weather-threat-types.ts
+++ b/src/services/weather/weather-threat-types.ts
@@ -106,6 +106,10 @@ export interface SavedPlace {
   /** Optional radius (km) defining a sensitivity buffer. Anything
    *  inside `radiusKm` of the polygon is treated as "near". */
   radiusKm?: number;
+  /** Optional UGC zone/county codes for this place (derived from NWS
+   *  `/points`). Lets the matcher fall back to zone matching when an
+   *  alert has no polygon. */
+  ugcZones?: string[];
 }
 
 // ── Match result ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes datacenter weather posture to handle NWS alerts that carry only UGC zone codes (no polygon geometry). Ice/heat/flood advisories are commonly issued by UGC zone only, causing them to read as clear at the data center site.

## Changes
- Fetches forecast zone + county for the data center site lat/lon on first weather refresh (cached by lat/lon, best-effort)
- Stores zones on `SiteConfig.ugcZones`
- `matchAlertToPlace` already handles UGC zone overlap for polygon-free alerts — this just populates the data

## Review fix (Codex)
Codex caught a stale-site race: re-reading `getDatacenterSite()` before write-back so a saved-place change during the async `fetchUgcZonesForPoint` doesn't overwrite a stale site.

## Markdown fix
MD032/MD031 blank-line errors in the intelligent-algorithms spec doc.

cross-agent review: codex — LGTM on UGC matching logic + null safety. One race (stale-site write after async) caught and fixed in this PR.