### PR TITLE
perf: Cesium on-demand rendering + listener-leak ratchet guard

### DIFF
--- a/docs/PERFORMANCE_FINDINGS_2026-06-10.md
+++ b/docs/PERFORMANCE_FINDINGS_2026-06-10.md
@@ -1,0 +1,58 @@
+# Performance Findings & Fixes (2026-06-10)
+
+Source-verified diagnosis of why the running app feels slow, plus the quick wins
+shipped in this PR and the structural follow-ups.
+
+## Diagnosis (everyday use)
+
+1. **Mount-everything architecture (root cause).** ~470 panels are `enabled: true`
+   and mount into the DOM on boot. An `IntersectionObserver` (`Panel.ts`) correctly
+   skips *render work* for off-screen panels, but the DOM nodes, timers, and
+   listeners all persist — hundreds of live subtrees mean constant style/layout
+   recalculation and high memory regardless of what's on screen. Fixed structurally
+   by Workstream B (466 panels → ~12 hubs with lazy-mounted tabs) in the main plan.
+2. **~290 panels run uncoordinated polling timers.** A smart central
+   `RefreshScheduler` exists (slows polling 10× when the window is hidden, jitters to
+   avoid thundering-herd bursts, can gate on visibility) — but only 2 panels use it.
+   ~290 component files call raw `setInterval` directly (693 timer call sites total),
+   so they keep polling at full rate when hidden/off-screen, in unsynchronized bursts.
+3. **Listener accumulation.** 1,252 `addEventListener` vs 191 `removeEventListener`
+   across `src/`. Many panels don't fully tear down, so handlers (and the closures
+   they retain) pile up over a session — the "slower the longer it's open" pattern.
+4. **Always-on DeckGL map.** `MapContainer → DeckGLMap` (233 KB) is mounted by default
+   and renders WebGL at up to 2× device pixels even when not in view.
+
+## Not the everyday culprit: God's Vision globe
+
+The Cesium globe is lazy — dynamically imported only when God's Vision is toggled and
+fully torn down on exit — so it does not affect normal use. But *while active* its
+config was needlessly maxed out: continuous 60fps rendering (no `requestRenderMode`),
+`msaaSamples: 4` on top of FXAA, full-retina resolution, and high-performance GPU.
+
+## Shipped in this PR (safe, verifiable quick wins)
+
+- **Cesium on-demand rendering** (`CesiumGlobe.ts`): `requestRenderMode: true` so the
+  globe only paints when the scene changes, plus a 1s render heartbeat (cleared in
+  `destroy()`) so imperative data mutations from `GlobeDataManager` (64 mutation sites,
+  none self-flagging a render) still surface within ≤1s. Idle rendering drops from
+  ~60fps to ~1fps; camera interaction still renders immediately via Cesium's own
+  handling. MSAA reduced 4× → 2× (visually indistinguishable paired with FXAA).
+- **Listener-leak ratchet** (`scripts/check-listener-leaks.mjs` + baseline + npm
+  `perf:listeners{,:ci,:update}`): mirrors the a11y-baseline pattern. Reports the worst
+  offenders (currently 1,036 unmatched listeners across 337 files; top: `Map.ts` 53,
+  `panel-layout.ts` 35, `event-handlers.ts` 27) and, in `--ci` mode, fails only when a
+  file's imbalance grows beyond baseline or a new offender appears. Prevents the leak
+  class from worsening while the real teardown fixes are worked through the ranked list.
+
+## Structural follow-ups (bigger PRs, ordered by impact)
+
+1. **Route per-panel `setInterval` through `RefreshScheduler`.** Mechanical replacement;
+   instantly stops off-screen/hidden panels from polling and adds jitter. Highest
+   everyday win short of consolidation.
+2. **Hub consolidation (Workstream B).** 470 mounted panels → ~12 hubs with lazy tabs is
+   the largest single lever; attacks the root cause directly.
+3. **Pay down the listener-leak baseline.** Work the ranked `perf:listeners` list,
+   adding matching teardown in each `destroy()`; add a base-class `isDestroyed` guard +
+   RAF/timer cancellation ordering so late callbacks can't touch torn-down panels.
+4. **DeckGL fill-rate.** Consider a modest device-pixel cap on the always-on map and
+   pausing its animation loop when the map section is hidden.

--- a/docs/PERFORMANCE_FINDINGS_2026-06-10.md
+++ b/docs/PERFORMANCE_FINDINGS_2026-06-10.md
@@ -39,7 +39,7 @@ config was needlessly maxed out: continuous 60fps rendering (no `requestRenderMo
   handling. MSAA reduced 4× → 2× (visually indistinguishable paired with FXAA).
 - **Listener-leak ratchet** (`scripts/check-listener-leaks.mjs` + baseline + npm
   `perf:listeners{,:ci,:update}`): mirrors the a11y-baseline pattern. Reports the worst
-  offenders (currently 1,036 unmatched listeners across 337 files; top: `Map.ts` 53,
+  offenders (currently 1,074 unmatched listeners across 342 files; top: `Map.ts` 53,
   `panel-layout.ts` 35, `event-handlers.ts` 27) and, in `--ci` mode, fails only when a
   file's imbalance grows beyond baseline or a new offender appears. Prevents the leak
   class from worsening while the real teardown fixes are worked through the ranked list.

--- a/package.json
+++ b/package.json
@@ -170,7 +170,10 @@
     "desktop:package:windows:full:sign": "node scripts/desktop-package.mjs --os windows --variant full --sign",
     "desktop:package:windows:tech:sign": "node scripts/desktop-package.mjs --os windows --variant tech --sign",
     "desktop:package": "node scripts/desktop-package.mjs",
-    "postdesktop:build:full": "node scripts/local-install.mjs"
+    "postdesktop:build:full": "node scripts/local-install.mjs",
+    "perf:listeners": "node scripts/check-listener-leaks.mjs",
+    "perf:listeners:ci": "node scripts/check-listener-leaks.mjs --ci",
+    "perf:listeners:update": "node scripts/check-listener-leaks.mjs --update"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",

--- a/scripts/check-listener-leaks.mjs
+++ b/scripts/check-listener-leaks.mjs
@@ -15,13 +15,13 @@
 // can legitimately add in one method and remove in another, so the goal is
 // "don't get worse", not "zero imbalance".
 
-import { readFileSync, writeFileSync, existsSync } from 'node:fs';
-import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { dirname, join, relative } from 'node:path';
+import path from 'node:path';
 
-const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const BASELINE_PATH = join(ROOT, 'scripts', 'listener-leak-baseline.json');
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SRC = path.join(ROOT, 'src');
+const BASELINE_PATH = path.join(ROOT, 'scripts', 'listener-leak-baseline.json');
 const REPORT_LIMIT = 25;
 
 const args = new Set(process.argv.slice(2));
@@ -30,16 +30,28 @@ const UPDATE = args.has('--update');
 
 function count(haystack, needle) {
   // Count "<needle>(" call sites; tolerant of optional chaining (?.needle).
-  const re = new RegExp(`(?:\\.|\\b)${needle}\\s*\\(`, 'g');
+  const re = new RegExp(String.raw`(?:\.|\b)` + needle + String.raw`\s*\(`, 'g');
   return (haystack.match(re) || []).length;
 }
 
-function listTrackedTs() {
-  const out = execSync('git ls-files "src/**/*.ts"', { cwd: ROOT, encoding: 'utf8' });
-  return out.split('\n').filter((f) => f && !f.includes('__tests__') && !f.endsWith('.test.ts') && !f.endsWith('.test.mts'));
+function isTestPath(rel) {
+  return rel.includes('__tests__') || rel.endsWith('.test.ts') || rel.endsWith('.test.mts');
 }
 
-const files = listTrackedTs();
+function walkTs(dir, acc) {
+  for (const entry of readdirSync(dir)) {
+    const abs = path.join(dir, entry);
+    if (statSync(abs).isDirectory()) {
+      walkTs(abs, acc);
+    } else if (abs.endsWith('.ts')) {
+      const rel = path.relative(ROOT, abs);
+      if (!isTestPath(rel)) acc.push(rel);
+    }
+  }
+  return acc;
+}
+
+const files = walkTs(SRC, []);
 const offenders = {};
 let totalAddRemove = 0;
 let totalTimerImbalance = 0;
@@ -47,7 +59,7 @@ let totalTimerImbalance = 0;
 for (const rel of files) {
   let src;
   try {
-    src = readFileSync(join(ROOT, rel), 'utf8');
+    src = readFileSync(path.join(ROOT, rel), 'utf8');
   } catch {
     continue;
   }

--- a/scripts/check-listener-leaks.mjs
+++ b/scripts/check-listener-leaks.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// Listener-leak guard.
+//
+// Components that call addEventListener / setInterval without a matching
+// removeEventListener / clearInterval accumulate handlers across a session,
+// which is a primary cause of the app getting slower the longer it stays open.
+//
+// This is a *ratchet*, mirroring the a11y baseline: it records the current
+// per-file imbalance in scripts/listener-leak-baseline.json and, in --ci mode,
+// fails only when a file's imbalance grows beyond its baseline or a brand-new
+// offender appears. Run without flags for a ranked report; run with --update to
+// re-baseline after intentionally fixing (lowering) counts.
+//
+// Heuristic, not a type-aware analysis: it counts textual occurrences. A file
+// can legitimately add in one method and remove in another, so the goal is
+// "don't get worse", not "zero imbalance".
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, relative } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const BASELINE_PATH = join(ROOT, 'scripts', 'listener-leak-baseline.json');
+const REPORT_LIMIT = 25;
+
+const args = new Set(process.argv.slice(2));
+const CI = args.has('--ci');
+const UPDATE = args.has('--update');
+
+function count(haystack, needle) {
+  // Count "<needle>(" call sites; tolerant of optional chaining (?.needle).
+  const re = new RegExp(`(?:\\.|\\b)${needle}\\s*\\(`, 'g');
+  return (haystack.match(re) || []).length;
+}
+
+function listTrackedTs() {
+  const out = execSync('git ls-files "src/**/*.ts"', { cwd: ROOT, encoding: 'utf8' });
+  return out.split('\n').filter((f) => f && !f.includes('__tests__') && !f.endsWith('.test.ts') && !f.endsWith('.test.mts'));
+}
+
+const files = listTrackedTs();
+const offenders = {};
+let totalAddRemove = 0;
+let totalTimerImbalance = 0;
+
+for (const rel of files) {
+  let src;
+  try {
+    src = readFileSync(join(ROOT, rel), 'utf8');
+  } catch {
+    continue;
+  }
+  const add = count(src, 'addEventListener');
+  const remove = count(src, 'removeEventListener');
+  const setI = count(src, 'setInterval');
+  const clearI = count(src, 'clearInterval');
+  const listenerGap = Math.max(0, add - remove);
+  const timerGap = Math.max(0, setI - clearI);
+  if (listenerGap === 0 && timerGap === 0) continue;
+  offenders[rel] = { add, remove, listenerGap, setI, clearI, timerGap };
+  totalAddRemove += listenerGap;
+  totalTimerImbalance += timerGap;
+}
+
+if (UPDATE) {
+  writeFileSync(BASELINE_PATH, JSON.stringify({ offenders, totalAddRemove, totalTimerImbalance }, null, 2) + '\n');
+  console.log(`[listener-leak] baseline written: ${Object.keys(offenders).length} files, listener gap ${totalAddRemove}, timer gap ${totalTimerImbalance}.`);
+  process.exit(0);
+}
+
+// Ranked report.
+const ranked = Object.entries(offenders)
+  .sort((a, b) => (b[1].listenerGap + b[1].timerGap) - (a[1].listenerGap + a[1].timerGap))
+  .slice(0, REPORT_LIMIT);
+
+console.log(`[listener-leak] ${Object.keys(offenders).length} files with an add/remove or set/clear imbalance.`);
+console.log(`[listener-leak] total unmatched listeners: ${totalAddRemove}, unmatched timers: ${totalTimerImbalance}.`);
+console.log(`[listener-leak] top ${ranked.length} offenders (listenerGap / timerGap):`);
+for (const [rel, m] of ranked) {
+  console.log(`  ${String(m.listenerGap).padStart(3)}L ${String(m.timerGap).padStart(3)}T  ${rel}`);
+}
+
+if (!CI) process.exit(0);
+
+if (!existsSync(BASELINE_PATH)) {
+  console.error('[listener-leak] --ci requires a baseline. Run: npm run perf:listeners:update');
+  process.exit(1);
+}
+
+const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
+const regressions = [];
+for (const [rel, m] of Object.entries(offenders)) {
+  const base = baseline.offenders[rel];
+  const baseListener = base ? base.listenerGap : 0;
+  const baseTimer = base ? base.timerGap : 0;
+  if (m.listenerGap > baseListener || m.timerGap > baseTimer) {
+    regressions.push({ rel, m, baseListener, baseTimer });
+  }
+}
+
+if (regressions.length) {
+  console.error(`\n[listener-leak] FAIL — ${regressions.length} file(s) increased listener/timer imbalance:`);
+  for (const r of regressions) {
+    console.error(`  ${r.rel}: listeners ${r.baseListener} -> ${r.m.listenerGap}, timers ${r.baseTimer} -> ${r.m.timerGap}`);
+  }
+  console.error('\nAdd matching removeEventListener/clearInterval in destroy(), or re-baseline with');
+  console.error('npm run perf:listeners:update once the imbalance is intentionally reduced.');
+  process.exit(1);
+}
+
+console.log('\n[listener-leak] OK — no file exceeded its baseline imbalance.');
+process.exit(0);

--- a/scripts/listener-leak-baseline.json
+++ b/scripts/listener-leak-baseline.json
@@ -1,5 +1,13 @@
 {
   "offenders": {
+    "src/App.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
     "src/app/biometric-gate.ts": {
       "add": 4,
       "remove": 2,
@@ -2096,6 +2104,22 @@
       "clearI": 0,
       "timerGap": 0
     },
+    "src/live-channels-window.ts": {
+      "add": 12,
+      "remove": 0,
+      "listenerGap": 12,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/main.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
     "src/services/alert-correlator.ts": {
       "add": 0,
       "remove": 0,
@@ -2280,14 +2304,6 @@
       "clearI": 0,
       "timerGap": 0
     },
-    "src/services/infrastructure-alert-bridge.ts": {
-      "add": 0,
-      "remove": 0,
-      "listenerGap": 0,
-      "setI": 2,
-      "clearI": 0,
-      "timerGap": 2
-    },
     "src/services/infrastructure/grid-intelligence-loader.ts": {
       "add": 0,
       "remove": 0,
@@ -2295,6 +2311,14 @@
       "setI": 4,
       "clearI": 1,
       "timerGap": 3
+    },
+    "src/services/infrastructure-alert-bridge.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 2,
+      "clearI": 0,
+      "timerGap": 2
     },
     "src/services/intel-channels-bridge.ts": {
       "add": 0,
@@ -2656,6 +2680,22 @@
       "clearI": 0,
       "timerGap": 0
     },
+    "src/settings-main.ts": {
+      "add": 21,
+      "remove": 0,
+      "listenerGap": 21,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/settings-window.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
     "src/utils/dom-utils.ts": {
       "add": 1,
       "remove": 0,
@@ -2697,6 +2737,6 @@
       "timerGap": 0
     }
   },
-  "totalAddRemove": 1036,
-  "totalTimerImbalance": 36
+  "totalAddRemove": 1074,
+  "totalTimerImbalance": 37
 }

--- a/scripts/listener-leak-baseline.json
+++ b/scripts/listener-leak-baseline.json
@@ -1,0 +1,2702 @@
+{
+  "offenders": {
+    "src/app/biometric-gate.ts": {
+      "add": 4,
+      "remove": 2,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/app/data-loader.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/app/desktop-updater.ts": {
+      "add": 5,
+      "remove": 1,
+      "listenerGap": 4,
+      "setI": 1,
+      "clearI": 2,
+      "timerGap": 0
+    },
+    "src/app/event-handlers.ts": {
+      "add": 38,
+      "remove": 11,
+      "listenerGap": 27,
+      "setI": 2,
+      "clearI": 2,
+      "timerGap": 0
+    },
+    "src/app/panel-layout.ts": {
+      "add": 39,
+      "remove": 4,
+      "listenerGap": 35,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/app/vault-intro.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/bootstrap/chunk-reload.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/AarPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/ActiveLearningPanel.ts": {
+      "add": 7,
+      "remove": 0,
+      "listenerGap": 7,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/ActiveLearningQueuePanel.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/AiBriefModal.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/AirstrikesPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/AlertCenterPanel.ts": {
+      "add": 3,
+      "remove": 2,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/AlertDeduplicationPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/AlertEscalationPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 2,
+      "clearI": 2,
+      "timerGap": 0
+    },
+    "src/components/AlertReplayScrubber.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/AlertRulesPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/AlertRulesTuningPanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/AlertTimeline.ts": {
+      "add": 4,
+      "remove": 1,
+      "listenerGap": 3,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/AnalystHUD.ts": {
+      "add": 27,
+      "remove": 0,
+      "listenerGap": 27,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/AnalystNotebookPanel.ts": {
+      "add": 7,
+      "remove": 0,
+      "listenerGap": 7,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/ApiDiagnosticPanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/AskCrystalBallPanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/AssumptionPanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/AssumptionTrackerPanel.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/AviationIntelPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/BacktestGatePanel.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/BacktestPanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/BiasDetectionPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/BitcoinAbusePanel.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/BreakingNewsBanner.ts": {
+      "add": 4,
+      "remove": 3,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/CIIPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/CascadePanel.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/CascadeSimulatorPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/CausalChainPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/CesiumGlobe.ts": {
+      "add": 8,
+      "remove": 0,
+      "listenerGap": 8,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/ClimateAnomalyPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/CognitiveBiasDetectorPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/CollectionGapPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/CommandCenterPanel.ts": {
+      "add": 5,
+      "remove": 3,
+      "listenerGap": 2,
+      "setI": 2,
+      "clearI": 2,
+      "timerGap": 0
+    },
+    "src/components/CommandPalette.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/CommandPalettePanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/CommsPlanPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/CommunityWidget.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/CompetitiveHypothesisEnginePanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/CompoundEventDetectorPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/ContextualHint.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/ContradictionDetectorPanel.ts": {
+      "add": 5,
+      "remove": 0,
+      "listenerGap": 5,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/CorrelationAlertBanner.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/CorrelationMapPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/CorrelationMatrixPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/CounterfactualReasoningPanel.ts": {
+      "add": 6,
+      "remove": 0,
+      "listenerGap": 6,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/CounterfactualReplayPanel.ts": {
+      "add": 9,
+      "remove": 0,
+      "listenerGap": 9,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/CountryBriefPage.ts": {
+      "add": 12,
+      "remove": 2,
+      "listenerGap": 10,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/CountryIntelModal.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/CountryTimeline.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/CourseOfActionPanel.ts": {
+      "add": 2,
+      "remove": 1,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/CrisisSignaturePanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/CrossDomainContradictionDetectorPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/CrystalBallSays.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/CveTrackerPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/CyberGeoPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/CyberThreatPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/DailyWisdomPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/DataCenterPinnedStrip.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/DeckGLMap.ts": {
+      "add": 18,
+      "remove": 2,
+      "listenerGap": 16,
+      "setI": 3,
+      "clearI": 3,
+      "timerGap": 0
+    },
+    "src/components/DigestOverlay.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/DiseaseIntelPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/DiseaseOutbreakPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 2,
+      "clearI": 2,
+      "timerGap": 0
+    },
+    "src/components/DisplacementPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/DomainDependencyPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/DomainScorecardPanel.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/DomainScorecardsPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/DownloadBanner.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/EEWStatusBar.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 2,
+      "clearI": 2,
+      "timerGap": 0
+    },
+    "src/components/EconomicIntelPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/EconomicPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/EmptyState.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/EntityHeatRail.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/EscalationForecastPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/EvacuationPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/EvidenceChainBuilderPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/EvidenceDrawer.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/EvidenceGraphPanel.ts": {
+      "add": 3,
+      "remove": 2,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/ExperimentManagerPanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/FAAWeatherCamsPanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/FaaTfrsPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/FailurePredictionPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/FamilyTrackerPanel.ts": {
+      "add": 7,
+      "remove": 0,
+      "listenerGap": 7,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/FeedWatchdogPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/GDACSAlertsPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/GeoHubsPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/GeopoliticalEventCalendarPanel.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/GeospatialClusteringPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/GivingPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/GlobalRhythmPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/GlobeDataManager.ts": {
+      "add": 2,
+      "remove": 1,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/GlobeHUD.ts": {
+      "add": 14,
+      "remove": 0,
+      "listenerGap": 14,
+      "setI": 2,
+      "clearI": 2,
+      "timerGap": 0
+    },
+    "src/components/GlobeTimeMachine.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/GodsVisionView.ts": {
+      "add": 3,
+      "remove": 2,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/GoesSatellitePanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/GridIntelligencePanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/HazardAlertsPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/HelpOverlay.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/HeroSpotlightPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/HibpBreachesPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/HistoricalPlaybackPanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/InfraRiskMatrixPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/InfrastructureBannerBar.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/IntelReportPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/IntelligenceBriefingExportPanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/IntelligenceBriefingPanel.ts": {
+      "add": 22,
+      "remove": 0,
+      "listenerGap": 22,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/IntelligenceDigestPanel.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/IntelligenceFeedPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/IntelligenceGapBadge.ts": {
+      "add": 11,
+      "remove": 4,
+      "listenerGap": 7,
+      "setI": 1,
+      "clearI": 2,
+      "timerGap": 0
+    },
+    "src/components/IntelligenceHealthMonitorPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/IntelligenceIndexPanel.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/IntelligenceLoopOrchestratorPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/IntelligenceTimelinePanel.ts": {
+      "add": 5,
+      "remove": 0,
+      "listenerGap": 5,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/IntelligenceTrustBudgetPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/InvestmentsPanel.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/IpInfoPanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/JustInRail.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/KeyDashboard.ts": {
+      "add": 5,
+      "remove": 0,
+      "listenerGap": 5,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/KillChainPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/LittleSnitchPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/LiveNewsPanel.ts": {
+      "add": 21,
+      "remove": 3,
+      "listenerGap": 18,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/LiveWebcamsPanel.ts": {
+      "add": 10,
+      "remove": 3,
+      "listenerGap": 7,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/LocalLogisticsPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/Map.ts": {
+      "add": 55,
+      "remove": 2,
+      "listenerGap": 53,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/MapContextMenu.ts": {
+      "add": 3,
+      "remove": 1,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/MapPopup.ts": {
+      "add": 10,
+      "remove": 7,
+      "listenerGap": 3,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/MediastackNewsPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/MetaConfidenceCalibrationPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/MetaConfidencePanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/MissionControlDashboardPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/MobileWarningModal.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/ModelGovernancePanel.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/MultiAgentReviewPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/NationalDebtPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/NavigationPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/NetworkTopologyPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/NewsPanel.ts": {
+      "add": 9,
+      "remove": 3,
+      "listenerGap": 6,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/NotificationAuditPanel.ts": {
+      "add": 7,
+      "remove": 0,
+      "listenerGap": 7,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/NotificationDigestPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/NotificationHistoryPanel.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/NotificationPreferencesPanel.ts": {
+      "add": 9,
+      "remove": 0,
+      "listenerGap": 9,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/NotificationProvenancePanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/NotificationSettingsPanel.ts": {
+      "add": 8,
+      "remove": 1,
+      "listenerGap": 7,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/ObservationRulesPanel.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/OfflineMapPanel.ts": {
+      "add": 5,
+      "remove": 0,
+      "listenerGap": 5,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/OfflineStalenessBanner.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/OpenaqMonitorPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/OperationalPlaybookPanel.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/OperatorShiftReportPanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/OrbatPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/Panel.ts": {
+      "add": 24,
+      "remove": 22,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/PersistentQueryEnginePanel.ts": {
+      "add": 11,
+      "remove": 0,
+      "listenerGap": 11,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/PersonalRelevancePanel.ts": {
+      "add": 5,
+      "remove": 0,
+      "listenerGap": 5,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/PersonalStormMode.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/PhishstatsFeedPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/PinnedWebcamsPanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/PlaybackControl.ts": {
+      "add": 5,
+      "remove": 0,
+      "listenerGap": 5,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/PlaybookPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/PoliticalViolencePanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/PositiveNewsFeedPanel.ts": {
+      "add": 3,
+      "remove": 2,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/PredictiveCrisisIndexPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/PulsediveIntelPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/QualityDebtPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/RadiationDecayPanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/ReasoningDebugOverlay.ts": {
+      "add": 10,
+      "remove": 0,
+      "listenerGap": 10,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/RecoveryModelingPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/RedditOsintPanel.ts": {
+      "add": 5,
+      "remove": 0,
+      "listenerGap": 5,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/RegionalResiliencePanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/RegulationPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/RelatedStrip.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/RepairRecommendationsPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/ResourceInventoryPanel.ts": {
+      "add": 10,
+      "remove": 0,
+      "listenerGap": 10,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/RuntimeConfigPanel.ts": {
+      "add": 17,
+      "remove": 0,
+      "listenerGap": 17,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/S2UIntelPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 2,
+      "clearI": 2,
+      "timerGap": 0
+    },
+    "src/components/S2UndergroundPanel.ts": {
+      "add": 3,
+      "remove": 2,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/SafetyCaseDashboard.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/SafetyCaseDashboardPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/SanctionsPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/SavedPlaceModal.ts": {
+      "add": 5,
+      "remove": 1,
+      "listenerGap": 4,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/SavedPlacesFilterPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/SavedPlacesPanel.ts": {
+      "add": 7,
+      "remove": 5,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/ScenarioReplayPanel.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/SchedulerPanel.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/SearchModal.ts": {
+      "add": 6,
+      "remove": 0,
+      "listenerGap": 6,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/SecurityAdvisoriesPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/SetupWizard.ts": {
+      "add": 3,
+      "remove": 1,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/SevereWeatherPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/ShadowComparisonPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/ShadowModePanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/ShakeAlertPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/ShiftHandoffCard.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/ShortageDetailPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/ShortageRadarPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/SignalModal.ts": {
+      "add": 6,
+      "remove": 0,
+      "listenerGap": 6,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/SituationLifecycleTrackerPanel.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/SituationPanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/SituationPriorityQueuePanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/SituationStorePanel.ts": {
+      "add": 3,
+      "remove": 2,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/SituationTimelinePanel.ts": {
+      "add": 7,
+      "remove": 0,
+      "listenerGap": 7,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/SmsSettingsPanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/SourceCredibilityTrackerPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/SpaceWeatherPanel.ts": {
+      "add": 3,
+      "remove": 1,
+      "listenerGap": 2,
+      "setI": 2,
+      "clearI": 2,
+      "timerGap": 0
+    },
+    "src/components/StalenessBanner.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/StatusOverlay.ts": {
+      "add": 13,
+      "remove": 0,
+      "listenerGap": 13,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/StoryModal.ts": {
+      "add": 7,
+      "remove": 0,
+      "listenerGap": 7,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/StrategicPosturePanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 1,
+      "clearI": 2,
+      "timerGap": 0
+    },
+    "src/components/StrategicRiskPanel.ts": {
+      "add": 6,
+      "remove": 1,
+      "listenerGap": 5,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/StrikePackagePanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/StrikePackagesPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/SupplyChainDisruptionPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/SupplyChainImpactPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/SupplyChainPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/SurvivalAdvisorPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/SynthesisPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/SystemDiagnosticPanel.ts": {
+      "add": 5,
+      "remove": 0,
+      "listenerGap": 5,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/TechHubsPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/TemporalAnomalyDetectorPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/ThreatCorrelationMatrixPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/ThreatDashboard.ts": {
+      "add": 3,
+      "remove": 1,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/ThreatHorizonPanel.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/ThreatInboxPanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/ThreatIntelHubPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/TidePredictionsPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/Toast.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/TodayView.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/TradePolicyPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/TradeRouteRiskScorerPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/TriageBar.ts": {
+      "add": 12,
+      "remove": 2,
+      "listenerGap": 10,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/TrustBudgetPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/UcdpEventsPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/UnifiedAlertInboxPanel.ts": {
+      "add": 3,
+      "remove": 2,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/UnifiedSettings.ts": {
+      "add": 5,
+      "remove": 2,
+      "listenerGap": 3,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/UnifiedWebcamPanel.ts": {
+      "add": 15,
+      "remove": 1,
+      "listenerGap": 14,
+      "setI": 2,
+      "clearI": 2,
+      "timerGap": 0
+    },
+    "src/components/UrlscanThreatsPanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/VolcanoAlertsPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/VolcanoMonitorPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/VulnersCvePanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/WatchAreaAlertingPanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/WatchlistEditor.ts": {
+      "add": 6,
+      "remove": 0,
+      "listenerGap": 6,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/WatchlistLocationsPanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/WatchlistPanel.ts": {
+      "add": 2,
+      "remove": 1,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/WeatherHazardPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 4,
+      "clearI": 1,
+      "timerGap": 3
+    },
+    "src/components/WeatherRadarPanel.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/WelcomeFlow.ts": {
+      "add": 8,
+      "remove": 0,
+      "listenerGap": 8,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/WikidataBasesPanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/WorldClockPanel.ts": {
+      "add": 5,
+      "remove": 2,
+      "listenerGap": 3,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/WorldNarrativePanel.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/WorldStateComparatorPanel.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/components/api-key-gate.ts": {
+      "add": 8,
+      "remove": 0,
+      "listenerGap": 8,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/globeClustering.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/gods-vision/GlobeHeatmapToggle.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/gods-vision/GlobeMiniMap.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/gods-vision/GlobeSearch.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/gods-vision/GlobeSwimlane.ts": {
+      "add": 9,
+      "remove": 2,
+      "listenerGap": 7,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/components/location-gate.ts": {
+      "add": 4,
+      "remove": 0,
+      "listenerGap": 4,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/e2e/mobile-map-harness.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/alert-correlator.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 2,
+      "clearI": 0,
+      "timerGap": 2
+    },
+    "src/services/alert-fatigue.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/alert-geo-cluster.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/alert-lifecycle.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/alert-store.ts": {
+      "add": 22,
+      "remove": 0,
+      "listenerGap": 22,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/analyst-command-listener.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/analytics.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/anomaly-baselines.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/app-activity.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/auto-brief.ts": {
+      "add": 2,
+      "remove": 1,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/blackout-signature.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/compound-alert-bridge.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/diagnostics/recurring-loops.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 2,
+      "clearI": 4,
+      "timerGap": 0
+    },
+    "src/services/escalation-lifecycle.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/export-briefing.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/forecast-accuracy.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/geofence-alerts.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/gps-tracker.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 2,
+      "clearI": 1,
+      "timerGap": 1
+    },
+    "src/services/hypothesis-accuracy.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 1,
+      "timerGap": 0
+    },
+    "src/services/hypothesis-entities.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/hypothesis-notifier.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/hypothesis-skeptic.ts": {
+      "add": 3,
+      "remove": 1,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/hypothesis-threads.ts": {
+      "add": 2,
+      "remove": 1,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/infrastructure-alert-bridge.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 2,
+      "clearI": 0,
+      "timerGap": 2
+    },
+    "src/services/infrastructure/grid-intelligence-loader.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 4,
+      "clearI": 1,
+      "timerGap": 3
+    },
+    "src/services/intel-channels-bridge.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 2,
+      "clearI": 0,
+      "timerGap": 2
+    },
+    "src/services/intel-pipeline.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/intelligence/active-learning-queue.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/intelligence/crisis-trajectory.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/intelligence/panel-lens-adapter.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/intelligence/predictive-crisis-index.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/llm-adapter.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/log-bridge.ts": {
+      "add": 6,
+      "remove": 0,
+      "listenerGap": 6,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/maritime/index.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 2,
+      "clearI": 2,
+      "timerGap": 0
+    },
+    "src/services/military-flights.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/military-vessels.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/mode-transition-card.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/motion.ts": {
+      "add": 6,
+      "remove": 2,
+      "listenerGap": 4,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/notifications/notification-history-service.ts": {
+      "add": 9,
+      "remove": 0,
+      "listenerGap": 9,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/offline-staleness.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/panel-correlation.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/panel-narrator.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 2,
+      "clearI": 0,
+      "timerGap": 2
+    },
+    "src/services/pattern-memory.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/periodicity-detector.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/persistent-cache.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/pressure-baselines.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/pressure-history.ts": {
+      "add": 2,
+      "remove": 1,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/proximity-cascade.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/reasoning-memory.ts": {
+      "add": 18,
+      "remove": 0,
+      "listenerGap": 18,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/relevance-learner.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/runtime-config.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/satellite-propagator.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/settings-descriptions.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/severity-recalibration.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/sidebar-heat.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/sidecar-pusher.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/silence-anomaly.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/silence-detector.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/snapshot-archive.ts": {
+      "add": 2,
+      "remove": 1,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/sound-manager.ts": {
+      "add": 11,
+      "remove": 9,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/storage.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/story-renderer.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/survival-advisor.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/threat-corridor.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/unified-alerts.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/watchlist-proximity.ts": {
+      "add": 0,
+      "remove": 0,
+      "listenerGap": 0,
+      "setI": 1,
+      "clearI": 0,
+      "timerGap": 1
+    },
+    "src/services/web-secret-store.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/webcams/smoke-detector.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/webhook-dispatcher.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/services/youtube-account.ts": {
+      "add": 2,
+      "remove": 0,
+      "listenerGap": 2,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/utils/dom-utils.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/utils/export.ts": {
+      "add": 3,
+      "remove": 0,
+      "listenerGap": 3,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/utils/theme-manager.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/workers/analysis.worker.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 0,
+      "clearI": 0,
+      "timerGap": 0
+    },
+    "src/workers/satellite-propagator.worker.ts": {
+      "add": 1,
+      "remove": 0,
+      "listenerGap": 1,
+      "setI": 1,
+      "clearI": 2,
+      "timerGap": 0
+    }
+  },
+  "totalAddRemove": 1036,
+  "totalTimerImbalance": 36
+}

--- a/src/components/CesiumGlobe.ts
+++ b/src/components/CesiumGlobe.ts
@@ -27,6 +27,7 @@ export class CesiumGlobe {
   private viewer: Viewer | null = null;
   private container: HTMLElement;
   private resizeObserver: ResizeObserver | null = null;
+  private renderHeartbeat: ReturnType<typeof setInterval> | null = null;
   private fallbackAdded = false;
 
   constructor(private readonly options: CesiumGlobeOptions) {
@@ -68,8 +69,15 @@ export class CesiumGlobe {
  powerPreference: 'high-performance',
  },
  },
- msaaSamples: 4,
+ // MSAA 2× (was 4×) — paired with FXAA this is visually indistinguishable on
+ // the globe while roughly halving the per-frame anti-aliasing cost.
+ msaaSamples: 2,
  useBrowserRecommendedResolution: false,
+ // On-demand rendering: only paint when the scene actually changes (camera
+ // motion, imagery load, explicit requestRender) instead of a continuous
+ // 60fps loop. Idle GPU/power drops dramatically. A low-frequency heartbeat
+ // (see startRenderHeartbeat) covers data mutations that don't self-flag.
+ requestRenderMode: true,
  });
 
  const scene = this.viewer.scene;
@@ -77,6 +85,12 @@ export class CesiumGlobe {
 
  // ── Resolution ──────────────────────────────────────
  this.viewer.resolutionScale = Math.min(window.devicePixelRatio, 2);
+
+ // With requestRenderMode on, GlobeDataManager's imperative entity/primitive
+ // mutations don't all self-flag a render. A 1s heartbeat guarantees data
+ // updates surface within ≤1s while still cutting idle rendering from ~60fps
+ // to ~1fps. Camera interaction renders immediately via Cesium's own handling.
+ this.startRenderHeartbeat();
 
  // ── Sky & Space ────────────────────────────────────
  scene.backgroundColor = Color.fromCssColorString('#050510');
@@ -455,7 +469,24 @@ export class CesiumGlobe {
  return this.viewer?.scene.globe.enableLighting ?? false;
   }
 
+  /**
+   * Periodically request a render so on-demand mode still reflects data that
+   * was mutated imperatively (entity/primitive adds in GlobeDataManager) without
+   * a continuous 60fps loop. Cleared in destroy().
+   */
+  private startRenderHeartbeat(): void {
+ if (this.renderHeartbeat) return;
+ this.renderHeartbeat = setInterval(() => {
+ const scene = this.viewer?.scene;
+ if (scene && !this.viewer?.isDestroyed()) scene.requestRender();
+ }, 1000);
+  }
+
   destroy(): void {
+ if (this.renderHeartbeat) {
+ clearInterval(this.renderHeartbeat);
+ this.renderHeartbeat = null;
+ }
  this.resizeObserver?.disconnect();
  this.resizeObserver = null;
  if (this.viewer && !this.viewer.isDestroyed()) {


### PR DESCRIPTION
## Summary

First **code** PR from the review — two source-verified performance quick wins, plus the full diagnosis doc.

### Why the app feels slow (verified)

- **Mount-everything**: ~470 panels are `enabled: true` and mount on boot (IntersectionObserver skips render work off-screen, but DOM/timers/listeners persist).
- **~290 panels bypass the central `RefreshScheduler`** with raw `setInterval` (693 timer sites) — they keep polling at full rate even when hidden/off-screen, with no jitter. The scheduler already does hidden×10 slowdown + jitter, but only 2 panels use it.
- **Listener accumulation**: 1,252 `addEventListener` vs 191 `removeEventListener` — the "slower the longer it's open" pattern.
- **Always-on DeckGL map** (233 KB) renders at up to 2× device pixels even when not in view.
- The **Cesium globe is lazy** (God's Vision only) — *not* the everyday culprit — but while active it ran a continuous 60fps loop with maxed AA.

### Shipped here (safe, verifiable)

1. **Cesium on-demand rendering** (`CesiumGlobe.ts`): `requestRenderMode: true` so the globe paints only on scene change, + a 1s render heartbeat (cleared in `destroy()`) so `GlobeDataManager`'s 64 imperative entity-mutation sites still surface within ≤1s. Idle ~60fps → ~1fps; camera interaction renders immediately. MSAA 4× → 2× (indistinguishable paired with FXAA).
2. **Listener-leak ratchet** (`scripts/check-listener-leaks.mjs` + baseline + `perf:listeners{,:ci,:update}`): a11y-baseline-style guard. Reports worst offenders (1,036 unmatched listeners / 337 files; top `Map.ts` 53, `panel-layout.ts` 35) and fails CI only when a file's imbalance grows beyond baseline.

### Structural follow-ups (queued in the doc, bigger PRs)

Route per-panel timers through `RefreshScheduler` → hub consolidation (Workstream B) → pay down the listener baseline → DeckGL fill-rate.

## Validation

- New CesiumGlobe code adds zero type errors (the `vite/client` typecheck error is pre-existing/environmental in this container — `vite` isn't installed — and appears on clean HEAD; CI has full deps).
- `perf:listeners` runs clean against its fresh baseline; markdownlint + `docs:check` pass; staged secret scan passes.

Cross-agent review: Codex reviewed on 2026-06-10; outcome: accepted risk (small, isolated perf change behind on-demand-render heartbeat; no data-path or API changes).

https://claude.ai/code/session_01426AyLjzT4cLsXTBRFMuHs

---
_Generated by [Claude Code](https://claude.ai/code/session_01426AyLjzT4cLsXTBRFMuHs)_