### PR TITLE
fix: pin web CSP frame-src to explicit port list instead of wildcard (M-2)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <head>
  <meta charset="UTF-8" />
  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
- <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https: ws: wss: blob: data:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' 'sha256-CEQjAz+RfGVMlmAv8C9h16vbduoug7nuW41coE/SDtM=' 'unsafe-eval' 'wasm-unsafe-eval' https://www.youtube.com https://static.cloudflareinsights.com https://vercel.live https://us-assets.i.posthog.com; worker-src 'self' blob:; font-src 'self' data: https:; media-src 'self' data: blob: https:; frame-src 'self' http://127.0.0.1:* http://localhost:46123 https://crystalball.app https://tech.crystalball.app https://happy.crystalball.app https://www.youtube.com https://www.youtube-nocookie.com;" />
+ <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https: ws: wss: blob: data:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' 'sha256-CEQjAz+RfGVMlmAv8C9h16vbduoug7nuW41coE/SDtM=' 'unsafe-eval' 'wasm-unsafe-eval' https://www.youtube.com https://static.cloudflareinsights.com https://vercel.live https://us-assets.i.posthog.com; worker-src 'self' blob:; font-src 'self' data: https:; media-src 'self' data: blob: https:; frame-src 'self' http://127.0.0.1:3000 http://127.0.0.1:1420 http://127.0.0.1:5173 http://127.0.0.1:46123 http://localhost:46123 https://crystalball.app https://tech.crystalball.app https://happy.crystalball.app https://www.youtube.com https://www.youtube-nocookie.com;" />
  <meta name="referrer" content="strict-origin-when-cross-origin" />
 
  <!-- Primary Meta Tags -->


### PR DESCRIPTION
Implements **T3-B** from `docs/SECURITY_FIX_PLAN_2026-06-11.md` (audit ref **M-2**).

Replaces the wildcard `frame-src http://127.0.0.1:*` in the web CSP meta tag (`index.html`) with an explicit port list:

```
http://127.0.0.1:3000 http://127.0.0.1:1420 http://127.0.0.1:5173 http://127.0.0.1:46123
```

These are the Vite/Tauri dev-server ports plus the sidecar port (46123). The desktop `tauri.conf.json` CSP uses `http://127.0.0.1:46123` for frame-src; this list is a superset, so the two stay in sync with no missing ports. The wildcard previously allowed any local port to be framed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Cross-agent review: Codex reviewed on 2026-06-11; outcome: pass.
