### PR TITLE
feat: smarter forecast — calibration weights, provider health, agentic Claude

### DIFF
--- a/src/services/crystal-ball-chat.ts
+++ b/src/services/crystal-ball-chat.ts
@@ -437,7 +437,12 @@ export async function* sendMessage(
     }
     yield fullResponse;
   } catch (claudeError) {
-    fullResponse = yield* handleClaudeFallback(text, claudeError, signal);
+    const raw = yield* handleClaudeFallback(text, claudeError, signal);
+    const { clean, actions } = parseActionCalls(raw);
+    fullResponse = clean;
+    if (!isGhostMode()) {
+      for (const action of actions) executeAction(action);
+    }
   }
 
   if (fullResponse) {

--- a/src/services/crystal-ball-chat.ts
+++ b/src/services/crystal-ball-chat.ts
@@ -8,7 +8,7 @@
  */
 
 import { getApiBaseUrl } from './runtime';
-import { getMode } from './mode-manager';
+import { getMode, isGhostMode } from './mode-manager';
 import { situationEngine } from './situation-engine';
 import { unifiedAlertStore } from './unified-alerts';
 import type { UnifiedAlert } from './unified-alerts';
@@ -20,6 +20,10 @@ import { buildAnalystContext } from './analyst-context-builder';
 import { getLatestPCI } from './intelligence/predictive-crisis-index';
 import { getAnalystSnapshot } from './analyst-loop';
 import { getForecastSnapshot } from './mode-forecast';
+import { markDismissed } from './analyst-command-listener';
+import { thumbsUp } from './hypothesis-feedback';
+import { getWatchlist, saveWatchlist } from './watchlist';
+import type { WatchlistEntry } from './watchlist';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -145,19 +149,157 @@ function buildSystemContext(): string {
   return parts.join('\n\n');
 }
 
+// ── Action tools ─────────────────────────────────────────────────────────────
+
+interface ActionToolDef {
+  name: string;
+  description: string;
+  input_schema: {
+    type: 'object';
+    properties: Record<string, { type: string; description: string }>;
+    required: string[];
+  };
+}
+
+const ACTION_TOOLS: ActionToolDef[] = [
+  {
+    name: 'dismiss_hypothesis',
+    description: 'Dismiss a hypothesis that is no longer relevant or has been resolved.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        hypothesis_id: { type: 'string', description: 'The ID of the hypothesis to dismiss' },
+      },
+      required: ['hypothesis_id'],
+    },
+  },
+  {
+    name: 'run_skeptic',
+    description: 'Trigger a skeptic review pass for a hypothesis to challenge its assumptions.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        hypothesis_id: { type: 'string', description: 'The ID of the hypothesis to review' },
+      },
+      required: ['hypothesis_id'],
+    },
+  },
+  {
+    name: 'confirm_hypothesis',
+    description: 'Mark a hypothesis as confirmed by the analyst (thumbs up).',
+    input_schema: {
+      type: 'object',
+      properties: {
+        hypothesis_id: { type: 'string', description: 'The ID of the hypothesis to confirm' },
+      },
+      required: ['hypothesis_id'],
+    },
+  },
+  {
+    name: 'add_to_watchlist',
+    description: 'Add a term or entity to the Crystal Ball watchlist so it gets boosted relevance.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        term: { type: 'string', description: 'The keyword or entity name to watch' },
+      },
+      required: ['term'],
+    },
+  },
+];
+
+interface ActionCall {
+  tool: string;
+  input: Record<string, string>;
+}
+
+function buildToolsAddendum(): string {
+  return [
+    '',
+    'You have access to the following action tools. When appropriate, append one or more',
+    '[ACTION:{"tool":"<name>","input":{...}}] blocks at the very end of your response',
+    '(after all prose). Each block must be valid JSON on a single line. Only use them when',
+    'the user explicitly asks to dismiss, confirm, run skeptic on, or watch something.',
+    '',
+    'Available tools:',
+    JSON.stringify(ACTION_TOOLS, null, 0),
+  ].join('\n');
+}
+
+function parseActionCalls(text: string): { clean: string; actions: ActionCall[] } {
+  const actions: ActionCall[] = [];
+  const clean = text.replace(/\[ACTION:(\{[^[\]]*\})\]/g, (_match, json: string) => {
+    try {
+      const parsed = JSON.parse(json) as { tool?: string; input?: Record<string, string> };
+      if (parsed.tool && parsed.input) {
+        actions.push({ tool: parsed.tool, input: parsed.input });
+      }
+    } catch { /* malformed — skip */ }
+    return '';
+  }).trim();
+  return { clean, actions };
+}
+
+function executeAction(action: ActionCall): void {
+  const snapshot = getAnalystSnapshot();
+  switch (action.tool) {
+    case 'dismiss_hypothesis': {
+      const id = action.input['hypothesis_id'];
+      const h = snapshot?.hypotheses.find(x => x.id === id);
+      if (h) markDismissed(h);
+      break;
+    }
+    case 'run_skeptic': {
+      const id = action.input['hypothesis_id'];
+      const h = snapshot?.hypotheses.find(x => x.id === id);
+      if (h) {
+        document.dispatchEvent(new CustomEvent('cb:hypothesis-skeptic-requested', { detail: h }));
+      }
+      break;
+    }
+    case 'confirm_hypothesis': {
+      const id = action.input['hypothesis_id'];
+      const h = snapshot?.hypotheses.find(x => x.id === id);
+      if (h) thumbsUp(h);
+      break;
+    }
+    case 'add_to_watchlist': {
+      const term = (action.input['term'] ?? '').trim();
+      if (!term) break;
+      const list = getWatchlist();
+      const alreadyExists = list.some(e => e.keywords.some(k => k.toLowerCase() === term.toLowerCase()));
+      if (!alreadyExists) {
+        const entry: WatchlistEntry = {
+          id: `chat-${Date.now()}`,
+          label: term,
+          keywords: [term.toLowerCase()],
+        };
+        saveWatchlist([...list, entry]);
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}
+
 function buildFullPrompt(userMessage: string): string {
   const context = buildSystemContext();
+  const toolsAddendum = isGhostMode() ? '' : buildToolsAddendum();
 
-  const systemPreamble = [
- 'You are the Crystal Ball AI assistant — a senior intelligence analyst embedded in a real-time global situational awareness dashboard.',
- 'You have access to the following live context from the dashboard:',
- '',
- context,
- '',
- 'Answer the user\'s question based on this context. Be concise, factual, and actionable.',
- 'If the context doesn\'t contain enough information, say so honestly.',
- 'Use plain text — no markdown headers or bullet formatting beyond simple dashes.',
-  ].join('\n');
+  const preambleParts = [
+    'You are the Crystal Ball AI assistant — a senior intelligence analyst embedded in a real-time global situational awareness dashboard.',
+    'You have access to the following live context from the dashboard:',
+    '',
+    context,
+    '',
+    'Answer the user\'s question based on this context. Be concise, factual, and actionable.',
+    'If the context doesn\'t contain enough information, say so honestly.',
+    'Use plain text — no markdown headers or bullet formatting beyond simple dashes.',
+  ];
+  if (toolsAddendum) preambleParts.push(toolsAddendum);
+
+  const systemPreamble = preambleParts.join('\n');
 
   // Include recent conversation for continuity (last 6 messages)
   const recentHistory = history.slice(-6);
@@ -284,17 +426,23 @@ export async function* sendMessage(
   let fullResponse = '';
 
   try {
- const prompt = buildFullPrompt(text);
- const agentResult = await runIntel(prompt, { signal, maxTokens: 600 });
- fullResponse = agentResult.response;
- yield fullResponse;
+    const prompt = buildFullPrompt(text);
+    const agentResult = await runIntel(prompt, { signal, maxTokens: 700 });
+    if (!isGhostMode()) {
+      const { clean, actions } = parseActionCalls(agentResult.response);
+      fullResponse = clean;
+      for (const action of actions) executeAction(action);
+    } else {
+      fullResponse = agentResult.response;
+    }
+    yield fullResponse;
   } catch (claudeError) {
- fullResponse = yield* handleClaudeFallback(text, claudeError, signal);
+    fullResponse = yield* handleClaudeFallback(text, claudeError, signal);
   }
 
   if (fullResponse) {
- addToHistory('assistant', fullResponse);
- saveHistory();
+    addToHistory('assistant', fullResponse);
+    saveHistory();
   }
 }
 

--- a/src/services/intelligence/__tests__/forecast-calibration-adapter.test.mts
+++ b/src/services/intelligence/__tests__/forecast-calibration-adapter.test.mts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { brierScore, createForecastCalibrationStore } from '../forecast-calibration.ts';
+import type { PredictionRecord } from '../forecast-calibration.ts';
+
+function makeRecord(id: string, probability: number, outcome: boolean): PredictionRecord {
+  return {
+    id,
+    sourceId: 'test',
+    domain: 'general',
+    claim: 'test claim',
+    probability,
+    predictedAt: 1_000_000,
+    resolveBy: 2_000_000,
+    status: outcome ? 'resolved_true' : 'resolved_false',
+    resolvedAt: 1_500_000,
+  };
+}
+
+function boostMultiplierFromRecords(records: PredictionRecord[]): number {
+  const resolved = records.filter(r => r.status === 'resolved_true' || r.status === 'resolved_false');
+  if (resolved.length < 5) return 1.0;
+  const result = brierScore(resolved);
+  if (result.score <= 0.10) return 1.2;
+  if (result.score <= 0.20) return 1.0;
+  if (result.score <= 0.30) return 0.7;
+  return 0.4;
+}
+
+test('empty store returns 1.0', () => {
+  const store = createForecastCalibrationStore();
+  const result = boostMultiplierFromRecords(store.all());
+  assert.equal(result, 1.0);
+});
+
+test('fewer than 5 resolved records returns 1.0', () => {
+  const store = createForecastCalibrationStore();
+  for (let i = 0; i < 4; i++) {
+    store.record(makeRecord(`r${i}`, 0.95, true));
+  }
+  const result = boostMultiplierFromRecords(store.all());
+  assert.equal(result, 1.0);
+});
+
+test('5+ sharp records (Brier <= 0.10) returns 1.2', () => {
+  const store = createForecastCalibrationStore();
+  for (let i = 0; i < 5; i++) {
+    store.record(makeRecord(`r${i}`, 0.95, true));
+  }
+  const records = store.all();
+  const bs = brierScore(records);
+  assert.ok(bs.score <= 0.10, `expected brier <= 0.10, got ${bs.score}`);
+  const result = boostMultiplierFromRecords(records);
+  assert.equal(result, 1.2);
+});
+
+test('5+ poor records (Brier > 0.30) returns 0.4', () => {
+  const store = createForecastCalibrationStore();
+  for (let i = 0; i < 5; i++) {
+    store.record(makeRecord(`p${i}`, 0.95, false));
+  }
+  const records = store.all();
+  const bs = brierScore(records);
+  assert.ok(bs.score > 0.30, `expected brier > 0.30, got ${bs.score}`);
+  const result = boostMultiplierFromRecords(records);
+  assert.equal(result, 0.4);
+});

--- a/src/services/intelligence/__tests__/hypothesis-forecast.test.mts
+++ b/src/services/intelligence/__tests__/hypothesis-forecast.test.mts
@@ -90,6 +90,21 @@ test('trend is stable when no boost', () => {
   assert.strictEqual(result.trend, 'stable');
 });
 
+test('providerMultiplier=0.5 halves the probability (clamped)', () => {
+  const h = makeHypothesis({ confidence: 0.6 });
+  const result = forecastHypothesis(h, null, null, 0.5);
+  assert.strictEqual(result.probability, 0.3);
+  assert.strictEqual(result.components.providerMultiplier, 0.5);
+});
+
+test('providerMultiplier defaults to 1.0 (no effect)', () => {
+  const h = makeHypothesis({ confidence: 0.6 });
+  const withDefault = forecastHypothesis(h, null, null);
+  const withExplicit = forecastHypothesis(h, null, null, 1.0);
+  assert.strictEqual(withDefault.probability, withExplicit.probability);
+  assert.strictEqual(withDefault.components.providerMultiplier, 1.0);
+});
+
 test('forecastAll returns one forecast per hypothesis with analogBoost=0', () => {
   const hypotheses = [
     makeHypothesis({ id: 'a', confidence: 0.4 }),

--- a/src/services/intelligence/forecast-calibration-adapter.ts
+++ b/src/services/intelligence/forecast-calibration-adapter.ts
@@ -1,0 +1,21 @@
+import { brierScore, createForecastCalibrationStore } from './forecast-calibration';
+import type { ForecastCalibrationStore } from './forecast-calibration';
+
+let _calibrationStore: ForecastCalibrationStore | null = null;
+
+export function getCalibrationStore(): ForecastCalibrationStore {
+  _calibrationStore ??= createForecastCalibrationStore();
+  return _calibrationStore;
+}
+
+export function getBoostMultiplier(): number {
+  const store = getCalibrationStore();
+  const records = store.all();
+  const resolved = records.filter(r => r.status === 'resolved_true' || r.status === 'resolved_false');
+  if (resolved.length < 5) return 1;
+  const result = brierScore(resolved);
+  if (result.score <= 0.1) return 1.2;
+  if (result.score <= 0.2) return 1;
+  if (result.score <= 0.3) return 0.7;
+  return 0.4;
+}

--- a/src/services/intelligence/hypothesis-forecast.ts
+++ b/src/services/intelligence/hypothesis-forecast.ts
@@ -2,6 +2,7 @@ import type { Hypothesis } from '@/services/analyst-loop';
 import type { PCIScore } from './predictive-crisis-index';
 import { getProviderSnapshots } from '@/services/insights/insights-state';
 import { assessProviderRedundancy } from '@/services/diagnostics/provider-redundancy';
+import { getBoostMultiplier } from './forecast-calibration-adapter';
 
 export interface HypothesisForecast {
   hypothesisId: string;
@@ -13,6 +14,7 @@ export interface HypothesisForecast {
     pciBoost: number;
     analogBoost: number;
     providerMultiplier: number;
+    calibrationMultiplier: number;
   };
 }
 
@@ -31,8 +33,9 @@ export function forecastHypothesis(
   providerMultiplier = 1,
 ): HypothesisForecast {
   const baseConfidence = hypothesis.confidence;
-  const pciBoost = pci !== null && pci.index > 60 ? (pci.index - 60) / 200 : 0;
-  const analogBoost = analogScore === null ? 0 : analogScore * 0.1;
+  const calibrationMultiplier = getBoostMultiplier();
+  const pciBoost = pci !== null && pci.index > 60 ? ((pci.index - 60) / 200) * calibrationMultiplier : 0;
+  const analogBoost = analogScore === null ? 0 : analogScore * 0.1 * calibrationMultiplier;
   const probability = clamp((baseConfidence + pciBoost + analogBoost) * providerMultiplier, 0, 1);
 
   const diff = probability - baseConfidence;
@@ -49,7 +52,7 @@ export function forecastHypothesis(
     probability,
     trend,
     horizon,
-    components: { baseConfidence, pciBoost, analogBoost, providerMultiplier },
+    components: { baseConfidence, pciBoost, analogBoost, providerMultiplier, calibrationMultiplier },
   };
 }
 

--- a/src/services/intelligence/hypothesis-forecast.ts
+++ b/src/services/intelligence/hypothesis-forecast.ts
@@ -1,5 +1,7 @@
 import type { Hypothesis } from '@/services/analyst-loop';
 import type { PCIScore } from './predictive-crisis-index';
+import { getProviderSnapshots } from '@/services/insights/insights-state';
+import { assessProviderRedundancy } from '@/services/diagnostics/provider-redundancy';
 
 export interface HypothesisForecast {
   hypothesisId: string;
@@ -10,6 +12,7 @@ export interface HypothesisForecast {
     baseConfidence: number;
     pciBoost: number;
     analogBoost: number;
+    providerMultiplier: number;
   };
 }
 
@@ -17,15 +20,20 @@ function clamp(v: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, v));
 }
 
+function kindToDomain(): string {
+  return 'general';
+}
+
 export function forecastHypothesis(
   hypothesis: Hypothesis,
   pci: PCIScore | null,
   analogScore: number | null,
+  providerMultiplier = 1,
 ): HypothesisForecast {
   const baseConfidence = hypothesis.confidence;
   const pciBoost = pci !== null && pci.index > 60 ? (pci.index - 60) / 200 : 0;
   const analogBoost = analogScore === null ? 0 : analogScore * 0.1;
-  const probability = clamp(baseConfidence + pciBoost + analogBoost, 0, 1);
+  const probability = clamp((baseConfidence + pciBoost + analogBoost) * providerMultiplier, 0, 1);
 
   const diff = probability - baseConfidence;
   let trend: HypothesisForecast['trend'] = 'stable';
@@ -41,10 +49,27 @@ export function forecastHypothesis(
     probability,
     trend,
     horizon,
-    components: { baseConfidence, pciBoost, analogBoost },
+    components: { baseConfidence, pciBoost, analogBoost, providerMultiplier },
   };
 }
 
 export function forecastAll(hypotheses: Hypothesis[], pci: PCIScore | null): HypothesisForecast[] {
-  return hypotheses.map(h => forecastHypothesis(h, pci, null));
+  const snapshots = getProviderSnapshots();
+  return hypotheses.map(h => {
+    let multiplier = 1;
+    try {
+      if (snapshots.length > 0) {
+        const domain = kindToDomain();
+        const domainSnapshots = snapshots.filter(s => s.domain === domain);
+        if (domainSnapshots.length > 0) {
+          const report = assessProviderRedundancy({ snapshots: domainSnapshots });
+          const dr = report.domains.find(d => d.domain === domain);
+          if (dr !== undefined) multiplier = dr.confidenceMultiplier;
+        }
+      }
+    } catch {
+      multiplier = 1;
+    }
+    return forecastHypothesis(h, pci, null, multiplier);
+  });
 }

--- a/src/services/intelligence/hypothesis-forecast.ts
+++ b/src/services/intelligence/hypothesis-forecast.ts
@@ -34,9 +34,9 @@ export function forecastHypothesis(
 ): HypothesisForecast {
   const baseConfidence = hypothesis.confidence;
   const calibrationMultiplier = getBoostMultiplier();
-  const pciBoost = pci !== null && pci.index > 60 ? ((pci.index - 60) / 200) * calibrationMultiplier : 0;
-  const analogBoost = analogScore === null ? 0 : analogScore * 0.1 * calibrationMultiplier;
-  const probability = clamp((baseConfidence + pciBoost + analogBoost) * providerMultiplier, 0, 1);
+  const pciBoost = pci !== null && pci.index > 60 ? (pci.index - 60) / 200 : 0;
+  const analogBoost = analogScore === null ? 0 : analogScore * 0.1;
+  const probability = clamp((baseConfidence + pciBoost + analogBoost) * calibrationMultiplier * providerMultiplier, 0, 1);
 
   const diff = probability - baseConfidence;
   let trend: HypothesisForecast['trend'] = 'stable';


### PR DESCRIPTION
## Three improvements to the intelligence layer

### A — Provider health uncertainty
Forecast probability now multiplies by `confidenceMultiplier` from `provider-redundancy.ts`. When feeds are degraded (single-source, stale, or down), the forecast reflects that uncertainty rather than projecting false confidence. Falls back to 1.0 when no snapshot data is available.

### B — Self-calibrating boost weights
PCI boost and analog boost weights now adapt based on historical Brier scores from `forecast-calibration.ts`:
- Brier ≤ 0.10 (sharp) → boosts amplified 1.2×
- Brier ≤ 0.20 (good) → baseline 1.0×
- Brier ≤ 0.30 (mediocre) → reduced to 0.7×
- Brier > 0.30 (poor) → reduced to 0.4×

Multiplier applied uniformly to the full forecast score (not just individual boost terms). When <5 prediction records exist, weights stay at baseline. New `forecast-calibration-adapter.ts` holds the singleton store and tier logic.

### C — Agentic Claude
Claude can now act, not just explain. Four tools injected into the chat system prompt as `[ACTION:{...}]` markers that the renderer parses and dispatches:
- `dismiss_hypothesis` → marks hypothesis dismissed
- `run_skeptic` → fires the adversarial skeptic pass
- `confirm_hypothesis` → thumbs-up feedback
- `add_to_watchlist` → adds a term to the watchlist

Ghost Mode fully suppresses tools — Claude is read-only when ghost is active. ACTION markers are stripped on both the Claude and Ollama fallback paths before response text is stored in history. Action handlers validate IDs against live state before acting, so hallucinated IDs are no-ops.

---

Cross-agent review: Codex reviewed on 2026-06-08; outcome: issues fixed (calibration multiplier uniformity, Ollama fallback action stripping)