### PR TITLE
fix: resolve sidecar URL for Live News playlist fetch in desktop mode

### DIFF
--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -801,7 +801,7 @@ export class LiveNewsPanel extends Panel {
 
   private async fetchChannelPlaylist(channel: LiveChannel): Promise<void> {
  try {
- const res = await fetch(`/api/local-youtube-recent-videos?channel=${encodeURIComponent(channel.handle)}&count=15`);
+ const res = await fetch(`${getApiBaseUrl()}/api/local-youtube-recent-videos?channel=${encodeURIComponent(channel.handle)}&count=15`);
  if (!res.ok) throw new Error(`HTTP ${res.status}`);
  const data = await res.json() as { videoIds?: unknown };
  if (Array.isArray(data.videoIds) && data.videoIds.length > 0) {


### PR DESCRIPTION
## Problem

`fetchChannelPlaylist()` used a bare `/api/local-youtube-recent-videos?...` relative URL. In the Tauri desktop app the WebView origin is `tauri://localhost`, so this resolved to the app bundle — not the sidecar running at `http://127.0.0.1:46123`. Every playlist fetch silently failed with "Load failed", leaving the \`Load Player\` placeholder visible even though the fallback video ID was set.

## Fix

Prefix the fetch URL with `getApiBaseUrl()` (already imported). In desktop mode this returns `http://127.0.0.1:${port}`; in web mode it returns `''` so relative URL behaviour is unchanged.

## Testing

- Type-check: zero errors
- In desktop app: S2 Underground (and any `autoPlaylist` channel) now reaches the sidecar endpoint, falls back to `lGyn-vcD7EU`, and the embed proxy loads the player automatically without requiring a button click.

Cross-agent review: Codex reviewed on 2026-06-08; outcome: approved