### PR TITLE
fix: staleness banner covers sidebar nav

### DIFF
--- a/src/components/OfflineStalenessBanner.ts
+++ b/src/components/OfflineStalenessBanner.ts
@@ -16,7 +16,7 @@ const STYLE_CSS = `
 }
 .cb-offline-staleness-banner {
   position: fixed;
-  top: var(--eew-bar-h, 32px);
+  top: var(--below-eew, 32px);
   left: 0;
   right: 0;
   z-index: 100000;

--- a/src/styles/macos-native.css
+++ b/src/styles/macos-native.css
@@ -114,6 +114,12 @@ body.is-desktop-macos .mac-sidebar {
   cursor: default;
 }
 
+/* When a staleness banner is fixed at the top of content, push the sidebar
+   nav down by the same amount so it isn't hidden under the banner. */
+body.has-staleness-banner .mac-sidebar-nav {
+  padding-top: var(--staleness-banner-h);
+}
+
 /* Sidebar scrollable nav */
 .mac-sidebar-nav {
   flex: 1;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -14947,7 +14947,8 @@ body.has-critical-banner .panels-grid {
   left: 0;
   right: 0;
   z-index: 998;
-  padding: 6px 16px;
+  height: var(--staleness-banner-h);
+  padding: 0 16px;
   display: flex;
   align-items: center;
   justify-content: space-between;


### PR DESCRIPTION
When the staleness banner fires, it covered the top portion of the sidebar nav.

**Fixes:**
- `OfflineStalenessBanner`: switch `top: var(--eew-bar-h)` → `top: var(--below-eew)` so it lands at toolbar bottom (44px on macOS) not inside the toolbar gap (32px)
- `StalenessBanner`: lock to `height: var(--staleness-banner-h)` so all offset calculations exactly match the token
- `body.has-staleness-banner .mac-sidebar-nav`: add `padding-top: var(--staleness-banner-h)` to push sidebar items below the banner

Cross-agent review: Codex reviewed 2026-06-08; outcome: pass