### PR TITLE
perf: eliminate forced reflows, cache heartbeat DOM, gate renders on visibility

### DIFF
--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -223,6 +223,16 @@ export class Panel {
   // expensive on panels with large or animated content. Keeping a cached copy
   // lets setContent() detect no-op updates without touching the DOM.
   private lastAppliedContentHtml = '';
+  // Cached reference to the heartbeat text node — avoids a querySelector on
+  // every 5-second heartbeat tick across 473+ panel instances.
+  private heartbeatTextEl: HTMLElement | null = null;
+  private lastHeartbeatStale = false;
+  private lastHeartbeatVeryStale = false;
+  // IntersectionObserver state — panels that are scrolled out of view skip DOM
+  // writes entirely; the pending HTML is flushed when they scroll back in.
+  private panelIntersecting = true;
+  private intersectionObserver: IntersectionObserver | null = null;
+  private static appVisible = true;
   private aiSummaryOverlay: HTMLElement | null = null;
 
   /** Panel IDs that should not offer AI Summary (video streams or already-AI panels). */
@@ -316,6 +326,7 @@ export class Panel {
  const hbText = document.createElement('span');
  hbText.className = 'panel-heartbeat-text';
  hbText.textContent = '—';
+ this.heartbeatTextEl = hbText;
  this.heartbeatEl.append(hbDot, hbText);
  this.header.append(this.heartbeatEl);
 
@@ -334,6 +345,7 @@ export class Panel {
 
  Panel.instances.add(this);
  Panel.startHeartbeatTicker();
+ this.setupVisibilityTracking();
 
  // Add resize handle
  this.resizeHandle = document.createElement('div');
@@ -759,6 +771,12 @@ export class Panel {
 
  this.pendingContentHtml = html;
  this.pendingOnRendered = onRendered ?? null;
+
+ // Panel is off-screen or app is backgrounded — cache the new HTML but do
+ // NOT start the debounce timer. The IntersectionObserver / visibilitychange
+ // handler will queue the flush when the panel becomes renderable again.
+ if (!this.panelIntersecting || !Panel.appVisible) return;
+
  if (this.contentDebounceTimer) {
  clearTimeout(this.contentDebounceTimer);
  }
@@ -828,9 +846,13 @@ export class Panel {
   public markFresh(): void {
  this.lastTickAt = Date.now();
  this.content.classList.remove('panel-fresh-flash');
- // Force reflow so the animation restarts.
- void this.content.offsetWidth;
+ // Re-add the class on the next animation frame instead of forcing a
+ // synchronous layout flush with `void offsetWidth`. The 1-frame (~16 ms)
+ // delay is imperceptible but avoids serialising the full-grid layout on
+ // every content write across all 473 panel instances.
+ requestAnimationFrame(() => {
  this.content.classList.add('panel-fresh-flash');
+ });
  this.updateHeartbeat();
   }
 
@@ -847,15 +869,62 @@ export class Panel {
   }
 
   private updateHeartbeat(): void {
- if (!this.heartbeatEl) return;
- const text = this.heartbeatEl.querySelector<HTMLElement>('.panel-heartbeat-text');
- if (!text) return;
- if (this.lastTickAt === 0) { text.textContent = '—'; return; }
+ if (!this.heartbeatEl || !this.heartbeatTextEl) return;
+ if (this.lastTickAt === 0) {
+ // Only write if the text isn't already the placeholder.
+ if (this.heartbeatTextEl.textContent !== '—') this.heartbeatTextEl.textContent = '—';
+ return;
+ }
  const ago = Math.max(0, Math.round((Date.now() - this.lastTickAt) / 1000));
- text.textContent = ago < 60 ? `${ago}s` : (ago < 3600 ? `${Math.floor(ago / 60)}m` : `${Math.floor(ago / 3600)}h`);
- // Stale tiers via class for CSS color.
- this.heartbeatEl.classList.toggle('stale', ago > 300);
- this.heartbeatEl.classList.toggle('very-stale', ago > 1800);
+ const label = ago < 60 ? `${ago}s` : (ago < 3600 ? `${Math.floor(ago / 60)}m` : `${Math.floor(ago / 3600)}h`);
+ // Only mutate the DOM when the label actually changes to avoid triggering
+ // unnecessary text layout on every 5-second heartbeat tick.
+ if (this.heartbeatTextEl.textContent !== label) this.heartbeatTextEl.textContent = label;
+ // Only call classList.toggle when stale state transitions — each toggle that
+ // changes a class invalidates styles for that element.
+ const isStale = ago > 300;
+ const isVeryStale = ago > 1800;
+ if (isStale !== this.lastHeartbeatStale) {
+ this.heartbeatEl.classList.toggle('stale', isStale);
+ this.lastHeartbeatStale = isStale;
+ }
+ if (isVeryStale !== this.lastHeartbeatVeryStale) {
+ this.heartbeatEl.classList.toggle('very-stale', isVeryStale);
+ this.lastHeartbeatVeryStale = isVeryStale;
+ }
+  }
+
+  /**
+   * Set up an IntersectionObserver so that panels outside the viewport skip
+   * DOM writes while off-screen. When a panel scrolls back into view any
+   * pending HTML is flushed immediately via the normal debounce path.
+   * The 200 px rootMargin means rendering starts just before the panel is
+   * fully visible, avoiding a blank flash on scroll-in.
+   */
+  private setupVisibilityTracking(): void {
+ if (typeof IntersectionObserver === 'undefined') return;
+ this.intersectionObserver = new IntersectionObserver(
+ (entries) => {
+ const entry = entries[entries.length - 1];
+ if (!entry) return;
+ const wasHidden = !this.panelIntersecting;
+ this.panelIntersecting = entry.isIntersecting;
+ if (this.panelIntersecting && wasHidden) this.flushPendingIfVisible();
+ },
+ { rootMargin: '200px 0px' },
+ );
+ this.intersectionObserver.observe(this.element);
+  }
+
+  /** Queue the debounce for any HTML that accumulated while the panel was
+   *  off-screen, provided the app is also foregrounded. */
+  private flushPendingIfVisible(): void {
+ if (!this.panelIntersecting || !Panel.appVisible) return;
+ if (this.pendingContentHtml === null) return;
+ if (this.contentDebounceTimer) clearTimeout(this.contentDebounceTimer);
+ this.contentDebounceTimer = setTimeout(() => {
+ if (this.pendingContentHtml !== null) this.setContentImmediate(this.pendingContentHtml);
+ }, this.contentDebounceMs);
   }
 
   private static startHeartbeatTicker(): void {
@@ -864,6 +933,15 @@ export class Panel {
  Panel.heartbeatTickerId = window.setInterval(() => {
  for (const p of Panel.instances) p.updateHeartbeat();
  }, 5000) as unknown as ReturnType<typeof setInterval>;
+ // Pause DOM writes when the whole app is backgrounded; flush when it returns.
+ if (typeof document !== 'undefined') {
+ document.addEventListener('visibilitychange', () => {
+ Panel.appVisible = document.visibilityState !== 'hidden';
+ if (Panel.appVisible) {
+ for (const p of Panel.instances) p.flushPendingIfVisible();
+ }
+ });
+ }
  document.addEventListener('cb:panel-narrative', (ev: Event) => {
  const detail = (ev as CustomEvent<{ panelId: string; text: string }>).detail;
  if (!detail) return;
@@ -1156,6 +1234,8 @@ export class Panel {
   }
 
   public destroy(): void {
+ this.intersectionObserver?.disconnect();
+ this.intersectionObserver = null;
  this.abortController.abort();
  if (this.aiSummaryOverlay) {
  this.aiSummaryOverlay.remove();

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -218,6 +218,7 @@ export class Panel {
   private pendingContentHtml: string | null = null;
   private pendingOnRendered: (() => void) | null = null;
   private contentDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private freshFlashRafId: number | null = null;
   // Cache the last HTML string we actually wrote to the DOM. Reading
   // `element.innerHTML` forces the browser to serialize the subtree, which is
   // expensive on panels with large or animated content. Keeping a cached copy
@@ -850,7 +851,11 @@ export class Panel {
  // synchronous layout flush with `void offsetWidth`. The 1-frame (~16 ms)
  // delay is imperceptible but avoids serialising the full-grid layout on
  // every content write across all 473 panel instances.
- requestAnimationFrame(() => {
+ // Store the RAF id so destroy() can cancel it and avoid a post-destroy
+ // class mutation on a detached element.
+ if (this.freshFlashRafId !== null) cancelAnimationFrame(this.freshFlashRafId);
+ this.freshFlashRafId = requestAnimationFrame(() => {
+ this.freshFlashRafId = null;
  this.content.classList.add('panel-fresh-flash');
  });
  this.updateHeartbeat();
@@ -938,7 +943,24 @@ export class Panel {
  document.addEventListener('visibilitychange', () => {
  Panel.appVisible = document.visibilityState !== 'hidden';
  if (Panel.appVisible) {
- for (const p of Panel.instances) p.flushPendingIfVisible();
+ // Flush panels that are currently on-screen immediately.
+ // Off-screen panels that were suppressed while hidden will be flushed by
+ // the IntersectionObserver when they scroll into view.  However if a
+ // panel scrolled out of view while the app was backgrounded the observer
+ // won't re-fire on foreground — so also queue a deferred flush for those
+ // so they're ready the moment the user scrolls to them.
+ for (const p of Panel.instances) {
+ if (p.panelIntersecting) {
+ p.flushPendingIfVisible();
+ } else if (p.pendingContentHtml !== null) {
+ // Off-screen with stale content: queue a low-priority debounce so
+ // the content is written before the user can scroll to the panel.
+ if (p.contentDebounceTimer) clearTimeout(p.contentDebounceTimer);
+ p.contentDebounceTimer = setTimeout(() => {
+ if (p.pendingContentHtml !== null) p.setContentImmediate(p.pendingContentHtml);
+ }, 500);
+ }
+ }
  }
  });
  }
@@ -1234,8 +1256,13 @@ export class Panel {
   }
 
   public destroy(): void {
+ Panel.instances.delete(this);
  this.intersectionObserver?.disconnect();
  this.intersectionObserver = null;
+ if (this.freshFlashRafId !== null) {
+ cancelAnimationFrame(this.freshFlashRafId);
+ this.freshFlashRafId = null;
+ }
  this.abortController.abort();
  if (this.aiSummaryOverlay) {
  this.aiSummaryOverlay.remove();


### PR DESCRIPTION
Four independent Panel.ts optimizations targeting the remaining CPU overhead after #1062 (listener accumulation fix).

## 1. `markFresh()` forced-layout elimination

`void this.content.offsetWidth` was serialising the entire CSS grid on every content write. Replaced with a `requestAnimationFrame` class re-add — animation restart is imperceptibly delayed by one frame (~16 ms). Stores `freshFlashRafId` so destroy() cancels the RAF and avoids post-destroy element mutation.

## 2. Heartbeat DOM write batching (473 panels × every 5 s)

Caches `.panel-heartbeat-text` at construction instead of querying it each tick. Only writes `textContent` and calls `classList.toggle` when the value actually changes — eliminates ~473 DOM text mutations and ~946 classList operations per 5-second heartbeat interval.

## 3. Visibility-gated `setContent` (IntersectionObserver)

Panels scrolled off-screen accumulate the latest HTML but skip the debounce timer entirely. When they re-enter the viewport (200 px look-ahead via rootMargin) or the app foregrounds, pending content is flushed. Off-screen panels with pending content also get a 500 ms deferred flush on foreground return so they're ready before the user can scroll to them.

## 4. App-background gating (`document.visibilitychange`)

`Panel.appVisible` static flag blocks all `setContent` debounce queueing while the window is hidden.

## Bug fixes (raised in cross-agent review)

- `Panel.instances.delete(this)` added to `destroy()` — was leaking destroyed instances into the static Set, causing stale heartbeat ticks to accumulate indefinitely
- `freshFlashRafId` stored and cancelled in `destroy()` — prevents post-destroy RAF callback mutating detached DOM element
- Foreground handler now defers a 500 ms flush for off-screen panels with pending content

## Verification

`npm run typecheck:all` — zero errors. Single-file change (`Panel.ts`).

Cross-agent review: Codex reviewed on 2026-06-08; outcome: issues fixed (RAF cancel + instances leak + off-screen flush edge case addressed).