### PR TITLE
fix: stop listener accumulation in 27 remaining panels

### DIFF
--- a/src/components/AnalystNotebookPanel.ts
+++ b/src/components/AnalystNotebookPanel.ts
@@ -81,8 +81,7 @@ export class AnalystNotebookPanel extends Panel {
       ${this.renderCategoryTabs(stats)}
       ${this.renderNotes(notes)}
     </div>`;
-    this.setContent(html);
-    this.wireHandlers();
+    this.setContent(html, () => this.wireHandlers());
   }
 
   private collectNotes(): Note[] {

--- a/src/components/AssumptionTrackerPanel.ts
+++ b/src/components/AssumptionTrackerPanel.ts
@@ -118,8 +118,7 @@ export class AssumptionTrackerPanel extends Panel {
       ${renderRecentViolations(summary.recentViolations)}
       ${this.renderAssumptionsList(filteredAssumptions)}
     </div>`;
-    this.setContent(html);
-    this.wireHandlers();
+    this.setContent(html, () => this.wireHandlers());
   }
 
   private renderFilterBar(domains: readonly string[]): string {

--- a/src/components/AviationIntelPanel.ts
+++ b/src/components/AviationIntelPanel.ts
@@ -175,8 +175,7 @@ export class AviationIntelPanel extends Panel {
         </div>
       </div>
     `;
-    this.setContent(html);
-    this.wireHandlers();
+    this.setContent(html, () => this.wireHandlers());
   }
 
   private renderTabBar(counts: Record<Tab, number>): string {

--- a/src/components/BitcoinAbusePanel.ts
+++ b/src/components/BitcoinAbusePanel.ts
@@ -226,8 +226,7 @@ export class BitcoinAbusePanel extends Panel {
       case 'domains': { body = this.renderDomains(); break; }
       case 'lookup': { body = this.renderLookup(); break; }
     }
-    this.setContent(`${this.renderTabStrip()}${body}`);
-    this.wireHandlers();
+    this.setContent(`${this.renderTabStrip()}${body}`, () => this.wireHandlers());
   }
 
   private wireHandlers(): void {

--- a/src/components/CounterfactualReasoningPanel.ts
+++ b/src/components/CounterfactualReasoningPanel.ts
@@ -109,8 +109,7 @@ export class CounterfactualReasoningPanel extends Panel {
       ${this.renderFilterBar(domains)}
       ${this.renderCards(filtered)}
     </div>`;
-    this.setContent(html);
-    this.wireHandlers();
+    this.setContent(html, () => this.wireHandlers());
   }
 
   private renderFilterBar(domains: readonly string[]): string {

--- a/src/components/CounterfactualReplayPanel.ts
+++ b/src/components/CounterfactualReplayPanel.ts
@@ -100,8 +100,7 @@ export class CounterfactualReplayPanel extends Panel {
         ${renderResultPane(selected)}
       </div>
     </div>`;
-    this.setContent(html);
-    this.wireHandlers();
+    this.setContent(html, () => this.wireHandlers());
   }
 
   private renderToolbar(): string {

--- a/src/components/GDACSAlertsPanel.ts
+++ b/src/components/GDACSAlertsPanel.ts
@@ -130,15 +130,13 @@ export class GDACSAlertsPanel extends Panel {
 
     if (level === 'raw') {
       const raw = this.rssData ?? { events: [], degraded: false };
-      this.setContent(`<div style="padding:8px;font-size:12px;">${switcherRow}<pre style="margin:0;padding:8px;font-size:11px;background:rgba(0,0,0,0.25);border:1px solid var(--border-subtle,#333);border-radius:4px;overflow:auto;max-height:520px;">${escapeHtml(JSON.stringify(raw, null, 2))}</pre></div>`);
-      this.wireHandlers();
+      this.setContent(`<div style="padding:8px;font-size:12px;">${switcherRow}<pre style="margin:0;padding:8px;font-size:11px;background:rgba(0,0,0,0.25);border:1px solid var(--border-subtle,#333);border-radius:4px;overflow:auto;max-height:520px;">${escapeHtml(JSON.stringify(raw, null, 2))}</pre></div>`, () => this.wireHandlers());
       return;
     }
 
     if (level === 'summary') {
       const summary = this.renderSummary();
-      this.setContent(`<div style="padding:8px;font-size:12px;">${switcherRow}${summary}</div>`);
-      this.wireHandlers();
+      this.setContent(`<div style="padding:8px;font-size:12px;">${switcherRow}${summary}</div>`, () => this.wireHandlers());
       return;
     }
 
@@ -154,8 +152,7 @@ export class GDACSAlertsPanel extends Panel {
 
     const content = this.activeTab === 'rss' ? this.renderRss() : this.renderJson();
 
-    this.setContent(`<div style="padding:8px;font-size:12px;">${switcherRow}${tabBar}${content}</div>`);
-    this.wireHandlers();
+    this.setContent(`<div style="padding:8px;font-size:12px;">${switcherRow}${tabBar}${content}</div>`, () => this.wireHandlers());
   }
 
   private renderSummary(): string {

--- a/src/components/HibpBreachesPanel.ts
+++ b/src/components/HibpBreachesPanel.ts
@@ -121,8 +121,7 @@ export class HibpBreachesPanel extends Panel {
       case 'search': { body = renderSearchTab(this.query, this.hits, this.searchLoading); break; }
       case 'stats': { body = renderStatisticsTab(this.stats, this.statsLoading); break; }
     }
-    this.setContent(`${this.renderTabStrip()}<div style="padding:0 2px;">${body}</div>`);
-    this.wireHandlers();
+    this.setContent(`${this.renderTabStrip()}<div style="padding:0 2px;">${body}</div>`, () => this.wireHandlers());
   }
 
   private renderTabStrip(): string {

--- a/src/components/InfraRiskMatrixPanel.ts
+++ b/src/components/InfraRiskMatrixPanel.ts
@@ -147,8 +147,7 @@ export class InfraRiskMatrixPanel extends Panel {
       case 'acled': { body = this.renderAcledTab(); break; }
     }
     const footer = '<div style="opacity:0.65;font-size:11px;margin-top:6px">Sources: poweroutage.us · CISA KEV · RIPE NCC · ACLED · 60s refresh</div>';
-    this.setContent(`${this.renderHeader()}${this.renderTabStrip()}${body}${footer}`);
-    this.wireHandlers();
+    this.setContent(`${this.renderHeader()}${this.renderTabStrip()}${body}${footer}`, () => this.wireHandlers());
   }
 
   private wireHandlers(): void {

--- a/src/components/IntelligenceHealthMonitorPanel.ts
+++ b/src/components/IntelligenceHealthMonitorPanel.ts
@@ -91,8 +91,7 @@ export class IntelligenceHealthMonitorPanel extends Panel {
       ${renderComponents(latest)}
       ${renderFooter(latest)}
     </div>`;
-    this.setContent(html);
-    this.wireHandlers();
+    this.setContent(html, () => this.wireHandlers());
   }
 
   private wireHandlers(): void {

--- a/src/components/IntelligenceLoopOrchestratorPanel.ts
+++ b/src/components/IntelligenceLoopOrchestratorPanel.ts
@@ -82,8 +82,7 @@ export class IntelligenceLoopOrchestratorPanel extends Panel {
       ${renderRunsTable(runs)}
       ${renderFooter()}
     </div>`;
-    this.setContent(html);
-    this.wireHandlers();
+    this.setContent(html, () => this.wireHandlers());
   }
 
   private wireHandlers(): void {

--- a/src/components/IntelligenceTimelinePanel.ts
+++ b/src/components/IntelligenceTimelinePanel.ts
@@ -214,8 +214,7 @@ export class IntelligenceTimelinePanel extends Panel {
     if (level === 'raw') {
       let raw = '[]';
       try { raw = JSON.stringify(events.slice(0, 50), null, 2); } catch { raw = '[]'; }
-      this.setContent(`<div style="padding:8px;">${switcherRow}<pre style="margin:0;padding:8px;font-size:11px;background:rgba(0,0,0,0.25);border:1px solid var(--border-subtle,#333);border-radius:4px;overflow:auto;max-height:520px;">${escapeHtml(raw)}</pre></div>`);
-      this.wireHandlers();
+      this.setContent(`<div style="padding:8px;">${switcherRow}<pre style="margin:0;padding:8px;font-size:11px;background:rgba(0,0,0,0.25);border:1px solid var(--border-subtle,#333);border-radius:4px;overflow:auto;max-height:520px;">${escapeHtml(raw)}</pre></div>`, () => this.wireHandlers());
       return;
     }
 
@@ -224,16 +223,14 @@ export class IntelligenceTimelinePanel extends Panel {
       const list = recent.length === 0
         ? '<div class="panel-empty" style="padding:16px 0;text-align:center;opacity:0.7;">No events.</div>'
         : `<div style="display:flex;flex-direction:column;gap:4px;">${recent.map((e) => this.renderEventRow(e)).join('')}</div>`;
-      this.setContent(`<div style="padding:8px;">${switcherRow}${list}<div style="opacity:0.5;font-size:11px;margin-top:6px;">5 most recent of ${events.length} · switch to Detail for filters</div></div>`);
-      this.wireHandlers();
+      this.setContent(`<div style="padding:8px;">${switcherRow}${list}<div style="opacity:0.5;font-size:11px;margin-top:6px;">5 most recent of ${events.length} · switch to Detail for filters</div></div>`, () => this.wireHandlers());
       return;
     }
 
     const list = events.length === 0
       ? '<div class="panel-empty" style="padding:16px 0;text-align:center;opacity:0.7;">No events in this time range. Adjust filters or wait for new data.</div>'
       : `<div style="display:flex;flex-direction:column;gap:4px;max-height:520px;overflow-y:auto;">${events.map((e) => this.renderEventRow(e)).join('')}</div>`;
-    this.setContent(`<div style="padding:8px;">${switcherRow}${this.renderFilterBar(domains)}${list}</div>`);
-    this.wireHandlers();
+    this.setContent(`<div style="padding:8px;">${switcherRow}${this.renderFilterBar(domains)}${list}</div>`, () => this.wireHandlers());
   }
 
   private wireHandlers(): void {

--- a/src/components/IpInfoPanel.ts
+++ b/src/components/IpInfoPanel.ts
@@ -141,8 +141,7 @@ export class IpInfoPanel extends Panel {
       case 'lookup': { body = this.renderLookupTab(); break; }
       case 'batch':  { body = this.renderBatchTab(); break; }
     }
-    this.setContent(`${this.renderTabStrip()}<div style="padding:0 2px;">${body}</div>`);
-    this.wireHandlers();
+    this.setContent(`${this.renderTabStrip()}<div style="padding:0 2px;">${body}</div>`, () => this.wireHandlers());
   }
 
   private renderTabStrip(): string {

--- a/src/components/MediastackNewsPanel.ts
+++ b/src/components/MediastackNewsPanel.ts
@@ -104,8 +104,7 @@ export class MediastackNewsPanel extends Panel {
   }
 
   private render(): void {
-    this.setContent(`${this.renderChipStrip()}${this.renderSearchInput()}${this.renderFeed()}`);
-    this.wireHandlers();
+    this.setContent(`${this.renderChipStrip()}${this.renderSearchInput()}${this.renderFeed()}`, () => this.wireHandlers());
   }
 
   private wireHandlers(): void {

--- a/src/components/NotificationHistoryPanel.ts
+++ b/src/components/NotificationHistoryPanel.ts
@@ -92,8 +92,7 @@ export class NotificationHistoryPanel extends Panel {
       ${this.renderFilterBar(stats)}
       ${renderTable(records, this.state.expandedId)}
     </div>`;
-    this.setContent(html);
-    this.wireHandlers();
+    this.setContent(html, () => this.wireHandlers());
   }
 
   private renderFilterBar(stats: NotificationProvenanceStats): string {

--- a/src/components/NotificationProvenancePanel.ts
+++ b/src/components/NotificationProvenancePanel.ts
@@ -76,8 +76,7 @@ export class NotificationProvenancePanel extends Panel {
       ${this.renderSearchBar()}
       ${renderList(records, this.state.expandedId)}
     </div>`;
-    this.setContent(html);
-    this.wireHandlers();
+    this.setContent(html, () => this.wireHandlers());
   }
 
   private renderSearchBar(): string {

--- a/src/components/OpenaqMonitorPanel.ts
+++ b/src/components/OpenaqMonitorPanel.ts
@@ -166,8 +166,7 @@ export class OpenaqMonitorPanel extends Panel {
       case 'worst': { body = this.renderWorstTab(); break; }
       case 'search': { body = this.renderSearchTab(); break; }
     }
-    this.setContent(`${this.renderTabStrip()}${body}`);
-    this.wireHandlers();
+    this.setContent(`${this.renderTabStrip()}${body}`, () => this.wireHandlers());
   }
 
   private wireHandlers(): void {

--- a/src/components/PersistentQueryEnginePanel.ts
+++ b/src/components/PersistentQueryEnginePanel.ts
@@ -97,8 +97,7 @@ export class PersistentQueryEnginePanel extends Panel {
       ${renderMatchesFeed(matches)}
       ${renderFooter()}
     </div>`;
-    this.setContent(html);
-    this.wireHandlers();
+    this.setContent(html, () => this.wireHandlers());
   }
 
   private renderCreateForm(): string {

--- a/src/components/PhishstatsFeedPanel.ts
+++ b/src/components/PhishstatsFeedPanel.ts
@@ -118,8 +118,7 @@ export class PhishstatsFeedPanel extends Panel {
         </table>
         ${more}
       </div>
-    `);
-    this.wireHandlers();
+    `, () => this.wireHandlers());
   }
 
   private renderSummary(stats: ReturnType<typeof summarisePhishing>): string {

--- a/src/components/PulsediveIntelPanel.ts
+++ b/src/components/PulsediveIntelPanel.ts
@@ -111,8 +111,7 @@ export class PulsediveIntelPanel extends Panel {
         ${this.renderTabBar()}
         <div style="margin-top:8px;">${body}</div>
       </div>
-    `);
-    this.wireHandlers();
+    `, () => this.wireHandlers());
   }
 
   private renderTabBar(): string {

--- a/src/components/RedditOsintPanel.ts
+++ b/src/components/RedditOsintPanel.ts
@@ -155,8 +155,7 @@ export class RedditOsintPanel extends Panel {
     } else {
       body = visible.slice(0, 200).map((entry) => this.renderPostRow(entry)).join('');
     }
-    this.setContent(`${chips}${keywords}${body}${this.renderFooter()}`);
-    this.wireHandlers();
+    this.setContent(`${chips}${keywords}${body}${this.renderFooter()}`, () => this.wireHandlers());
   }
 
   private wireHandlers(): void {

--- a/src/components/SanctionsPanel.ts
+++ b/src/components/SanctionsPanel.ts
@@ -211,8 +211,7 @@ export class SanctionsPanel extends Panel {
       case 'vessels': { body = this.renderVesselsTab(); break; }
       case 'aircraft': { body = this.renderAircraftTab(); break; }
     }
-    this.setContent(`${this.renderTabStrip()}${body}`);
-    this.wireHandlers();
+    this.setContent(`${this.renderTabStrip()}${body}`, () => this.wireHandlers());
   }
 
   private wireHandlers(): void {

--- a/src/components/ScenarioReplayPanel.ts
+++ b/src/components/ScenarioReplayPanel.ts
@@ -109,8 +109,7 @@ export class ScenarioReplayPanel extends Panel {
         </div>
         <div style="display:flex;flex-direction:column;gap:8px;">${cards}</div>
       </div>
-    `);
-    this.wireHandlers();
+    `, () => this.wireHandlers());
   }
 
   private renderSummary(passCount: number, failCount: number): string {

--- a/src/components/SituationPriorityQueuePanel.ts
+++ b/src/components/SituationPriorityQueuePanel.ts
@@ -76,8 +76,7 @@ export class SituationPriorityQueuePanel extends Panel {
       ${renderWeightEditor(snapshot.weights)}
       ${renderQueue(entries, snapshot.computedAt)}
     </div>`;
-    this.setContent(html);
-    this.wireHandlers();
+    this.setContent(html, () => this.wireHandlers());
   }
 
   private wireHandlers(): void {

--- a/src/components/SituationTimelinePanel.ts
+++ b/src/components/SituationTimelinePanel.ts
@@ -89,8 +89,7 @@ export class SituationTimelinePanel extends Panel {
       ${this.renderFilterBar(breakdown)}
       ${renderTimeline(entries, this.state.expandedId)}
     </div>`;
-    this.setContent(html);
-    this.wireHandlers();
+    this.setContent(html, () => this.wireHandlers());
   }
 
   private renderFilterBar(breakdown: readonly DomainBreakdownRow[]): string {

--- a/src/components/ThreatHorizonPanel.ts
+++ b/src/components/ThreatHorizonPanel.ts
@@ -82,8 +82,7 @@ export class ThreatHorizonPanel extends Panel {
       ${this.renderTabs(scanner)}
       ${renderThreatList(active)}
     </div>`;
-    this.setContent(html);
-    this.wireHandlers();
+    this.setContent(html, () => this.wireHandlers());
   }
 
   private renderTabs(scanner: ReturnType<typeof getThreatHorizonScanner>): string {

--- a/src/components/UrlscanThreatsPanel.ts
+++ b/src/components/UrlscanThreatsPanel.ts
@@ -132,8 +132,7 @@ export class UrlscanThreatsPanel extends Panel {
         ${summaryHtml}
         <div style="display:flex;flex-direction:column;gap:4px;">${listHtml}</div>
       </div>
-    `);
-    this.wireHandlers();
+    `, () => this.wireHandlers());
   }
 
   private renderSubmit(): string {


### PR DESCRIPTION
PR #1062 fixed 41 panels that used `queueMicrotask(() => wireHandlers())` but missed panels that called `wireHandlers()` directly after `setContent()`. These 27 panels had the same O(N²) WebKit `addEventListener` scan — confirmed still hot in the stack profiler after the PR #1062/1063 build.

Each fix: `this.setContent(html); this.wireHandlers();` → `this.setContent(html, () => this.wireHandlers());`

Cross-agent review: Codex reviewed on 2026-06-08; pattern is mechanical and identical to #1062 — no new issues.