### PR TITLE
perf: stop continuous frame painting that caused typing lag

### DIFF
--- a/src/components/CesiumGlobe.ts
+++ b/src/components/CesiumGlobe.ts
@@ -17,6 +17,7 @@ import {
 } from 'cesium';
 import 'cesium/Build/Cesium/Widgets/widgets.css';
 import { initCesium } from '@/config/cesium-init';
+import { isAppActive } from '@/services/app-activity';
 
 export interface CesiumGlobeOptions {
   container: HTMLElement;
@@ -29,6 +30,7 @@ export class CesiumGlobe {
   private resizeObserver: ResizeObserver | null = null;
   private renderHeartbeat: ReturnType<typeof setInterval> | null = null;
   private fallbackAdded = false;
+  private renderTickId: ReturnType<typeof setInterval> | null = null;
 
   constructor(private readonly options: CesiumGlobeOptions) {
  this.container = options.container;
@@ -73,11 +75,13 @@ export class CesiumGlobe {
  // the globe while roughly halving the per-frame anti-aliasing cost.
  msaaSamples: 2,
  useBrowserRecommendedResolution: false,
- // On-demand rendering: only paint when the scene actually changes (camera
- // motion, imagery load, explicit requestRender) instead of a continuous
- // 60fps loop. Idle GPU/power drops dramatically. A low-frequency heartbeat
- // (see startRenderHeartbeat) covers data mutations that don't self-flag.
+ // On-demand rendering: only paint when the scene changes, not every
+ // frame. maximumRenderTimeChange: Infinity disables clock-driven
+ // re-renders; the throttled tick (startRenderTick) drives CallbackProperty
+ // pulses while a low-frequency heartbeat (startRenderHeartbeat) covers
+ // data mutations that don't self-flag a render.
  requestRenderMode: true,
+ maximumRenderTimeChange: Infinity,
  });
 
  const scene = this.viewer.scene;
@@ -268,9 +272,27 @@ export class CesiumGlobe {
  // log any polyline/point that sits above the ellipsoid. This catches
  // "floating cable" regressions at runtime instead of waiting for user reports.
  setTimeout(() => this.auditEntityHeights(), 10_000);
+
+ // ── On-demand render driver ──────────────────────────
+ // With requestRenderMode, Cesium only paints when something requests
+ // a render. Camera/scene changes auto-request, but the Date.now()-based
+ // CallbackProperty pulses (radnet/conflict/strike beacons) need a steady
+ // nudge. Tick at ~20fps while the app is active; when hidden/blurred we
+ // request nothing, so the globe stops painting entirely.
+ this.startRenderTick();
   }
 
-   
+  private startRenderTick(): void {
+ if (this.renderTickId !== null) return;
+ this.renderTickId = setInterval(() => {
+ if (!isAppActive()) return;
+ const viewer = this.viewer;
+ if (!viewer || viewer.isDestroyed()) return;
+ viewer.scene.requestRender();
+ }, 50);
+  }
+
+
   private auditEntityHeights(): void {
  const viewer = this.viewer;
  if (!viewer) return;
@@ -477,6 +499,7 @@ export class CesiumGlobe {
   private startRenderHeartbeat(): void {
  if (this.renderHeartbeat) return;
  this.renderHeartbeat = setInterval(() => {
+ if (!isAppActive()) return;
  const scene = this.viewer?.scene;
  if (scene && !this.viewer?.isDestroyed()) scene.requestRender();
  }, 1000);
@@ -486,6 +509,10 @@ export class CesiumGlobe {
  if (this.renderHeartbeat) {
  clearInterval(this.renderHeartbeat);
  this.renderHeartbeat = null;
+ }
+ if (this.renderTickId !== null) {
+ clearInterval(this.renderTickId);
+ this.renderTickId = null;
  }
  this.resizeObserver?.disconnect();
  this.resizeObserver = null;

--- a/src/components/CountersPanel.ts
+++ b/src/components/CountersPanel.ts
@@ -5,6 +5,7 @@ import {
   formatCounterValue,
   type CounterMetric,
 } from '@/services/humanity-counters';
+import { isAppActive, onActivityChange } from '@/services/app-activity';
 
 /**
  * CountersPanel -- Worldometer-style ticking counters showing positive global metrics.
@@ -19,11 +20,17 @@ import {
 export class CountersPanel extends Panel {
   private animFrameId: number | null = null;
   private valueElements = new Map<string, HTMLElement>();
+  private _unsubActivity: (() => void) | null = null;
 
   constructor() {
  super({ id: 'counters', title: 'Live Counters', trackActivity: false });
  this.createCounterGrid();
  this.startTicking();
+ // Resume the 60fps tick when the window regains focus/visibility — the
+ // tick stops itself while inactive (counters recompute from absolute time).
+ this._unsubActivity = onActivityChange((active) => {
+ if (active) this.startTicking();
+ });
   }
 
   /**
@@ -97,6 +104,12 @@ export class CountersPanel extends Panel {
  * to avoid layout thrashing at 60fps.
  */
   private tick = (): void => {
+ // Pause when the window is hidden/blurred — stop re-scheduling so the
+ // loop idles entirely (constructor's activity listener restarts it).
+ if (!isAppActive()) {
+ this.animFrameId = null;
+ return;
+ }
  for (const metric of COUNTER_METRICS) {
  const el = this.valueElements.get(metric.id);
  if (el) {
@@ -114,6 +127,10 @@ export class CountersPanel extends Panel {
  if (this.animFrameId !== null) {
  cancelAnimationFrame(this.animFrameId);
  this.animFrameId = null;
+ }
+ if (this._unsubActivity) {
+ this._unsubActivity();
+ this._unsubActivity = null;
  }
  this.valueElements.clear();
  super.destroy();

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -56,6 +56,7 @@ import { escapeHtml } from '@/utils/sanitize';
 import { tokenizeForMatch, matchKeyword, matchesAnyKeyword, findMatchingKeywords } from '@/utils/keyword-match';
 import { t } from '@/services/i18n';
 import { debounce, rafSchedule, getCurrentTheme } from '@/utils/index';
+import { isAppActive, onActivityChange } from '@/services/app-activity';
 import {
   INTEL_HOTSPOTS,
   CONFLICT_ZONES,
@@ -616,11 +617,18 @@ export class DeckGLMap {
   private moveTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private _themeChangedHandler: ((e: Event) => void) | null = null;
   private mapEventHandlers: Array<{ event: string; handler: (...args: unknown[]) => void }> = [];
+  private _unsubActivity: (() => void) | null = null;
 
   constructor(container: HTMLElement, initialState: DeckMapState) {
  this.container = container;
  this.state = initialState;
  this.hotspots = [...INTEL_HOTSPOTS];
+
+ // Resume self-arming animation loops (alert pulses) when the window
+ // regains focus/visibility — they stop re-arming while inactive.
+ this._unsubActivity = onActivityChange((active) => {
+ if (active && this.alertPulses.length > 0) this.rafUpdateLayers();
+ });
 
  this.debouncedRebuildLayers = debounce(() => {
  if (this.renderPaused || this.webglLost || !this.maplibreMap) return;
@@ -1495,8 +1503,10 @@ export class DeckGLMap {
  },
  updateTriggers: { getRadius: t, getLineColor: t },
  }));
- // Throttled repaint — drives alert pulse at ~4fps instead of unbounded RAF loop
- if (!this.rafUpdateLayersPending) {
+ // Throttled repaint — drives alert pulse at ~4fps instead of unbounded RAF loop.
+ // Gated on render state + app activity so the self-arming loop stops when the
+ // map is paused or the window is hidden/blurred (resumed via onActivityChange).
+ if (!this.rafUpdateLayersPending && !this.renderPaused && isAppActive()) {
  setTimeout(() => this.rafUpdateLayers(), 250);
  }
  }
@@ -5943,6 +5953,11 @@ export class DeckGLMap {
  if (this._themeChangedHandler) {
  window.removeEventListener('theme-changed', this._themeChangedHandler);
  this._themeChangedHandler = null;
+ }
+
+ if (this._unsubActivity) {
+ this._unsubActivity();
+ this._unsubActivity = null;
  }
 
  // Remove all MapLibre event listeners to prevent leaks

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -174,10 +174,12 @@ export class Panel {
   protected header: HTMLElement;
   protected heartbeatEl: HTMLElement | null = null;
   protected narrativeEl: HTMLElement | null = null;
+  private heartbeatDotEl: HTMLElement | null = null;
   private lastTickAt = 0;
   private static instances = new Set<Panel>();
   private static tickerStarted = false;
   private static heartbeatTickerId: ReturnType<typeof setInterval> | null = null;
+  private static heartbeatObserver: IntersectionObserver | null = null;
   public getPanelId(): string { return this.panelId; }
 
   /** Returns the panel's content element for external mounting (e.g. embedding in settings modal). */
@@ -323,13 +325,15 @@ export class Panel {
  this.heartbeatEl = document.createElement('span');
  this.heartbeatEl.className = 'panel-heartbeat';
  const hbDot = document.createElement('span');
- hbDot.className = 'panel-heartbeat-dot';
+ hbDot.className = 'panel-heartbeat-dot hb-offscreen';
+ this.heartbeatDotEl = hbDot;
  const hbText = document.createElement('span');
  hbText.className = 'panel-heartbeat-text';
  hbText.textContent = '—';
  this.heartbeatTextEl = hbText;
  this.heartbeatEl.append(hbDot, hbText);
  this.header.append(this.heartbeatEl);
+ Panel.observeHeartbeatDot(hbDot);
 
  this.content = document.createElement('div');
  this.content.className = 'panel-content';
@@ -932,6 +936,24 @@ export class Panel {
  }, this.contentDebounceMs);
   }
 
+  /** Lazily create a shared observer that pauses heartbeat-dot animation
+   *  while the dot is scrolled out of view. Dots start paused (hb-offscreen)
+   *  and are un-paused only when they enter the viewport. */
+  private static observeHeartbeatDot(dot: HTMLElement): void {
+ if (typeof IntersectionObserver === 'undefined') {
+ dot.classList.remove('hb-offscreen');
+ return;
+ }
+ if (!Panel.heartbeatObserver) {
+ Panel.heartbeatObserver = new IntersectionObserver((entries) => {
+ for (const entry of entries) {
+ entry.target.classList.toggle('hb-offscreen', !entry.isIntersecting);
+ }
+ }, { rootMargin: '100px' });
+ }
+ Panel.heartbeatObserver.observe(dot);
+  }
+
   private static startHeartbeatTicker(): void {
  if (Panel.tickerStarted) return;
  Panel.tickerStarted = true;
@@ -1264,6 +1286,11 @@ export class Panel {
  this.freshFlashRafId = null;
  }
  this.abortController.abort();
+ Panel.instances.delete(this);
+ if (this.heartbeatDotEl) {
+ Panel.heartbeatObserver?.unobserve(this.heartbeatDotEl);
+ this.heartbeatDotEl = null;
+ }
  if (this.aiSummaryOverlay) {
  this.aiSummaryOverlay.remove();
  this.aiSummaryOverlay = null;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -18844,7 +18844,13 @@ body.has-breaking-alert .panels-grid {
   background: #4ade80;
   box-shadow: 0 0 6px rgba(74, 222, 128, 0.6);
   animation: panel-hb-pulse 2.4s ease-in-out infinite;
-  will-change: opacity;
+}
+/* Pause + de-promote dots scrolled out of view. The dashboard mounts hundreds
+   of panels; only the handful on-screen should animate (set by Panel's
+   IntersectionObserver). Without this every dot is a live compositor layer. */
+.panel-heartbeat-dot.hb-offscreen {
+  animation-play-state: paused;
+  will-change: auto;
 }
 .panel-heartbeat.stale .panel-heartbeat-dot { background: var(--mac-orange, #ff9f0a); box-shadow: 0 0 6px rgba(251, 191, 36, 0.6); }
 .panel-heartbeat.very-stale .panel-heartbeat-dot { background: var(--mac-red, #ff453a); box-shadow: 0 0 6px rgba(239, 68, 68, 0.6); animation: none; }
@@ -18921,8 +18927,9 @@ body.has-breaking-alert .panels-grid {
 .mac-sidebar-heat-badge[data-sev="critical"] {
   background: var(--mac-red, #ff453a) !important;
   color: #fff;
-  box-shadow: 0 0 8px rgba(239, 68, 68, 0.7);
+  box-shadow: 0 0 10px rgba(239, 68, 68, 0.8);
   animation: sidebar-heat-pulse 1.6s ease-in-out infinite;
+  will-change: opacity;
 }
 .mac-sidebar-heat-badge[data-sev="high"] {
   background: #fb923c !important;
@@ -18934,9 +18941,11 @@ body.has-breaking-alert .panels-grid {
 }
 .mac-sidebar-panel-item.heat-critical { border-left: 2px solid var(--mac-red, #ff453a); }
 .mac-sidebar-panel-item.heat-high { border-left: 2px solid #fb923c; }
+/* Pulse via opacity (compositor-only) rather than animating box-shadow,
+   which forces a full raster repaint every frame. Static glow is kept above. */
 @keyframes sidebar-heat-pulse {
-  0%, 100% { box-shadow: 0 0 6px rgba(239, 68, 68, 0.5); }
-  50% { box-shadow: 0 0 14px rgba(239, 68, 68, 0.95); }
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.62; }
 }
 
 /* ── SIGINT legend chip ───────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

The app was nearly unusable for typing — the renderer core and WindowServer were pegged by **continuous frame painting** competing with the main thread on every keystroke. Root-cause hunt found four always-on render/animation loops; this fixes all of them so painting is on-demand or viewport-gated.

- **Panel heartbeat dots (dominant cost):** ~384 dots animated forever, each a live compositor layer. A shared `IntersectionObserver` now pauses + de-promotes the hundreds off-screen; only visible dots animate. Removed the blanket `will-change` that was force-promoting every dot.
- **Cesium globe:** `requestRenderMode: true` + `maximumRenderTimeChange: Infinity` so it paints on change, not every frame. An `isAppActive`-gated ~20fps tick keeps the `Date.now()`-driven `CallbackProperty` beacon pulses alive without freezing under on-demand mode.
- **DeckGL alert-pulse:** self-arming 4fps repaint loop now gated on `!renderPaused && isAppActive()`, with an `onActivityChange` resume; stops entirely when hidden/blurred.
- **CountersPanel:** 60fps rAF idles when the window is hidden/blurred, resumes on focus.
- **Sidebar heat pulse:** animates `opacity` (compositor-only) instead of `box-shadow` (full raster repaint per frame).
- Drive-by fix: destroyed panels are now removed from the static `Panel.instances` set (pre-existing leak).

## Reconciliation with #1069

#1069 (merged) also added Cesium on-demand rendering. This branch was rebased and the `CesiumGlobe.ts` overlap merged as a **union**: kept #1069's `msaaSamples: 2` + 1s data-mutation heartbeat (now also `isAppActive`-gated so it idles when backgrounded) **and** this PR's `maximumRenderTimeChange: Infinity` + 50fps gated beacon tick. Both render drivers and both `destroy()` clears are present.

## Validation

- `npm run typecheck:all` — zero errors.
- Live preview: 384 heartbeat dots off-screen → all paused, zero `will-change`; toggle to `running` when scrolled into view.

Cross-agent review: Claude independent review pass on 2026-06-10; outcome: pass — verified lifecycle/teardown (observers + both timers cleared on destroy), the gated tick is idempotent and non-leaking, requestRenderMode does not freeze the CallbackProperty beacons, and the `Panel.instances` delete does not break iteration. Cesium overlap with #1069 reconciled as a verified union.

https://claude.ai/code/session_01426AyLjzT4cLsXTBRFMuHs