### PR TITLE
fix: create events.db and sidecar log files with mode 0600 (L-7)

### DIFF
--- a/src-tauri/sidecar/event-store.mjs
+++ b/src-tauri/sidecar/event-store.mjs
@@ -8,7 +8,7 @@
 
 import { DatabaseSync } from 'node:sqlite';
 import path from 'node:path';
-import { statSync } from 'node:fs';
+import { statSync, chmodSync, existsSync } from 'node:fs';
 
 const EVENT_TYPES = new Set([
   'observation',
@@ -77,9 +77,16 @@ export class EventStore {
   constructor({ dataDir, dbPath, retentionMonths } = {}) {
     this._filePath = dbPath ?? path.join(dataDir ?? '.', 'events.db');
     this.db = new DatabaseSync(this._filePath);
+    // Restrict the DB to owner-only — the event log can contain
+    // location/saved-place data, so it must not be world-readable.
+    try { chmodSync(this._filePath, 0o600); } catch { /* best effort */ }
     this.db.prepare('PRAGMA journal_mode = WAL').get();
     this.db.prepare('PRAGMA synchronous = NORMAL').get();
     for (const stmt of SCHEMA_STATEMENTS) this.db.prepare(stmt).run();
+    // The -wal sidecar only exists once WAL mode is active and a write has
+    // happened (the schema statements above), so chmod it here, not at open.
+    const walPath = `${this._filePath}-wal`;
+    try { if (existsSync(walPath)) chmodSync(walPath, 0o600); } catch { /* best effort */ }
     this.retentionMonths = resolveRetentionMonths(retentionMonths);
     // Plain INSERT — the log is append-only, so a duplicate id must fail closed
     // rather than silently overwrite prior history (INSERT OR REPLACE would).

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -16156,8 +16156,10 @@ export async function createLocalApiServer(options = {}) {
    heap_mb: Math.round(mem0.heapUsed / 1024 / 1024),
    ais_connected: false,
    ais_vessels: 0,
-  }));
-  // Owner-only: the heartbeat exposes pid/port/memory state to local users.
+  }), { mode: 0o600 });
+  // `mode` only applies when the file is created, so chmod tightens any stale
+  // world-readable heartbeat left by a pre-fix session. The interval writer
+  // below also passes `mode` so a mid-run recreate is never briefly exposed.
   try { chmodSync(heartbeatPath, 0o600); } catch {}
  } catch {}
  setInterval(() => {
@@ -16176,7 +16178,7 @@ export async function createLocalApiServer(options = {}) {
  heap_mb: Math.round(mem.heapUsed / 1024 / 1024),
  ais_connected: aisState.socket?.readyState === 1,
  ais_vessels: aisState.vessels.size,
- }));
+ }), { mode: 0o600 });
  } catch {}
  if (eventLoopLagMs > 2000) {
  context.logger.warn(`[local-api] event loop lag ${eventLoopLagMs}ms`);

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -5,7 +5,7 @@ import http, { createServer } from 'node:http';
 import { timingSafeEqual, randomUUID } from 'node:crypto';
 import https from 'node:https';
 import dns from 'node:dns/promises';
-import { existsSync, readFileSync, writeFileSync, statSync, openSync, readSync, closeSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, statSync, openSync, readSync, closeSync, chmodSync } from 'node:fs';
 import { readdir, readFile } from 'node:fs/promises';
 import { promisify } from 'node:util';
 import { brotliCompress, gzip } from 'node:zlib';
@@ -16157,6 +16157,8 @@ export async function createLocalApiServer(options = {}) {
    ais_connected: false,
    ais_vessels: 0,
   }));
+  // Owner-only: the heartbeat exposes pid/port/memory state to local users.
+  try { chmodSync(heartbeatPath, 0o600); } catch {}
  } catch {}
  setInterval(() => {
  const now = Date.now();


### PR DESCRIPTION
## Summary
Implements **T2-B** from `docs/SECURITY_FIX_PLAN_2026-06-11.md` (audit ref **L-7**).

The event store DB and sidecar heartbeat file were created with the default umask (0644), making them world-readable. The event log can contain location / saved-place data, so it must be owner-only.

## Changes
- **`event-store.mjs`** — after `new DatabaseSync(dbPath)`, `chmodSync(dbPath, 0o600)`. The `-wal` sidecar is chmod'd after the schema writes (it only materializes once WAL mode is active and a write has happened — not at open time).
- **`local-api-server.mjs`** — `chmodSync(heartbeatPath, 0o600)` right after `sidecar.health.json` is first created.

## Scope note
`local-api.log` / `sidecar.log` are **not** created in `local-api-server.mjs` — they're written by the Rust host (`src-tauri/src/main.rs`), out of scope for this PR. The only file created in the sidecar `.mjs` is `sidecar.health.json`, which is now 0600.

## Verification
Runtime test confirmed `events.db`, `events.db-wal` (and `-shm`) are all created with mode `600`. Both files `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Cross-agent review: Codex reviewed on 2026-06-11; outcome: 1 P2 finding (heartbeat file briefly world-readable on create/recreate) — fixed in a3f68da6 by writing sidecar.health.json atomically with { mode: 0o600 } on both write paths. Re-reviewed clean.