### PR TITLE
docs: reconcile CLAUDE.md with code (Ghost-only modes, 73 keys)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ src/                        # TypeScript frontend (Vite)
   config/
     panels.ts               # FULL_PANELS, PANEL_CATEGORY_MAP, FULL_MAP_LAYERS
   services/
-    mode-manager.ts         # AppMode: peace/finance/war/disaster/ghost
+    mode-manager.ts         # AppMode: ghost | gods-vision (manual only; null = default)
     runtime-config.ts       # API key definitions, feature toggles, web verifySecret probes
     settings-constants.ts   # HUMAN_LABELS, KEY_DESCRIPTIONS, SIGNUP_URLS, SETTINGS_CATEGORIES
     web-secret-store.ts     # browser-only passphrase-encrypted vault (see "Web key vault" below)
@@ -329,15 +329,21 @@ Four basemaps (`dark | light | satellite | terrain`) selected by the `wm-basemap
 
 ## App Modes (`src/services/mode-manager.ts`)
 
+Mode is **manual only**. `AppMode` is `'ghost' | 'gods-vision'`; `null` is the
+default (no special mode) state. The former auto-triggered modes
+(peace/finance/war/disaster) have been removed — their behaviors are inlined
+into the default state. The old evaluators (`evaluateWarThreat`,
+`evaluateFinanceTrigger`, `evaluateDisasterTrigger`, etc.) remain as **no-ops**
+for call-site compatibility; data feeds still flow but no longer drive mode
+transitions.
+
 | Mode | Trigger |
 |------|---------|
-| Peace | default |
-| Finance | S&P500 ≥2.5% OR BTC ≥5% OR Oil ≥4% OR Gold ≥2% |
-| War | ≥2 war signals > confidence 0.6 (normalized by conflict baselines) |
-| Disaster | GDACS Red OR 3+ Orange OR M≥6.5 quake |
+| default (`null`) | no special mode |
 | Ghost | Manual only — ⌘⇧G / sidebar / File menu |
+| God's Vision | Manual — the God's Eye 3D globe view |
 
-Ghost Mode: polling ×5, analytics suppressed, notifications suppressed, dark crimson sidebar.
+Ghost Mode: polling ×5 (`getGhostRefreshMultiplier()`), analytics suppressed, notifications suppressed, dark crimson sidebar.
 
 ## CSP Posture
 
@@ -358,7 +364,7 @@ Ghost Mode: polling ×5, analytics suppressed, notifications suppressed, dark cr
 
 ## Settings / API Keys
 
-API keys entered via gear icon → API Keys tab. None embed the brand in their names; all 48 supported keys are generic API names (ANTHROPIC_API_KEY, GROQ_API_KEY, etc).
+API keys entered via gear icon → API Keys tab. None embed the brand in their names; all 73 supported keys are generic API names (ANTHROPIC_API_KEY, GROQ_API_KEY, etc). The authoritative list is `SUPPORTED_SECRET_KEYS` in `src-tauri/src/main.rs`.
 
 ## Secret Scan Guardrail
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -364,7 +364,7 @@ Ghost Mode: polling ×5 (`getGhostRefreshMultiplier()`), analytics suppressed, n
 
 ## Settings / API Keys
 
-API keys entered via gear icon → API Keys tab. None embed the brand in their names; all 73 supported keys are generic API names (ANTHROPIC_API_KEY, GROQ_API_KEY, etc). The authoritative list is `SUPPORTED_SECRET_KEYS` in `src-tauri/src/main.rs`.
+API keys entered via gear icon → API Keys tab. Almost all of the 73 supported keys use standard provider env-var names (ANTHROPIC_API_KEY, GROQ_API_KEY, etc); the only app-branded key is `CRYSTALBALL_API_KEY`. The authoritative list is `SUPPORTED_SECRET_KEYS` in `src-tauri/src/main.rs`.
 
 ## Secret Scan Guardrail
 

--- a/docs/DIAGNOSTICS_OBSERVABILITY_ENHANCEMENT_PLAN.md
+++ b/docs/DIAGNOSTICS_OBSERVABILITY_ENHANCEMENT_PLAN.md
@@ -171,7 +171,7 @@ Crystal Ball should notify or visibly warn when it becomes blind in a critical d
 Examples:
 
 - Weather feed failing while severe weather risk is active
-- ADS-B unavailable in war/disaster mode
+- ADS-B unavailable while tracking aircraft of interest
 - Provider keys missing for enabled panels
 - Sidecar heartbeat stale
 - Notification permission missing


### PR DESCRIPTION
## What

Reconciles `CLAUDE.md` with the actual code state. Two stale claims fixed, plus one mode-agnostic edit to a living plan doc.

## Fixes

1. **App Modes** — `src/services/mode-manager.ts` now exposes only `AppMode = 'ghost' | 'gods-vision'` (manual, `null` default). The peace/finance/war/disaster auto-triggered modes were removed; their evaluators (`evaluateWarThreat`, `evaluateFinanceTrigger`, `evaluateDisasterTrigger`, …) remain as **no-ops** for call-site compatibility. CLAUDE.md's 5-mode trigger table + architecture comment were rewritten to match.
2. **Key count** — `SUPPORTED_SECRET_KEYS` in `src-tauri/src/main.rs` is **73**, not 48. Corrected CLAUDE.md and pointed to the authoritative source. (README / `docs/API_KEYS.md` already said 73.)
3. **`docs/DIAGNOSTICS_OBSERVABILITY_ENHANCEMENT_PLAN.md`** — one illustrative bullet ("ADS-B unavailable in war/disaster mode") rephrased mode-agnostically.

## Scope

Living docs only. Deliberately **not** touched: `CHANGELOG.md` (historical record) and dated `docs/superpowers/**` plan/spec snapshots (point-in-time artifacts, excluded from lint) — editing those would falsify history.

## Verification

- Ground truth confirmed by reading `mode-manager.ts` and `main.rs` directly.
- `npm run docs:check` → fresh. Pre-commit gates green: secret scan, markdown lint (0 errors), `typecheck:all` clean.

---

Cross-agent review: Codex reviewed on 2026-06-08; outcome: issues fixed. Codex verified the diff against source — AppMode/no-op claim, 73-key count + main.rs pointer, and Ghost polling ×5 all CORRECT. It flagged one NEW ERROR: the carried-over "none embed the brand" sentence was false because `CRYSTALBALL_API_KEY` is app-branded. Fixed in `6f171e14` (sentence now names that key as the sole app-branded exception).
