### PR TITLE
fix: anchor Vercel preview-origin regex to account scope to prevent lookalike CORS (M-5)

### DIFF
--- a/api/_api-key.js
+++ b/api/_api-key.js
@@ -8,7 +8,12 @@ const DESKTOP_ORIGIN_PATTERNS = [
 const BROWSER_ORIGIN_PATTERNS = [
   /^https:\/\/crystalball\.app$/,
   /^https:\/\/(tech|finance|happy|api)\.crystalball\.app$/,
-  // Vercel preview URLs anchored to known owner accounts (mirrors _cors.ts)
+  // Vercel preview URLs anchored to known owner accounts (mirrors _cors.ts).
+  // The `-<account-slug>` suffix (e.g. `-bradleybond512`) is appended by Vercel
+  // from the OWNING account and cannot be forged by a third party. Without it,
+  // `crystalball-[a-z0-9-]+\.vercel\.app` would match any project literally named
+  // `crystalball-<anything>` — e.g. an attacker's `crystalball-evil.vercel.app` —
+  // granting it trusted-browser CORS. Keep every preview pattern account-anchored.
   /^https:\/\/crystalball-[a-z0-9-]+-bradleybond512\.vercel\.app$/,
   /^https:\/\/crystal-ball-[a-z0-9-]+-bradleybond512\.vercel\.app$/,
   /^https:\/\/crystalball-[a-z0-9-]+-elie-[a-z0-9]+\.vercel\.app$/,

--- a/api/youtube/embed.js
+++ b/api/youtube/embed.js
@@ -13,7 +13,12 @@ function sanitizeVideoId(value) {
 const ALLOWED_ORIGINS = [
   /^https:\/\/crystalball\.app$/,
   /^https:\/\/(tech|finance|happy|api)\.crystalball\.app$/,
-  // Vercel preview URLs anchored to known owner accounts (mirrors _cors.ts)
+  // Vercel preview URLs anchored to known owner accounts (mirrors _cors.ts).
+  // The `-<account-slug>` suffix (e.g. `-bradleybond512`) is appended by Vercel
+  // from the OWNING account and cannot be forged by a third party. Without it,
+  // `crystalball-[a-z0-9-]+\.vercel\.app` would match any project literally named
+  // `crystalball-<anything>` — e.g. an attacker's `crystalball-evil.vercel.app` —
+  // granting it a trusted embed origin. Keep every preview pattern account-anchored.
   /^https:\/\/crystalball-[a-z0-9-]+-bradleybond512\.vercel\.app$/,
   /^https:\/\/crystal-ball-[a-z0-9-]+-bradleybond512\.vercel\.app$/,
   /^https:\/\/crystalball-[a-z0-9-]+-elie-[a-z0-9]+\.vercel\.app$/,


### PR DESCRIPTION
## T2-D — Vercel preview-origin regex (audit ref M-5)

### Finding
The audit (`SECURITY_FIX_PLAN_2026-06-11.md` T2-D) flagged that the Vercel serverless routes could accept any `crystalball-[a-z0-9-]+.vercel.app` origin, letting anyone deploy a lookalike project and obtain trusted-browser CORS.

### State on `origin/main`
The substantive fix **already landed** — every preview pattern in `api/_api-key.js`, `api/youtube/embed.js`, `api/_cors.js`, and `api/[domain]/v1/[rpc].js` is already anchored to the owning account slug (`-bradleybond512` / `-elie-*`). Lookalike-rejection tests already exist (`_api-key.test.mjs`, `embed.test.mjs` incl. the `R2-SEC-006` case, `_cors.test.mjs`).

### This PR
The one unmet part of T2-D was the plan's explicit ask to *"add a comment explaining why the account slug anchoring is required."* The existing comment stated *what* but not *why*. This PR documents the lookalike-CORS rationale inline in both `api/_api-key.js` and `api/youtube/embed.js` so a future simplification doesn't strip the account anchor and silently re-open the bypass.

No behavior change — comments only. All 21 route tests pass (`node --test api/_api-key.test.mjs api/youtube/embed.test.mjs`).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Cross-agent review: Codex reviewed on 2026-06-11; outcome: pass (comments-only, no issues found)