### PR TITLE
fix(triage): dismiss button per pill + stop cyber scenarios on weather alerts

### DIFF
--- a/src/components/TriageBar.ts
+++ b/src/components/TriageBar.ts
@@ -169,6 +169,18 @@ export class TriageBar {
       elements.push(escBadge);
     }
     elements.push(age);
+
+    // Dismiss button — acknowledges all alerts in the story
+    const dismissBtn = document.createElement('button');
+    dismissBtn.className = 'triage-dismiss-btn';
+    dismissBtn.textContent = '×';
+    dismissBtn.title = 'Dismiss';
+    dismissBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      unifiedAlertStore.acknowledgeMany(story.alerts.map(sa => sa.id));
+    });
+    elements.push(dismissBtn);
+
     el.append(...elements);
     el.addEventListener('click', () => {
       if (story.alerts.length > 1 && story.entityName) {

--- a/src/services/situation-correlator.ts
+++ b/src/services/situation-correlator.ts
@@ -215,17 +215,33 @@ export function computeSituationConfidence(signals: SituationSignalSnapshot[]): 
 export function matchCausalChain(signals: SituationSignalSnapshot[]): CausalTemplate | null {
   const signalTypes = new Set(signals.map(s => s.type));
 
+  // Majority domain of the signal set — used to penalise cross-domain template matches.
+  const domainCounts: Partial<Record<SituationDomain, number>> = {};
+  for (const s of signals) {
+    const d = classifyDomain(s.type);
+    domainCounts[d] = (domainCounts[d] ?? 0) + 1;
+  }
+  let majorityDomain: SituationDomain = 'compound';
+  let maxCount = 0;
+  for (const [d, n] of Object.entries(domainCounts) as [SituationDomain, number][]) {
+    if (n > maxCount) { maxCount = n; majorityDomain = d; }
+  }
+
   let bestMatch: CausalTemplate | null = null;
   let bestScore = 0;
 
   for (const template of CAUSAL_TEMPLATES) {
- const chainTypes = template.links.map(l => l.triggerType);
- const matched = chainTypes.filter(t => signalTypes.has(t)).length;
- const coverage = matched / chainTypes.length;
- if (coverage > bestScore && coverage >= 0.4) {
- bestScore = coverage;
- bestMatch = template;
- }
+    const chainTypes = template.links.map(l => l.triggerType);
+    const matched = chainTypes.filter(t => signalTypes.has(t)).length;
+    let coverage = matched / chainTypes.length;
+    // Penalise templates whose domain conflicts with the signal majority
+    if (template.domain !== 'compound' && template.domain !== majorityDomain && majorityDomain !== 'compound') {
+      coverage *= 0.3;
+    }
+    if (coverage > bestScore && coverage >= 0.4) {
+      bestScore = coverage;
+      bestMatch = template;
+    }
   }
   return bestMatch;
 }

--- a/src/styles/alerts.css
+++ b/src/styles/alerts.css
@@ -74,6 +74,20 @@
 }
 .triage-title { font-weight: 500; max-width: 220px; overflow: hidden; text-overflow: ellipsis; }
 .triage-age { font-size: 10px; opacity: 0.6; font-variant-numeric: tabular-nums; }
+.triage-dismiss-btn {
+  background: none;
+  border: none;
+  color: inherit;
+  opacity: 0;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 2px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: opacity 0.15s;
+}
+.triage-bar-item:hover .triage-dismiss-btn { opacity: 0.5; }
+.triage-dismiss-btn:hover { opacity: 1 !important; }
 
 .triage-bar-ack {
   background: rgba(255, 255, 255, 0.08);


### PR DESCRIPTION
Two fixes:

**1. Dismiss button on triage pills**
Each triage pill now has a × dismiss button (hover-reveal, so it doesn't clutter the bar). Clicking it calls `acknowledgeMany()` on all alerts in the story — they score 0 and disappear from the triage bar immediately.

**2. Wrong scenario text on weather situations**
`matchCausalChain` was matching weather alert signals (whose generic signal types also appear in the cyber-escalation template) to the wrong template, causing Flood Warning cards to show 'Targeted critical infrastructure attack / Verify critical system patches and backups'. Fix: penalise (×0.3 on coverage) any template whose declared domain conflicts with the signal-set's majority domain.

Cross-agent review: requesting Codex review.