### PR TITLE
fix: stop event listener accumulation in timer-driven panels (kill 100% WebContent CPU)

### DIFF
--- a/src/components/ActiveLearningPanel.ts
+++ b/src/components/ActiveLearningPanel.ts
@@ -72,8 +72,7 @@ export class ActiveLearningPanel extends Panel {
     const svc = getActiveLearningQueue();
     const pending = svc.getPending();
     this.setCount(pending.length);
-    this.setContent(this.buildHtml(pending, svc.getAll()));
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(pending, svc.getAll()), () => this.wireHandlers());
   }
 
   private buildHtml(pending: LearningItem[], all: LearningItem[]): string {

--- a/src/components/ActiveLearningQueuePanel.ts
+++ b/src/components/ActiveLearningQueuePanel.ts
@@ -73,8 +73,7 @@ export class ActiveLearningQueuePanel extends Panel {
     try {
       const stats = this.service.getStats();
       this.setCount(stats.pending + stats.claimed);
-      this.setContent(this.buildHtml(stats));
-      queueMicrotask(() => this.wireHandlers());
+      this.setContent(this.buildHtml(stats), () => this.wireHandlers());
     } catch (error) {
       this.setContent(
         `<div style="padding:12px;color:var(--severity-critical);">Active-learning panel error: ${escapeHtml(String(error))}</div>`,

--- a/src/components/AlertDeduplicationPanel.ts
+++ b/src/components/AlertDeduplicationPanel.ts
@@ -62,8 +62,7 @@ export class AlertDeduplicationPanel extends Panel {
       const stats = this.service.getStats();
       const duplicates = this.service.getRecords({ isDuplicate: true }, DEDUP_LIST_LIMIT);
       this.setCount(stats.duplicates);
-      this.setContent(this.buildHtml(stats, duplicates));
-      queueMicrotask(() => this.wireHandlers());
+      this.setContent(this.buildHtml(stats, duplicates), () => this.wireHandlers());
     } catch (error) {
       this.setContent(
         `<div style="padding:12px;color:var(--severity-critical);">Dedup panel error: ${escapeHtml(String(error))}</div>`,

--- a/src/components/AlertEscalationPanel.ts
+++ b/src/components/AlertEscalationPanel.ts
@@ -78,8 +78,7 @@ export class AlertEscalationPanel extends Panel {
       const pending = this.service.getRecords({ status: 'pending' }, LIST_LIMIT);
       const escalated = this.service.getRecords({ status: 'escalated' }, LIST_LIMIT);
       this.setCount(summary.pending + summary.escalated);
-      this.setContent(this.buildHtml(summary, pending, escalated));
-      queueMicrotask(() => this.wireHandlers());
+      this.setContent(this.buildHtml(summary, pending, escalated), () => this.wireHandlers());
     } catch (error) {
       this.setContent(
         `<div style="padding:12px;color:var(--severity-critical);">Escalation panel error: ${escapeHtml(String(error))}</div>`,

--- a/src/components/ApiDiagnosticPanel.ts
+++ b/src/components/ApiDiagnosticPanel.ts
@@ -62,9 +62,7 @@ export class ApiDiagnosticPanel extends Panel {
   private render(): void {
     const report = diagnoseAll();
     this.setCount(report.failing + report.silent);
-    this.setContent(this.buildHtml(report));
-    // Attach click handlers after DOM update
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(report), () => this.wireHandlers());
   }
 
   private buildHtml(report: DiagnosticReport): string {

--- a/src/components/AssumptionPanel.ts
+++ b/src/components/AssumptionPanel.ts
@@ -79,8 +79,7 @@ export class AssumptionPanel extends Panel {
   private render(): void {
     try {
       const html = this.buildHtml();
-      this.setContent(html);
-      queueMicrotask(() => this.wireHandlers());
+      this.setContent(html, () => this.wireHandlers());
     } catch (error) {
       this.setContent(
         `<div style="padding:12px;color:var(--severity-critical);">Assumption panel error: ${escapeHtml(String(error))}</div>`,

--- a/src/components/BiasDetectionPanel.ts
+++ b/src/components/BiasDetectionPanel.ts
@@ -98,8 +98,7 @@ export class BiasDetectionPanel extends Panel {
     const svc = getBiasDetectorService();
     const active = svc.getActive();
     this.setCount(active.length);
-    this.setContent(this.buildHtml(active, svc.getHistory()));
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(active, svc.getHistory()), () => this.wireHandlers());
   }
 
   private buildHtml(active: BiasSignal[], history: BiasSignal[]): string {

--- a/src/components/CausalChainPanel.ts
+++ b/src/components/CausalChainPanel.ts
@@ -55,8 +55,7 @@ export class CausalChainPanel extends Panel {
     try {
       const chains = [...this.builder.getChains()].sort((a, b) => b.builtAt - a.builtAt);
       this.setCount(chains.length);
-      this.setContent(this.buildHtml(chains));
-      queueMicrotask(() => this.wireHandlers());
+      this.setContent(this.buildHtml(chains), () => this.wireHandlers());
     } catch (error) {
       this.setContent(
         `<div style="padding:12px;color:var(--severity-critical);">Causal-chain panel error: ${escapeHtml(String(error))}</div>`,

--- a/src/components/CompoundEventDetectorPanel.ts
+++ b/src/components/CompoundEventDetectorPanel.ts
@@ -73,8 +73,7 @@ export class CompoundEventDetectorPanel extends Panel {
       const history = this.service.getHistory(HISTORY_LIMIT);
       const summary = this.service.getSummary();
       this.setCount(summary.activeEvents.length);
-      this.setContent(this.buildHtml(active, history, summary));
-      queueMicrotask(() => this.wireHandlers());
+      this.setContent(this.buildHtml(active, history, summary), () => this.wireHandlers());
     } catch (error) {
       this.setContent(
         `<div style="padding:12px;color:var(--severity-critical);">Compound Events panel error: ${escapeHtml(String(error))}</div>`,

--- a/src/components/ContradictionDetectorPanel.ts
+++ b/src/components/ContradictionDetectorPanel.ts
@@ -75,8 +75,7 @@ export class ContradictionDetectorPanel extends Panel {
     const open = svc.getOpen();
     const all = svc.getAll();
     this.setCount(open.length);
-    this.setContent(this.buildHtml(open, all, svc.stats()));
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(open, all, svc.stats()), () => this.wireHandlers());
   }
 
   private buildHtml(

--- a/src/components/CrossDomainContradictionDetectorPanel.ts
+++ b/src/components/CrossDomainContradictionDetectorPanel.ts
@@ -55,8 +55,7 @@ export class CrossDomainContradictionDetectorPanel extends Panel {
     const stats = det.getStats();
     const active = det.getActive();
     this.setCount(stats.active);
-    this.setContent(this.buildHtml(stats, active));
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(stats, active), () => this.wireHandlers());
   }
 
   private buildHtml(

--- a/src/components/DomainScorecardPanel.ts
+++ b/src/components/DomainScorecardPanel.ts
@@ -102,8 +102,7 @@ export class DomainScorecardPanel extends Panel {
     const summary = this.service.generateAll(this.feedMap());
     const cards = this.sortCards(summary.scorecards);
     this.setCount(summary.domainsNeedingAttention.length);
-    this.setContent(this.buildHtml(summary.systemGrade, summary.domainsNeedingAttention, cards));
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(summary.systemGrade, summary.domainsNeedingAttention, cards), () => this.wireHandlers());
   }
 
   private feedMap(): Record<string, FeedHealth> {

--- a/src/components/DomainScorecardsPanel.ts
+++ b/src/components/DomainScorecardsPanel.ts
@@ -99,8 +99,7 @@ export class DomainScorecardsPanel extends Panel {
     const cards = this.sortCards(svc.getAllScorecards());
     const flagged = cards.filter((c) => c.overallGrade === 'D' || c.overallGrade === 'F').length;
     this.setCount(flagged);
-    this.setContent(this.buildHtml(cards));
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(cards), () => this.wireHandlers());
   }
 
   private sortCards(cards: readonly DomainScorecard[]): DomainScorecard[] {

--- a/src/components/ExperimentManagerPanel.ts
+++ b/src/components/ExperimentManagerPanel.ts
@@ -81,8 +81,7 @@ export class ExperimentManagerPanel extends Panel {
     const experiments = svc.getExperiments();
     const running = experiments.filter((e) => e.status === 'running').length;
     this.setCount(running);
-    this.setContent(this.buildHtml(experiments));
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(experiments), () => this.wireHandlers());
   }
 
   private buildHtml(experiments: readonly Experiment[]): string {

--- a/src/components/FailurePredictionPanel.ts
+++ b/src/components/FailurePredictionPanel.ts
@@ -81,8 +81,7 @@ export class FailurePredictionPanel extends Panel {
       const top = risks.slice(0, 10);
       const counts = countByBand(risks);
       this.setCount(counts.critical + counts.high);
-      this.setContent(this.buildHtml(counts, top, risks.length));
-      queueMicrotask(() => this.wireHandlers());
+      this.setContent(this.buildHtml(counts, top, risks.length), () => this.wireHandlers());
     } catch (error) {
       this.setContent(
         `<div style="padding:12px;color:var(--severity-critical);">Failure-prediction panel error: ${escapeHtml(String(error))}</div>`,

--- a/src/components/GeopoliticalEventCalendarPanel.ts
+++ b/src/components/GeopoliticalEventCalendarPanel.ts
@@ -94,8 +94,7 @@ export class GeopoliticalEventCalendarPanel extends Panel {
     const events = svc.getUpcoming(horizonMs, filter);
     const summary = svc.getSummary();
     this.setCount(summary.highRiskCount);
-    this.setContent(this.buildHtml(events, summary.highRiskCount));
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(events, summary.highRiskCount), () => this.wireHandlers());
   }
 
   private buildFilter(): UpcomingFilter | undefined {

--- a/src/components/GeospatialClusteringPanel.ts
+++ b/src/components/GeospatialClusteringPanel.ts
@@ -65,8 +65,7 @@ export class GeospatialClusteringPanel extends Panel {
     const svc = getGeospatialClusteringService();
     const summary = svc.getSummary();
     this.setCount(summary.hotspots.length);
-    this.setContent(this.buildHtml(summary));
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(summary), () => this.wireHandlers());
   }
 
   private buildHtml(summary: ClusterSummary): string {

--- a/src/components/HistoricalPlaybackPanel.ts
+++ b/src/components/HistoricalPlaybackPanel.ts
@@ -131,8 +131,7 @@ export class HistoricalPlaybackPanel extends Panel {
     this.setCount(stats.highSeverityDomainCount);
     this.setContent(this.buildHtml({
       timeline, activeId, liveId, selected, live, stats, comparison,
-    }));
-    queueMicrotask(() => this.wireHandlers());
+    }), () => this.wireHandlers());
   }
 
   private buildHtml(view: {

--- a/src/components/IntelligenceBriefingExportPanel.ts
+++ b/src/components/IntelligenceBriefingExportPanel.ts
@@ -88,8 +88,7 @@ export class IntelligenceBriefingExportPanel extends Panel {
   private render(): void {
     const history = this.service.getBriefings(10);
     this.setCount(history.length);
-    this.setContent(this.buildHtml(history));
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(history), () => this.wireHandlers());
   }
 
   private buildHtml(history: readonly IntelligenceBriefing[]): string {

--- a/src/components/IntelligenceDigestPanel.ts
+++ b/src/components/IntelligenceDigestPanel.ts
@@ -64,8 +64,7 @@ export class IntelligenceDigestPanel extends Panel {
     const svc = getIntelligenceDigestService();
     const digest = svc.getLatestDigest();
     this.setCount(digest ? digest.totalAlerts : 0);
-    this.setContent(this.buildHtml(digest));
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(digest), () => this.wireHandlers());
   }
 
   private buildHtml(digest: IntelligenceDigest | undefined): string {

--- a/src/components/IntelligenceIndexPanel.ts
+++ b/src/components/IntelligenceIndexPanel.ts
@@ -96,8 +96,7 @@ export class IntelligenceIndexPanel extends Panel {
     const svc = getIntelligenceIndexService();
     const stats = svc.getStats();
     this.setCount(stats.total);
-    this.setContent(this.buildHtml());
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(), () => this.wireHandlers());
   }
 
   private buildHtml(): string {

--- a/src/components/IntelligenceTrustBudgetPanel.ts
+++ b/src/components/IntelligenceTrustBudgetPanel.ts
@@ -61,8 +61,7 @@ export class IntelligenceTrustBudgetPanel extends Panel {
       const statuses = [...this.service.getAllStatuses()].sort((a, b) => a.domain.localeCompare(b.domain));
       const suppressedCount = statuses.filter((s) => s.suppressionActive).length;
       this.setCount(suppressedCount);
-      this.setContent(this.buildHtml(statuses));
-      queueMicrotask(() => this.wireHandlers());
+      this.setContent(this.buildHtml(statuses), () => this.wireHandlers());
     } catch (error) {
       this.setContent(
         `<div style="padding:12px;color:var(--severity-critical);">Trust-budget panel error: ${escapeHtml(String(error))}</div>`,

--- a/src/components/MetaConfidenceCalibrationPanel.ts
+++ b/src/components/MetaConfidenceCalibrationPanel.ts
@@ -64,8 +64,7 @@ export class MetaConfidenceCalibrationPanel extends Panel {
       const summaries = this.service.getAllSummaries();
       const totalRecords = this.service.getRecords().length;
       this.setCount(summaries.length);
-      this.setContent(this.buildHtml(summaries, totalRecords));
-      queueMicrotask(() => this.wireHandlers());
+      this.setContent(this.buildHtml(summaries, totalRecords), () => this.wireHandlers());
     } catch (error) {
       this.setContent(
         `<div style="padding:12px;color:var(--severity-critical);">Meta-confidence panel error: ${escapeHtml(String(error))}</div>`,

--- a/src/components/MissionControlDashboardPanel.ts
+++ b/src/components/MissionControlDashboardPanel.ts
@@ -83,8 +83,7 @@ export class MissionControlDashboardPanel extends Panel {
     try {
       const snap = this.service.getLatest();
       this.setCount(snap ? snap.activeSituationCount : 0);
-      this.setContent(this.buildHtml(snap));
-      queueMicrotask(() => this.wireHandlers());
+      this.setContent(this.buildHtml(snap), () => this.wireHandlers());
     } catch (error) {
       this.setContent(
         `<div style="padding:12px;color:var(--severity-critical);">Mission Control panel error: ${escapeHtml(String(error))}</div>`,

--- a/src/components/ModelGovernancePanel.ts
+++ b/src/components/ModelGovernancePanel.ts
@@ -48,8 +48,7 @@ export class ModelGovernancePanel extends Panel {
     const all = svc.getAll();
     this.setCount(all.length);
     const visible = this.applyFilters(all);
-    this.setContent(this.buildHtml(visible, all));
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(visible, all), () => this.wireHandlers());
   }
 
   private applyFilters(cards: ModelCard[]): ModelCard[] {

--- a/src/components/NetworkTopologyPanel.ts
+++ b/src/components/NetworkTopologyPanel.ts
@@ -57,6 +57,14 @@ export class NetworkTopologyPanel extends Panel {
  trackActivity: true,
  infoTooltip: 'Network topology and asset visibility dashboard. Tracks nodes (servers, firewalls, ICS devices), connections, and security alerts. Highlights compromised assets and suspicious connections.',
  });
+ // Delegate node-row clicks once so re-renders never accumulate listeners.
+ this.getContentElement().addEventListener('click', (e) => {
+ const row = (e.target as Element).closest<HTMLElement>('.topo-node-row');
+ if (!row) return;
+ const id = row.dataset.nodeId ?? null;
+ this.selectedNodeId = this.selectedNodeId === id ? null : id;
+ this.render();
+ });
  this.showLoading('Mapping network topology\u2026');
  this.start();
   }
@@ -117,14 +125,6 @@ export class NetworkTopologyPanel extends Panel {
  ${alertHtml}
  </div>
  `);
-
- this.getContentElement().querySelectorAll('.topo-node-row').forEach(row => {
- row.addEventListener('click', () => {
- const id = row.getAttribute('data-node-id');
- this.selectedNodeId = this.selectedNodeId === id ? null : id;
- this.render();
- });
- });
   }
 
   private renderNode(n: TopoNode): string {

--- a/src/components/NotificationAuditPanel.ts
+++ b/src/components/NotificationAuditPanel.ts
@@ -111,8 +111,7 @@ export class NotificationAuditPanel extends Panel {
   private render(): void {
     const svc = getNotificationAuditService();
     this.setCount(svc.unreadCount());
-    this.setContent(this.buildHtml());
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(), () => this.wireHandlers());
   }
 
   private buildHtml(): string {

--- a/src/components/NotificationPreferencesPanel.ts
+++ b/src/components/NotificationPreferencesPanel.ts
@@ -67,8 +67,7 @@ export class NotificationPreferencesPanel extends Panel {
       ? prefs.domains.filter((d) => d.enabled).length
       : 0;
     this.setCount(enabledCount);
-    this.setContent(this.buildHtml());
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(), () => this.wireHandlers());
   }
 
   private buildHtml(): string {

--- a/src/components/NotificationSettingsPanel.ts
+++ b/src/components/NotificationSettingsPanel.ts
@@ -54,8 +54,7 @@ export class NotificationSettingsPanel extends Panel {
       (d) => settings.global.masterMute || !settings.domains[d].enabled,
     ).length;
     this.setCount(mutedOrDisabled);
-    this.setContent(this.buildHtml());
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(), () => this.wireHandlers());
   }
 
   private buildHtml(): string {

--- a/src/components/OperationalPlaybookPanel.ts
+++ b/src/components/OperationalPlaybookPanel.ts
@@ -72,8 +72,7 @@ export class OperationalPlaybookPanel extends Panel {
       const history = this.engine.getAll().filter((p) => p.status !== 'active');
       const stats = this.engine.stats();
       this.setCount(active.length);
-      this.setContent(this.buildHtml(active, history, stats));
-      queueMicrotask(() => this.wireHandlers());
+      this.setContent(this.buildHtml(active, history, stats), () => this.wireHandlers());
     } catch (error) {
       this.setContent(
         `<div style="padding:12px;color:var(--severity-critical);">Operational-playbook panel error: ${escapeHtml(String(error))}</div>`,

--- a/src/components/OperatorShiftReportPanel.ts
+++ b/src/components/OperatorShiftReportPanel.ts
@@ -63,8 +63,7 @@ export class OperatorShiftReportPanel extends Panel {
         ? reports.find((r) => r.id === this.selectedReportId) ?? null
         : reports[0] ?? null;
       this.setCount(reports.length);
-      this.setContent(this.buildHtml(reports, selected));
-      queueMicrotask(() => this.wireHandlers());
+      this.setContent(this.buildHtml(reports, selected), () => this.wireHandlers());
     } catch (error) {
       this.setContent(
         `<div style="padding:12px;color:var(--severity-critical);">Shift-report panel error: ${escapeHtml(String(error))}</div>`,

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -216,6 +216,7 @@ export class Panel {
   private colSpanReconcileRaf: number | null = null;
   private readonly contentDebounceMs = 150;
   private pendingContentHtml: string | null = null;
+  private pendingOnRendered: (() => void) | null = null;
   private contentDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   // Cache the last HTML string we actually wrote to the DOM. Reading
   // `element.innerHTML` forces the browser to serialize the subtree, which is
@@ -750,13 +751,14 @@ export class Panel {
  }
   }
 
-  public setContent(html: string): void {
+  public setContent(html: string, onRendered?: () => void): void {
  // No-op detection uses only cached strings — avoid reading innerHTML, which
  // forces a full subtree serialization every call.
  if (this.pendingContentHtml === html) return;
  if (this.pendingContentHtml === null && this.lastAppliedContentHtml === html) return;
 
  this.pendingContentHtml = html;
+ this.pendingOnRendered = onRendered ?? null;
  if (this.contentDebounceTimer) {
  clearTimeout(this.contentDebounceTimer);
  }
@@ -775,7 +777,9 @@ export class Panel {
  }
 
  this.pendingContentHtml = null;
- if (this.lastAppliedContentHtml !== html) {
+ if (this.lastAppliedContentHtml === html) {
+ this.pendingOnRendered = null;
+ } else {
  // Crash-isolate the DOM write so a malformed string from one panel subclass
  // (bad escaping, oversized attribute, CSP blocker) can't abort the debounce
  // timer. On failure we swap in a minimal error card and mark the cache so
@@ -784,9 +788,13 @@ export class Panel {
  this.content.innerHTML = html;
  this.lastAppliedContentHtml = html;
  this.markFresh();
+ const cb = this.pendingOnRendered;
+ this.pendingOnRendered = null;
+ cb?.();
  } catch (error) {
  // eslint-disable-next-line no-console
  console.warn(`[Panel ${this.panelId}] setContent failed:`, error);
+ this.pendingOnRendered = null;
  this.renderErrorFallback(error instanceof Error ? error.message : String(error));
  }
  }

--- a/src/components/QualityDebtPanel.ts
+++ b/src/components/QualityDebtPanel.ts
@@ -94,8 +94,7 @@ export class QualityDebtPanel extends Panel {
     try {
       const summary = this.tracker.scan(this.collectScanParams());
       this.setCount(summary.items.length);
-      this.setContent(this.buildHtml(summary));
-      queueMicrotask(() => this.wireHandlers());
+      this.setContent(this.buildHtml(summary), () => this.wireHandlers());
     } catch (error) {
       this.setContent(
         `<div style="padding:12px;color:var(--severity-critical);">Quality debt scan error: ${escapeHtml(String(error))}</div>`,

--- a/src/components/RecoveryModelingPanel.ts
+++ b/src/components/RecoveryModelingPanel.ts
@@ -84,8 +84,7 @@ export class RecoveryModelingPanel extends Panel {
     const active = svc.getActiveProfiles();
     const completed = svc.getCompletedProfiles(HISTORY_LIMIT);
     this.setCount(active.length);
-    this.setContent(this.buildHtml(active, completed));
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(active, completed), () => this.wireHandlers());
   }
 
   private buildHtml(active: RecoveryProfile[], completed: RecoveryProfile[]): string {

--- a/src/components/RegionalResiliencePanel.ts
+++ b/src/components/RegionalResiliencePanel.ts
@@ -76,8 +76,7 @@ export class RegionalResiliencePanel extends Panel {
     const svc = getRegionalResilienceIndex();
     const all = svc.getAllScores();
     this.setCount(all.length);
-    this.setContent(this.buildHtml(all));
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(all), () => this.wireHandlers());
   }
 
   private buildHtml(all: RegionalScore[]): string {

--- a/src/components/SafetyCaseDashboardPanel.ts
+++ b/src/components/SafetyCaseDashboardPanel.ts
@@ -68,8 +68,7 @@ export class SafetyCaseDashboardPanel extends Panel {
     const svc = getSafetyCaseDashboardService();
     const summary = svc.getSummary();
     this.setCount(summary.criticalFailures.length);
-    this.setContent(this.buildHtml(summary));
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(summary), () => this.wireHandlers());
   }
 
   private buildHtml(summary: SafetyCaseSummary): string {

--- a/src/components/SchedulerPanel.ts
+++ b/src/components/SchedulerPanel.ts
@@ -59,8 +59,7 @@ export class SchedulerPanel extends Panel {
     const tasks = svc.getAllTasks();
     const enabledCount = tasks.filter((t) => t.enabled).length;
     this.setCount(enabledCount);
-    this.setContent(this.buildHtml(tasks, svc.getHistory(undefined, HISTORY_DISPLAY_LIMIT), svc.isRunning(), svc.stats()));
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(tasks, svc.getHistory(undefined, HISTORY_DISPLAY_LIMIT), svc.isRunning(), svc.stats()), () => this.wireHandlers());
   }
 
   private buildHtml(

--- a/src/components/SituationLifecycleTrackerPanel.ts
+++ b/src/components/SituationLifecycleTrackerPanel.ts
@@ -74,8 +74,7 @@ export class SituationLifecycleTrackerPanel extends Panel {
       const lifecycles = this.service.getAll(filterArg, RECENT_LIMIT);
       const stats = this.service.getStats(this.filterDomain ?? undefined);
       this.setCount(lifecycles.length);
-      this.setContent(this.buildHtml(stats, lifecycles));
-      queueMicrotask(() => this.wireHandlers());
+      this.setContent(this.buildHtml(stats, lifecycles), () => this.wireHandlers());
     } catch (error) {
       this.setContent(
         `<div style="padding:12px;color:var(--severity-critical);">Lifecycle panel error: ${escapeHtml(String(error))}</div>`,

--- a/src/components/SystemDiagnosticPanel.ts
+++ b/src/components/SystemDiagnosticPanel.ts
@@ -131,8 +131,7 @@ export class SystemDiagnosticPanel extends Panel {
   private render(): void {
     try {
       const html = this.buildHtml();
-      this.setContent(html);
-      queueMicrotask(() => this.wireHandlers());
+      this.setContent(html, () => this.wireHandlers());
     } catch (error) {
       console.warn('[SystemDiagnosticPanel] render failed:', error);
       this.setContent(`<div style="padding:12px;color:var(--severity-critical);">Diagnostic render error: ${escapeHtml(String(error))}</div>`);

--- a/src/components/ThreatCorrelationMatrixPanel.ts
+++ b/src/components/ThreatCorrelationMatrixPanel.ts
@@ -67,8 +67,7 @@ export class ThreatCorrelationMatrixPanel extends Panel {
     const svc = getThreatCorrelationMatrix();
     const snapshot = svc.getSnapshot();
     this.setCount(snapshot.hotPairs.length);
-    this.setContent(this.buildHtml(snapshot));
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(snapshot), () => this.wireHandlers());
   }
 
   private buildHtml(snapshot: MatrixSnapshot): string {

--- a/src/components/TrustBudgetPanel.ts
+++ b/src/components/TrustBudgetPanel.ts
@@ -63,8 +63,7 @@ export class TrustBudgetPanel extends Panel {
   private render(): void {
     const snap = getTrustBudgetService().getSnapshot();
     this.setCount(snap.exhaustedDomains.length);
-    this.setContent(this.buildHtml(snap));
-    queueMicrotask(() => this.wireHandlers());
+    this.setContent(this.buildHtml(snap), () => this.wireHandlers());
   }
 
   private buildHtml(snap: TrustBudgetSnapshot): string {

--- a/src/components/VulnersCvePanel.ts
+++ b/src/components/VulnersCvePanel.ts
@@ -74,8 +74,7 @@ export class VulnersCvePanel extends Panel {
   private render(): void {
     const critical = this.records.filter((r) => r.exploitRiskTier === 'critical').length;
     this.setCount(critical);
-    this.setContent(this.buildHtml());
-    this.attachHandlers();
+    this.setContent(this.buildHtml(), () => this.attachHandlers());
   }
 
   private buildHtml(): string {

--- a/src/components/WorldNarrativePanel.ts
+++ b/src/components/WorldNarrativePanel.ts
@@ -75,8 +75,7 @@ export class WorldNarrativePanel extends Panel {
     try {
       const narrative = getWorldNarrativeEngine().getLatestNarrative();
       this.setCount(narrative?.criticalAlertCount ?? 0);
-      this.setContent(this.buildHtml(narrative));
-      queueMicrotask(() => this.wireHandlers());
+      this.setContent(this.buildHtml(narrative), () => this.wireHandlers());
     } catch (error) {
       this.setContent(`<div style="padding:12px;color:var(--severity-critical);">World-narrative render error: ${escapeHtml(String(error))}</div>`);
     }

--- a/src/components/WorldStateComparatorPanel.ts
+++ b/src/components/WorldStateComparatorPanel.ts
@@ -109,8 +109,7 @@ export class WorldStateComparatorPanel extends Panel {
       nowSnapshot,
       deltas,
       summary,
-    }));
-    queueMicrotask(() => this.wireHandlers());
+    }), () => this.wireHandlers());
   }
 
   private buildHtml(view: {


### PR DESCRIPTION
## Problem

The WebKit WebContent process (PID 11094) was sustaining 100%+ CPU continuously from app launch. A `sample` profile showed one `DOMTimer::fired` callback running for ~5 seconds doing nothing but `addEventListener` calls.

### Root cause: queueMicrotask + setContent debounce race

Every panel with a periodic `setInterval` render was doing:

```typescript
private render(): void {
  this.setContent(html);                     // debounced 150ms
  queueMicrotask(() => this.wireHandlers()); // fires ~0ms later
}
```

**The microtask fires before the 150ms debounce timer.** `wireHandlers()` queries and binds listeners on the _old_ DOM nodes — the ones `setContent` hasn't replaced yet.

When the HTML hasn't changed (the common case), `setContent()` is a no-op — those nodes persist forever. So every render tick adds another layer of duplicate event listeners to the same persistent elements. WebKit's `EventTarget::addEventListener` linearly scans existing listeners to deduplicate; after N accumulations, each new bind is O(N). After 20 minutes with a 5-second panel:

```
240 render ticks × 5 elements × 240 existing listeners = 288,000 comparison operations per wireHandlers call
```

With 41 panels doing this at intervals from 5–60s, the cumulative cost is what produced the profiler trace.

## Fix

`Panel.setContent(html, onRendered?)` now accepts an optional callback that is **only called inside `setContentImmediate()` after `innerHTML` is actually written**. No-op renders (same HTML) never trigger `wireHandlers`. Real renders trigger it exactly once on fresh nodes.

```typescript
// Before (accumulates):
this.setContent(html);
queueMicrotask(() => this.wireHandlers());

// After (one-shot on real DOM change only):
this.setContent(html, () => this.wireHandlers());
```

**Files changed:**
- `Panel.ts`: `pendingOnRendered` field + optional param on `setContent` + call-site in `setContentImmediate`
- 41 panel components: removed `queueMicrotask` line, added callback arg to `setContent`
- `NetworkTopologyPanel.ts`: replaced synchronous querySelector+addEventListener loop with event delegation registered once in constructor
- `VulnersCvePanel.ts`: synchronous `attachHandlers()` moved to new callback

## Verification

`npm run typecheck:all` — zero errors.