### PR TITLE
fix: eliminate TriageBar/EntityHeatRail overlap in header

### DIFF
--- a/src/components/TriageBar.ts
+++ b/src/components/TriageBar.ts
@@ -84,9 +84,11 @@ export class TriageBar {
     if (stories.length === 0 && this.facet === 'all') {
       this.element.hidden = true;
       this.element.replaceChildren();
+      document.body.classList.remove('has-triage-bar');
       return;
     }
     this.element.hidden = false;
+    document.body.classList.add('has-triage-bar');
     const label = document.createElement('div');
     label.className = 'triage-bar-label';
     label.textContent = '⚡ TRIAGE';

--- a/src/styles/macos-native.css
+++ b/src/styles/macos-native.css
@@ -14,6 +14,11 @@ body.is-desktop-macos {
   --mac-toolbar-height: 44px;
   --mac-traffic-lights-height: 44px; /* safe area below traffic lights */
 
+  /* The content area starts at the toolbar bottom (44px), not the EEW bar
+     bottom (32px). Fixed overlays that should appear below the header must
+     use this value, not --eew-bar-h. */
+  --below-eew: var(--mac-toolbar-height);
+
   /* Dark-mode macOS system colors (approximated) */
   --mac-window-bg: #1c1c1e;
   --mac-sidebar-bg: rgba(44, 44, 46, 0.72);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -14936,7 +14936,7 @@ a.prediction-link:hover {
 
 /* Push content down when critical banner is visible */
 body.has-critical-banner .panels-grid {
-  padding-top: 50px;
+  padding-top: var(--staleness-banner-h);
 }
 
 /* ============ Data Staleness Banner ============ */
@@ -19015,6 +19015,12 @@ body.has-breaking-alert .panels-grid {
 .ehr-anomaly-burst { animation: pulse-orange 1.5s infinite; }
 body.has-staleness-banner .entity-heat-rail {
   top: calc(var(--below-banners) + 6px);
+}
+/* TriageBar and EntityHeatRail occupy the same horizontal slot.
+   When alerts are active the triage bar is the primary surface. */
+body.has-triage-bar .entity-heat-rail,
+body.has-triage-bar .related-strip {
+  display: none;
 }
 @keyframes pulse-orange {
   0%, 100% { box-shadow: 0 0 0 0 rgba(255, 140, 40, 0.6); }


### PR DESCRIPTION
The TriageBar and EntityHeatRail were competing for the same vertical slot.

**Root cause:**
- `--below-eew` was 32px (EEW bar height) but the macOS content area starts at 44px (toolbar bottom)
- EntityHeatRail/RelatedStrip landed at y=38 — inside the toolbar zone, overlapping with the TriageBar at y=44

**Changes:**
- Override `--below-eew: var(--mac-toolbar-height)` on `body.is-desktop-macos` so fixed overlays land below the toolbar
- Suppress `.entity-heat-rail` and `.related-strip` via `body.has-triage-bar` (TriageBar is the primary surface when alerts are active; EntityHeatRail shows when no alerts)
- Toggle `body.has-triage-bar` in TriageBar.render()
- Replace hardcoded 50px in `has-critical-banner .panels-grid` with `--staleness-banner-h` token

Cross-agent review: Codex reviewed on 2026-06-08; outcome: pass