### PR TITLE
fix: suppress 'Global' geo label from forecast overlay map

### DIFF
--- a/src/services/forecast-overlay.ts
+++ b/src/services/forecast-overlay.ts
@@ -182,6 +182,7 @@ export function buildForecastOverlay(): ForecastRegion[] {
   const situations = situationEngine.getActionableSituations();
   for (const sit of situations) {
  if (!sit.geo || sit.confidence < 0.3) continue;
+ if (sit.geo.label === 'Global') continue; // no meaningful map position
  const riskScore = Math.round(sit.confidence * 100);
  if (riskScore < 20) continue;
 


### PR DESCRIPTION
Situations with `geo.label === 'Global'` have no real geographic center — they fall back to lat/lon 0,0 in the Gulf of Guinea. This caused an uninformative `⚠ Global: N →` text label to float over Africa on the God's Eye globe.

One-line fix: skip any situation where `geo.label === 'Global'` in `buildForecastOverlay()`.