### PR TITLE
reduce log noise: fix test, burst grace, heartbeat, dead feeds, T5/cluster warns

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -15858,6 +15858,23 @@ export async function createLocalApiServer(options = {}) {
  const heartbeatPath = path.join(context.dataDir, 'sidecar.health.json');
  let lastEventLoopCheck = Date.now();
  const heartbeatInterval = SIDECAR_TRACE ? 1000 : 10_000;
+ // Write immediately so the Rust watcher sees a fresh file from the first
+ // poll (1.5s) — prevents spurious "heartbeat stale" warnings at startup
+ // caused by the previous session's heartbeat file still being present.
+ const mem0 = process.memoryUsage();
+ try {
+  writeFileSync(heartbeatPath, JSON.stringify({
+   pid: process.pid,
+   port: boundPort,
+   uptime_ms: 0,
+   last_heartbeat: wmTimestamp(),
+   event_loop_lag_ms: 0,
+   rss_mb: Math.round(mem0.rss / 1024 / 1024),
+   heap_mb: Math.round(mem0.heapUsed / 1024 / 1024),
+   ais_connected: false,
+   ais_vessels: 0,
+  }));
+ } catch {}
  setInterval(() => {
  const now = Date.now();
  const eventLoopLagMs = Math.max(0, now - lastEventLoopCheck - heartbeatInterval);

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -602,10 +602,10 @@ const FULL_FEEDS: Record<string, Feed[]> = {
  { name: 'Responsible Statecraft', url: rss('https://responsiblestatecraft.org/feed/') },
  // RUSI - Royal United Services Institute (UK defense & security)
  { name: 'RUSI', url: rss('https://news.google.com/rss/search?q=site:rusi.org+when:3d&hl=en-US&gl=US&ceid=US:en') },
- // FPRI - Foreign Policy Research Institute (US foreign policy)
- { name: 'FPRI', url: rss('https://www.fpri.org/feed/') },
- // Jamestown Foundation - Eurasia/China/Terrorism analysis
- { name: 'Jamestown', url: rss('https://jamestown.org/feed/') },
+ // FPRI - Foreign Policy Research Institute (US foreign policy) — direct feed blocks bots; use Google News proxy
+ { name: 'FPRI', url: rss('https://news.google.com/rss/search?q=site:fpri.org+when:7d&hl=en-US&gl=US&ceid=US:en') },
+ // Jamestown Foundation - Eurasia/China/Terrorism analysis — direct feed blocks bots; use Google News proxy
+ { name: 'Jamestown', url: rss('https://news.google.com/rss/search?q=site:jamestown.org+when:7d&hl=en-US&gl=US&ceid=US:en') },
  // ISW - Institute for the Study of War (daily Ukraine/Russia/MENA conflict assessments)
  { name: 'ISW', url: rss('https://news.google.com/rss/search?q=site:understandingwar.org+when:3d&hl=en-US&gl=US&ceid=US:en') },
  // Middle East Eye - regional news and analysis
@@ -1120,7 +1120,8 @@ export const INTEL_SOURCES: Feed[] = [
   { name: 'RUSI', url: rss('https://news.google.com/rss/search?q=site:rusi.org+when:7d&hl=en-US&gl=US&ceid=US:en'), type: 'research' },
   { name: 'Wilson Center', url: rss('https://news.google.com/rss/search?q=site:wilsoncenter.org+when:7d&hl=en-US&gl=US&ceid=US:en'), type: 'research' },
   { name: 'GMF', url: rss('https://news.google.com/rss/search?q=site:gmfus.org+when:7d&hl=en-US&gl=US&ceid=US:en'), type: 'research' },
-  { name: 'Stimson Center', url: rss('https://www.stimson.org/feed/'), type: 'research' },
+  // Stimson Center — direct feed blocks bots; use Google News proxy
+  { name: 'Stimson Center', url: rss('https://news.google.com/rss/search?q=site:stimson.org+when:7d&hl=en-US&gl=US&ceid=US:en'), type: 'research' },
   { name: 'CNAS', url: rss('https://news.google.com/rss/search?q=site:cnas.org+when:7d&hl=en-US&gl=US&ceid=US:en'), type: 'research' },
   { name: 'Lowy Institute', url: rss('https://news.google.com/rss/search?q=site:lowyinstitute.org+when:7d&hl=en-US&gl=US&ceid=US:en'), type: 'research' },
 

--- a/src/services/clustering.ts
+++ b/src/services/clustering.ts
@@ -5,11 +5,15 @@
  */
 
 import type { NewsItem, ClusteredEvent } from '@/types';
+
 import { getSourceTier } from '@/config';
 import { clusterNewsCore } from './analysis-core';
 import { mlWorker } from './ml-worker';
 import { ML_THRESHOLDS } from '@/config/ml-config';
 import { buildClusterEvidencePack } from './evidence-pack';
+
+// Warn once per session — WKWebView can't run ONNX SIMD models so this fires constantly.
+let clusterWarnedThisSession = false;
 
 export function clusterNews(items: NewsItem[]): ClusteredEvent[] {
   return clusterNewsCore(items, getSourceTier) as ClusteredEvent[];
@@ -42,10 +46,50 @@ export async function clusterNewsHybrid(items: NewsItem[]): Promise<ClusteredEve
 
  // Merge semantically similar clusters
  return mergeSemanticallySimilarClusters(jaccardClusters, semanticGroups);
-  } catch (error) {
- console.warn('[Clustering] Semantic clustering failed, using Jaccard only:', error);
+  } catch {
+ if (!clusterWarnedThisSession) {
+ clusterWarnedThisSession = true;
+ // eslint-disable-next-line no-console
+ console.warn('[Clustering] Semantic clustering unavailable, using Jaccard only (suppressing further warnings)');
+ }
  return jaccardClusters;
   }
+}
+
+/** Combine multiple semantically-similar clusters into one, using the highest-tier source as base. */
+function combineGroupClusters(groupClusters: ClusteredEvent[]): ClusteredEvent {
+  const sortedByTier = [...groupClusters].sort((a, b) => {
+ const diff = getSourceTier(a.primarySource) - getSourceTier(b.primarySource);
+ return diff === 0 ? b.lastUpdated.getTime() - a.lastUpdated.getTime() : diff;
+  });
+  const primary = sortedByTier[0]!;
+  const allItems = [...primary.allItems];
+  const topSourcesSet = new Map(primary.topSources.map(s => [s.url, s]));
+  for (const other of sortedByTier.slice(1)) {
+ allItems.push(...other.allItems);
+ for (const src of other.topSources) {
+ if (!topSourcesSet.has(src.url)) topSourcesSet.set(src.url, src);
+ }
+  }
+  const sortedTopSources = [...topSourcesSet.values()].sort((a, b) => a.tier - b.tier).slice(0, 5);
+  const allDates = allItems.map(i => i.pubDate.getTime());
+  const merged: ClusteredEvent = {
+ id: primary.id,
+ primaryTitle: primary.primaryTitle,
+ primaryLink: primary.primaryLink,
+ primarySource: primary.primarySource,
+ sourceCount: allItems.length,
+ topSources: sortedTopSources,
+ allItems,
+ firstSeen: new Date(Math.min(...allDates)),
+ lastUpdated: new Date(Math.max(...allDates)),
+ isAlert: allItems.some(i => i.isAlert),
+ monitorColor: primary.monitorColor,
+ velocity: primary.velocity,
+ threat: primary.threat,
+  };
+  merged.evidence = buildClusterEvidencePack(merged);
+  return merged;
 }
 
 /**
@@ -61,91 +105,18 @@ function mergeSemanticallySimilarClusters(
 
   for (const group of semanticGroups) {
  if (group.length === 0) continue;
-
- // Get all clusters in this semantic group
  const groupClusters = group
  .map(id => clusterMap.get(id))
  .filter((c): c is ClusteredEvent => c !== undefined && !usedIds.has(c.id));
-
  if (groupClusters.length === 0) continue;
-
- // Mark all as used
  groupClusters.forEach(c => usedIds.add(c.id));
-
- const firstCluster = groupClusters[0];
- if (!firstCluster) continue;
-
- if (groupClusters.length === 1) {
- // No merging needed
- merged.push(firstCluster);
- continue;
- }
-
- // Merge multiple clusters into one
- // Use the cluster with the highest-tier primary source as the base
- const sortedByTier = [...groupClusters].sort((a, b) => {
- const tierA = getSourceTier(a.primarySource);
- const tierB = getSourceTier(b.primarySource);
- if (tierA !== tierB) return tierA - tierB;
- return b.lastUpdated.getTime() - a.lastUpdated.getTime();
- });
-
- const primary = sortedByTier[0];
- if (!primary) continue;
-
- const others = sortedByTier.slice(1);
-
- // Combine all items, sources, etc.
- const allItems = [...primary.allItems];
- const topSourcesSet = new Map(primary.topSources.map(s => [s.url, s]));
-
- for (const other of others) {
- allItems.push(...other.allItems);
- for (const src of other.topSources) {
- if (!topSourcesSet.has(src.url)) {
- topSourcesSet.set(src.url, src);
- }
- }
- }
-
- // Sort top sources by tier, keep top 5
- const sortedTopSources = [...topSourcesSet.values()]
- .sort((a, b) => a.tier - b.tier)
- .slice(0, 5);
-
- // Calculate merged timestamps
- const allDates = allItems.map(i => i.pubDate.getTime());
- const firstSeen = new Date(Math.min(...allDates));
- const lastUpdated = new Date(Math.max(...allDates));
-
- const mergedCluster: ClusteredEvent = {
- id: primary.id,
- primaryTitle: primary.primaryTitle,
- primaryLink: primary.primaryLink,
- primarySource: primary.primarySource,
- sourceCount: allItems.length,
- topSources: sortedTopSources,
- allItems,
- firstSeen,
- lastUpdated,
- isAlert: allItems.some(i => i.isAlert),
- monitorColor: primary.monitorColor,
- velocity: primary.velocity,
- threat: primary.threat,
- };
- mergedCluster.evidence = buildClusterEvidencePack(mergedCluster);
- merged.push(mergedCluster);
+ merged.push(groupClusters.length === 1 ? groupClusters[0]! : combineGroupClusters(groupClusters));
   }
 
-  // Add any clusters that weren't in any semantic group
   for (const cluster of clusters) {
- if (!usedIds.has(cluster.id)) {
- merged.push(cluster);
- }
+ if (!usedIds.has(cluster.id)) merged.push(cluster);
   }
 
-  // Sort by last updated
   merged.sort((a, b) => b.lastUpdated.getTime() - a.lastUpdated.getTime());
-
   return merged;
 }

--- a/src/services/log-bridge.ts
+++ b/src/services/log-bridge.ts
@@ -235,6 +235,11 @@ function installInteractionLatencyObserver(): void {
 // which the diagnostics bundle can include.
 interface FetchStat { ok: number; fail: number; lastErrorAt: number }
 const FETCH_WINDOW_MS = 5 * 60 * 1000;
+// Startup grace period — panels initialize simultaneously on launch and hit the
+// sidecar before it is ready, producing a burst of expected failures. Suppress
+// the burst alarm until the app has been running for this long.
+const BURST_ALARM_GRACE_MS = 20_000;
+let bridgeInstalledAt = 0;
 const fetchStats = new Map<string, FetchStat>();
 const fetchFailureTimes = new Map<string, number[]>();
 
@@ -251,8 +256,10 @@ function bumpFetchStat(host: string, ok: boolean): void {
  const cutoff = Date.now() - FETCH_WINDOW_MS;
  while (arr.length > 0 && arr[0]! < cutoff) arr.shift();
  fetchFailureTimes.set(host, arr);
- // Log an alarm if 5+ failures for the same host in the window.
- if (arr.length === 5) {
+ // Log an alarm if 5+ failures for the same host in the window, but skip
+ // the grace period after startup so panel-initialization races don't fire it.
+ const inGrace = bridgeInstalledAt > 0 && Date.now() - bridgeInstalledAt < BURST_ALARM_GRACE_MS;
+ if (arr.length === 5 && !inGrace) {
  recordBreadcrumb('WARN', 'fetch-burst', `${host}: ${arr.length} failures in <5m`);
  logToDesktop('WARN', `fetch failure burst: ${host} (${arr.length} in <5m)`);
  }
@@ -296,6 +303,7 @@ export function getFetchFailureSummary(): { host: string; ok: number; fail: numb
 export function installLogBridge(): void {
   if (installed) return;
   installed = true;
+  bridgeInstalledAt = Date.now();
 
   window.addEventListener('error', (e) => {
  const err = e.error as Error | undefined;

--- a/src/services/notifications/__tests__/notification-history-service.test.mts
+++ b/src/services/notifications/__tests__/notification-history-service.test.mts
@@ -180,12 +180,14 @@ test('DOMAIN_ICON covers every HistoryDomain value', () => {
 });
 
 test('SEVERITY_BADGE + ACTION_BADGE have colour + label per value', () => {
+  // Colors are CSS custom properties (var(--*)) for theming — accept both forms.
+  const validColor = /^(#[0-9a-f]{6}|var\(--[a-z-]+\))$/i;
   for (const s of ['critical', 'high', 'medium', 'low'] as const) {
-    assert.match(SEVERITY_BADGE[s].color, /^#[0-9a-f]{6}$/i);
+    assert.match(SEVERITY_BADGE[s].color, validColor);
     assert.ok(SEVERITY_BADGE[s].label);
   }
   for (const a of ['fired', 'suppressed', 'escalated'] as const) {
-    assert.match(ACTION_BADGE[a].color, /^#[0-9a-f]{6}$/i);
+    assert.match(ACTION_BADGE[a].color, validColor);
     assert.ok(ACTION_BADGE[a].label);
   }
 });

--- a/src/services/summarization.ts
+++ b/src/services/summarization.ts
@@ -15,6 +15,11 @@ import { trackLLMUsage, trackLLMFailure } from './analytics';
 import { NewsServiceClient, type SummarizeArticleResponse } from '@/generated/client/crystalball/news/v1/service_client';
 import { createCircuitBreaker } from '@/utils';
 
+// Suppress repeated T5/all-providers-failed warnings — WKWebView can't run ONNX
+// SIMD models, so these fire on every summarization attempt. Warn once per session.
+let t5WarnedThisSession = false;
+let allProvidersWarnedThisSession = false;
+
 export type SummarizationProvider = 'ollama' | 'groq' | 'openrouter' | 'browser' | 'cache';
 
 export interface SummarizationResult {
@@ -148,8 +153,11 @@ async function tryBrowserT5(headlines: string[], modelId?: string): Promise<Summ
  cached: false,
  };
   } catch (error) {
+ if (!t5WarnedThisSession) {
+ t5WarnedThisSession = true;
  // eslint-disable-next-line no-console
- console.warn('[Summarization] Browser T5 failed:', error);
+ console.warn('[Summarization] Browser T5 unavailable (suppressing further warnings):', error instanceof Error ? error.message : String(error));
+ }
  return null;
   }
 }
@@ -259,8 +267,11 @@ async function generateSummaryInternal(
  onProgress?.(totalSteps, totalSteps, 'No providers available');
  }
 
+ if (!allProvidersWarnedThisSession) {
+ allProvidersWarnedThisSession = true;
  // eslint-disable-next-line no-console
- console.warn('[BETA] All providers failed');
+ console.warn('[Summarization] All providers failed (suppressing further warnings)');
+ }
  return null;
   }
 
@@ -279,8 +290,11 @@ async function generateSummaryInternal(
  if (browserResult) return browserResult;
   }
 
-  // eslint-disable-next-line no-console
-  console.warn('[Summarization] All providers failed');
+  if (!allProvidersWarnedThisSession) {
+ allProvidersWarnedThisSession = true;
+ // eslint-disable-next-line no-console
+ console.warn('[Summarization] All providers failed (suppressing further warnings)');
+  }
   return null;
 }
 


### PR DESCRIPTION
## Summary

Five log noise sources fixed:

1. **Notification history test** — updated color regex to accept CSS custom properties (`var(--*)`)
2. **Burst alarm false positives** — 20s startup grace period in `log-bridge.ts` suppresses burst alarms during initial data load
3. **Sidecar heartbeat stale warning** — write `sidecar.health.json` immediately at startup before the 10s interval fires
4. **Dead feeds (403)** — replaced FPRI, Jamestown, Stimson direct RSS with Google News RSS proxies
5. **Repeated T5 / all-providers-failed warns** — session-level flags in `summarization.ts` warn once then suppress; same for semantic clustering in `clustering.ts`

**Bonus:** extracted `combineGroupClusters()` helper to fix pre-existing `sonarjs/cognitive-complexity` lint violation (23→8) that was blocking all previous commits on this file.

## Testing
- All existing tests pass
- `npm run typecheck:all` clean
- ESLint clean (no staged violations)

---

Cross-agent review: Codex reviewed on 2026-06-08; outcome: pass / issues fixed / accepted risk.