### PR TITLE
feat(header): collapse banners into one NotificationStack

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -61,6 +61,7 @@ import {
 import { SatelliteFiresPanel } from '@/components/SatelliteFiresPanel';
 import { WatchAreaAlertingPanel } from '@/components/WatchAreaAlertingPanel';
 import { TriageBar } from '@/components/TriageBar';
+import { notificationStack } from '@/components/NotificationStack';
 import { EEWStatusBar } from '@/components/EEWStatusBar';
 import { CorrelationAlertBanner } from '@/components/CorrelationAlertBanner';
 import { startSpaceWeatherStatusBarPoller } from '@/services/spaceweather/status-bar-poller';
@@ -639,7 +640,8 @@ export class PanelLayoutManager implements AppModule {
   init(): void {
  this.renderLayout();
  document.addEventListener('wm:update-state', this._onUpdateState);
- this.stalenessBanner = StalenessBanner.mount();
+ // Mount staleness banner into the notification stack (first row).
+ this.stalenessBanner = StalenessBanner.mount(notificationStack.element);
   }
 
   destroy(): void {
@@ -820,12 +822,15 @@ export class PanelLayoutManager implements AppModule {
   private createPanels(): void {
  const panelsGrid = document.getElementById('panelsGrid')!;
 
- // Mount the EEW status bar at the top of the body — sits above
- // everything else (above the panel grid + triage bar). Layer 9
- // of the seismic intelligence stack.
+ // Mount the EEW status bar at top of body — the anchor (z:9000).
  const eewStatusBar = new EEWStatusBar();
  eewStatusBar.mount(document.body);
  startSpaceWeatherStatusBarPoller(eewStatusBar);
+
+ // Mount the notification stack directly below the EEW bar. All secondary
+ // banners mount into this container so they flow vertically without overlap.
+ // A ResizeObserver publishes --notification-stack-h so content shifts correctly.
+ notificationStack.mount(document.body);
 
  // Mount Personal Storm Mode banner — shows when a severe NWS alert
  // matches a saved place. The data-loader dispatches 'cb:storm-decision'
@@ -844,9 +849,9 @@ export class PanelLayoutManager implements AppModule {
  const correlationBanner = new CorrelationAlertBanner();
  correlationBanner.mount(document.body);
 
- // Mount the triage bar above the panel grid (auto-hides when nothing is hot).
+ // Mount the triage bar into the notification stack (last row — below staleness).
  const triageBar = new TriageBar();
- triageBar.mount(panelsGrid.parentElement ?? panelsGrid);
+ triageBar.mount(notificationStack.element);
  const justInRail = new JustInRail();
  justInRail.mount(document.body);
  startPanelNarrator();

--- a/src/components/BreakingNewsBanner.ts
+++ b/src/components/BreakingNewsBanner.ts
@@ -95,15 +95,16 @@ export class BreakingNewsBanner {
   }
 
   private updatePosition(): void {
- let top = 50;
- if (document.body.classList.contains('has-critical-banner')) {
- this.attachResizeObserverIfNeeded();
- const postureBanner = document.querySelector('.critical-posture-banner');
- if (postureBanner) {
- top += postureBanner.getBoundingClientRect().height;
- }
- }
- this.container.style.top = `${top}px`;
+    const stack = document.getElementById('cb-notification-stack');
+    let top = stack ? stack.getBoundingClientRect().bottom : 44;
+    if (document.body.classList.contains('has-critical-banner')) {
+      this.attachResizeObserverIfNeeded();
+      const postureBanner = document.querySelector('.critical-posture-banner');
+      if (postureBanner) {
+        top += postureBanner.getBoundingClientRect().height;
+      }
+    }
+    this.container.style.top = `${top}px`;
  this.updateOffset();
   }
 

--- a/src/components/NotificationStack.ts
+++ b/src/components/NotificationStack.ts
@@ -1,0 +1,58 @@
+/**
+ * NotificationStack — single fixed-position column that owns all secondary
+ * banners (staleness, offline, triage). Children render in priority order and
+ * push each other down naturally. A ResizeObserver publishes the live height
+ * as --notification-stack-h on :root so every content area shifts correctly
+ * without manual class arithmetic.
+ *
+ * Z-index hierarchy:
+ *   EEW bar          z: 9000  (unchanged — macOS window-chrome stand-in)
+ *   NotificationStack z: 9001  (sits immediately below EEW bar)
+ *
+ * No child needs its own position:fixed — they flow as flex rows.
+ */
+
+const STACK_ID = 'cb-notification-stack';
+const CSS_VAR = '--notification-stack-h';
+
+export class NotificationStack {
+  readonly element: HTMLDivElement;
+  private ro: ResizeObserver | null = null;
+
+  constructor() {
+    const el = document.createElement('div');
+    el.id = STACK_ID;
+    Object.assign(el.style, {
+      position: 'fixed',
+      top: 'var(--eew-bar-h, 32px)',
+      left: '0',
+      right: '0',
+      zIndex: '9001',
+      display: 'flex',
+      flexDirection: 'column',
+      pointerEvents: 'none', // individual children re-enable as needed
+    });
+    this.element = el;
+  }
+
+  mount(parent: HTMLElement = document.body): void {
+    parent.append(this.element);
+    this.ro = new ResizeObserver(() => {
+      document.documentElement.style.setProperty(
+        CSS_VAR,
+        `${this.element.offsetHeight}px`,
+      );
+    });
+    this.ro.observe(this.element);
+    // Publish initial height synchronously.
+    document.documentElement.style.setProperty(CSS_VAR, '0px');
+  }
+
+  destroy(): void {
+    this.ro?.disconnect();
+    this.element.remove();
+    document.documentElement.style.removeProperty(CSS_VAR);
+  }
+}
+
+export const notificationStack = new NotificationStack();

--- a/src/components/OfflineStalenessBanner.ts
+++ b/src/components/OfflineStalenessBanner.ts
@@ -15,11 +15,9 @@ const STYLE_CSS = `
   50%, 100% { opacity: 0.55; }
 }
 .cb-offline-staleness-banner {
-  position: fixed;
-  top: var(--below-eew, 32px);
-  left: 0;
-  right: 0;
-  z-index: 100000;
+  /* Flow child of NotificationStack — no own position:fixed needed. */
+  position: relative;
+  width: 100%;
   height: 48px;
   display: flex;
   flex-direction: column;

--- a/src/components/StalenessBanner.ts
+++ b/src/components/StalenessBanner.ts
@@ -37,7 +37,7 @@ export class StalenessBanner {
   private dismissedLevel: BannerLevel = 'hidden';
   private currentLevel: BannerLevel = 'hidden';
 
-  private constructor() {
+  private constructor(parent: HTMLElement = document.body) {
  this.el = document.createElement('div');
  this.el.className = 'staleness-banner staleness-banner-hidden';
  this.el.setAttribute('role', 'status');
@@ -57,8 +57,10 @@ export class StalenessBanner {
  this.toggleDetails();
  });
 
- document.body.prepend(this.detailsEl);
- document.body.prepend(this.el);
+ // Both banner and its collapsible details flow inside the same parent so
+ // the NotificationStack ResizeObserver picks up the expanded height.
+ parent.append(this.el);
+ parent.append(this.detailsEl);
 
  // Listen for online/offline
  window.addEventListener('online', () => this.evaluate());
@@ -74,8 +76,8 @@ export class StalenessBanner {
  this.evaluate();
   }
 
-  static mount(): StalenessBanner {
- instance ??= new StalenessBanner();
+  static mount(parent?: HTMLElement): StalenessBanner {
+ instance ??= new StalenessBanner(parent);
  return instance;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -258,7 +258,11 @@ initMetaTags();
 // Offline staleness monitor + banner — mount early so cached-data warnings
 // are visible the moment the app boots (before any data loads complete).
 import('./services/offline-staleness').then(({ startOfflineMonitor }) => { startOfflineMonitor(); }).catch((error: unknown) => console.warn('[boot] offline-staleness failed to mount', error));
-import('./components/OfflineStalenessBanner').then(({ offlineStalenessBanner }) => { offlineStalenessBanner.mount(); }).catch((error: unknown) => console.warn('[boot] OfflineStalenessBanner failed to mount', error));
+import('./components/OfflineStalenessBanner').then(({ offlineStalenessBanner }) => {
+  // Mount into the notification stack if it's already in the DOM, else body.
+  const stack = document.getElementById('cb-notification-stack');
+  offlineStalenessBanner.mount(stack ?? document.body);
+}).catch((error: unknown) => console.warn('[boot] OfflineStalenessBanner failed to mount', error));
 import('./services/api-diagnostic').then(({ attachDiagnosticToWindow }) => { attachDiagnosticToWindow(); }).catch((error: unknown) => console.warn('[boot] api-diagnostic failed to mount', error));
 
 // In desktop mode, route /api/* calls to the local Tauri sidecar backend.

--- a/src/main.ts
+++ b/src/main.ts
@@ -258,10 +258,11 @@ initMetaTags();
 // Offline staleness monitor + banner — mount early so cached-data warnings
 // are visible the moment the app boots (before any data loads complete).
 import('./services/offline-staleness').then(({ startOfflineMonitor }) => { startOfflineMonitor(); }).catch((error: unknown) => console.warn('[boot] offline-staleness failed to mount', error));
-import('./components/OfflineStalenessBanner').then(({ offlineStalenessBanner }) => {
-  // Mount into the notification stack if it's already in the DOM, else body.
-  const stack = document.getElementById('cb-notification-stack');
-  offlineStalenessBanner.mount(stack ?? document.body);
+Promise.all([
+  import('./components/OfflineStalenessBanner'),
+  import('./components/NotificationStack'),
+]).then(([{ offlineStalenessBanner }, { notificationStack }]) => {
+  offlineStalenessBanner.mount(notificationStack.element);
 }).catch((error: unknown) => console.warn('[boot] OfflineStalenessBanner failed to mount', error));
 import('./services/api-diagnostic').then(({ attachDiagnosticToWindow }) => { attachDiagnosticToWindow(); }).catch((error: unknown) => console.warn('[boot] api-diagnostic failed to mount', error));
 

--- a/src/styles/alerts.css
+++ b/src/styles/alerts.css
@@ -5,15 +5,16 @@
   align-items: center;
   gap: 12px;
   padding: 8px 14px;
-  margin: 0 0 10px 0;
+  margin: 0;
   background: linear-gradient(90deg, rgba(40, 0, 0, 0.85), rgba(20, 20, 30, 0.85));
-  border: 1px solid rgba(255, 80, 80, 0.4);
-  border-radius: 8px;
+  border-bottom: 1px solid rgba(255, 80, 80, 0.4);
   font: 12px/1.2 -apple-system, system-ui, sans-serif;
   color: #f5f5f7;
-  position: sticky;
-  top: 0;
-  z-index: 50;
+  /* Flow child of NotificationStack — no sticky/fixed needed. */
+  position: relative;
+  width: 100%;
+  box-sizing: border-box;
+  pointer-events: auto;
   backdrop-filter: blur(10px);
 }
 .triage-bar[hidden] { display: none; }

--- a/src/styles/macos-native.css
+++ b/src/styles/macos-native.css
@@ -117,7 +117,7 @@ body.is-desktop-macos .mac-sidebar {
 /* When a staleness banner is fixed at the top of content, push the sidebar
    nav down by the same amount so it isn't hidden under the banner. */
 body.has-staleness-banner .mac-sidebar-nav {
-  padding-top: var(--staleness-banner-h);
+  padding-top: var(--notification-stack-h);
 }
 
 /* Sidebar scrollable nav */

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -70,9 +70,12 @@
      --eew-bar-h matches the min-height set on .eew-status-bar below. */
   --eew-bar-h: 32px;
   --staleness-banner-h: 32px;
+  /* Live height of the NotificationStack column — updated by ResizeObserver. */
+  --notification-stack-h: 0px;
   /* Derived: where things sit when both bars are visible */
   --below-eew: var(--eew-bar-h);
-  --below-banners: calc(var(--eew-bar-h) + var(--staleness-banner-h));
+  /* --below-banners tracks the full header height dynamically via ResizeObserver. */
+  --below-banners: calc(var(--eew-bar-h) + var(--notification-stack-h));
 
   /* Overlay stacking scale — single source of truth for layering. */
   --z-strip: 1040;
@@ -14934,20 +14937,21 @@ a.prediction-link:hover {
   to   { opacity: 1; }
 }
 
-/* Push content down when critical banner is visible */
+/* Push content down when critical banner is visible — kept for JS that only
+   adds this class without the has-staleness-banner class; ResizeObserver on
+   the NotificationStack handles the common case automatically. */
 body.has-critical-banner .panels-grid {
-  padding-top: var(--staleness-banner-h);
+  padding-top: var(--notification-stack-h);
 }
 
 /* ============ Data Staleness Banner ============ */
 
 .staleness-banner {
-  position: fixed;
-  top: var(--below-eew);
-  left: 0;
-  right: 0;
-  z-index: 998;
+  /* Flow child of NotificationStack — position is inherited from container. */
+  position: relative;
+  width: 100%;
   height: var(--staleness-banner-h);
+  pointer-events: auto;
   padding: 0 16px;
   display: flex;
   align-items: center;
@@ -15046,11 +15050,9 @@ body.has-critical-banner .panels-grid {
 }
 
 .staleness-details {
-  position: fixed;
-  top: 82px;
-  left: 0;
-  right: 0;
-  z-index: 997;
+  /* Flow child of NotificationStack — expands the stack height when visible. */
+  position: relative;
+  width: 100%;
   max-height: 300px;
   overflow-y: auto;
   background: var(--surface);
@@ -15089,11 +15091,12 @@ body.has-critical-banner .panels-grid {
 }
 
 body.has-staleness-banner .panels-grid {
+  /* --below-banners = eew-bar-h + notification-stack-h, updated by ResizeObserver. */
   padding-top: var(--below-banners);
 }
 
 body.has-staleness-banner.has-critical-banner .panels-grid {
-  padding-top: calc(var(--below-banners) + var(--staleness-banner-h));
+  padding-top: var(--below-banners);
 }
 
 /* ============ Breaking News Alert Banner ============ */
@@ -18968,7 +18971,7 @@ body.has-breaking-alert .panels-grid {
 /* ─── Entity heat rail ─── */
 .entity-heat-rail {
   position: fixed;
-  top: calc(var(--below-eew) + 6px);
+  top: calc(var(--below-banners) + 6px);
   left: 50%;
   transform: translateX(-50%);
   display: flex;
@@ -19014,9 +19017,6 @@ body.has-breaking-alert .panels-grid {
 .ehr-anomaly { background: rgba(255, 140, 40, 0.15); border-color: rgba(255, 140, 40, 0.4); }
 .ehr-anomaly .ehr-dot { background: #ff8c28; }
 .ehr-anomaly-burst { animation: pulse-orange 1.5s infinite; }
-body.has-staleness-banner .entity-heat-rail {
-  top: calc(var(--below-banners) + 6px);
-}
 /* TriageBar and EntityHeatRail occupy the same horizontal slot.
    When alerts are active the triage bar is the primary surface. */
 body.has-triage-bar .entity-heat-rail,
@@ -19392,7 +19392,7 @@ body.gods-vision-lock .replay-scrubber { display: none; }
 /* ── Related Strip ──────────────────────────────────────────────── */
 .related-strip {
   position: fixed;
-  top: calc(var(--below-eew) + 4px);
+  top: calc(var(--below-banners) + 4px);
   left: 50%;
   transform: translateX(-50%);
   z-index: 1060;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -14854,7 +14854,7 @@ a.prediction-link:hover {
 
 .critical-posture-banner {
   position: fixed;
-  top: var(--below-eew);
+  top: var(--below-banners);
   left: 0;
   right: 0;
   z-index: 999;
@@ -15103,7 +15103,7 @@ body.has-staleness-banner.has-critical-banner .panels-grid {
 
 .breaking-news-container {
   position: fixed;
-  top: var(--below-eew);
+  top: var(--below-banners);
   left: 0;
   right: 0;
   z-index: 1001;


### PR DESCRIPTION
## Problem

The header had 13 independently `position: fixed` elements all calculating `top: var(--below-eew)` independently. Every banner rendered at the exact same pixel and visually collided (the root cause of the overlapping/messy menu bar the user reported). z-indices ran from 50 to 100000.

## Solution

**One `position: fixed` flex-column under the EEW bar — children flow in priority order and push each other down.**

### New architecture

`NotificationStack` (z:9001, top:`var(--eew-bar-h)`) is the single owner:
- `OfflineStalenessBanner` — top priority (data reliability)
- `StalenessBanner` + its collapsible details — second row
- `TriageBar` — third row (active alerts)

A `ResizeObserver` publishes `--notification-stack-h` on `:root`. Every consumer — `--below-banners`, `panels-grid` padding, sidebar padding, entity-heat-rail top, related-strip top — auto-updates via the CSS token.

### What changed

| File | Change |
|------|--------|
| `NotificationStack.ts` | New: fixed flex-column + ResizeObserver |
| `OfflineStalenessBanner.ts` | position:fixed → position:relative (flow child), z:100000 eliminated |
| `StalenessBanner.ts` | Accept optional parent; both `el` + `detailsEl` mount into stack |
| `TriageBar.ts` | position:sticky → position:relative, full-width row |
| `panel-layout.ts` | Mount stack after EEW bar; wire staleness + triage into it |
| `main.ts` | Mount OfflineStalenessBanner into stack element |
| `main.css` | Add `--notification-stack-h`, `--below-banners` uses it; strip fixed CSS from banners; collapse class-cascade overrides |
| `alerts.css` | Triage bar becomes full-width flow row |
| `macos-native.css` | Sidebar padding uses `--notification-stack-h` |

Cross-agent review: pending Codex review per repo policy.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Cross-agent review: Codex reviewed on 2026-06-08; outcome: REQUEST_CHANGES → addressed.
- Timing race: OfflineStalenessBanner now imports notificationStack singleton directly (no getElementById)
- Residual fixed banners: critical-posture-banner + breaking-news-container use --below-banners
- BreakingNewsBanner.updatePosition(): stack.getBoundingClientRect().bottom replaces hardcoded 50px