### PR TITLE
ci: block plain-HTTP external URLs in sidecar (H-1/H-2 root-cause guardrail)

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -36,3 +36,24 @@ jobs:
       - name: cargo audit
         working-directory: src-tauri
         run: cargo audit
+
+  sidecar-http-guardrail:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - name: No plain-HTTP external URLs in sidecar
+        run: |
+          # Flag plain-HTTP only when it targets a real external host (dotted TLD).
+          # This shape requirement already drops loopback IPs (digit after the final
+          # dot), `ws://`->`http://` scheme transforms, and `http://x` URL-parse
+          # bases (no TLD). XML namespace identifiers, comments, and test/spec
+          # fixtures are excluded explicitly. `|| true` keeps the step alive under
+          # bash -eo pipefail when grep finds nothing.
+          matches="$(grep -rnE "http://[a-zA-Z0-9.-]+\.[a-zA-Z]" src-tauri/sidecar/ \
+              | grep -v "127\.0\.0\.1\|localhost\|xmlns\|#\|\.test\.\|spec\." || true)"
+          if [ -n "$matches" ]; then
+            echo "ERROR: Plain HTTP external URL found in sidecar. Use HTTPS." >&2
+            echo "$matches" >&2
+            exit 1
+          fi
+          echo "OK: No plain-HTTP external URLs in sidecar."


### PR DESCRIPTION
## What

Adds a `sidecar-http-guardrail` job to **Security Audit** (`.github/workflows/security-audit.yml`) that fails CI when a plain-HTTP URL targeting a real external host appears in `src-tauri/sidecar/`. This is the root-cause guardrail for **H-1/H-2** — it prevents the HTTPS fix in **T1-A** from silently regressing.

## Why Security Audit (not lint.yml)

`lint.yml` has `paths:` filters that exclude sidecar `.mjs` files, so a guardrail there wouldn't run when the sidecar changes. `security-audit.yml` runs on **every** PR with no path filter and is thematically the right home. The new job needs only checkout + grep (no `npm ci`), and intentionally omits the fork `if:` guard the other jobs use — the check needs no secrets and is strictly more valuable when it also runs on fork PRs.

## Filter hardening (vs. the plan's literal snippet)

The detector matches `http://` only when followed by a **dotted TLD host**, which precisely targets real external URLs and avoids false positives the literal snippet would have flagged under GNU grep:

- `s2u-xmpp-source.mjs` — `xmlns: 'http://jabber.org/...'` XMPP namespace identifier (excluded via `xmlns`)
- `local-api-server.mjs` — `.replace('ws://', 'http://')` scheme transform (no TLD → not matched)
- `local-api-server.mjs` — `new URL(req.url, 'http://x')` parse base (no TLD → not matched)
- loopback IPs (digit after final dot → not matched); `.test.`/`spec.` fixtures excluded

`|| true` keeps the step alive under `bash -eo pipefail` when grep finds nothing.

## ⚠️ Sequencing — expected RED until T1-A lands

`origin/main` still contains the 5 plain-HTTP URLs that **T1-A** (HTTP→HTTPS) will fix (mediastack ×2, aviationstack, geonames, ip-api). This guardrail correctly flags all 5, so **this PR's check is red by design until T1-A merges**. After T1-A lands I'll rebase and it goes green (verified: filter matches exactly those 5 lines, 0 false positives).

Audit refs: H-1, H-2 (root-cause guardrail). Plan: `docs/SECURITY_FIX_PLAN_2026-06-11.md` T2-A.


Cross-agent review: Codex reviewed on 2026-06-11; outcome: 1 P1 raised — guardrail flags the 5 existing plain-HTTP URLs in `src-tauri/sidecar/local-api-server.mjs` (mediastack ×2, aviationstack, geonames, ip-api), so this check is RED until T1-A (HTTP→HTTPS) lands. This is the known/documented sequencing condition accepted for this PR, not a defect in the guardrail logic; T1-A is intentionally NOT batched in per the plan. No other issues found.
