### PR TITLE
Enhance OpenSanctions panel with coverage stats + freshness

### DIFF
--- a/src/app/loaders/utility.ts
+++ b/src/app/loaders/utility.ts
@@ -8,7 +8,7 @@
 import type { AppContext } from '@/app/app-context';
 import { fetchSavedPlaceWeather, getSavedPlaces } from '@/services';
 import { fetchGlobalWeather } from '@/services/global-weather';
-import { fetchRecentSanctions } from '@/services/opensanctions';
+import { fetchSanctionsCoverage } from '@/services/opensanctions';
 import { fetchRecentEdgarFilings } from '@/services/sec-edgar';
 import { fetchCommsHealth } from '@/services/comms-health';
 import { fetchGridStatus } from '@/services/power-grid';
@@ -76,8 +76,8 @@ export async function loadGlobalWeather(ctx: AppContext): Promise<void> {
 
 export async function loadOpenSanctions(ctx: AppContext): Promise<void> {
   try {
- const entities = await fetchRecentSanctions();
- (ctx.panels.opensanctions as OpenSanctionsPanel | undefined)?.update(entities);
+ const datasets = await fetchSanctionsCoverage();
+ (ctx.panels.opensanctions as OpenSanctionsPanel | undefined)?.update(datasets);
   } catch (error) {
  // eslint-disable-next-line no-console
  console.warn('[opensanctions] fetch failed', error);

--- a/src/components/OpenSanctionsPanel.ts
+++ b/src/components/OpenSanctionsPanel.ts
@@ -1,62 +1,107 @@
 import { Panel } from './Panel';
-import type { SanctionedEntity } from '@/services/opensanctions';
+import {
+  type SanctionsDataset,
+  type SanctionsStats,
+  aggregateStats,
+  formatDatasetName,
+  getFreshnessLabel,
+  getFreshnessStatus,
+  mostStaleDataset,
+} from './open-sanctions-helpers';
 import { escapeHtml } from '@/utils/sanitize';
 
+const FRESHNESS_ICON = { fresh: '✓', aging: '◷', stale: '⚠' } as const;
+const FRESHNESS_COLOR = { fresh: '#4ade80', aging: '#fbbf24', stale: '#f87171' } as const;
+
 export class OpenSanctionsPanel extends Panel {
-  private entities: SanctionedEntity[] = [];
+  private stats: SanctionsStats | null = null;
 
   constructor() {
- super({
- id: 'opensanctions',
- title: 'Global Sanctions',
- showCount: true,
- trackActivity: true,
- infoTooltip: 'Recently sanctioned entities from OpenSanctions — individuals, companies, and organizations on global watchlists.',
- });
- this.showLoading('Fetching sanctions data...');
+    super({
+      id: 'opensanctions',
+      title: 'Global Sanctions & PEP Intelligence',
+      showCount: true,
+      trackActivity: true,
+      infoTooltip:
+        'Consolidated global sanctions & PEP coverage from OpenSanctions — 150+ watchlists (OFAC, EU, UK OFSI, UN, BIS) with per-dataset freshness.',
+    });
+    this.showLoading('Fetching sanctions coverage...');
   }
 
-  public update(entities: SanctionedEntity[]): void {
- this.entities = entities;
- this.setCount(entities.length);
- this.render();
+  public update(datasets: SanctionsDataset[]): void {
+    this.stats = datasets.length > 0 ? aggregateStats(datasets) : null;
+    this.setCount(this.stats?.totalDatasets ?? 0);
+    this.render();
   }
 
   private render(): void {
- if (this.entities.length === 0) {
- this.setContent('<div class="panel-empty">No sanctions data available.</div>');
- return;
- }
+    const stats = this.stats;
+    if (!stats || stats.totalDatasets === 0) {
+      this.setContent('<div class="panel-empty">No sanctions coverage data available.</div>');
+      return;
+    }
 
- const rows = this.entities.slice(0, 15).map(e => {
- const country = e.countries.length > 0 ? e.countries[0]!.toUpperCase() : '—';
- const dataset = e.datasets.length > 0 ? e.datasets[0]! : '—';
- const date = e.firstSeen ? new Date(e.firstSeen).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: '2-digit' }) : '—';
- return `<tr>
- <td>${escapeHtml(e.name.length > 40 ? e.name.slice(0, 40) + '…' : e.name)}</td>
- <td>${escapeHtml(country)}</td>
- <td style="opacity:0.7;font-size:0.85em">${escapeHtml(dataset.length > 20 ? dataset.slice(0, 20) + '…' : dataset)}</td>
- <td style="opacity:0.6;white-space:nowrap">${date}</td>
- </tr>`;
- }).join('');
+    const num = (n: number): string => n.toLocaleString('en-US');
 
- this.setContent(`
- <div class="ct-panel-content">
- <table class="eq-table ct-table">
- <thead>
- <tr>
- <th>Name</th>
- <th>Country</th>
- <th>List</th>
- <th>Date</th>
- </tr>
- </thead>
- <tbody>${rows}</tbody>
- </table>
- <div class="fires-footer">
- <span class="fires-source">OpenSanctions</span>
- </div>
- </div>
- `);
+    const coverage = [
+      ['Datasets', `${num(stats.totalDatasets)} sources`],
+      ['Entities', `${num(stats.totalEntities)} sanctioned individuals & orgs`],
+      ...(stats.vessels > 0 ? [['Vessels', `${num(stats.vessels)} flagged ships`]] : []),
+      ...(stats.aircraft > 0 ? [['Aircraft', `${num(stats.aircraft)} flagged aircraft`]] : []),
+    ]
+      .map(
+        ([label, value]) =>
+          `<div class="os-stat" style="display:flex;justify-content:space-between;gap:8px;padding:2px 0"><span class="os-stat-label" style="opacity:0.6">${escapeHtml(label!)}</span><span class="os-stat-value">${escapeHtml(value!)}</span></div>`,
+      )
+      .join('');
+
+    const topDatasets = [...stats.datasets]
+      .sort((a, b) => (b.entityCount || 0) - (a.entityCount || 0))
+      .slice(0, 8);
+
+    const rows = topDatasets
+      .map((d) => {
+        const status = getFreshnessStatus(d.lastUpdated);
+        const icon = FRESHNESS_ICON[status];
+        const name = formatDatasetName(d.name) || d.title;
+        return `<tr>
+          <td class="os-fresh os-fresh-${status}" style="color:${FRESHNESS_COLOR[status]}">${icon}</td>
+          <td>${escapeHtml(name)}</td>
+          <td style="opacity:0.6;white-space:nowrap">${escapeHtml(getFreshnessLabel(d.lastUpdated))}</td>
+          <td style="text-align:right;opacity:0.7">${num(d.entityCount || 0)}</td>
+        </tr>`;
+      })
+      .join('');
+
+    const stale = mostStaleDataset(stats.datasets);
+    const agingOrStale = stats.datasets.filter((d) => getFreshnessStatus(d.lastUpdated) !== 'fresh');
+    const freshnessLine =
+      agingOrStale.length === 0
+        ? '<span style="color:#4ade80">✓</span> All datasets fresh (&lt;7 days)'
+        : `${agingOrStale.length} of ${stats.totalDatasets} datasets aging or stale`;
+    const staleLine = stale
+      ? `Most stale: ${escapeHtml(formatDatasetName(stale.name) || stale.title)} (${escapeHtml(getFreshnessLabel(stale.lastUpdated))})`
+      : '';
+
+    this.setContent(`
+      <div class="ct-panel-content os-panel">
+        <div class="os-section-title" style="font-size:0.7rem;letter-spacing:0.05em;opacity:0.5;text-transform:uppercase;margin:4px 0">Consolidated Watchlist Coverage</div>
+        <div class="os-coverage">${coverage}</div>
+
+        <div class="os-section-title" style="font-size:0.7rem;letter-spacing:0.05em;opacity:0.5;text-transform:uppercase;margin:8px 0 4px">Dataset Status</div>
+        <table class="eq-table ct-table os-dataset-table">
+          <tbody>${rows}</tbody>
+        </table>
+
+        <div class="os-freshness" style="margin-top:8px;font-size:0.8rem">
+          <div>${freshnessLine}</div>
+          ${staleLine ? `<div style="opacity:0.7">${staleLine}</div>` : ''}
+        </div>
+
+        <div class="fires-footer">
+          <span class="fires-source">OpenSanctions · CC-BY 4.0</span>
+        </div>
+      </div>
+    `);
   }
 }

--- a/src/components/__tests__/open-sanctions-helpers.test.mts
+++ b/src/components/__tests__/open-sanctions-helpers.test.mts
@@ -1,0 +1,284 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  type SanctionedEntity,
+  type SanctionsDataset,
+  aggregateStats,
+  countBySchema,
+  formatDatasetName,
+  getFreshnessLabel,
+  getFreshnessStatus,
+  getTopicBadge,
+  mostStaleDataset,
+} from '../open-sanctions-helpers.ts';
+
+const NOW = Date.parse('2026-06-10T12:00:00Z');
+const daysAgo = (n: number): string => new Date(NOW - n * 86_400_000).toISOString();
+
+function dataset(partial: Partial<SanctionsDataset> = {}): SanctionsDataset {
+  return {
+    name: 'us_ofac_sdn',
+    title: 'OFAC SDN List',
+    entityCount: 100,
+    lastUpdated: daysAgo(1),
+    countries: ['us'],
+    ...partial,
+  };
+}
+
+function entity(partial: Partial<SanctionedEntity> = {}): SanctionedEntity {
+  return {
+    id: 'NK-abc',
+    caption: 'John Smith',
+    schema: 'Person',
+    datasets: ['us_ofac_sdn'],
+    topics: ['sanction'],
+    countries: ['ru'],
+    aliases: [],
+    ...partial,
+  };
+}
+
+// ── getFreshnessStatus ──────────────────────────────────────────────────────
+
+test('getFreshnessStatus: today is fresh', () => {
+  assert.equal(getFreshnessStatus(daysAgo(0), NOW), 'fresh');
+});
+
+test('getFreshnessStatus: 3 days ago is fresh', () => {
+  assert.equal(getFreshnessStatus(daysAgo(3), NOW), 'fresh');
+});
+
+test('getFreshnessStatus: 6 days ago is still fresh', () => {
+  assert.equal(getFreshnessStatus(daysAgo(6), NOW), 'fresh');
+});
+
+test('getFreshnessStatus: 7 days ago crosses into aging', () => {
+  assert.equal(getFreshnessStatus(daysAgo(7), NOW), 'aging');
+});
+
+test('getFreshnessStatus: 13 days ago is aging', () => {
+  assert.equal(getFreshnessStatus(daysAgo(13), NOW), 'aging');
+});
+
+test('getFreshnessStatus: 14 days ago is stale', () => {
+  assert.equal(getFreshnessStatus(daysAgo(14), NOW), 'stale');
+});
+
+test('getFreshnessStatus: 30 days ago is stale', () => {
+  assert.equal(getFreshnessStatus(daysAgo(30), NOW), 'stale');
+});
+
+test('getFreshnessStatus: future timestamp (clock skew) is treated as fresh', () => {
+  assert.equal(getFreshnessStatus(daysAgo(-2), NOW), 'fresh');
+});
+
+test('getFreshnessStatus: unparseable date fails safe to stale', () => {
+  assert.equal(getFreshnessStatus('not-a-date', NOW), 'stale');
+  assert.equal(getFreshnessStatus('', NOW), 'stale');
+});
+
+// ── getFreshnessLabel ───────────────────────────────────────────────────────
+
+test('getFreshnessLabel: under a day reads "today"', () => {
+  assert.equal(getFreshnessLabel(daysAgo(0), NOW), 'today');
+});
+
+test('getFreshnessLabel: a few hours ago reads "today"', () => {
+  assert.equal(getFreshnessLabel(new Date(NOW - 5 * 3_600_000).toISOString(), NOW), 'today');
+});
+
+test('getFreshnessLabel: exactly one day uses singular', () => {
+  assert.equal(getFreshnessLabel(daysAgo(1), NOW), '1 day ago');
+});
+
+test('getFreshnessLabel: multiple days uses plural', () => {
+  assert.equal(getFreshnessLabel(daysAgo(2), NOW), '2 days ago');
+  assert.equal(getFreshnessLabel(daysAgo(12), NOW), '12 days ago');
+});
+
+test('getFreshnessLabel: future timestamp reads "just now"', () => {
+  assert.equal(getFreshnessLabel(daysAgo(-1), NOW), 'just now');
+});
+
+test('getFreshnessLabel: unparseable date reads "unknown"', () => {
+  assert.equal(getFreshnessLabel('garbage', NOW), 'unknown');
+});
+
+// ── formatDatasetName ───────────────────────────────────────────────────────
+
+test('formatDatasetName: known OpenSanctions IDs map to human names', () => {
+  assert.equal(formatDatasetName('us_ofac_sdn'), 'OFAC SDN');
+  assert.equal(formatDatasetName('eu_fsf'), 'EU Sanctions');
+  assert.equal(formatDatasetName('gb_hmt_sanctions'), 'UK OFSI');
+  assert.equal(formatDatasetName('un_sc_sanctions'), 'UN Security Council');
+  assert.equal(formatDatasetName('us_bis_denied'), 'BIS Entity List');
+  assert.equal(formatDatasetName('interpol_red'), 'INTERPOL Red Notices');
+});
+
+test('formatDatasetName: known mapping is case-insensitive on input', () => {
+  assert.equal(formatDatasetName('US_OFAC_SDN'), 'OFAC SDN');
+});
+
+test('formatDatasetName: unknown IDs are de-slugged and title-cased', () => {
+  assert.equal(formatDatasetName('ru_egrul'), 'RU Egrul');
+  assert.equal(formatDatasetName('my_custom_list'), 'MY Custom List');
+});
+
+test('formatDatasetName: short tokens are upper-cased as acronyms', () => {
+  assert.equal(formatDatasetName('za_fic'), 'ZA FIC');
+});
+
+test('formatDatasetName: hyphen and whitespace separators are handled', () => {
+  assert.equal(formatDatasetName('some-list name'), 'Some List Name');
+});
+
+test('formatDatasetName: empty string returns empty string', () => {
+  assert.equal(formatDatasetName(''), '');
+});
+
+// ── getTopicBadge ───────────────────────────────────────────────────────────
+
+test('getTopicBadge: known topics get short labels', () => {
+  assert.equal(getTopicBadge('sanction'), 'Sanctioned');
+  assert.equal(getTopicBadge('pep'), 'PEP');
+  assert.equal(getTopicBadge('crime'), 'Crime');
+  assert.equal(getTopicBadge('wanted'), 'Wanted');
+  assert.equal(getTopicBadge('debarment'), 'Debarred');
+});
+
+test('getTopicBadge: dotted OpenSanctions topic prefixes resolve to base label', () => {
+  assert.equal(getTopicBadge('role.pep'), 'PEP');
+  assert.equal(getTopicBadge('sanction.linked'), 'Sanctioned');
+});
+
+test('getTopicBadge: badge lookup is case-insensitive', () => {
+  assert.equal(getTopicBadge('PEP'), 'PEP');
+});
+
+test('getTopicBadge: unknown topic is title-cased as fallback', () => {
+  assert.equal(getTopicBadge('export.control'), 'Export Control');
+  assert.equal(getTopicBadge('poi'), 'Poi');
+});
+
+test('getTopicBadge: empty topic returns empty string', () => {
+  assert.equal(getTopicBadge(''), '');
+});
+
+// ── countBySchema ───────────────────────────────────────────────────────────
+
+test('countBySchema: empty list yields empty map', () => {
+  assert.deepEqual(countBySchema([]), {});
+});
+
+test('countBySchema: tallies entities by schema', () => {
+  const result = countBySchema([
+    entity({ schema: 'Person' }),
+    entity({ schema: 'Person' }),
+    entity({ schema: 'Organization' }),
+    entity({ schema: 'Vessel' }),
+  ]);
+  assert.equal(result.Person, 2);
+  assert.equal(result.Organization, 1);
+  assert.equal(result.Vessel, 1);
+});
+
+test('countBySchema: missing/blank schema buckets under "Unknown"', () => {
+  const result = countBySchema([entity({ schema: '' }), entity({ schema: undefined as unknown as string })]);
+  assert.equal(result.Unknown, 2);
+});
+
+test('countBySchema: counts aircraft distinctly', () => {
+  const result = countBySchema([entity({ schema: 'Aircraft' }), entity({ schema: 'Aircraft' })]);
+  assert.equal(result.Aircraft, 2);
+  assert.equal(result.Person, undefined);
+});
+
+// ── aggregateStats ──────────────────────────────────────────────────────────
+
+test('aggregateStats: sums entity counts and counts datasets', () => {
+  const stats = aggregateStats(
+    [dataset({ entityCount: 100 }), dataset({ name: 'eu_fsf', entityCount: 250 })],
+    [],
+    NOW,
+  );
+  assert.equal(stats.totalDatasets, 2);
+  assert.equal(stats.totalEntities, 350);
+});
+
+test('aggregateStats: derives schema breakdown from entities', () => {
+  const stats = aggregateStats(
+    [dataset()],
+    [
+      entity({ schema: 'Person' }),
+      entity({ schema: 'Organization' }),
+      entity({ schema: 'Vessel' }),
+      entity({ schema: 'Vessel' }),
+      entity({ schema: 'Aircraft' }),
+    ],
+    NOW,
+  );
+  assert.equal(stats.persons, 1);
+  assert.equal(stats.organizations, 1);
+  assert.equal(stats.vessels, 2);
+  assert.equal(stats.aircraft, 1);
+});
+
+test('aggregateStats: missing entityCount is treated as zero', () => {
+  const stats = aggregateStats(
+    [dataset({ entityCount: undefined as unknown as number }), dataset({ entityCount: 40 })],
+    [],
+    NOW,
+  );
+  assert.equal(stats.totalEntities, 40);
+});
+
+test('aggregateStats: stamps fetchedAt from the provided clock', () => {
+  const stats = aggregateStats([dataset()], [], NOW);
+  assert.equal(stats.fetchedAt, new Date(NOW).toISOString());
+});
+
+test('aggregateStats: empty dataset list yields all-zero stats', () => {
+  const stats = aggregateStats([], [], NOW);
+  assert.equal(stats.totalDatasets, 0);
+  assert.equal(stats.totalEntities, 0);
+  assert.equal(stats.persons, 0);
+  assert.equal(stats.organizations, 0);
+  assert.equal(stats.vessels, 0);
+  assert.equal(stats.aircraft, 0);
+  assert.deepEqual(stats.datasets, []);
+});
+
+test('aggregateStats: omitting entities yields zero schema counts but keeps dataset totals', () => {
+  const stats = aggregateStats([dataset({ entityCount: 10 })], undefined, NOW);
+  assert.equal(stats.totalEntities, 10);
+  assert.equal(stats.persons, 0);
+  assert.equal(stats.vessels, 0);
+});
+
+test('aggregateStats: passes the datasets through verbatim', () => {
+  const ds = dataset({ name: 'un_sc_sanctions' });
+  const stats = aggregateStats([ds], [], NOW);
+  assert.equal(stats.datasets.length, 1);
+  assert.equal(stats.datasets[0]!.name, 'un_sc_sanctions');
+});
+
+// ── mostStaleDataset ────────────────────────────────────────────────────────
+
+test('mostStaleDataset: returns the oldest dataset by lastUpdated', () => {
+  const fresh = dataset({ name: 'us_ofac_sdn', lastUpdated: daysAgo(2) });
+  const stale = dataset({ name: 'interpol_red', lastUpdated: daysAgo(12) });
+  const mid = dataset({ name: 'eu_fsf', lastUpdated: daysAgo(5) });
+  assert.equal(mostStaleDataset([fresh, stale, mid])!.name, 'interpol_red');
+});
+
+test('mostStaleDataset: empty list returns null', () => {
+  assert.equal(mostStaleDataset([]), null);
+});
+
+test('mostStaleDataset: datasets with unparseable dates sort as most stale', () => {
+  const ok = dataset({ name: 'us_ofac_sdn', lastUpdated: daysAgo(2) });
+  const broken = dataset({ name: 'broken', lastUpdated: 'n/a' });
+  assert.equal(mostStaleDataset([ok, broken])!.name, 'broken');
+});

--- a/src/components/open-sanctions-helpers.ts
+++ b/src/components/open-sanctions-helpers.ts
@@ -1,0 +1,183 @@
+/**
+ * Pure helpers for OpenSanctionsPanel.
+ * No DOM, no fetch — safe to import in Node.js tests.
+ *
+ * Backs the consolidated-watchlist coverage view: dataset freshness,
+ * topic badges, per-schema tallies, and aggregate coverage stats over
+ * the free OpenSanctions /catalog feed.
+ */
+
+export interface SanctionsDataset {
+  name: string;
+  title: string;
+  entityCount: number;
+  lastUpdated: string;
+  countries: string[];
+}
+
+export interface SanctionedEntity {
+  id: string;
+  caption: string; // display name
+  schema: string; // 'Person' | 'Organization' | 'Vessel' | 'Aircraft'
+  datasets: string[]; // which sanctions lists this entity is on
+  topics: string[]; // 'sanction' | 'pep' | 'crime' etc
+  countries: string[];
+  aliases: string[];
+}
+
+export interface SanctionsStats {
+  totalEntities: number;
+  totalDatasets: number;
+  vessels: number;
+  aircraft: number;
+  persons: number;
+  organizations: number;
+  datasets: SanctionsDataset[];
+  fetchedAt: string;
+}
+
+export type FreshnessStatus = 'fresh' | 'aging' | 'stale';
+
+const DAY_MS = 86_400_000;
+const FRESH_DAYS = 7; // < 7 days → fresh
+const AGING_DAYS = 14; // 7–13 days → aging, ≥ 14 → stale
+
+/** Whole days between `lastUpdated` and `now`. NaN when unparseable. */
+function ageInDays(lastUpdated: string, now: number): number {
+  const ts = Date.parse(lastUpdated);
+  if (Number.isNaN(ts)) return Number.NaN;
+  return Math.floor((now - ts) / DAY_MS);
+}
+
+/**
+ * Freshness verdict for a dataset's last export.
+ * Fails safe to 'stale' when the date can't be parsed — a watchlist we
+ * can't confirm is current must not be presented as fresh.
+ */
+export function getFreshnessStatus(lastUpdated: string, now: number = Date.now()): FreshnessStatus {
+  const days = ageInDays(lastUpdated, now);
+  if (Number.isNaN(days)) return 'stale';
+  if (days < 0) return 'fresh'; // future export timestamp (clock skew)
+  if (days < FRESH_DAYS) return 'fresh';
+  if (days < AGING_DAYS) return 'aging';
+  return 'stale';
+}
+
+/** Human-readable relative age, e.g. "today", "1 day ago", "12 days ago". */
+export function getFreshnessLabel(lastUpdated: string, now: number = Date.now()): string {
+  const days = ageInDays(lastUpdated, now);
+  if (Number.isNaN(days)) return 'unknown';
+  if (days < 0) return 'just now';
+  if (days === 0) return 'today';
+  if (days === 1) return '1 day ago';
+  return `${days} days ago`;
+}
+
+const KNOWN_DATASET_NAMES: Record<string, string> = {
+  us_ofac_sdn: 'OFAC SDN',
+  eu_fsf: 'EU Sanctions',
+  gb_hmt_sanctions: 'UK OFSI',
+  un_sc_sanctions: 'UN Security Council',
+  us_bis_denied: 'BIS Entity List',
+  interpol_red: 'INTERPOL Red Notices',
+};
+
+const ACRONYMS = new Set([
+  'us', 'eu', 'un', 'uk', 'gb', 'ru', 'za', 'ofac', 'sdn', 'bis', 'sc',
+  'hmt', 'ofsi', 'fsf', 'pep', 'fic', 'csl', 'nsl',
+]);
+
+function titleCaseToken(token: string): string {
+  const lower = token.toLowerCase();
+  if (ACRONYMS.has(lower) || token.length <= 3) return token.toUpperCase();
+  return token.charAt(0).toUpperCase() + lower.slice(1);
+}
+
+/** Turn an OpenSanctions dataset ID (e.g. "us_ofac_sdn") into a display name. */
+export function formatDatasetName(name: string): string {
+  if (!name) return '';
+  const known = KNOWN_DATASET_NAMES[name.toLowerCase()];
+  if (known) return known;
+  return name
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map(titleCaseToken)
+    .join(' ');
+}
+
+const TOPIC_BADGES: Record<string, string> = {
+  sanction: 'Sanctioned',
+  pep: 'PEP',
+  crime: 'Crime',
+  wanted: 'Wanted',
+  debarment: 'Debarred',
+};
+
+/** Short, human display label for an OpenSanctions topic tag. */
+export function getTopicBadge(topic: string): string {
+  if (!topic) return '';
+  for (const segment of topic.toLowerCase().split('.')) {
+    const known = TOPIC_BADGES[segment];
+    if (known) return known;
+  }
+  return topic
+    .split(/[._\s-]+/)
+    .filter(Boolean)
+    .map((t) => t.charAt(0).toUpperCase() + t.slice(1).toLowerCase())
+    .join(' ');
+}
+
+/** Tally entities by their schema (Person / Organization / Vessel / Aircraft / …). */
+export function countBySchema(entities: SanctionedEntity[]): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const e of entities) {
+    const key = e.schema && e.schema.trim() ? e.schema : 'Unknown';
+    out[key] = (out[key] ?? 0) + 1;
+  }
+  return out;
+}
+
+/**
+ * Aggregate coverage stats over the catalog datasets, optionally enriched with
+ * a sample of entities for the per-schema breakdown (vessels / aircraft / …).
+ * The free /catalog feed has no schema histogram, so those counts are 0 unless
+ * entities are supplied.
+ */
+export function aggregateStats(
+  datasets: SanctionsDataset[],
+  entities: SanctionedEntity[] = [],
+  now: number = Date.now(),
+): SanctionsStats {
+  const totalEntities = datasets.reduce((sum, d) => sum + (Number(d.entityCount) || 0), 0);
+  const bySchema = countBySchema(entities);
+  return {
+    totalEntities,
+    totalDatasets: datasets.length,
+    persons: bySchema.Person ?? 0,
+    organizations: bySchema.Organization ?? 0,
+    vessels: bySchema.Vessel ?? 0,
+    aircraft: bySchema.Aircraft ?? 0,
+    datasets,
+    fetchedAt: new Date(now).toISOString(),
+  };
+}
+
+/**
+ * The least-recently-updated dataset, for the "Most stale" headline.
+ * Unparseable dates sort as maximally stale so they surface, not hide.
+ */
+export function mostStaleDataset(datasets: SanctionsDataset[]): SanctionsDataset | null {
+  if (datasets.length === 0) return null;
+  let worst = datasets[0]!;
+  let worstTs = Date.parse(worst.lastUpdated);
+  if (Number.isNaN(worstTs)) worstTs = -Infinity;
+  for (const d of datasets.slice(1)) {
+    let ts = Date.parse(d.lastUpdated);
+    if (Number.isNaN(ts)) ts = -Infinity;
+    if (ts < worstTs) {
+      worst = d;
+      worstTs = ts;
+    }
+  }
+  return worst;
+}

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -148,7 +148,7 @@ const FULL_PANELS: Record<string, PanelConfig> = {
   'faa-tfrs': { name: 'FAA TFRs', enabled: true, priority: 2 },
   'air-traffic': { name: 'Air Traffic', enabled: true, priority: 2 },
   'global-weather': { name: 'Global Weather', enabled: true, priority: 1 },
-  'opensanctions': { name: 'Global Sanctions', enabled: true, priority: 2 },
+  'opensanctions': { name: 'Global Sanctions & PEP Intelligence', enabled: true, priority: 2 },
   'sanctions-intel': { name: 'OFAC Sanctions Intel', enabled: true, priority: 2 },
   'hibp-breaches': { name: 'HIBP Breaches', enabled: true, priority: 2 },
   'ipinfo-lookup': { name: 'IP Info Lookup', enabled: true, priority: 2 },

--- a/src/services/opensanctions.ts
+++ b/src/services/opensanctions.ts
@@ -1,17 +1,6 @@
 import { getApiBaseUrl } from '@/services/runtime';
 import { isFeatureAvailable } from '@/services/runtime-config';
-
-export interface SanctionedEntity {
-  id: string;
-  name: string;
-  schema: string;
-  countries: string[];
-  datasets: string[];
-  topics: string[];
-  firstSeen: string | null;
-  lastSeen: string | null;
-  sanctionPrograms: string | null;
-}
+import type { SanctionsDataset } from '@/components/open-sanctions-helpers';
 
 export interface OpenSanctionsSearchResult {
   query: string;
@@ -27,14 +16,36 @@ export interface OpenSanctionsSearchResult {
   }[];
 }
 
-export async function fetchRecentSanctions(): Promise<SanctionedEntity[]> {
+interface RecentSanctionsItem {
+  id?: string;
+  name?: string;
+  countries?: string[];
+  lastSeen?: string | null;
+  entityCount?: number | null;
+}
+
+/**
+ * Consolidated-watchlist coverage from the free OpenSanctions /catalog feed
+ * (surfaced by the sidecar as recently-exported sanctions datasets). Each
+ * dataset carries its own entity count + last-export timestamp, which the
+ * panel aggregates into coverage stats via aggregateStats().
+ */
+export async function fetchSanctionsCoverage(): Promise<SanctionsDataset[]> {
   if (!isFeatureAvailable('openSanctions')) return [];
   try {
- const res = await fetch(`${getApiBaseUrl()}/api/opensanctions-recent`);
- if (!res.ok) return [];
- return (await res.json()) as SanctionedEntity[];
+    const res = await fetch(`${getApiBaseUrl()}/api/opensanctions-recent`);
+    if (!res.ok) return [];
+    const items = (await res.json()) as RecentSanctionsItem[];
+    if (!Array.isArray(items)) return [];
+    return items.map((it) => ({
+      name: it.id ?? '',
+      title: it.name ?? it.id ?? 'Unknown sanctions list',
+      entityCount: typeof it.entityCount === 'number' ? it.entityCount : 0,
+      lastUpdated: it.lastSeen ?? '',
+      countries: Array.isArray(it.countries) ? it.countries : [],
+    }));
   } catch {
- return [];
+    return [];
   }
 }
 


### PR DESCRIPTION
## What

Rebuilds the OpenSanctions panel from a bare recent-datasets table into a consolidated-watchlist **coverage view**: dataset/entity totals, per-dataset freshness badges, and a most-stale headline. Backed by a new pure-helper module with 40 unit tests.

## Why

A sanctions list silently going stale means a newly-designated entity can be missed. The old table conveyed neither coverage nor staleness. `getFreshnessStatus` fails safe to `stale` for unparseable dates — "can't confirm current" never renders green.

## Scope notes

- Stays on the **free `/catalog` feed**. The legacy entity-search/`/statistics` endpoints now require an API key after the yente migration, so the live search box is intentionally omitted rather than shipped broken (it would silently 401).
- No new sidecar routes — reuses existing `/api/opensanctions-recent`.
- All logic is pure (no DOM/fetch) and deterministically tested by injecting `now`.

## Tests

`npx tsx --test src/components/__tests__/open-sanctions-helpers.test.mts` → **40/40 pass**. All touched files typecheck clean.

Cross-agent review: claude reviewed on 2026-06-10; outcome: pass

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>