### PR TITLE
Fix ESLint violations in OpenSanctions panel

### DIFF
--- a/src/components/OpenSanctionsPanel.ts
+++ b/src/components/OpenSanctionsPanel.ts
@@ -13,6 +13,8 @@ import { escapeHtml } from '@/utils/sanitize';
 const FRESHNESS_ICON = { fresh: '✓', aging: '◷', stale: '⚠' } as const;
 const FRESHNESS_COLOR = { fresh: '#4ade80', aging: '#fbbf24', stale: '#f87171' } as const;
 
+const num = (n: number): string => n.toLocaleString('en-US');
+
 export class OpenSanctionsPanel extends Panel {
   private stats: SanctionsStats | null = null;
 
@@ -40,8 +42,6 @@ export class OpenSanctionsPanel extends Panel {
       this.setContent('<div class="panel-empty">No sanctions coverage data available.</div>');
       return;
     }
-
-    const num = (n: number): string => n.toLocaleString('en-US');
 
     const coverage = [
       ['Datasets', `${num(stats.totalDatasets)} sources`],

--- a/src/components/open-sanctions-helpers.ts
+++ b/src/components/open-sanctions-helpers.ts
@@ -101,7 +101,7 @@ export function formatDatasetName(name: string): string {
   return name
     .split(/[_\s-]+/)
     .filter(Boolean)
-    .map(titleCaseToken)
+    .map((token) => titleCaseToken(token))
     .join(' ');
 }
 
@@ -131,7 +131,7 @@ export function getTopicBadge(topic: string): string {
 export function countBySchema(entities: SanctionedEntity[]): Record<string, number> {
   const out: Record<string, number> = {};
   for (const e of entities) {
-    const key = e.schema && e.schema.trim() ? e.schema : 'Unknown';
+    const key = e.schema?.trim() ? e.schema : 'Unknown';
     out[key] = (out[key] ?? 0) + 1;
   }
   return out;


### PR DESCRIPTION
Follow-up to #1097. Three ESLint errors landed on main (ESLint is a non-required check):

- `OpenSanctionsPanel.ts` — `num` formatter hoisted to module scope (unicorn/consistent-function-scoping)
- `open-sanctions-helpers.ts` — `titleCaseToken` wrapped in an arrow instead of a bare `.map` callback reference (unicorn/no-array-callback-reference)
- `open-sanctions-helpers.ts` — optional chain for the schema check (@typescript-eslint/prefer-optional-chain)

`npx eslint` on both files → exit 0. Helper tests → 40/40 pass.

Cross-agent review: claude reviewed on 2026-06-10; outcome: pass

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>