### PR TITLE
fix: refuse to load .env.local when world-readable; enforce mode 0600 (H-3, L-6)

### DIFF
--- a/src-tauri/sidecar/__tests__/env-local-loader.test.mjs
+++ b/src-tauri/sidecar/__tests__/env-local-loader.test.mjs
@@ -5,7 +5,7 @@
  */
 
 import { strict as assert } from 'node:assert';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -101,6 +101,7 @@ test('loadEnvFile: applies new keys, returns count', () => {
   const dir = mkdtempSync(path.join(tmpdir(), 'env-loader-'));
   const file = path.join(dir, '.env.local');
   writeFileSync(file, 'FOO=bar\nBAZ=qux\n');
+  chmodSync(file, 0o600);
   try {
     const env = {};
     const n = loadEnvFile(file, env);
@@ -116,6 +117,7 @@ test('loadEnvFile: never overwrites an already-set env var', () => {
   const dir = mkdtempSync(path.join(tmpdir(), 'env-loader-'));
   const file = path.join(dir, '.env.local');
   writeFileSync(file, 'FOO=fromfile\nBAZ=fromfile\n');
+  chmodSync(file, 0o600);
   try {
     const env = { FOO: 'from-keychain' };
     const n = loadEnvFile(file, env);
@@ -131,11 +133,42 @@ test('loadEnvFile: empty-string env vars are treated as unset and overwritten', 
   const dir = mkdtempSync(path.join(tmpdir(), 'env-loader-'));
   const file = path.join(dir, '.env.local');
   writeFileSync(file, 'FOO=fromfile\n');
+  chmodSync(file, 0o600);
   try {
     const env = { FOO: '' };
     const n = loadEnvFile(file, env);
     assert.equal(n, 1);
     assert.equal(env.FOO, 'fromfile');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadEnvFile: refuses to load a world/group-readable file (mode 0644)', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'env-loader-'));
+  const file = path.join(dir, '.env.local');
+  writeFileSync(file, 'FOO=secret\n');
+  chmodSync(file, 0o644);
+  try {
+    const env = {};
+    const n = loadEnvFile(file, env);
+    assert.equal(n, 0, 'must refuse an insecurely-permissioned file');
+    assert.equal(env.FOO, undefined, 'no key may leak from a 0644 file');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadEnvFile: loads normally from a 0600 file', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'env-loader-'));
+  const file = path.join(dir, '.env.local');
+  writeFileSync(file, 'FOO=secret\n');
+  chmodSync(file, 0o600);
+  try {
+    const env = {};
+    const n = loadEnvFile(file, env);
+    assert.equal(n, 1);
+    assert.equal(env.FOO, 'secret');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/src-tauri/sidecar/env-local-loader.mjs
+++ b/src-tauri/sidecar/env-local-loader.mjs
@@ -11,7 +11,7 @@
  * Pure parser is exported for tests; IO sits in `loadEnvFile`.
  */
 
-import { existsSync, readFileSync } from 'node:fs';
+import { readFileSync, statSync } from 'node:fs';
 
 /**
  * Parse a `.env.local` blob into a Map<key, value>. Handles:
@@ -54,15 +54,34 @@ export function parseEnvFile(content) {
  *
  * Returns 0 (no error thrown) when the file is missing — fallback is
  * advisory; a real keychain read should still be the primary source.
+ *
+ * Also returns 0 (refuses to load) when the file is group- or
+ * world-readable. Plaintext credentials must live in a 0600 file; loading
+ * from a looser mode would leak every API key to any local user, so we
+ * warn and decline rather than silently regress after the initial chmod.
  */
 export function loadEnvFile(path, env = process.env) {
-  if (!existsSync(path)) return 0;
+  let stat;
+  try {
+    stat = statSync(path);
+  } catch {
+    return 0; // missing or unreadable — fallback is advisory
+  }
+  if ((stat.mode & 0o077) !== 0) {
+    console.warn(
+      `[env-local-loader] WARNING: ${path} is readable by other users ` +
+      `(mode ${(stat.mode & 0o777).toString(8)}). ` +
+      `Run \`chmod 600 ${path}\` to fix. Refusing to load plaintext credentials from an insecure file.`
+    );
+    return 0;
+  }
   let content;
   try {
     content = readFileSync(path, 'utf8');
   } catch {
     return 0;
   }
+  console.info('[env-local-loader] INFO: Loading API keys from plaintext .env.local fallback (keychain unavailable).');
   const parsed = parseEnvFile(content);
   let applied = 0;
   for (const [key, value] of parsed) {


### PR DESCRIPTION
## Summary
Implements **T1-B** from `docs/SECURITY_FIX_PLAN_2026-06-11.md` (audit refs **H-3**, **L-6**).

`loadEnvFile` is the plaintext `.env.local` keychain-loss fallback. It now:
- **`statSync`s the file first** and **refuses to parse it** (returns `0`, no keys applied) when any group/world bit is set (`mode & 0o077 !== 0`), logging a `WARNING` telling the user to `chmod 600`. This prevents a silent regression after the initial chmod — an insecure file leaks every API key to any local user.
- Emits a one-line **`INFO`** notice whenever the plaintext fallback path is actually used.

### Implementation note
The plan's pseudocode said `return {}`, but this function returns a **number** (count of applied keys) and its only caller (`local-api-server.mjs:124` → `if (applied > 0)`) depends on that. Returning `{}` would break the caller, so the faithful "refuse to load" return here is `return 0`.

## Tests
- Two new cases: 0644 file → returns `0`, no key leaks; 0600 file → loads normally.
- Existing tmp-file tests `chmod 600` their fixtures (default umask creates them 0644, which the new check now rejects).
- All 19 tests pass.

## ⚠️ Deploy reminder
**Run `chmod 600 .env.local` on the deployed file before next launch** — otherwise the sidecar will warn and skip the fallback. `.env.local` remains gitignored and is not committed.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>