### PR TITLE
feat: add Twilio HMAC-SHA1 request-signature validation to SMS webhook (L-5)

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -34,6 +34,7 @@ import {
   loadSmsConfig, saveSmsConfig,
   handleSmsCommand,
 } from './sms-command-parser.mjs';
+import { validateTwilioSignature } from './sms-security.mjs';
 import { buildRecentChanges } from './recent-changes.mjs';
 import { explain as explainEvent } from './explainer.mjs';
 import { EventStore } from './event-store.mjs';
@@ -112,6 +113,7 @@ const _smsRateLimitMap = new Map();
 const _smsCommandLog = [];
 const _smsWatchRegistry = [];
 const _smsAlertRegistry = [];
+let _smsTwilioTokenWarned = false;
 
 // Keychain-loss fallback: a 2026-05-08 incident wiped the macOS Keychain
 // vault, taking 29 API credentials with it. If the keychain is empty
@@ -5080,10 +5082,40 @@ async function dispatch(requestUrl, req, routes, context) {
   // Security is enforced by the phone-number allowlist in sms-config.json.
   if (requestUrl.pathname === '/api/sms/command' && req.method === 'POST') {
     if (!_smsConfig.enabled) return json({ error: 'SMS command interface is disabled.' }, 503);
-    let smsBody;
-    try { smsBody = JSON.parse(await readBody(req)); } catch { return json({ error: 'Invalid JSON' }, 400); }
-    const from = String(smsBody.from ?? '');
-    const body = String(smsBody.body ?? '');
+
+    const rawBodyBuf = await readBody(req);
+    const rawBody = rawBodyBuf ? rawBodyBuf.toString('utf8') : '';
+    const contentType = String(req.headers['content-type'] || '').toLowerCase();
+    // Twilio webhooks POST application/x-www-form-urlencoded; the internal/test
+    // contract POSTs JSON {from, body}. Parse params accordingly so the signature
+    // is computed over exactly the fields the gateway sent.
+    let params;
+    if (contentType.includes('application/x-www-form-urlencoded')) {
+      params = Object.fromEntries(new URLSearchParams(rawBody));
+    } else {
+      try { params = JSON.parse(rawBody || '{}'); } catch { return json({ error: 'Invalid JSON' }, 400); }
+    }
+
+    // Caller-ID (From) is spoofable. When a TWILIO_AUTH_TOKEN is configured we
+    // require a valid HMAC-SHA1 request signature before trusting the webhook;
+    // without a token we log once and fall back to phone-number-only validation.
+    const twilioToken = process.env.TWILIO_AUTH_TOKEN || '';
+    if (twilioToken) {
+      const signature = req.headers['x-twilio-signature'] || '';
+      const proto = String(req.headers['x-forwarded-proto'] || 'https').split(',')[0].trim() || 'https';
+      const host = req.headers['x-forwarded-host'] || req.headers.host || '';
+      const fullUrl = `${proto}://${host}${requestUrl.pathname}${requestUrl.search}`;
+      if (!validateTwilioSignature(twilioToken, fullUrl, params, signature)) {
+        context.logger.warn(`[local-api] rejected SMS webhook: invalid Twilio signature (from ${host || 'unknown host'})`);
+        return json({ error: 'Invalid Twilio signature' }, 403);
+      }
+    } else if (!_smsTwilioTokenWarned) {
+      _smsTwilioTokenWarned = true;
+      context.logger.warn('[local-api] TWILIO_AUTH_TOKEN not configured — SMS webhook accepted on phone-number allowlist only (set TWILIO_AUTH_TOKEN to require signed requests).');
+    }
+
+    const from = String(params.From ?? params.from ?? '');
+    const body = String(params.Body ?? params.body ?? '');
     const analystState = context._analystState ?? null;
     const result = await handleSmsCommand({
       from, body, analystState,

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -5099,15 +5099,23 @@ async function dispatch(requestUrl, req, routes, context) {
     // Caller-ID (From) is spoofable. When a TWILIO_AUTH_TOKEN is configured we
     // require a valid HMAC-SHA1 request signature before trusting the webhook;
     // without a token we log once and fall back to phone-number-only validation.
+    //
+    // The in-app test command (SmsSettingsPanel) POSTs to this same pre-auth
+    // route but carries a valid LOCAL_API_TOKEN via the renderer's fetch
+    // wrapper. A valid token already proves a trusted local caller, so skip the
+    // Twilio-signature requirement for it — external webhooks never have one.
+    const trustedLocalCaller = isValidToken(req.headers.authorization || '');
     const twilioToken = process.env.TWILIO_AUTH_TOKEN || '';
     if (twilioToken) {
-      const signature = req.headers['x-twilio-signature'] || '';
-      const proto = String(req.headers['x-forwarded-proto'] || 'https').split(',')[0].trim() || 'https';
-      const host = req.headers['x-forwarded-host'] || req.headers.host || '';
-      const fullUrl = `${proto}://${host}${requestUrl.pathname}${requestUrl.search}`;
-      if (!validateTwilioSignature(twilioToken, fullUrl, params, signature)) {
-        context.logger.warn(`[local-api] rejected SMS webhook: invalid Twilio signature (from ${host || 'unknown host'})`);
-        return json({ error: 'Invalid Twilio signature' }, 403);
+      if (!trustedLocalCaller) {
+        const signature = req.headers['x-twilio-signature'] || '';
+        const proto = String(req.headers['x-forwarded-proto'] || 'https').split(',')[0].trim() || 'https';
+        const host = req.headers['x-forwarded-host'] || req.headers.host || '';
+        const fullUrl = `${proto}://${host}${requestUrl.pathname}${requestUrl.search}`;
+        if (!validateTwilioSignature(twilioToken, fullUrl, params, signature)) {
+          context.logger.warn(`[local-api] rejected SMS webhook: invalid Twilio signature (from ${host || 'unknown host'})`);
+          return json({ error: 'Invalid Twilio signature' }, 403);
+        }
       }
     } else if (!_smsTwilioTokenWarned) {
       _smsTwilioTokenWarned = true;

--- a/src-tauri/sidecar/sms-security.mjs
+++ b/src-tauri/sidecar/sms-security.mjs
@@ -17,6 +17,7 @@
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import path from 'node:path';
+import { createHmac, timingSafeEqual } from 'node:crypto';
 
 export const DEFAULT_ALLOWLIST_PATH = path.join(homedir(), '.config', 'crystalball', 'sms-allowlist.json');
 export const RATE_LIMIT_MAX = 10;
@@ -112,4 +113,32 @@ export function logCommand(phoneNumber, command, outcome, commandLog, now = Date
     at: now,
   });
   if (commandLog.length > 50) commandLog.length = 50;
+}
+
+// Validate a Twilio webhook request signature.
+//
+// Twilio signs each request with HMAC-SHA1 over (full request URL + the POST
+// params concatenated in lexical key order, as key1value1key2value2...), keyed
+// by the account's auth token, then base64-encodes the digest into the
+// X-Twilio-Signature header. Caller-ID (the From number) is spoofable, so this
+// signature is the only thing that proves the request actually came from Twilio.
+//
+// Returns false (never throws) when the token or signature is missing, or when
+// the digests differ. The comparison is constant-time once lengths match.
+export function validateTwilioSignature(authToken, url, params, signature) {
+  if (!authToken || !signature) return false;
+  const sortedKeys = Object.keys(params ?? {}).sort();
+  const paramString = sortedKeys.reduce((acc, k) => acc + k + params[k], '');
+  const expected = createHmac('sha1', authToken)
+    .update(url + paramString)
+    .digest('base64');
+  let sigBuf;
+  try {
+    sigBuf = Buffer.from(signature, 'base64');
+  } catch {
+    return false;
+  }
+  const expBuf = Buffer.from(expected, 'base64');
+  if (sigBuf.length !== expBuf.length) return false;
+  return timingSafeEqual(sigBuf, expBuf);
 }

--- a/src-tauri/sidecar/sms-security.test.mjs
+++ b/src-tauri/sidecar/sms-security.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { createHmac } from 'node:crypto';
 import {
   loadAllowlist,
   saveAllowlist,
@@ -12,7 +13,14 @@ import {
   recordRateLimit,
   logCommand,
   normalizePhone,
+  validateTwilioSignature,
 } from './sms-security.mjs';
+
+// Mirror of Twilio's signing algorithm so tests can sign their own fixtures.
+function signTwilio(authToken, url, params) {
+  const paramString = Object.keys(params).sort().reduce((acc, k) => acc + k + params[k], '');
+  return createHmac('sha1', authToken).update(url + paramString).digest('base64');
+}
 
 describe('normalizePhone', () => {
   it('strips non-digits', () => {
@@ -172,5 +180,58 @@ describe('loadAllowlist / saveAllowlist', () => {
     ], p);
     const list = loadAllowlist(p);
     assert.equal(list.length, 1);
+  });
+});
+
+describe('validateTwilioSignature', () => {
+  const token = 'test_auth_token_0123456789';
+  const url = 'https://example.ngrok.app/api/sms/command';
+  const params = { From: '+15550001234', Body: 'STATUS', MessageSid: 'SM123' };
+
+  it('accepts a correctly-signed request', () => {
+    const sig = signTwilio(token, url, params);
+    assert.equal(validateTwilioSignature(token, url, params, sig), true);
+  });
+
+  it('is independent of param insertion order (signs in sorted key order)', () => {
+    const sig = signTwilio(token, url, params);
+    const reordered = { MessageSid: 'SM123', Body: 'STATUS', From: '+15550001234' };
+    assert.equal(validateTwilioSignature(token, url, reordered, sig), true);
+  });
+
+  it('rejects a tampered body', () => {
+    const sig = signTwilio(token, url, params);
+    const tampered = { ...params, Body: 'WATCH AAPL' };
+    assert.equal(validateTwilioSignature(token, url, tampered, sig), false);
+  });
+
+  it('rejects when the URL differs', () => {
+    const sig = signTwilio(token, url, params);
+    assert.equal(validateTwilioSignature(token, 'https://evil.example/api/sms/command', params, sig), false);
+  });
+
+  it('rejects when signed with a different auth token', () => {
+    const sig = signTwilio('other_token', url, params);
+    assert.equal(validateTwilioSignature(token, url, params, sig), false);
+  });
+
+  it('returns false when the auth token is missing', () => {
+    const sig = signTwilio(token, url, params);
+    assert.equal(validateTwilioSignature('', url, params, sig), false);
+  });
+
+  it('returns false when the signature header is missing', () => {
+    assert.equal(validateTwilioSignature(token, url, params, ''), false);
+    assert.equal(validateTwilioSignature(token, url, params, undefined), false);
+  });
+
+  it('returns false (no throw) for a malformed signature', () => {
+    assert.doesNotThrow(() => validateTwilioSignature(token, url, params, '!!!not base64!!!'));
+    assert.equal(validateTwilioSignature(token, url, params, '!!!not base64!!!'), false);
+  });
+
+  it('handles empty params', () => {
+    const sig = signTwilio(token, url, {});
+    assert.equal(validateTwilioSignature(token, url, {}, sig), true);
   });
 });


### PR DESCRIPTION
## What

Implements **T3-C** from `docs/SECURITY_FIX_PLAN_2026-06-11.md` (audit ref **L-5**).

The `/api/sms/command` webhook is pre-auth (no `LOCAL_API_TOKEN`) so SMS gateways can POST to it. Until now it trusted the sender's phone number against an allowlist — but caller-ID is spoofable, so anyone who knows an allowlisted number could forge a command.

## Changes

- **`sms-security.mjs`** — new `validateTwilioSignature(authToken, url, params, signature)`: HMAC-SHA1 over `url + sorted-param-concat`, base64, constant-time compare via `timingSafeEqual`. Returns `false` (never throws) on missing/malformed inputs.
- **`local-api-server.mjs`** — the `/api/sms/command` handler now:
  - Parses form-urlencoded (real Twilio) **or** JSON (internal/test) bodies.
  - When `TWILIO_AUTH_TOKEN` is set: reconstructs the request URL (`x-forwarded-proto`/`host`), validates the `X-Twilio-Signature` header, and returns **403** on mismatch.
  - When `TWILIO_AUTH_TOKEN` is **not** set: logs a one-time warning and falls through to the existing phone-number allowlist (backward compatible).
- **`sms-security.test.mjs`** — 9 new cases: valid signature, param-order independence, tampered body, wrong URL, wrong token, missing token/signature, malformed signature (no throw), empty params.

## Verification

- `npm run test:sms` → 87 pass
- `npm run test:sidecar` → 287 pass
- `node --check` clean on both `.mjs` files
- eslint clean on changed lines (pre-existing `unicorn`/`sonarjs` errors in untouched `sms-security.mjs` code remain)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Cross-agent review: Codex reviewed on 2026-06-11; outcome: 1 P2 issue found (in-app SMS test command would 403 once TWILIO_AUTH_TOKEN is set) — fixed in commit 0f3d1abb (skip signature check for token-authenticated local callers). No other issues.
