### PR TITLE
fix: add trusted-window gate to list_supported_secret_keys IPC command (L-1)

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -713,11 +713,12 @@ fn get_local_api_port(webview: Webview, state: tauri::State<'_, LocalApiState>) 
 }
 
 #[tauri::command]
-fn list_supported_secret_keys() -> Vec<String> {
- SUPPORTED_SECRET_KEYS
+fn list_supported_secret_keys(webview: Webview) -> Result<Vec<String>, String> {
+ require_trusted_window(webview.label())?;
+ Ok(SUPPORTED_SECRET_KEYS
  .iter()
  .map(|key| (*key).to_string())
- .collect()
+ .collect())
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Summary
Adds the `require_trusted_window()` gate to the `list_supported_secret_keys` Tauri command (audit finding **L-1**, plan task **T2-C**). Every other secret operation (`get_secret`, `set_secret`, `delete_secret`, `get_local_api_token`, etc.) already enforces this gate; this command was the lone exception, letting an untrusted-origin window enumerate the full supported-secret key list.

## Change
- `list_supported_secret_keys()` → `list_supported_secret_keys(webview: Webview) -> Result<Vec<String>, String>`
- Calls `require_trusted_window(webview.label())?` before returning the list.
- Matches the existing synchronous `webview: Webview` convention used by every sibling secret command (rather than the plan's `async`/`WebviewWindow` snippet) for file consistency. The `generate_handler!` registration needs no change — Tauri injects the `Webview` from invocation context.

## Verification
- `cargo check` → `Finished` (clean). The only non-trivial step was that a fresh worktree lacks the gitignored generated artifacts (`s2u-xmpp.bundle.mjs`, frontend `dist`); generating those let the build script and `generate_context!` pass, after which the Rust type-checks cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Cross-agent review: Codex reviewed on 2026-06-11; outcome: pass (no correctness issues found)