### PR TITLE
fix: use correct lat/lon fields for earthquake map layer

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -2209,7 +2209,7 @@ export class DeckGLMap {
  return new IconLayer({
  id: 'earthquakes-layer',
  data: earthquakes,
- getPosition: (d) => [d.location?.longitude ?? 0, d.location?.latitude ?? 0],
+ getPosition: (d) => [d.lon, d.lat],
  getIcon: () => 'earthquake',
  iconAtlas: getIconAtlas(),
  iconMapping: getIconMapping(),


### PR DESCRIPTION
The earthquake DeckGL layer was reading `d.location?.longitude` / `d.location?.latitude` but the `Earthquake` interface exposes `d.lon` / `d.lat` directly. Every earthquake was silently rendering at 0,0 (Gulf of Guinea) instead of its real location.

One-line fix: `getPosition: (d) => [d.lon, d.lat]`