### PR TITLE
fix(logging): surface backoff state, dedup hits, error messages, and unknown regions

### DIFF
--- a/server/crystalball/military/v1/get-usni-fleet-report.ts
+++ b/server/crystalball/military/v1/get-usni-fleet-report.ts
@@ -130,6 +130,12 @@ const REGION_COORDS: Record<string, { lat: number; lon: number }> = {
   'New Orleans': { lat: 29.95, lon: -90.07 },
   'Kingston, Jamaica': { lat: 17.99, lon: -76.79 },
   'Portsmouth, England': { lat: 50.80, lon: -1.09 },
+  'English Channel': { lat: 50.50, lon: -1.20 },
+  // Additional straits that appear in USNI articles
+  'Strait of Gibraltar': { lat: 35.97, lon: -5.45 },
+  'Denmark Strait': { lat: 66.00, lon: -24.00 },
+  'Norwegian Sea': { lat: 68.00, lon: 5.00 },
+  'North Sea': { lat: 56.00, lon: 3.00 },
 };
 
 function getRegionCoords(regionText: string): { lat: number; lon: number } | null {
@@ -147,6 +153,9 @@ function getRegionCoords(regionText: string): { lat: number; lon: number } | nul
   }
   return null;
 }
+
+// Suppress repeated unknown-region noise — warn once per region name per process lifetime
+const warnedUnknownRegions = new Set<string>();
 
 function parseLeadingInteger(text: string): number | undefined {
   const match = text.match(/\d{1,3}(?:,\d{3})*/);
@@ -245,7 +254,8 @@ function parseUSNIArticle(
  regionsSet.add(regionName);
 
  const coords = getRegionCoords(regionName);
- if (!coords) {
+ if (!coords && !warnedUnknownRegions.has(regionName)) {
+ warnedUnknownRegions.add(regionName);
  warnings.push(`Unknown region: "${regionName}"`);
  }
  const regionLat = coords?.lat ?? 0;

--- a/src/services/cached-theater-posture.ts
+++ b/src/services/cached-theater-posture.ts
@@ -195,6 +195,9 @@ export async function fetchCachedTheaterPosture(signal?: AbortSignal): Promise<C
 
   // Throttle retries after errors — prevents retry storms when the sidecar is down
   if (lastErrorAt && now - lastErrorAt < ERROR_BACKOFF_MS) {
+ const remainingSecs = Math.round((ERROR_BACKOFF_MS - (now - lastErrorAt)) / 1000);
+ // eslint-disable-next-line no-console
+ console.warn(`[CachedTheaterPosture] retry suppressed — backoff active (${remainingSecs}s remaining), returning ${cachedPosture ? 'stale cache' : 'null'}`);
  return cachedPosture;
   }
 
@@ -212,12 +215,16 @@ export async function fetchCachedTheaterPosture(signal?: AbortSignal): Promise<C
  const data = toPostureData(resp);
  cachedPosture = data;
  lastFetchTime = Date.now();
+ lastErrorAt = 0; // Reset backoff on success
  saveToStorage(data);
+ // eslint-disable-next-line no-console
+ console.info(`[CachedTheaterPosture] OK — ${data.postures.length} theaters, ${data.totalFlights} active flights`);
  return cachedPosture;
  } catch (error) {
  if (error instanceof DOMException && error.name === 'AbortError') throw error;
+ const msg = error instanceof Error ? error.message : String(error);
  // eslint-disable-next-line no-console
- console.error('[CachedTheaterPosture] Fetch error:', error);
+ console.error(`[CachedTheaterPosture] Fetch error: ${msg}`);
  lastErrorAt = Date.now();
  return cachedPosture; // Return stale cache on error
  } finally {

--- a/src/services/usni-fleet.ts
+++ b/src/services/usni-fleet.ts
@@ -58,7 +58,11 @@ export function fetchUSNIFleetReport(): Promise<USNIFleetReport | null> {
   }
 
   // Deduplicate concurrent callers (e.g. two data-loader code paths at startup)
-  if (inflight) return inflight;
+  if (inflight) {
+ // eslint-disable-next-line no-console
+ console.info('[USNIFleet] dedup — reusing inflight fetch');
+ return inflight;
+  }
 
   inflight = breaker.execute(async () => {
  const resp = await client.getUSNIFleetReport({ forceRefresh: false });
@@ -68,6 +72,8 @@ export function fetchUSNIFleetReport(): Promise<USNIFleetReport | null> {
  if (report) {
  lastReport = report;
  lastFetchTime = Date.now();
+ // eslint-disable-next-line no-console
+ console.info(`[USNIFleet] OK — ${report.vessels.length} vessels, ${report.strikeGroups.length} CSGs`);
  }
  return report;
   }).finally(() => {


### PR DESCRIPTION
Five logging blind spots fixed:

1. **CachedTheaterPosture backoff is now visible** — when the 60s error backoff suppresses a retry, `console.warn` emits the remaining seconds and whether stale cache is being returned. Previously completely silent.
2. **Error messages are readable** — changed from `console.error('[...] Fetch error:', error)` (which serialized to a minified stack trace) to `console.error(`[...] Fetch error: ${msg}`)` so the actual error message (e.g. `Request failed with status 503`) appears in the log.
3. **Backoff resets cleanly** — added `lastErrorAt = 0` on success so a recovered sidecar immediately allows fresh fetches.
4. **USNI inflight dedup is visible** — logs `[USNIFleet] dedup — reusing inflight fetch` when the second concurrent caller is deduplicated, confirming the fix from PR #1046 is active.
5. **Unknown region noise eliminated** — added English Channel, North Sea, Norwegian Sea, Strait of Gibraltar, Denmark Strait to `REGION_COORDS`; remaining unknowns only warn once per process lifetime via `warnedUnknownRegions Set`.

Cross-agent review: Codex reviewed on 2026-06-08; outcome: pass / issues fixed / accepted risk.