### PR TITLE
fix(geocode): repair broken Nominatim throttle + cancel stale searches

### DIFF
--- a/src/utils/geocode.ts
+++ b/src/utils/geocode.ts
@@ -7,24 +7,39 @@ export interface GeocodeResult {
 const NOMINATIM_BASE = 'https://nominatim.openstreetmap.org';
 const REQUEST_TIMEOUT_MS = 8000;
 
-let lastRequestTime = 0;
+// Initialise to (now - interval) so the first request fires immediately
+// but subsequent rapid-fire calls are staggered by MIN_INTERVAL_MS.
+// The old initialisation (0) was always in the past relative to Date.now()
+// (~1.7e12), which meant the throttle never engaged and every request fired
+// instantly — flooding Nominatim and triggering rate-limit slowdowns.
 const MIN_INTERVAL_MS = 1000;
+let lastRequestTime = Date.now() - MIN_INTERVAL_MS;
 
-async function throttledFetch(url: string): Promise<Response> {
-  const sleepUntil = lastRequestTime + MIN_INTERVAL_MS;
-  lastRequestTime = sleepUntil;
-  const wait = sleepUntil - Date.now();
-  if (wait > 0) await new Promise((resolve) => setTimeout(resolve, wait));
+// In-flight AbortController so a new forward-geocode can cancel the previous one.
+let activeController: AbortController | null = null;
 
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+async function throttledFetch(url: string, signal?: AbortSignal): Promise<Response> {
+  const now = Date.now();
+  const sleepUntil = Math.max(lastRequestTime + MIN_INTERVAL_MS, now);
+  lastRequestTime = sleepUntil; // reserve this time slot
+  const wait = sleepUntil - now;
+  if (wait > 0) await new Promise<void>((resolve) => setTimeout(resolve, wait));
+
+  // If the caller already cancelled us during the wait, bail early.
+  if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+
+  const timeoutController = new AbortController();
+  const combinedAbort = () => timeoutController.abort();
+  signal?.addEventListener('abort', combinedAbort);
+  const timer = setTimeout(() => timeoutController.abort(), REQUEST_TIMEOUT_MS);
   try {
- return await fetch(url, {
- signal: controller.signal,
- headers: { 'Accept-Language': 'en', 'User-Agent': 'CrystalBall/1.0' },
- });
+    return await fetch(url, {
+      signal: timeoutController.signal,
+      headers: { 'Accept-Language': 'en', 'User-Agent': 'CrystalBall/1.0' },
+    });
   } finally {
- clearTimeout(timer);
+    clearTimeout(timer);
+    signal?.removeEventListener('abort', combinedAbort);
   }
 }
 
@@ -32,32 +47,39 @@ export async function forwardGeocode(query: string): Promise<GeocodeResult[]> {
   const trimmed = query.trim();
   if (!trimmed) return [];
 
+  // Cancel any in-flight forward-geocode before starting a new one.
+  activeController?.abort();
+  const controller = new AbortController();
+  activeController = controller;
+
   const url = `${NOMINATIM_BASE}/search?q=${encodeURIComponent(trimmed)}&format=json&limit=5&addressdetails=0`;
   try {
- const res = await throttledFetch(url);
- if (!res.ok) return [];
- const data = (await res.json()) as { display_name: string; lat: string; lon: string }[];
- return data
- .filter((item) => item.display_name && item.lat && item.lon)
- .map((item) => ({
- displayName: item.display_name,
- lat: Number.parseFloat(item.lat),
- lon: Number.parseFloat(item.lon),
- }))
- .filter((item) => Number.isFinite(item.lat) && Number.isFinite(item.lon));
+    const res = await throttledFetch(url, controller.signal);
+    if (!res.ok) return [];
+    const data = (await res.json()) as { display_name: string; lat: string; lon: string }[];
+    return data
+      .filter((item) => item.display_name && item.lat && item.lon)
+      .map((item) => ({
+        displayName: item.display_name,
+        lat: Number.parseFloat(item.lat),
+        lon: Number.parseFloat(item.lon),
+      }))
+      .filter((item) => Number.isFinite(item.lat) && Number.isFinite(item.lon));
   } catch {
- return [];
+    return [];
+  } finally {
+    if (activeController === controller) activeController = null;
   }
 }
 
 export async function reverseGeocodeLabel(lat: number, lon: number): Promise<string | null> {
   const url = `${NOMINATIM_BASE}/reverse?lat=${lat}&lon=${lon}&format=json&zoom=10&addressdetails=0`;
   try {
- const res = await throttledFetch(url);
- if (!res.ok) return null;
- const data = (await res.json()) as { display_name?: string };
- return data.display_name ?? null;
+    const res = await throttledFetch(url);
+    if (!res.ok) return null;
+    const data = (await res.json()) as { display_name?: string };
+    return data.display_name ?? null;
   } catch {
- return null;
+    return null;
   }
 }


### PR DESCRIPTION
The Nominatim rate-limit throttle in `src/utils/geocode.ts` was completely non-functional:

```js
let lastRequestTime = 0; // bug: always in the past
const sleepUntil = lastRequestTime + 1000; // = 1000
const wait = sleepUntil - Date.now(); // ~= -1.7e12, always negative → no wait
```

Every geocode request fired immediately with zero delay, flooding Nominatim. Once Nominatim started rate-limiting (slow/dropped responses), the saved-places modal felt "horribly slow".

**Fixes:**
- Init `lastRequestTime = Date.now() - MIN_INTERVAL_MS` so the first request is immediate but concurrent calls are staggered 1s apart
- Use `Math.max(lastRequestTime + interval, now)` so `sleepUntil` never goes into the past
- `forwardGeocode` cancels any in-flight previous search via AbortController, so rapid debounced typing never queues stale requests behind the active one
- Pass caller's AbortSignal into `throttledFetch` so the wait itself respects cancellation

Cross-agent review: Codex reviewed — single-file utility fix, no logic concerns.