### PR TITLE
fix(cognition): test isolation, dedupe assertion, self-consistency call counts

### DIFF
--- a/src/services/cognition/entity-dossier.ts
+++ b/src/services/cognition/entity-dossier.ts
@@ -206,7 +206,11 @@ export function configure(opts: EntityDossierOptions): void {
   _putMemoryOverride = opts.putMemoryFn ?? null;
   _nowFn = opts.now ?? Date.now;
   dossiers.clear();
-  loaded = false;
+  // Mark as already loaded so subsequent reads do NOT reload from the injected
+  // storage (which may still contain data from a prior test run). Tests that
+  // want to pre-seed the store should do so via ingestFromHypotheses() after
+  // calling configure(), not by relying on the storage auto-load path.
+  loaded = true;
   writtenSinceLoad = false;
 }
 


### PR DESCRIPTION
## fix(cognition): entity-dossier `configure()` marks store loaded to stop stale reload

`configure()` cleared the in-memory dossier map but left `loaded = false`, so the next `getDossierCount()`/read re-ran `load()` and rehydrated stale data from the injected storage (and scheduled an async IDB `.then()` that could clobber the map on a later microtask). Setting `loaded = true` after the clear makes a freshly configured store start empty; callers that want seed data use `ingestFromHypotheses()` rather than the storage auto-load path.

`configure()` has **no production caller** — `src/services/analyst-loop.ts` imports `ingestFromHypotheses` only — so this is test-isolation-only with no runtime behavior change.

### Scope note
This PR was isolated from the long `claude/cognition-test-fixes` stack (source commit 05f79852). The other two fixes in that commit are intentionally **not** included here:
- `self-consistency.test.mts` fix — already landed via #1087 (PR 15), with a more robust unconditional-localStorage stub.
- `memory-hygiene.test.mts` summary-drift assertion — belongs to the unmerged PR 14 and rides with it (the file does not exist on `main`).

So the net change against `main` is the single `entity-dossier.ts` `configure()` guard.

### Verification (Node v25.7.0)
- `tsc --noEmit -p tsconfig.json` → 0 errors
- `test:cognition` → 463/463 pass (incl. `entity-dossier.test.mts` 28/28)

---

Cross-agent review: coderabbit — independent CodeRabbit code-reviewer agent reviewed the full `origin/main..HEAD` diff (single file). Verdict: **no findings at any severity**. Confirmed the `load()` early-return guard makes `loaded = true` + `dossiers.clear()` correctly suppress the sync localStorage rehydrate AND the async IDB `.then()` clobber; confirmed `configure()` is genuinely test-only (`analyst-loop.ts` uses `ingestFromHypotheses` exclusively), so no production initial-load is suppressed; confirmed `loaded`/`writtenSinceLoad`/IDB-`.then()` state stays consistent and `resetEntityDossiers()` → reconfigure still works.

Disclosure: this was a CodeRabbit independent-agent review, not a Codex review. CodeRabbit is an accepted independent cross-agent reviewer for this repo.
