### PR TITLE
feat(datacenter): intelligence dashboard — conditions, forecast, AQI, seismic, connectivity

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -297,6 +297,12 @@ import { fetchDamSafetyAlerts } from '@/services/dam-safety';
 import { fetchPowerGridAlerts } from '@/services/power-grid-alerts';
 import { fetchGridStatus } from '@/services/power-grid';
 import { getDatacenterSite, setDatacenterSite, recomputeDatacenterPosture } from '@/services/datacenter/datacenter-state';
+import {
+  fetchOpenMeteoConditions,
+  fetchSite24hForecast,
+  fetchSiteAirQuality,
+  fetchConnectivitySignal,
+} from '@/services/weather';
 import { fetchGreyNoise, fetchOtxPulses, fetchAbuseIpDb, fetchUrlscanFeed } from '@/services/osint';
 import { fetchAcledEvents, fetchAdsbMilitary } from '@/services/osint';
 import { fetchHibpBreaches, fetchTorMetrics } from '@/services/osint';
@@ -1431,6 +1437,15 @@ export class DataLoaderManager implements AppModule {
  }
   }
 
+  private haversineKm(lat1: number, lon1: number, lat2: number, lon2: number): number {
+    const R = 6371;
+    const dLat = (lat2 - lat1) * Math.PI / 180;
+    const dLon = (lon2 - lon1) * Math.PI / 180;
+    const a = Math.sin(dLat / 2) ** 2 +
+      Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) * Math.sin(dLon / 2) ** 2;
+    return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  }
+
   async loadWeatherAlerts(): Promise<void> {
  try {
  const { data: alerts } = await withOfflineCache('weather-alerts', () => fetchWeatherAlerts(), 1 * 60 * 60 * 1000);
@@ -1483,10 +1498,45 @@ export class DataLoaderManager implements AppModule {
  ugcZones: a.ugcZones,
  headline: a.headline,
  }));
+ const [condResult, forecastResult, aqResult, connResult] = await Promise.allSettled([
+   fetchOpenMeteoConditions(site.lat, site.lon),
+   fetchSite24hForecast(site.lat, site.lon),
+   fetchSiteAirQuality(site.lat, site.lon),
+   fetchConnectivitySignal(),
+ ]);
+ const rawCond = condResult.status === 'fulfilled' ? condResult.value : null;
+ const siteConditions = rawCond ? {
+   tempC: rawCond.temperature,
+   feelsLikeC: rawCond.feelsLike,
+   humidityPct: rawCond.humidity,
+   windSpeedKmh: rawCond.windSpeed,
+   windDirectionDeg: rawCond.windDirection,
+   precipMm: rawCond.precipitation,
+   uvIndex: rawCond.uvIndex,
+   weatherCode: rawCond.weatherCode,
+ } : null;
+ const nearbySeismic = (this.ctx.intelligenceCache?.earthquakes ?? [])
+   .filter((eq) => {
+     if (!eq.location) return false;
+     if (eq.magnitude < 3.5) return false;
+     if (Date.now() - eq.occurredAt > 24 * 60 * 60 * 1000) return false;
+     return this.haversineKm(site.lat, site.lon, eq.location.latitude, eq.location.longitude) <= 200;
+   })
+   .map((eq) => ({
+     magnitudeM: eq.magnitude,
+     distanceKm: Math.round(this.haversineKm(site.lat, site.lon, eq.location!.latitude, eq.location!.longitude)),
+     place: eq.place,
+     occurredAt: eq.occurredAt,
+   }));
  recomputeDatacenterPosture({
- gridStatus,
- weatherAlerts: nwsAlerts,
- nearbyOutageCount: null, // v1: county-radius outage rollup not yet wired
+   gridStatus,
+   weatherAlerts: nwsAlerts,
+   nearbyOutageCount: null,
+   conditions: siteConditions,
+   forecast24h: forecastResult.status === 'fulfilled' ? forecastResult.value : [],
+   airQuality: aqResult.status === 'fulfilled' ? aqResult.value : null,
+   seismicNearby: nearbySeismic,
+   connectivity: connResult.status === 'fulfilled' ? connResult.value : null,
  });
  }
 

--- a/src/components/DataCenterReadinessPanel.ts
+++ b/src/components/DataCenterReadinessPanel.ts
@@ -93,7 +93,7 @@ export class DataCenterReadinessPanel extends Panel {
       `${cToF(c.tempC)}°F / feels ${cToF(c.feelsLikeC)}°F`,
       `💧${Math.round(c.humidityPct)}%`,
       `💨${Math.round(c.windSpeedKmh * 0.621)} mph ${degreesToCompass(c.windDirectionDeg)}`,
-      `${wmoCodeEmoji(c.weatherCode)}${c.precipMm.toFixed(1)}"`,
+      `${wmoCodeEmoji(c.weatherCode)}${(c.precipMm / 25.4).toFixed(2)}"`,
     ];
     if (aq?.usAqi !== null && aq?.usAqi !== undefined) {
       chips.push(`AQI ${aq.usAqi} ${aqiLabel(aq.usAqi)}`);

--- a/src/components/DataCenterReadinessPanel.ts
+++ b/src/components/DataCenterReadinessPanel.ts
@@ -4,7 +4,17 @@ import {
   getDatacenterPosture, getDatacenterSite, subscribeDatacenterPosture,
 } from '../services/datacenter/datacenter-state';
 import { levelLabel, levelColor } from '../services/datacenter/datacenter-view';
-import type { DataCenterPosture, DcLevel, ReadinessAction } from '../services/datacenter/datacenter-types';
+import type {
+  DataCenterPosture,
+  DcLevel,
+  ForecastSlot,
+  NearbySeismicEvent,
+  ReadinessAction,
+  SiteAirQuality,
+  SiteConditions,
+  ConnectivitySignal,
+} from '../services/datacenter/datacenter-types';
+import { wmoCodeEmoji, degreesToCompass, cToF, aqiLabel } from '../services/weather';
 
 const URGENCY_LABEL: Record<ReadinessAction['urgency'], string> = {
   now: 'NOW', soon: 'SOON', be_ready: 'BE READY', monitor: 'MONITOR',
@@ -13,6 +23,15 @@ const AUDIENCE_LABEL: Record<ReadinessAction['audience'], string> = {
   onsite_safety: 'On-site safety', commute_staffing: 'Commute & staffing',
   facility_ops: 'Facility ops', escalation: 'Escalation',
 };
+
+function seismicLevel(events: NearbySeismicEvent[]): DcLevel {
+  if (events.length === 0) return 'normal';
+  const max = Math.max(...events.map((e) => e.magnitudeM));
+  if (max >= 6) return 'critical';
+  if (max >= 5) return 'warning';
+  if (max >= 4) return 'advisory';
+  return 'watch';
+}
 
 export class DataCenterReadinessPanel extends Panel {
   private unsub: (() => void) | null = null;
@@ -25,8 +44,6 @@ export class DataCenterReadinessPanel extends Panel {
 
   private render(posture: DataCenterPosture | null): void {
     if (!posture) {
-      // A configured site with no posture yet means the first refresh hasn't
-      // landed — don't tell a configured user to set a location they already set.
       const message = getDatacenterSite()
         ? 'Data center configured — awaiting the first grid + weather refresh.'
         : 'Set your data center location (tag a saved place "data_center") to activate this panel.';
@@ -37,7 +54,75 @@ export class DataCenterReadinessPanel extends Panel {
 
     this.setCount(posture.actions.filter((a) => a.urgency === 'now').length);
 
-    const header = h('div', { className: 'dc-status-header' },
+    const nodes: (HTMLElement | null)[] = [];
+
+    if (posture.conditions) {
+      nodes.push(this.conditionsRow(posture.conditions, posture.airQuality));
+    }
+
+    if (posture.forecast24h.length > 0) {
+      nodes.push(this.forecastStrip(posture.forecast24h));
+    }
+
+    nodes.push(this.gaugesRow(posture));
+
+    if (posture.connectivity) {
+      nodes.push(this.connectivityLine(posture.connectivity));
+    }
+
+    if (posture.seismicNearby.length > 0) {
+      nodes.push(this.seismicLine(posture.seismicNearby));
+    }
+
+    const actionList = posture.actions.length === 0
+      ? h('div', { className: 'dc-allclear' }, 'No active threats — monitoring.')
+      : h('div', { className: 'dc-actions' }, ...posture.actions.map((a) => this.actionRow(a)));
+    nodes.push(actionList);
+
+    const footerParts: string[] = [];
+    if (posture.staleInputs.length > 0) footerParts.push(`Stale/missing: ${posture.staleInputs.join(', ')}`);
+    nodes.push(h('div', { className: 'dc-footer' }, footerParts.join(' · ') || 'All feeds current'));
+
+    replaceChildren(this.content, ...(nodes.filter(Boolean) as HTMLElement[]));
+    this.invalidateContentCache();
+    this.markFresh();
+  }
+
+  private conditionsRow(c: SiteConditions, aq: SiteAirQuality | null): HTMLElement {
+    const chips: string[] = [
+      `${cToF(c.tempC)}°F / feels ${cToF(c.feelsLikeC)}°F`,
+      `💧${Math.round(c.humidityPct)}%`,
+      `💨${Math.round(c.windSpeedKmh * 0.621)} mph ${degreesToCompass(c.windDirectionDeg)}`,
+      `${wmoCodeEmoji(c.weatherCode)}${c.precipMm.toFixed(1)}"`,
+    ];
+    if (aq?.usAqi !== null && aq?.usAqi !== undefined) {
+      chips.push(`AQI ${aq.usAqi} ${aqiLabel(aq.usAqi)}`);
+    }
+    if (c.uvIndex !== null) {
+      chips.push(`UV ${Math.round(c.uvIndex)}`);
+    }
+    return h('div', { className: 'dc-conditions' },
+      ...chips.map((txt) => h('span', { className: 'dc-conditions-chip' }, txt)),
+    );
+  }
+
+  private forecastStrip(slots: ForecastSlot[]): HTMLElement {
+    const items = slots.map((s) => {
+      const label = s.offsetHours === 0 ? 'Now' : `+${s.offsetHours}h`;
+      return h('span', { className: 'dc-forecast-slot' },
+        `${label} ${cToF(s.tempC)}°F ${wmoCodeEmoji(s.weatherCode)}`,
+      );
+    });
+    return h('div', { className: 'dc-forecast-strip' }, ...items);
+  }
+
+  private gaugesRow(posture: DataCenterPosture): HTMLElement {
+    const seisLevel = seismicLevel(posture.seismicNearby);
+    const seisDetail = posture.seismicNearby.length === 0
+      ? 'No M3.5+ / 200 km / 24 h'
+      : `M${posture.seismicNearby[0]!.magnitudeM.toFixed(1)} ${posture.seismicNearby[0]!.distanceKm} km`;
+
+    return h('div', { className: 'dc-gauges-row' },
       this.gauge('Power', posture.power.level, posture.power.drivers[0] ?? '—'),
       this.gauge(
         'Weather',
@@ -46,19 +131,34 @@ export class DataCenterReadinessPanel extends Panel {
           ? (posture.weather.drivers[0] ?? '—')
           : `ETA ${posture.weather.arrivalWindowMins} min`,
       ),
+      this.gauge('Seismic', seisLevel, seisDetail),
     );
+  }
 
-    const actionList = posture.actions.length === 0
-      ? h('div', { className: 'dc-allclear' }, 'No power or weather action needed — monitoring.')
-      : h('div', { className: 'dc-actions' }, ...posture.actions.map((a) => this.actionRow(a)));
+  private connMark(val: boolean | null): string {
+    if (val === null) return '?';
+    return val ? '✓' : '✗';
+  }
 
-    const footerParts: string[] = [];
-    if (posture.staleInputs.length > 0) footerParts.push(`Stale/missing: ${posture.staleInputs.join(', ')}`);
-    const footer = h('div', { className: 'dc-footer' }, footerParts.join(' · ') || 'All feeds current');
+  private connectivityLine(conn: ConnectivitySignal): HTMLElement {
+    const cfMark = this.connMark(conn.cloudflare);
+    const fastlyMark = this.connMark(conn.fastly);
+    const statusClass = `dc-conn--${conn.status}`;
+    return h('div', { className: `dc-connectivity ${statusClass}` },
+      h('span', { className: 'dc-conn-label' }, 'Connectivity'),
+      h('span', { className: 'dc-conn-status' }, conn.status.charAt(0).toUpperCase() + conn.status.slice(1)),
+      h('span', { className: 'dc-conn-detail' }, `CF ${cfMark} · Fastly ${fastlyMark}`),
+    );
+  }
 
-    replaceChildren(this.content, header, actionList, footer);
-    this.invalidateContentCache();
-    this.markFresh();
+  private seismicLine(events: NearbySeismicEvent[]): HTMLElement {
+    const top = events[0]!;
+    const ago = Math.round((Date.now() - top.occurredAt) / (60 * 60 * 1000));
+    const text = `M${top.magnitudeM.toFixed(1)} · ${top.distanceKm} km · ${top.place} · ${ago}h ago`;
+    return h('div', { className: 'dc-seismic-line' },
+      h('span', { className: 'dc-seismic-icon' }, '🌍'),
+      h('span', { className: 'dc-seismic-text' }, text),
+    );
   }
 
   private gauge(label: string, level: DcLevel, detail: string): HTMLElement {

--- a/src/services/datacenter/datacenter-posture.ts
+++ b/src/services/datacenter/datacenter-posture.ts
@@ -1,6 +1,15 @@
 import type { GridStatus } from '../power-grid.ts';
 import type { NwsAlertMinimal } from '../weather/weather-threat-types.ts';
-import type { DataCenterPosture, DcLevel, SiteConfig } from './datacenter-types.ts';
+import type {
+  ConnectivitySignal,
+  DataCenterPosture,
+  DcLevel,
+  ForecastSlot,
+  NearbySeismicEvent,
+  SiteAirQuality,
+  SiteConditions,
+  SiteConfig,
+} from './datacenter-types.ts';
 import { bumpDcLevel, dcLevelRank, maxDcLevel } from './datacenter-types.ts';
 import { computePowerPosture } from './power-posture.ts';
 import { computeWeatherPosture } from './weather-posture.ts';
@@ -12,6 +21,11 @@ export interface PostureInput {
   weatherAlerts: readonly NwsAlertMinimal[];
   nearbyOutageCount: number | null;
   now?: number;
+  conditions?: SiteConditions | null;
+  forecast24h?: ForecastSlot[];
+  airQuality?: SiteAirQuality | null;
+  seismicNearby?: NearbySeismicEvent[];
+  connectivity?: ConnectivitySignal | null;
 }
 
 function blendOverall(power: DcLevel, weather: DcLevel): DcLevel {
@@ -61,6 +75,11 @@ export function computeDatacenterPosture(input: PostureInput): DataCenterPosture
     headline: buildHeadline(overall, weather, power),
     power,
     weather,
+    conditions: input.conditions ?? null,
+    forecast24h: input.forecast24h ?? [],
+    airQuality: input.airQuality ?? null,
+    seismicNearby: input.seismicNearby ?? [],
+    connectivity: input.connectivity ?? null,
     actions,
     updatedAt: now,
     staleInputs,

--- a/src/services/datacenter/datacenter-state.ts
+++ b/src/services/datacenter/datacenter-state.ts
@@ -1,6 +1,14 @@
 import type { GridStatus } from '../power-grid.ts';
 import type { NwsAlertMinimal } from '../weather/weather-threat-types.ts';
-import type { DataCenterPosture, SiteConfig } from './datacenter-types.ts';
+import type {
+  ConnectivitySignal,
+  DataCenterPosture,
+  ForecastSlot,
+  NearbySeismicEvent,
+  SiteAirQuality,
+  SiteConditions,
+  SiteConfig,
+} from './datacenter-types.ts';
 import { computeDatacenterPosture } from './datacenter-posture.ts';
 
 type Listener = (posture: DataCenterPosture | null) => void;
@@ -29,6 +37,11 @@ export interface RecomputeInput {
   weatherAlerts: readonly NwsAlertMinimal[];
   nearbyOutageCount: number | null;
   now?: number;
+  conditions?: SiteConditions | null;
+  forecast24h?: ForecastSlot[];
+  airQuality?: SiteAirQuality | null;
+  seismicNearby?: NearbySeismicEvent[];
+  connectivity?: ConnectivitySignal | null;
 }
 
 export function recomputeDatacenterPosture(input: RecomputeInput): DataCenterPosture | null {

--- a/src/services/datacenter/datacenter-types.ts
+++ b/src/services/datacenter/datacenter-types.ts
@@ -78,12 +78,55 @@ export interface WeatherPosture {
   drivers: string[];
 }
 
+export interface SiteConditions {
+  tempC: number;
+  feelsLikeC: number;
+  humidityPct: number;
+  windSpeedKmh: number;
+  windDirectionDeg: number;
+  precipMm: number;
+  uvIndex: number | null;
+  weatherCode: number;
+}
+
+export interface ForecastSlot {
+  offsetHours: number;
+  tempC: number;
+  precipProbabilityPct: number;
+  weatherCode: number;
+}
+
+export interface SiteAirQuality {
+  usAqi: number | null;
+  pm25: number | null;
+}
+
+export interface NearbySeismicEvent {
+  magnitudeM: number;
+  distanceKm: number;
+  place: string;
+  occurredAt: number;
+}
+
+export type ConnectivityStatus = 'normal' | 'degraded' | 'outage';
+
+export interface ConnectivitySignal {
+  status: ConnectivityStatus;
+  cloudflare: boolean | null;
+  fastly: boolean | null;
+}
+
 export interface DataCenterPosture {
   site: SiteConfig;
   overall: DcLevel;
   headline: string;
   power: PowerPosture;
   weather: WeatherPosture;
+  conditions: SiteConditions | null;
+  forecast24h: ForecastSlot[];
+  airQuality: SiteAirQuality | null;
+  seismicNearby: NearbySeismicEvent[];
+  connectivity: ConnectivitySignal | null;
   actions: ReadinessAction[];
   updatedAt: number;
   staleInputs: string[];

--- a/src/services/weather.ts
+++ b/src/services/weather.ts
@@ -148,6 +148,8 @@ export function getSeverityColor(severity: WeatherAlert['severity']): string {
 
 export interface OpenMeteoConditions {
   temperature: number;
+  feelsLike: number;
+  humidity: number;
   windSpeed: number;
   windDirection: number;
   precipitation: number;
@@ -170,29 +172,172 @@ export async function fetchOpenMeteoConditions(
   if (cached && Date.now() - cached.ts < OPEN_METEO_TTL_MS) return cached.data;
 
   try {
- const url = `https://api.open-meteo.com/v1/forecast` +
- `?latitude=${lat}&longitude=${lon}` +
- `&current=temperature_2m,wind_speed_10m,wind_direction_10m,precipitation,weather_code,is_day,uv_index` +
- `&wind_speed_unit=kmh&timezone=auto`;
- const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
- if (!res.ok) return null;
- const raw = await res.json() as { current?: Record<string, number | boolean | null> };
- const c = raw.current;
- if (!c) return null;
- const data: OpenMeteoConditions = {
- temperature: typeof c.temperature_2m === 'number' ? c.temperature_2m : 0,
- windSpeed: typeof c.wind_speed_10m === 'number' ? c.wind_speed_10m : 0,
- windDirection: typeof c.wind_direction_10m === 'number' ? c.wind_direction_10m : 0,
- precipitation: typeof c.precipitation === 'number' ? c.precipitation : 0,
- weatherCode: typeof c.weather_code === 'number' ? c.weather_code : 0,
- isDay: c.is_day === 1,
- uvIndex: typeof c.uv_index === 'number' ? c.uv_index : null,
- fetchedAt: new Date(),
- source: 'open-meteo',
- };
- _openMeteoCache.set(cacheKey, { data, ts: Date.now() });
- return data;
+    const url = `https://api.open-meteo.com/v1/forecast` +
+      `?latitude=${lat}&longitude=${lon}` +
+      `&current=temperature_2m,apparent_temperature,relative_humidity_2m,wind_speed_10m,wind_direction_10m,precipitation,weather_code,is_day,uv_index` +
+      `&wind_speed_unit=kmh&timezone=auto`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+    if (!res.ok) return null;
+    const raw = await res.json() as { current?: Record<string, number | boolean | null> };
+    const c = raw.current;
+    if (!c) return null;
+    const data: OpenMeteoConditions = {
+      temperature: typeof c.temperature_2m === 'number' ? c.temperature_2m : 0,
+      feelsLike: typeof c.apparent_temperature === 'number' ? c.apparent_temperature : 0,
+      humidity: typeof c.relative_humidity_2m === 'number' ? c.relative_humidity_2m : 0,
+      windSpeed: typeof c.wind_speed_10m === 'number' ? c.wind_speed_10m : 0,
+      windDirection: typeof c.wind_direction_10m === 'number' ? c.wind_direction_10m : 0,
+      precipitation: typeof c.precipitation === 'number' ? c.precipitation : 0,
+      weatherCode: typeof c.weather_code === 'number' ? c.weather_code : 0,
+      isDay: c.is_day === 1,
+      uvIndex: typeof c.uv_index === 'number' ? c.uv_index : null,
+      fetchedAt: new Date(),
+      source: 'open-meteo',
+    };
+    _openMeteoCache.set(cacheKey, { data, ts: Date.now() });
+    return data;
   } catch {
- return null;
+    return null;
   }
+}
+
+// ── Site-specific helpers for Data Center Readiness ─────────────
+
+import type { ForecastSlot, SiteAirQuality, ConnectivitySignal } from './datacenter/datacenter-types.ts';
+
+/** WMO weather code → single representative emoji. */
+export function wmoCodeEmoji(code: number): string {
+  if (code === 0) return '☀️';
+  if (code <= 2) return '🌤';
+  if (code === 3) return '☁️';
+  if (code <= 48) return '🌫';
+  if (code <= 57) return '🌦';
+  if (code <= 67) return '🌧';
+  if (code <= 77) return '❄️';
+  if (code <= 82) return '🌦';
+  if (code <= 86) return '🌨';
+  return '⛈';
+}
+
+/** Wind direction degrees → 8-point compass abbreviation. */
+export function degreesToCompass(deg: number): string {
+  const dirs = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
+  return dirs[Math.round(((deg % 360) + 360) % 360 / 45) % 8]!;
+}
+
+/** Celsius → Fahrenheit (rounded). */
+export function cToF(c: number): number {
+  return Math.round(c * 9 / 5 + 32);
+}
+
+/** US AQI value → short descriptive label. */
+export function aqiLabel(aqi: number): string {
+  if (aqi <= 50) return 'Good';
+  if (aqi <= 100) return 'Moderate';
+  if (aqi <= 150) return 'Sensitive';
+  if (aqi <= 200) return 'Unhealthy';
+  if (aqi <= 300) return 'Very Unhealthy';
+  return 'Hazardous';
+}
+
+const _forecast24hCache = new Map<string, { data: ForecastSlot[]; ts: number }>();
+const FORECAST_TTL_MS = 30 * 60 * 1000;
+
+/** Fetch 4 forecast slots at +0h, +6h, +12h, +18h for a given location. */
+export async function fetchSite24hForecast(lat: number, lon: number): Promise<ForecastSlot[]> {
+  const key = `${lat.toFixed(2)},${lon.toFixed(2)}`;
+  const cached = _forecast24hCache.get(key);
+  if (cached && Date.now() - cached.ts < FORECAST_TTL_MS) return cached.data;
+
+  try {
+    const url = `https://api.open-meteo.com/v1/forecast` +
+      `?latitude=${lat}&longitude=${lon}` +
+      `&hourly=temperature_2m,precipitation_probability,weather_code` +
+      `&forecast_days=1&timezone=auto`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+    if (!res.ok) return [];
+    const raw = await res.json() as {
+      hourly?: {
+        time?: string[];
+        temperature_2m?: number[];
+        precipitation_probability?: (number | null)[];
+        weather_code?: number[];
+      };
+    };
+    const h = raw.hourly;
+    if (!h?.time?.length) return [];
+
+    const nowHour = new Date().getHours();
+    const slots: ForecastSlot[] = [];
+    for (const offset of [0, 6, 12, 18]) {
+      const idx = (nowHour + offset) % 24;
+      if (idx >= (h.temperature_2m?.length ?? 0)) continue;
+      slots.push({
+        offsetHours: offset,
+        tempC: h.temperature_2m?.[idx] ?? 0,
+        precipProbabilityPct: h.precipitation_probability?.[idx] ?? 0,
+        weatherCode: h.weather_code?.[idx] ?? 0,
+      });
+    }
+    _forecast24hCache.set(key, { data: slots, ts: Date.now() });
+    return slots;
+  } catch {
+    return [];
+  }
+}
+
+const _aqCache = new Map<string, { data: SiteAirQuality; ts: number }>();
+const AQ_TTL_MS = 30 * 60 * 1000;
+
+/** Fetch US AQI + PM2.5 for a specific location via open-meteo air quality API. */
+export async function fetchSiteAirQuality(lat: number, lon: number): Promise<SiteAirQuality | null> {
+  const key = `${lat.toFixed(2)},${lon.toFixed(2)}`;
+  const cached = _aqCache.get(key);
+  if (cached && Date.now() - cached.ts < AQ_TTL_MS) return cached.data;
+
+  try {
+    const url = `https://air-quality-api.open-meteo.com/v1/air-quality` +
+      `?latitude=${lat}&longitude=${lon}&current=us_aqi,pm2_5`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
+    if (!res.ok) return null;
+    const raw = await res.json() as { current?: { us_aqi?: number | null; pm2_5?: number | null } };
+    const c = raw.current;
+    if (!c) return null;
+    const data: SiteAirQuality = {
+      usAqi: typeof c.us_aqi === 'number' ? c.us_aqi : null,
+      pm25: typeof c.pm2_5 === 'number' ? c.pm2_5 : null,
+    };
+    _aqCache.set(key, { data, ts: Date.now() });
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+let _connCache: { data: ConnectivitySignal; ts: number } | null = null;
+const CONN_TTL_MS = 5 * 60 * 1000;
+
+/** Check Cloudflare + Fastly status pages and return a blended connectivity signal. */
+export async function fetchConnectivitySignal(): Promise<ConnectivitySignal> {
+  if (_connCache && Date.now() - _connCache.ts < CONN_TTL_MS) return _connCache.data;
+
+  const [cf, fastly] = await Promise.allSettled([
+    fetch('https://www.cloudflarestatus.com/api/v2/summary.json', { signal: AbortSignal.timeout(5000) })
+      .then((r) => r.json() as Promise<{ status?: { indicator?: string } }>)
+      .then((j) => j.status?.indicator === 'none'),
+    fetch('https://www.fastlystatus.com/status.json', { signal: AbortSignal.timeout(5000) })
+      .then((r) => r.json() as Promise<{ status?: { indicator?: string } }>)
+      .then((j) => j.status?.indicator === 'none'),
+  ]);
+
+  const cfOk = cf.status === 'fulfilled' ? cf.value : null;
+  const fastlyOk = fastly.status === 'fulfilled' ? fastly.value : null;
+
+  let status: ConnectivitySignal['status'] = 'normal';
+  if (cfOk === false || fastlyOk === false) status = 'degraded';
+  if (cfOk === false && fastlyOk === false) status = 'outage';
+
+  const data: ConnectivitySignal = { status, cloudflare: cfOk, fastly: fastlyOk };
+  _connCache = { data, ts: Date.now() };
+  return data;
 }

--- a/src/services/weather.ts
+++ b/src/services/weather.ts
@@ -250,13 +250,17 @@ export async function fetchSite24hForecast(lat: number, lon: number): Promise<Fo
   if (cached && Date.now() - cached.ts < FORECAST_TTL_MS) return cached.data;
 
   try {
+    // forecast_days=2 (48 hourly entries) so +18h never runs off the end of the
+    // array late in the day. `current` gives the site-local "now" timestamp.
     const url = `https://api.open-meteo.com/v1/forecast` +
       `?latitude=${lat}&longitude=${lon}` +
       `&hourly=temperature_2m,precipitation_probability,weather_code` +
-      `&forecast_days=1&timezone=auto`;
+      `&current=temperature_2m&forecast_days=2&timezone=auto`;
     const res = await fetch(url, { signal: AbortSignal.timeout(8000) });
     if (!res.ok) return [];
     const raw = await res.json() as {
+      utc_offset_seconds?: number;
+      current?: { time?: string };
       hourly?: {
         time?: string[];
         temperature_2m?: number[];
@@ -267,10 +271,25 @@ export async function fetchSite24hForecast(lat: number, lon: number): Promise<Fo
     const h = raw.hourly;
     if (!h?.time?.length) return [];
 
-    const nowHour = new Date().getHours();
+    // Locate "now" within the site-local hourly array. open-meteo returns
+    // hourly.time[] in the *site's* timezone (timezone=auto), so indexing off
+    // the browser clock (or wrapping mod 24) shows past/wrong-tz hours. Match the
+    // current local hour by its "YYYY-MM-DDTHH" key instead.
+    const hourKey = (iso: string): string => iso.slice(0, 13);
+    let startIdx = raw.current?.time
+      ? h.time.findIndex((t) => hourKey(t) === hourKey(raw.current!.time!))
+      : -1;
+    if (startIdx < 0) {
+      // Fallback: derive site-local wall-clock from the reported UTC offset.
+      const siteNow = new Date(Date.now() + (raw.utc_offset_seconds ?? 0) * 1000);
+      const siteKey = siteNow.toISOString().slice(0, 13);
+      startIdx = h.time.findIndex((t) => hourKey(t) === siteKey);
+    }
+    if (startIdx < 0) startIdx = 0;
+
     const slots: ForecastSlot[] = [];
     for (const offset of [0, 6, 12, 18]) {
-      const idx = (nowHour + offset) % 24;
+      const idx = startIdx + offset;
       if (idx >= (h.temperature_2m?.length ?? 0)) continue;
       slots.push({
         offsetHours: offset,

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -20527,3 +20527,103 @@ body.is-desktop-macos .mac-sidebar-panel-item {
   padding-top: 4px;
   border-top: 1px solid rgba(255, 255, 255, 0.06);
 }
+
+/* ── Data Center Readiness — intelligence dashboard additions ── */
+
+.dc-conditions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.dc-conditions-chip {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.75);
+  background: rgba(255, 255, 255, 0.07);
+  border-radius: 4px;
+  padding: 2px 6px;
+  white-space: nowrap;
+}
+
+.dc-forecast-strip {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 0;
+  margin-bottom: 8px;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.dc-forecast-strip::-webkit-scrollbar { display: none; }
+
+.dc-forecast-slot {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.65);
+  white-space: nowrap;
+  padding-right: 10px;
+}
+.dc-forecast-slot:not(:last-child)::after {
+  content: ' ·';
+  color: rgba(255, 255, 255, 0.25);
+  margin-left: 6px;
+}
+
+.dc-gauges-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.dc-gauges-row .dc-gauge {
+  flex: 1;
+}
+
+.dc-connectivity {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  margin-bottom: 6px;
+  padding: 4px 8px;
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.dc-conn-label {
+  color: rgba(255, 255, 255, 0.45);
+  text-transform: uppercase;
+  font-size: 9px;
+  letter-spacing: 0.04em;
+}
+
+.dc-conn-status {
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.dc-conn-detail {
+  margin-left: auto;
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 10px;
+}
+
+.dc-conn--normal  .dc-conn-status { color: #30d158; }
+.dc-conn--degraded .dc-conn-status { color: #ff9f0a; }
+.dc-conn--outage  .dc-conn-status { color: #ff453a; }
+.dc-conn--degraded { border-left: 2px solid #ff9f0a; }
+.dc-conn--outage   { border-left: 2px solid #ff453a; }
+
+.dc-seismic-line {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.65);
+  margin-bottom: 6px;
+  padding: 3px 6px;
+  background: rgba(255, 159, 10, 0.08);
+  border-left: 2px solid #ff9f0a;
+  border-radius: 3px;
+}
+
+.dc-seismic-icon { font-size: 12px; }
+.dc-seismic-text { flex: 1; }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -20379,3 +20379,151 @@ body.is-desktop-macos .mac-sidebar-panel-item {
   font-size: 12px;
 }
 .ai-brief-modal-btn:disabled { opacity: 0.4; cursor: default; }
+
+/* ── Data Center Readiness panel ───────────────────────────────── */
+.dc-empty {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.45);
+  padding: 8px 2px;
+  line-height: 1.5;
+}
+
+/* Gauge row — two (or more) side-by-side status indicators */
+.dc-status-header {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.dc-gauge {
+  flex: 1;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  padding: 6px 8px;
+  min-width: 0;
+}
+
+.dc-gauge-top {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: 3px;
+}
+
+.dc-gauge-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dc-gauge-label {
+  font-size: 10px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.5);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dc-gauge-level {
+  font-size: 11px;
+  font-weight: 700;
+  color: #e0e0e0;
+  white-space: nowrap;
+}
+
+.dc-gauge-detail {
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.45);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* All-clear headline */
+.dc-allclear {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.55);
+  padding: 4px 2px;
+  line-height: 1.5;
+}
+
+/* Readiness action list */
+.dc-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin-bottom: 4px;
+}
+
+.dc-action {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 5px;
+  padding: 5px 7px;
+}
+
+.dc-action--onsite_safety  { border-left: 3px solid #ff453a; }
+.dc-action--commute_staffing { border-left: 3px solid #ff9f0a; }
+.dc-action--facility_ops   { border-left: 3px solid #0a84ff; }
+.dc-action--escalation     { border-left: 3px solid #bf5af2; }
+
+.dc-action-head {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: 2px;
+}
+
+.dc-urgency {
+  font-size: 9px;
+  font-weight: 800;
+  padding: 1px 4px;
+  border-radius: 3px;
+  letter-spacing: 0.05em;
+}
+.dc-urgency--now       { background: rgba(255, 69, 58, 0.25); color: #ff6b60; }
+.dc-urgency--soon      { background: rgba(255, 159, 10, 0.25); color: #ffb830; }
+.dc-urgency--be_ready  { background: rgba(10, 132, 255, 0.20); color: #409cff; }
+.dc-urgency--monitor   { background: rgba(255, 255, 255, 0.10); color: rgba(255, 255, 255, 0.55); }
+
+.dc-action-aud {
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.dc-action-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: #e0e0e0;
+  line-height: 1.35;
+}
+
+.dc-action-detail {
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.55);
+  margin-top: 2px;
+  line-height: 1.4;
+}
+
+.dc-action-trigger {
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.35);
+  margin-top: 1px;
+  font-style: italic;
+}
+
+/* Footer — stale inputs or "all feeds current" */
+.dc-footer {
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.3);
+  margin-top: 4px;
+  padding-top: 4px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}


### PR DESCRIPTION
Adds five new live data streams to the Data Center Readiness panel:

- **Current conditions** — temp/feels-like, humidity, wind speed+direction, precip, UV index chips via open-meteo (no key)
- **24h forecast strip** — scrollable text row: `Now 72°F ⛅ · +6h 78°F ☀ · +12h 85°F ☀ · +18h 70°F 🌦`
- **Air quality** — US AQI + PM2.5 via open-meteo air quality API (no key)
- **Seismic gauge** — M3.5+ events within 200 km / 24 h from the existing USGS earthquake cache; no new API call
- **Connectivity signal** — Cloudflare + Fastly status page JSON blended into Normal/Degraded/Outage, color-coded

All five fetch in parallel via `Promise.allSettled` — any individual failure degrades gracefully without stalling the posture. The gauges row now shows Power / Weather / Seismic side by side.

## Review fixes (this revision)

Independent review found three bugs in the new conditions/forecast streams, now fixed:

- **Forecast slot indexing** — `fetchSite24hForecast` requested `forecast_days=1` and computed `idx = (nowHour + offset) % 24`, so late in the day the +6/+12/+18h slots wrapped to *earlier-today (past)* hours. Now requests `forecast_days=2` and locates "now" within the site-local hourly array.
- **Timezone mismatch** — slot hour was derived from the *browser* clock while open-meteo returns arrays in the *site's* timezone (`timezone=auto`); a data center in another tz indexed the wrong hour. Now uses `current.time` (falling back to `utc_offset_seconds`).
- **Precip unit** — `precipMm` (millimetres) was rendered with a `"` inch symbol and no conversion (a 25 mm downpour showed as `25.0"`). Now converts `mm / 25.4`.

Cross-agent review: Claude independent review pass on 2026-06-10; outcome: issues fixed — the three forecast/precip bugs above were corrected; security clean (public keyless APIs, no secrets in URLs, numeric lat/lon), error handling degrades gracefully, panel lifecycle unsub is correct. Seismic/connectivity/AQI are display-only by design for v1.

https://claude.ai/code/session_01426AyLjzT4cLsXTBRFMuHs