### PR TITLE
feat(command-center): situation lifecycle timeline (spine question 2)

### DIFF
--- a/src/components/CommandCenterPanel.ts
+++ b/src/components/CommandCenterPanel.ts
@@ -60,6 +60,7 @@ import {
 import { loadRules } from '@/services/intelligence/rules-engine';
 import {
   buildCommandCenterSummary,
+  buildSituationTimeline,
   type CommandCenterSummary,
   type SituationSummary,
   type WhatChangedItem,
@@ -301,6 +302,7 @@ export class CommandCenterPanel extends Panel {
     return `<div style="display:flex;flex-direction:column;gap:10px;padding:10px;border:1px solid var(--border-subtle,#333);border-radius:6px;background:rgba(255,255,255,0.02);">
       <div style="font-size:10px;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-secondary,#aaa);">Command Center · Five questions</div>
       ${this.renderSpineSituations(summary.topSituations)}
+      ${this.renderSpineTimeline(summary.topSituations)}
       ${this.renderSpineWhatChanged(summary.whatChanged)}
       ${this.renderSpineFeedHealth(summary.feedHealth)}
       ${this.renderSpineActions(summary.suggestedActions)}
@@ -333,6 +335,24 @@ export class CommandCenterPanel extends Panel {
       </div>`;
     }).join('');
     return spineSection('1. What matters right now? (with: why does it matter to me?)', `<div style="display:flex;flex-direction:column;gap:4px;">${rows}</div>`);
+  }
+
+  private renderSpineTimeline(situations: readonly SituationSummary[]): string {
+    const top = situations[0];
+    if (!top) {
+      return spineSection('2. How did this develop?', '<div style="font-size:12px;color:var(--text-secondary,#aaa);">No active situation to trace yet.</div>');
+    }
+    const steps = buildSituationTimeline(top);
+    const rows = steps.map((step, idx) => `<li style="font-size:12px;display:flex;gap:6px;align-items:baseline;">
+      <span style="color:var(--text-secondary,#aaa);">${idx === steps.length - 1 ? '└' : '├'}</span>
+      <strong style="font-size:11px;">${escapeHtml(step.label)}</strong>
+      <span style="color:var(--text-secondary,#aaa);font-size:10px;">${escapeHtml(step.detail)}</span>
+      <span style="color:var(--text-secondary,#aaa);margin-left:auto;font-size:10px;">${timeAgo(step.at)}</span>
+    </li>`).join('');
+    return spineSection(
+      `2. How did this develop? (${escapeHtml(top.name)})`,
+      `<ul style="list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:3px;">${rows}</ul>`,
+    );
   }
 
   private renderSpineWhatChanged(items: readonly WhatChangedItem[]): string {

--- a/src/services/intelligence/__tests__/command-center-summary.test.mts
+++ b/src/services/intelligence/__tests__/command-center-summary.test.mts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import {
   buildCommandCenterSummary,
+  buildSituationTimeline,
   rankSituations,
   buildSituationSummary,
   matchingRulesFor,
@@ -12,6 +13,7 @@ import {
   haversineKm,
   describePlaybookStep,
   type SavedPlaceLite,
+  type SituationSummary,
 } from '../command-center-summary.ts';
 import type { Situation, AlertRule, Playbook } from '@/types/intelligence';
 import type { WhatChangedReport } from '../what-changed.ts';
@@ -330,4 +332,50 @@ test('builder: never returns more than 3 top situations', () => {
     now: NOW,
   });
   assert.equal(out.topSituations.length, 3);
+});
+
+function summ(over: Partial<SituationSummary> = {}): SituationSummary {
+  return {
+    id: 'sit-1',
+    name: 'Test situation',
+    severity: 'moderate',
+    domain: 'earthquake',
+    summary: 'A test situation',
+    observationCount: 2,
+    correlationCount: 1,
+    startedAt: NOW - HOUR,
+    updatedAt: NOW - HOUR,
+    nearestPlace: null,
+    matchingRules: [],
+    domainIcon: '⚑',
+    ...over,
+  };
+}
+
+test('timeline: same start/update collapses to a single detected step', () => {
+  const steps = buildSituationTimeline(summ({ startedAt: NOW, updatedAt: NOW }));
+  assert.equal(steps.length, 1);
+  assert.equal(steps[0]!.kind, 'detected');
+  assert.equal(steps[0]!.at, NOW);
+  assert.match(steps[0]!.detail, /2 signals · 1 correlation/);
+});
+
+test('timeline: distinct update produces detected + latest steps in order', () => {
+  const steps = buildSituationTimeline(summ({ startedAt: NOW - HOUR, updatedAt: NOW }));
+  assert.equal(steps.length, 2);
+  assert.equal(steps[0]!.kind, 'detected');
+  assert.equal(steps[0]!.at, NOW - HOUR);
+  assert.equal(steps[1]!.kind, 'latest');
+  assert.equal(steps[1]!.at, NOW);
+  assert.match(steps[1]!.detail, /2 signals · 1 correlation/);
+});
+
+test('timeline: sub-minute update stays a single step', () => {
+  const steps = buildSituationTimeline(summ({ startedAt: NOW, updatedAt: NOW + 30_000 }));
+  assert.equal(steps.length, 1);
+});
+
+test('timeline: singular signal/correlation labels', () => {
+  const steps = buildSituationTimeline(summ({ startedAt: NOW, updatedAt: NOW, observationCount: 1, correlationCount: 1 }));
+  assert.match(steps[0]!.detail, /1 signal · 1 correlation/);
 });

--- a/src/services/intelligence/command-center-summary.ts
+++ b/src/services/intelligence/command-center-summary.ts
@@ -54,6 +54,38 @@ export interface SituationSummary {
   domainIcon: string;
 }
 
+/** One step in a situation's lifecycle chronology. */
+export interface SituationTimelineStep {
+  kind: 'detected' | 'latest';
+  /** ms-epoch of the step. */
+  at: number;
+  label: string;
+  detail: string;
+}
+
+/** Treat detected/latest as distinct steps only when at least this far apart. */
+const TIMELINE_DISTINCT_MS = 60_000;
+
+/**
+ * Derive an honest lifecycle chronology from the data a SituationSummary
+ * actually carries (startedAt / updatedAt / accumulated counts). It does not
+ * fabricate per-event rows the summary does not resolve — at most two steps:
+ * when the situation was first detected and its latest update.
+ */
+export function buildSituationTimeline(s: SituationSummary): SituationTimelineStep[] {
+  const signalDetail = `${s.observationCount} signal${s.observationCount === 1 ? '' : 's'} · ${s.correlationCount} correlation${s.correlationCount === 1 ? '' : 's'}`;
+  const detected: SituationTimelineStep = {
+    kind: 'detected',
+    at: s.startedAt,
+    label: 'Detected',
+    detail: `${s.severity} · ${s.domain}`,
+  };
+  if (s.updatedAt - s.startedAt >= TIMELINE_DISTINCT_MS) {
+    return [detected, { kind: 'latest', at: s.updatedAt, label: 'Last update', detail: signalDetail }];
+  }
+  return [{ ...detected, detail: `${detected.detail} · ${signalDetail}` }];
+}
+
 export interface WhatChangedItem {
   /** Stable id derived from the underlying change so consumers can
    *  dedupe across renders. */


### PR DESCRIPTION
## Summary

Closes the 9th and final Command Center capability from the deferred spec — a **per-situation lifecycle timeline**. An audit confirmed `CommandCenterPanel` already covered the other 8 capabilities and is fully wired; only the chronology was missing. This fills the previously-empty **"question 2"** slot in the five-question spine.

## What it does

- `buildSituationTimeline(s: SituationSummary)` — pure, deterministic. Derives a 1–2 step lifecycle (**Detected** → optional **Last update**) from data the summary already carries (`startedAt` / `updatedAt` / `observationCount` / `correlationCount`).
- Deliberately does **not** fabricate per-event rows the summary doesn't resolve — at most two honest steps. Steps split only when `updatedAt − startedAt >= 60s`; otherwise they collapse into a single detected step with combined detail.
- `renderSpineTimeline()` in the panel renders it as spine question 2 ("How did this develop?").

## Tests

- 4 new unit tests in `command-center-summary.test.mts` (collapse, split-in-order, sub-minute collapse, singular/plural). 33/33 in that file, 210/210 intelligence suite. Typecheck + ESLint clean.

## Edge cases

- `updatedAt < startedAt` collapses to a single detected step — never renders an out-of-order "latest".

cross-agent review: codex — no issue found. Verified the 60s split threshold is sound, signal/correlation pluralization is correct, and updatedAt < startedAt safely collapses to one step (no out-of-order latest).