### PR TITLE
Fix ESLint violations in GDELT panel files

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -5754,12 +5754,12 @@ async function dispatch(requestUrl, req, routes, context) {
     try {
       const data = await cachedFetch('gdelt-summary-v1', 15 * 60 * 1000, fetchGdeltSummary);
       return json(data, 200, makeCorsHeaders(req));
-    } catch (err) {
+    } catch (error) {
       // Throttled and no fresh cache — serve last-good if we have one.
       if (_gdeltLastGood) {
         return json({ ..._gdeltLastGood, stale: true }, 200, makeCorsHeaders(req));
       }
-      return json({ error: `GDELT unavailable: ${String(err)}` }, 502, makeCorsHeaders(req));
+      return json({ error: `GDELT unavailable: ${String(error)}` }, 502, makeCorsHeaders(req));
     }
   }
 

--- a/src/components/GdeltPanel.ts
+++ b/src/components/GdeltPanel.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-async-constructor */
 import { Panel } from './Panel';
 import { h, replaceChildren } from '@/utils/dom-utils';
 import { getApiBaseUrl } from '@/services/runtime';
@@ -17,15 +18,15 @@ function relativeTime(iso: string): string {
   if (!iso) return '';
   const then = new Date(iso).getTime();
   if (!Number.isFinite(then)) return '';
-  const mins = Math.max(0, Math.round((Date.now() - then) / 60000));
+  const mins = Math.max(0, Math.round((Date.now() - then) / 60_000));
   if (mins < 1) return 'just now';
   if (mins < 60) return `${mins} min ago`;
   const hrs = Math.round(mins / 60);
   return `${hrs}h ago`;
 }
 
-function maxCount(rows: Array<{ count: number }>): number {
-  return rows.reduce((m, r) => (r.count > m ? r.count : m), 0);
+function maxCount(rows: { count: number }[]): number {
+  return rows.reduce((m, r) => (Math.max(r.count, m)), 0);
 }
 
 export class GdeltPanel extends Panel {

--- a/src/components/gdelt-helpers.ts
+++ b/src/components/gdelt-helpers.ts
@@ -8,10 +8,10 @@
 
 export interface GdeltSummary {
   tone: number;
-  topThemes: Array<{ theme: string; count: number }>;
-  topLocations: Array<{ name: string; count: number }>;
-  topPeople: Array<{ name: string; count: number }>;
-  topOrgs: Array<{ name: string; count: number }>;
+  topThemes: { theme: string; count: number }[];
+  topLocations: { name: string; count: number }[];
+  topPeople: { name: string; count: number }[];
+  topOrgs: { name: string; count: number }[];
   fetchedAt: string;
 }
 
@@ -23,10 +23,14 @@ const EMPTY = '░';
 /** Human-readable tone band. */
 export function parseToneDescription(tone: number): string {
   switch (getToneClass(tone)) {
-    case 'crisis': return 'Extremely Negative';
-    case 'negative': return 'Negative';
-    case 'positive': return 'Positive';
-    default: return 'Neutral';
+    case 'crisis': { return 'Extremely Negative';
+    }
+    case 'negative': { return 'Negative';
+    }
+    case 'positive': { return 'Positive';
+    }
+    default: { return 'Neutral';
+    }
   }
 }
 
@@ -77,7 +81,7 @@ export function formatThemeName(gdeltTheme: string): string {
 
   // If stripping consumed everything, fall back to the raw tokens.
   const meaningful = start < tokens.length ? tokens.slice(start) : tokens;
-  return meaningful.map(titleCaseToken).join(' ');
+  return meaningful.map(t => titleCaseToken(t)).join(' ');
 }
 
 function normalizeCountRows<T extends { count: number }>(
@@ -100,7 +104,7 @@ function normalizeCountRows<T extends { count: number }>(
 //
 // THEME_SIGNALS is mirrored verbatim in the sidecar route
 // (src-tauri/sidecar/local-api-server.mjs, fetchGdeltSummary). Keep in sync.
-export const THEME_SIGNALS: Array<[label: string, pattern: RegExp]> = [
+export const THEME_SIGNALS: [label: string, pattern: RegExp][] = [
   ['Conflict & Violence', /\b(war|wars|attack|attacks|strike|strikes|clash|clashes|fighting|killed|kills|troops|missile|missiles|shelling|combat|offensive)\b/i],
   ['Protest & Unrest', /\b(protest|protests|riot|riots|unrest|rally|uprising|demonstration|demonstrations)\b/i],
   ['Military & Defense', /\b(military|army|navy|defense|defence|nato|weapon|weapons|drone|drones|warship|warships|deploy|deployment)\b/i],
@@ -132,7 +136,7 @@ function latestFiniteTone(toneJson: unknown): number {
   return tone;
 }
 
-function countLocations(articles: unknown[]): Array<{ name: string; count: number }> {
+function countLocations(articles: unknown[]): { name: string; count: number }[] {
   const counts = new Map<string, number>();
   for (const a of articles) {
     if (!a || typeof a !== 'object') continue;
@@ -147,7 +151,7 @@ function countLocations(articles: unknown[]): Array<{ name: string; count: numbe
     .slice(0, MAX_LOCATIONS);
 }
 
-function tallyThemes(articles: unknown[]): Array<{ theme: string; count: number }> {
+function tallyThemes(articles: unknown[]): { theme: string; count: number }[] {
   const counts = new Map<string, number>();
   for (const a of articles) {
     if (!a || typeof a !== 'object') continue;


### PR DESCRIPTION
The GDELT 2.0 panel (#1094) auto-merged before its ESLint fixes landed — ESLint is not a required merge check, so the pre-lint commit reached main. This follow-up brings the lint-clean versions of the three files to main.

Fixes applied:
- `@typescript-eslint/array-type` — `T[]` over `Array<T>`
- `unicorn/switch-case-braces`
- `unicorn/no-array-callback-reference`
- `unicorn/numeric-separators-style`
- `unicorn/prefer-math-min-max`
- `sonarjs/no-async-constructor` (file-level disable, mirrors GdeltIntelPanel)
- `unicorn/catch-error-name` (`error` not `err`)

Verification: ESLint clean, `npm run typecheck:all` zero errors, 64/64 helper tests pass.

Cross-agent review: claude reviewed on 2026-06-10; outcome: pass