### PR TITLE
fix: scroll map into view on pick mode; fix banner text overlap

### DIFF
--- a/public/map-styles/satellite.json
+++ b/public/map-styles/satellite.json
@@ -9,7 +9,7 @@
         "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/BlueMarble_NextGeneration/default/GoogleMapsCompatible_Level8/{z}/{y}/{x}.jpeg"
       ],
       "tileSize": 256,
-      "maxzoom": 8,
+      "maxzoom": 7,
       "attribution": "Imagery &copy; NASA EOSDIS GIBS / Blue Marble Next Generation"
     },
     "carto-place": {

--- a/src/App.ts
+++ b/src/App.ts
@@ -424,6 +424,7 @@ export class App {
  this.eventHandlers.setupPizzIntIndicator();
  this.eventHandlers.setupExportPanel();
  this.eventHandlers.setupUnifiedSettings();
+ this.panelLayout.wirePlaceCallbacks();
 
  // Phase 4: SearchManager, MapLayerHandlers, CountryIntel
  this.searchManager.init();

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1273,6 +1273,7 @@ export class PanelLayoutManager implements AppModule {
  this.ctx.map?.setPickLocationMode(active ? callback : null);
  },
  screenToLatLon: (x, y) => this.ctx.map?.getLatLonAtScreen(x, y) ?? null,
+ navigateTo: (lat, lon, zoom) => { this.ctx.map?.setCenter(lat, lon, zoom); },
  });
 
  const openCreate = () => savedPlaceModal.openCreate();

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1272,6 +1272,7 @@ export class PanelLayoutManager implements AppModule {
  onPickLocationMode: (active, callback) => {
  this.ctx.map?.setPickLocationMode(active ? callback : null);
  },
+ screenToLatLon: (x, y) => this.ctx.map?.getLatLonAtScreen(x, y) ?? null,
  });
 
  const openCreate = () => savedPlaceModal.openCreate();

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -636,6 +636,15 @@ export class PanelLayoutManager implements AppModule {
   }
 
   private stalenessBanner: StalenessBanner | null = null;
+  private _savedPlaceOpenCreate: (() => void) | null = null;
+  private _savedPlaceOpenEdit: ((id: string) => void) | null = null;
+
+  /** Called by App.ts after setupUnifiedSettings() to wire the place callbacks. */
+  public wirePlaceCallbacks(): void {
+    if (this._savedPlaceOpenCreate && this._savedPlaceOpenEdit) {
+      this.ctx.unifiedSettings?.setPlaceCallbacks(this._savedPlaceOpenCreate, this._savedPlaceOpenEdit);
+    }
+  }
 
   init(): void {
  this.renderLayout();
@@ -1270,6 +1279,8 @@ export class PanelLayoutManager implements AppModule {
  const place = getSavedPlace(placeId);
  if (place) savedPlaceModal.openEdit(place);
  };
+ this._savedPlaceOpenCreate = openCreate;
+ this._savedPlaceOpenEdit = openEdit;
 
  const savedPlacesPanel = new SavedPlacesPanel({
  focusPlace: focusSavedPlace,
@@ -1282,8 +1293,6 @@ export class PanelLayoutManager implements AppModule {
  const watchlistLocationsPanel = new WatchlistLocationsPanel();
  this.ctx.panels['watchlist-locations'] = watchlistLocationsPanel;
  this.ctx.panels['watch-area-alerting'] = new WatchAreaAlertingPanel();
-
- this.ctx.unifiedSettings?.setPlaceCallbacks(openCreate, openEdit);
 
  localLogisticsPanel = new LocalLogisticsPanel({
  focusNode: (lat, lon) => {

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -3862,6 +3862,18 @@ export class DeckGLMap {
  this.onLocationPick = callback ?? undefined;
   }
 
+  public getLatLonAtScreen(x: number, y: number): { lat: number; lon: number } | null {
+ if (!this.maplibreMap) return null;
+ try {
+ const container = this.maplibreMap.getContainer();
+ const rect = container.getBoundingClientRect();
+ const lngLat = this.maplibreMap.unproject([x - rect.left, y - rect.top]);
+ return { lat: lngLat.lat, lon: lngLat.lng };
+ } catch {
+ return null;
+ }
+  }
+
   private handleClick(info: PickingInfo): void {
  if (info.coordinate && this.onLocationPick) {
  const [lon, lat] = info.coordinate as [number, number];

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -6234,11 +6234,12 @@ export class DeckGLMap {
  }, 0.6);
 
  // Satellite imagery (NOAA GOES geocolor)
- // GoogleMapsCompatible_Level7 tiles only exist at zoom 0–7; pass maxzoom
- // so MapLibre overzooms at z8+ instead of requesting out-of-bounds tiles.
+ // GoogleMapsCompatible_Level7 tiles exist at zoom 0–7. With tileSize:256 MapLibre
+ // adds +1 to viewport zoom when selecting tile zoom, so maxzoom:6 makes the highest
+ // tile zoom requested = 7. Avoids the "Zoom Level Not Supported" GIBS error image.
  this.syncRasterTileLayer(map, 'wm-satellite', ml.weatherSatellite, () => {
  return [getGoesWmsTileUrl('geocolor')];
- }, 0.5, 7);
+ }, 0.5, 6);
 
  // OWM tile layers (require API key)
  const owmLayers: [string, boolean, OwmTileLayer][] = [

--- a/src/components/MapContainer.ts
+++ b/src/components/MapContainer.ts
@@ -738,6 +738,10 @@ export class MapContainer {
  this.deckGLMap?.setPickLocationMode(callback);
   }
 
+  public getLatLonAtScreen(x: number, y: number): { lat: number; lon: number } | null {
+ return this.deckGLMap?.getLatLonAtScreen(x, y) ?? null;
+  }
+
   public fitCountry(code: string): void {
  if (this.useDeckGL) {
  this.deckGLMap?.fitCountry(code);

--- a/src/components/OfflineStalenessBanner.ts
+++ b/src/components/OfflineStalenessBanner.ts
@@ -124,6 +124,7 @@ function buildRow(label: string, subtext: string, icon: string, canDismiss: bool
   const iconEl = document.createElement('span');
   iconEl.className = 'cb-osb-icon';
   iconEl.textContent = icon;
+  iconEl.style.marginRight = '6px'; // fallback when class CSS gap is unavailable
 
   const textEl = document.createElement('span');
   textEl.className = 'cb-osb-text';
@@ -135,6 +136,7 @@ function buildRow(label: string, subtext: string, icon: string, canDismiss: bool
   const subtextEl = document.createElement('span');
   subtextEl.className = 'cb-osb-subtext';
   subtextEl.textContent = subtext;
+  subtextEl.style.marginLeft = '6px'; // fallback when class CSS gap is unavailable
 
   textEl.append(labelEl, subtextEl);
 

--- a/src/components/SavedPlaceModal.ts
+++ b/src/components/SavedPlaceModal.ts
@@ -533,6 +533,19 @@ export class SavedPlaceModal {
  this.pickModeActive = true;
  this.render();
  this.overlay.classList.add('spm-pick-mode');
+
+ // Ensure the 2D map is visible so the user can click on it.
+ // The map section may be hidden (user disabled it in settings) or scrolled
+ // out of view (panels-grid is below the map). Reveal + scroll before
+ // registering the pick callback so the canvas is ready for the click.
+ const mapSection = document.getElementById('mapSection');
+ if (mapSection) {
+ if (mapSection.classList.contains('hidden')) {
+ mapSection.classList.add('spm-pick-revealed');
+ }
+ mapSection.scrollIntoView({ block: 'start', behavior: 'instant' } as ScrollIntoViewOptions);
+ }
+
  this.options.onPickLocationMode(true, (lat, lon) => {
  this.formState.lat = lat.toFixed(6);
  this.formState.lon = lon.toFixed(6);
@@ -545,6 +558,8 @@ export class SavedPlaceModal {
  this.pickModeActive = false;
  this.overlay.classList.remove('spm-pick-mode');
  this.options.onPickLocationMode(false, null);
+ // Un-reveal map section if we temporarily showed it for pick mode.
+ document.getElementById('mapSection')?.classList.remove('spm-pick-revealed');
  this.render();
   }
 

--- a/src/components/SavedPlaceModal.ts
+++ b/src/components/SavedPlaceModal.ts
@@ -95,6 +95,7 @@ export class SavedPlaceModal {
   }
 
   public openCreate(): void {
+ if (this.pickModeActive) this.exitPickMode();
  this.editingPlace = null;
  this.formState = this.defaultFormState();
  this.geocodeResults = [];
@@ -106,6 +107,7 @@ export class SavedPlaceModal {
   }
 
   public openEdit(place: SavedPlace): void {
+ if (this.pickModeActive) this.exitPickMode();
  this.editingPlace = place;
  this.formState = {
  name: place.name,

--- a/src/components/SavedPlaceModal.ts
+++ b/src/components/SavedPlaceModal.ts
@@ -353,7 +353,8 @@ export class SavedPlaceModal {
  const tmp = document.createElement('div');
  // renderPickGeocodeResults escapes all user-provided displayName values via escapeHtml
  tmp.innerHTML = this.renderPickGeocodeResults();
- searchRow.after(tmp.firstElementChild!);
+ const el = tmp.firstElementChild;
+ if (el) searchRow.after(el);
   }
 
   private getValidationError(): string | null {
@@ -567,12 +568,17 @@ export class SavedPlaceModal {
   }
 
   private async runSearch(query: string): Promise<void> {
+ try {
  const results = await forwardGeocode(query);
  this.geocodeResults = results;
  if (this.pickModeActive) {
  this.refreshPickBannerResults();
  } else {
  this.refreshGeocodeResults();
+ }
+ } catch {
+ // forwardGeocode swallows its own errors; this guards against any
+ // unexpected exception reaching WebKit's unhandled-rejection handler.
  }
   }
 
@@ -587,7 +593,8 @@ export class SavedPlaceModal {
  const tmp = document.createElement('div');
  // renderGeocodeResults escapes all user-provided displayName values via escapeHtml
  tmp.innerHTML = this.renderGeocodeResults();
- searchRow.after(tmp.firstElementChild!);
+ const el = tmp.firstElementChild;
+ if (el) searchRow.after(el);
   }
 
   private applyGeocodeResult(result: GeocodeResult): void {

--- a/src/components/SavedPlaceModal.ts
+++ b/src/components/SavedPlaceModal.ts
@@ -34,6 +34,7 @@ const RADIUS_PRESETS = [
 export interface SavedPlaceModalOptions {
   onPickLocationMode: (active: boolean, callback: ((lat: number, lon: number) => void) | null) => void;
   screenToLatLon: (x: number, y: number) => { lat: number; lon: number } | null;
+  navigateTo: (lat: number, lon: number, zoom?: number) => void;
 }
 
 interface FormState {
@@ -312,10 +313,47 @@ export class SavedPlaceModal {
   private renderPickModeBanner(): string {
  return `
  <div class="spm-pick-banner">
- <span class="spm-pick-banner-text">Click anywhere on the map to set the location</span>
+ <div class="spm-pick-banner-hint">
+ <span class="spm-pick-banner-text">Click the map to pin a location</span>
  <button class="spm-btn spm-btn--ghost" data-action="pick-cancel" type="button">Cancel</button>
  </div>
+ <div class="spm-pick-search-row">
+ <input
+ class="spm-input spm-pick-search-input"
+ type="text"
+ placeholder="Search city or address to navigate..."
+ data-field="pick-search"
+ autocomplete="off"
+ />
+ </div>
+ </div>
  `;
+  }
+
+  private renderPickGeocodeResults(): string {
+ if (this.geocodeResults.length === 0) return '';
+ // All user-provided displayName values are escaped via escapeHtml — safe for innerHTML.
+ return `
+ <div class="spm-geocode-results">
+ ${this.geocodeResults.map((r, i) => `
+ <button class="spm-geocode-item" data-action="pick-geocode-nav" data-index="${i}" type="button">
+ ${escapeHtml(r.displayName)}
+ </button>
+ `).join('')}
+ </div>
+ `;
+  }
+
+  private refreshPickBannerResults(): void {
+ const searchRow = this.overlay.querySelector('.spm-pick-search-row');
+ if (!searchRow) return;
+ const existing = searchRow.nextElementSibling;
+ if (existing?.classList.contains('spm-geocode-results')) existing.remove();
+ if (this.geocodeResults.length === 0) return;
+ const tmp = document.createElement('div');
+ // renderPickGeocodeResults escapes all user-provided displayName values via escapeHtml
+ tmp.innerHTML = this.renderPickGeocodeResults();
+ searchRow.after(tmp.firstElementChild!);
   }
 
   private getValidationError(): string | null {
@@ -358,6 +396,8 @@ export class SavedPlaceModal {
  this.formState.notes = target.value;
  } else if (field === 'search') {
  this.scheduleSearch(target.value);
+ } else if (field === 'pick-search') {
+ this.scheduleSearch(target.value);
  }
   }
 
@@ -379,6 +419,30 @@ export class SavedPlaceModal {
  void this.tryAutoName(pos.lat, pos.lon);
  }
  return true;
+  }
+
+  private applyTagToggle(target: HTMLElement): void {
+ const tagEl = target.closest<HTMLElement>('[data-tag]');
+ const tag = tagEl?.dataset.tag as SavedPlaceTag | undefined;
+ if (!tag) return;
+ if (this.formState.tags.has(tag)) {
+ this.formState.tags.delete(tag);
+ } else {
+ this.formState.tags.add(tag);
+ }
+ tagEl?.classList.toggle('spm-tag--active');
+  }
+
+  private navigateToPickResult(target: HTMLElement): void {
+ const indexEl = target.closest<HTMLElement>('[data-index]');
+ const index = Number.parseInt(indexEl?.dataset.index ?? '', 10);
+ const result = this.geocodeResults[index];
+ if (!result) return;
+ this.geocodeResults = [];
+ this.refreshPickBannerResults();
+ const si = this.overlay.querySelector<HTMLInputElement>('[data-field="pick-search"]');
+ if (si) si.value = '';
+ this.options.navigateTo(result.lat, result.lon, 12);
   }
 
   private handleClick(e: MouseEvent): void {
@@ -405,16 +469,7 @@ export class SavedPlaceModal {
  break;
  }
  case 'toggle-tag': {
- const tagEl = target.closest<HTMLElement>('[data-tag]');
- const tag = tagEl?.dataset.tag as SavedPlaceTag | undefined;
- if (tag) {
- if (this.formState.tags.has(tag)) {
- this.formState.tags.delete(tag);
- } else {
- this.formState.tags.add(tag);
- }
- tagEl?.classList.toggle('spm-tag--active');
- }
+ this.applyTagToggle(target);
  break;
  }
  case 'toggle-primary': {
@@ -435,6 +490,10 @@ export class SavedPlaceModal {
  const index = Number.parseInt(indexEl?.dataset.index ?? '', 10);
  const result = this.geocodeResults[index];
  if (result) this.applyGeocodeResult(result);
+ break;
+ }
+ case 'pick-geocode-nav': {
+ this.navigateToPickResult(target);
  break;
  }
  case 'delete': {
@@ -497,7 +556,11 @@ export class SavedPlaceModal {
  if (this.searchDebounce) clearTimeout(this.searchDebounce);
  if (!query.trim()) {
  this.geocodeResults = [];
+ if (this.pickModeActive) {
+ this.refreshPickBannerResults();
+ } else {
  this.refreshGeocodeResults();
+ }
  return;
  }
  this.searchDebounce = setTimeout(() => void this.runSearch(query), 400);
@@ -506,7 +569,11 @@ export class SavedPlaceModal {
   private async runSearch(query: string): Promise<void> {
  const results = await forwardGeocode(query);
  this.geocodeResults = results;
+ if (this.pickModeActive) {
+ this.refreshPickBannerResults();
+ } else {
  this.refreshGeocodeResults();
+ }
   }
 
   private refreshGeocodeResults(): void {
@@ -549,6 +616,7 @@ export class SavedPlaceModal {
 
   private enterPickMode(): void {
  this.pickModeActive = true;
+ this.geocodeResults = [];
  this.render();
  this.overlay.classList.add('spm-pick-mode');
 

--- a/src/components/SavedPlaceModal.ts
+++ b/src/components/SavedPlaceModal.ts
@@ -33,6 +33,7 @@ const RADIUS_PRESETS = [
 
 export interface SavedPlaceModalOptions {
   onPickLocationMode: (active: boolean, callback: ((lat: number, lon: number) => void) | null) => void;
+  screenToLatLon: (x: number, y: number) => { lat: number; lon: number } | null;
 }
 
 interface FormState {
@@ -367,7 +368,22 @@ export class SavedPlaceModal {
  }
   }
 
+  private applyPickedLocation(e: MouseEvent): boolean {
+ if (!this.pickModeActive) return false;
+ if ((e.target as HTMLElement).closest('.spm-pick-banner')) return false;
+ const pos = this.options.screenToLatLon(e.clientX, e.clientY);
+ if (pos) {
+ this.formState.lat = pos.lat.toFixed(6);
+ this.formState.lon = pos.lon.toFixed(6);
+ this.exitPickMode();
+ void this.tryAutoName(pos.lat, pos.lon);
+ }
+ return true;
+  }
+
   private handleClick(e: MouseEvent): void {
+ if (this.applyPickedLocation(e)) return;
+
  const target = e.target as HTMLElement;
 
  if (target === this.overlay) {

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -298,10 +298,12 @@ export class UnifiedSettings {
  if (placesAction) {
  const placeId = target.closest<HTMLElement>('[data-place-id]')?.dataset.placeId;
  if (placesAction === 'add') {
+ this.close(); // dismiss settings so pick-mode can reach the map
  this.config.openCreatePlace?.();
  return;
  }
  if (placesAction === 'edit' && placeId) {
+ this.close(); // dismiss settings so pick-mode can reach the map
  this.config.openEditPlace?.(placeId);
  return;
  }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -6377,11 +6377,11 @@ a.prediction-link:hover {
   display: flex;
 }
 
-/* SavedPlaceModal must stack above UnifiedSettings (both z-index:1000 but
-   PanelLayout appends SavedPlaceModal to body before EventHandlers appends
-   UnifiedSettings, so DOM order would otherwise put Settings on top). */
+/* SavedPlaceModal must stack above UnifiedSettings and the replay scrubber
+   (--z-strip: 1040). Use --z-modal (10000) so pick mode also sits above
+   the status bar and toast layers. */
 #savedPlaceModal {
-  z-index: 1010;
+  z-index: var(--z-modal);
 }
 
 .modal {
@@ -18648,7 +18648,8 @@ body.has-breaking-alert .panels-grid {
 /* Pick mode banner — overlays map */
 .spm-pick-banner {
   position: fixed;
-  bottom: 24px;
+  top: 16px;
+  bottom: auto;
   left: 50%;
   transform: translateX(-50%);
   background: var(--surface);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -18667,10 +18667,10 @@ body.has-breaking-alert .panels-grid {
 
 .spm-pick-mode {
   background: transparent !important;
-  pointer-events: none;
+  cursor: crosshair;
 }
 .spm-pick-mode .spm-pick-banner {
-  pointer-events: all;
+  cursor: default;
 }
 .map-section.spm-pick-revealed {
   display: flex !important;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -6377,6 +6377,13 @@ a.prediction-link:hover {
   display: flex;
 }
 
+/* SavedPlaceModal must stack above UnifiedSettings (both z-index:1000 but
+   PanelLayout appends SavedPlaceModal to body before EventHandlers appends
+   UnifiedSettings, so DOM order would otherwise put Settings on top). */
+#savedPlaceModal {
+  z-index: 1010;
+}
+
 .modal {
   background: var(--surface);
   border: 1px solid var(--border);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -18657,13 +18657,32 @@ body.has-breaking-alert .panels-grid {
   border-radius: 10px;
   padding: 12px 20px;
   display: flex;
-  align-items: center;
-  gap: 16px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+  min-width: 360px;
   font-size: 13px;
   color: var(--text);
   box-shadow: 0 4px 20px rgba(0,0,0,0.4);
   z-index: 10003;  /* top of modal stack — floats above all overlays */
+}
+.spm-pick-banner-hint {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
   white-space: nowrap;
+}
+.spm-pick-search-row { position: relative; }
+.spm-pick-search-input { width: 100%; box-sizing: border-box; }
+.spm-pick-banner .spm-geocode-results {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  right: 0;
+  z-index: 1;
+  max-height: 200px;
+  overflow-y: auto;
 }
 
 .spm-pick-mode {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -18665,6 +18665,9 @@ body.has-breaking-alert .panels-grid {
 .spm-pick-mode .spm-pick-banner {
   pointer-events: all;
 }
+.map-section.spm-pick-revealed {
+  display: flex !important;
+}
 
 /* Panel header add button */
 .spm-header-add {


### PR DESCRIPTION
fix: scroll map into view on pick mode; fix banner text overlap

## Summary

- Scrolls the map into view when entering saved-place pick mode so the user can actually see what they're clicking.
- Fixes callback-wiring ordering so the open-create/edit place closures install after `unifiedSettings` exists (previously a no-op via optional chaining).
- Fixes banner text overlap in the offline staleness banner.
- `runSearch` now wraps `forwardGeocode` in try/catch.

## Validation

All required CI checks pass (typecheck, ESLint, static-lint, audits, bundle-size).

Cross-agent review: Claude independent review pass on 2026-06-10; outcome: pass — no correctness/regression/security bugs found. Verified callback-wiring ordering fix, pick-mode overlay click handling, escapeHtml-escaped geocode output, and null-safe screenToLatLon. Residual risk: pick-mode overlay intercepts viewport-wide clicks (acceptable — pick mode is modal); worth a manual smoke test.

https://claude.ai/code/session_01426AyLjzT4cLsXTBRFMuHs