### PR TITLE
fix: switch all sidecar plain-HTTP external URLs to HTTPS (H-1, H-2)

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -1116,23 +1116,31 @@ const ROUTE_ALIASES = {
 };
 
 // ── IP geolocation helpers ────────────────────────────────────────────────
-// ip-api.com batch endpoint: free, no key, up to 100 IPs per request.
-// Note: free tier requires HTTP (not HTTPS).
+// IPQuery.io bulk endpoint: free, no key, HTTPS-only, comma-separated IPs.
+// (ip-api.com's free tier only serves plaintext HTTP, so we standardize on
+// the same HTTPS provider already used for IP risk scoring below.)
 async function geolocateIPs(ips) {
   if (!ips || ips.length === 0) return new Map();
   try {
- const batch = ips.slice(0, 100).map(ip => ({ query: ip, fields: 'query,country,countryCode,lat,lon' }));
- const resp = await fetchWithTimeout('http://ip-api.com/batch?fields=query,country,countryCode,lat,lon', {
- method: 'POST',
- headers: { 'Content-Type': 'application/json', 'User-Agent': 'CrystalBall/1.0' },
- body: JSON.stringify(batch),
+ const batch = ips.slice(0, 100);
+ const resp = await fetchWithTimeout(`https://api.ipquery.io/${batch.map(ip => encodeURIComponent(ip)).join(',')}`, {
+ headers: { 'User-Agent': 'CrystalBall/1.0', Accept: 'application/json' },
  }, 8000);
  if (!resp.ok) return new Map();
  const results = await resp.json();
+ const rows = Array.isArray(results) ? results : [results];
  const map = new Map();
- for (const r of results) {
- if (r.query && r.lat && r.lon) {
- map.set(r.query, { lat: r.lat, lon: r.lon, country: r.country ?? '', countryCode: r.countryCode ?? '' });
+ for (const r of rows) {
+ const query = r?.ip;
+ const lat = r?.location?.latitude;
+ const lon = r?.location?.longitude;
+ if (query && lat != null && lon != null) {
+ map.set(query, {
+ lat,
+ lon,
+ country: r.location?.country ?? '',
+ countryCode: r.location?.country_code ?? '',
+ });
  }
  }
  return map;
@@ -4333,7 +4341,7 @@ async function validateSecretAgainstProvider(key, rawValue, context = {}) {
  }
 
  case 'MEDIASTACK_API_KEY': {
- const response = await fetchWithTimeout(`http://api.mediastack.com/v1/news?access_key=${encodeURIComponent(value)}&limit=1`, {
+ const response = await fetchWithTimeout(`https://api.mediastack.com/v1/news?access_key=${encodeURIComponent(value)}&limit=1`, {
  headers: { Accept: 'application/json' },
  });
  const text = await response.text();
@@ -4464,14 +4472,25 @@ async function validateSecretAgainstProvider(key, rawValue, context = {}) {
  }
 
  case 'AVIATIONSTACK_API': {
- const response = await fetchWithTimeout(`http://api.aviationstack.com/v1/flights?access_key=${encodeURIComponent(value)}&limit=1`, {
+ // AviationStack's free tier serves the API over plaintext HTTP only and
+ // returns an https_access_restricted error on HTTPS. We never fall back to
+ // HTTP for the key probe — if HTTPS is rejected, skip live validation
+ // rather than send the access key in the clear.
+ try {
+ const response = await fetchWithTimeout(`https://api.aviationstack.com/v1/flights?access_key=${encodeURIComponent(value)}&limit=1`, {
  headers: { Accept: 'application/json' },
  });
  const text = await response.text();
  if (/invalid_access_key/i.test(text)) return fail('AviationStack rejected this key');
  if (/usage_limit_reached/i.test(text)) return ok('AviationStack key verified (usage limit reached)');
+ if (/https_access_restricted|function_access_restricted/i.test(text)) {
+ return ok('HTTPS validation skipped — not available on free tier');
+ }
  if (!response.ok) return fail(`AviationStack probe failed (${response.status})`);
  return ok('AviationStack key verified');
+ } catch {
+ return ok('HTTPS validation skipped — not available on free tier');
+ }
  }
 
  case 'ICAO_API_KEY': {
@@ -4539,7 +4558,7 @@ async function validateSecretAgainstProvider(key, rawValue, context = {}) {
  }
 
  case 'GEONAMES_USERNAME': {
- const response = await fetchWithTimeout(`http://api.geonames.org/searchJSON?q=london&maxRows=1&username=${encodeURIComponent(value)}`, {
+ const response = await fetchWithTimeout(`https://secure.geonames.org/searchJSON?q=london&maxRows=1&username=${encodeURIComponent(value)}`, {
  headers: { Accept: 'application/json' },
  });
  const text = await response.text();
@@ -10168,7 +10187,7 @@ async function dispatch(requestUrl, req, routes, context) {
  sort: 'published_desc',
  });
  const r = await fetchWithTimeout(
- `http://api.mediastack.com/v1/news?${params}`,
+ `https://api.mediastack.com/v1/news?${params}`,
  { headers: { Accept: 'application/json' } },
  12000,
  );

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -4347,6 +4347,9 @@ async function validateSecretAgainstProvider(key, rawValue, context = {}) {
  const text = await response.text();
  if (/usage_limit_reached/i.test(text)) return ok('MediaStack key verified (usage limit reached)');
  if (/invalid_access_key/i.test(text)) return fail('MediaStack rejected this key');
+ // Free tier serves over plaintext HTTP only and rejects HTTPS with this
+ // code; we never probe over HTTP, so skip live validation instead.
+ if (/https_access_restricted/i.test(text)) return ok('HTTPS validation skipped — not available on free tier');
  if (!response.ok) return fail(`MediaStack probe failed (${response.status})`);
  return ok('MediaStack key verified');
  }
@@ -10191,7 +10194,16 @@ async function dispatch(requestUrl, req, routes, context) {
  { headers: { Accept: 'application/json' } },
  12000,
  );
- if (!r.ok) throw new Error(`MediaStack ${r.status}`);
+ if (!r.ok) {
+ // MediaStack's free tier rejects HTTPS with https_access_restricted. We
+ // never fall back to plaintext HTTP — surface a clear degraded reason
+ // instead of a generic upstream error so the cause is actionable.
+ const errText = await r.text().catch(() => '');
+ if (/https_access_restricted/i.test(errText)) {
+ return json({ error: 'MediaStack HTTPS requires a paid plan; free-tier keys cannot be served over HTTPS', degraded: true, reason: 'mediastack_https_restricted', source: 'mediastack.com' }, 502);
+ }
+ throw new Error(`MediaStack ${r.status}`);
+ }
  const data = await r.json();
  const articles = (data.data ?? []).map((item, i) => ({
  id: `ms-${i}`,


### PR DESCRIPTION
Implements **T1-A** from `docs/SECURITY_FIX_PLAN_2026-06-11.md` (audit refs H-1, H-2).

Switches all 5 plain-HTTP external URLs in the sidecar to HTTPS so API keys and geolocation queries are no longer sent in the clear:

1. **MediaStack** key-validation probe → `https://`
2. **AviationStack** key-validation probe → `https://`. The free tier only serves HTTP and returns `https_access_restricted` on HTTPS — the probe now catches that (and any connection error) and returns a valid "HTTPS validation skipped — not available on free tier" result instead of falling back to HTTP. The access key is never sent in the clear.
3. **GeoNames** key-validation probe → `https://secure.geonames.org` (GeoNames' HTTPS host)
4. **MediaStack** production news fetch → `https://`
5. **ip-api.com** batch geolocation (HTTP-only on free tier) → replaced with the **already-integrated** HTTPS `ipquery.io` provider used right below for IP risk scoring. The returned `Map` value shape (`lat`, `lon`, `country`, `countryCode`) is preserved, so callers are unchanged.

### Notes
- The spec suggested returning `{ valid: true, note: ... }` for the AviationStack skip. The verify-result consumer (`runtime-config.ts:1316`) only renders `rec.message`, so a `note` field would be silently dropped and the UI would show a generic "Verified". Mapped it onto the existing `ok()` helper's `message` field so the skip reason actually surfaces.
- `grep -n "http://" src-tauri/sidecar/local-api-server.mjs | grep -v "127.0.0.1\|localhost\|#"` now returns only two non-fetch false positives: a `ws://`→`http://` scheme transform (line ~6758, scheme-preserving for a user-configured relay) and a dummy `http://x` URL-parse base (line ~16059, never fetched).
- `node --check` passes.

---

**Cross-agent review: Codex reviewed on 2026-06-11; outcome: issues fixed.**

Codex (`codex exec review --base origin/main`) raised one P2: MediaStack free-tier keys cannot be served over HTTPS (`https_access_restricted`). Fixed in db2b30ab — the key probe now skips live validation (matching AviationStack) instead of marking a valid free key failed, and the production `/api/mediastack-news` fetch returns a clear degraded reason instead of a generic upstream error. No fallback to plaintext HTTP. The ipquery.io migration, AviationStack skip path, and GeoNames `secure.geonames.org` host drew no findings.
