### PR TITLE
perf: cache storm polygon math and remove rIC timeout forcing

### DIFF
--- a/src/components/SavedPlacesPanel.ts
+++ b/src/components/SavedPlacesPanel.ts
@@ -104,7 +104,8 @@ export class SavedPlacesPanel extends Panel {
       if (typeof requestIdleCallback === 'undefined') {
         setTimeout(() => { this.refreshPending = false; this.refresh(); }, 0);
       } else {
-        requestIdleCallback(() => { this.refreshPending = false; this.refresh(); }, { timeout: 500 });
+        // No timeout — never preempt user input to run a background panel update.
+        requestIdleCallback(() => { this.refreshPending = false; this.refresh(); });
       }
     };
     document.addEventListener('wm:breaking-news', this.boundRefresh);

--- a/src/services/place-briefs.ts
+++ b/src/services/place-briefs.ts
@@ -11,7 +11,26 @@ import {
 } from './saved-place-weather';
 import { getSavedPlace, getSavedPlaces, type SavedPlace } from './saved-places';
 import { isOffline, readOfflineCacheEntry, writeOfflineCacheEntry } from './offline-alert-cache';
-import { getStormPreparednessForPlace, summarizeStormPreparedness, type PlaceStormPreparedness } from './storm-preparedness';
+import {
+  getStormPreparednessContext,
+  getStormPreparednessForPlace,
+  summarizeStormPreparedness,
+  type PlaceStormPreparedness,
+} from './storm-preparedness';
+
+// Per-place storm preparedness cache keyed by stormContext.updatedAt.
+// Polygon math (ray-cast over NWS alert geometry) is O(places × alerts × vertices)
+// and must not run on every panel re-render — only when storm data actually changes.
+const stormPrepCache = new Map<string, { result: PlaceStormPreparedness | null; version: number }>();
+
+function getCachedStormPreparedness(place: SavedPlace): PlaceStormPreparedness | null {
+  const version = getStormPreparednessContext().updatedAt;
+  const cached = stormPrepCache.get(place.id);
+  if (cached?.version === version) return cached.result;
+  const result = getStormPreparednessForPlace(place);
+  stormPrepCache.set(place.id, { result, version });
+  return result;
+}
 
 export interface PlaceBriefItem {
   kind: 'breaking' | 'signal' | 'preparedness' | 'forecast' | 'logistics';
@@ -206,7 +225,7 @@ export function getPlaceBriefSnapshot(
   const now = options.now ?? Date.now();
   const breakingAlerts = options.breakingAlerts ?? getRecentBreakingAlerts();
   const signals = options.signals ?? getRecentSignals();
-  const stormPreparedness = options.stormPreparedness ?? getStormPreparednessForPlace(place);
+  const stormPreparedness = options.stormPreparedness ?? getCachedStormPreparedness(place);
   const forecastSnapshot = options.forecastSnapshot ?? getCachedSavedPlaceWeather(place.id);
   const logisticsSnapshot = options.logisticsSnapshot ?? getCachedLocalLogistics(place.id);
   const offline = options.offline ?? isOffline();


### PR DESCRIPTION
## Root causes

### 1. Storm preparedness polygon math ran on every render (critical)

`getStormPreparednessForPlace()` loops over all NWS alerts (100–500 on a busy day) and runs ray-cast polygon math for each one, per place, per render. With 5 places × 300 alerts × 100 polygon vertices that's ~150,000 float ops happening synchronously on the main thread every time any subscribed event fires. The storm context only changes when `wm:storm-data-updated` fires (~every 10–30 min).

**Fix:** `getCachedStormPreparedness(place)` in `place-briefs.ts` — memoizes the result per place keyed by `stormContext.updatedAt`. Polygon math now runs once per storm data update, not on every panel repaint. Cache is invalidated automatically whenever new storm data arrives.

### 2. `requestIdleCallback({ timeout: 500 })` forced the browser to run the refresh mid-click

Once 500ms elapsed since a refresh was queued, the browser had to execute the rIC callback even during active user interaction. If the user clicked at 450ms, the refresh ran first.

**Fix:** Removed the `{ timeout: 500 }` option. Without a timeout, `requestIdleCallback` only runs during genuine browser idle time — it never preempts a click, tap, or keypress.

Cross-agent review: Codex reviewed on 2026-06-08; outcome: approved