### PR TITLE
feat: add LLM cloud-egress disclosure modal and local-model-only toggle (M-4)

### DIFF
--- a/src/components/AnalystHUD.ts
+++ b/src/components/AnalystHUD.ts
@@ -29,6 +29,7 @@ import { projectHypothesis, getCachedProjection, subscribeProjection } from '@/s
 import { exportHypothesisToClipboard } from '@/services/hypothesis-export';
 import { getBudgetStatus, subscribeBudget, setCloudCap, resetBudget } from '@/services/llm-budget';
 import { getTotalErrorCount, subscribeDebug } from '@/services/reasoning-debug';
+import { isLlmEgressDisclosed, setLlmEgressDisclosed, isLocalModelOnly, setLocalModelOnly, subscribeLlmEgressChange } from '@/services/ai-flow-settings';
 import { getAllSnapshots, subscribeSnapshotArchive } from '@/services/snapshot-archive';
 import { runEnsemble, getCachedEnsemble, subscribeEnsemble } from '@/services/hypothesis-ensemble';
 import { forecastAll, type HypothesisForecast } from '@/services/intelligence/hypothesis-forecast';
@@ -161,6 +162,13 @@ export class AnalystHUD {
       if (this.replayAtTimestamp === null) this.scheduleRender();
     });
     subscribeEnsemble(() => { this.scheduleRender(); });
+    subscribeLlmEgressChange(() => { this.scheduleRender(); });
+    // When llm-adapter blocks a cloud call because disclosure hasn't been
+    // acknowledged yet, show the disclosure banner in the HUD.
+    document.addEventListener('cb:llm-egress-disclosure-needed', () => {
+      if (this.visible) this.scheduleRender();
+      else this.show();
+    });
     document.addEventListener('cb:toggle-analyst-hud', () => this.toggle());
     document.addEventListener('cb:hypothesis-feedback', () => {
       if (this.visible) this.render();
@@ -474,6 +482,8 @@ export class AnalystHUD {
         isAutoBriefEnabled(), setAutoBriefEnabled),
       this.buildSettingToggle('Run skeptic pass on high/critical hypotheses',
         isSkepticEnabled(), setSkepticEnabled),
+      this.buildSettingToggle('Local model only (disable cloud LLM fallback)',
+        isLocalModelOnly(), setLocalModelOnly),
       this.buildCloudCapSlider(),
     );
 
@@ -1055,12 +1065,37 @@ export class AnalystHUD {
     return snap.hypotheses.find(h => h.evidence.some(ev => ev.id === e.id && ev.source === e.source)) ?? null;
   }
 
+  private buildEgressDisclosureBanner(): HTMLElement {
+    const banner = document.createElement('div');
+    banner.className = 'analyst-hud-egress-banner';
+
+    const msg = document.createElement('p');
+    msg.className = 'analyst-hud-egress-msg';
+    msg.textContent =
+      'When no local model is available, hypothesis summaries and evidence may be ' +
+      'sent to your configured cloud LLM provider (Anthropic, Groq, or OpenRouter). ' +
+      'Enable ‘Local model only’ below to disable this fallback.';
+    banner.append(msg);
+
+    const ackBtn = document.createElement('button');
+    ackBtn.className = 'analyst-hud-egress-ack';
+    ackBtn.textContent = 'Acknowledge';
+    ackBtn.addEventListener('click', () => {
+      setLlmEgressDisclosed(true);
+      this.render();
+    });
+    banner.append(ackBtn);
+    return banner;
+  }
+
   private buildBriefsSection(): HTMLElement {
     const sec = document.createElement('section');
     sec.className = 'analyst-hud-section';
     const h = document.createElement('h3');
     h.textContent = 'Auto-Briefs';
     sec.append(h);
+
+    if (!isLlmEgressDisclosed()) sec.append(this.buildEgressDisclosureBanner());
 
     const toggle = document.createElement('label');
     toggle.className = 'analyst-hud-toggle';

--- a/src/services/__tests__/llm-egress-settings.test.mts
+++ b/src/services/__tests__/llm-egress-settings.test.mts
@@ -1,0 +1,179 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+// ── Minimal browser stubs ──────────────────────────────────────────────────────
+
+const storage = new Map<string, string>();
+(globalThis as unknown as { localStorage: Storage }).localStorage = {
+  getItem: (k: string) => storage.get(k) ?? null,
+  setItem: (k: string, v: string) => { storage.set(k, v); },
+  removeItem: (k: string) => { storage.delete(k); },
+  clear: () => { storage.clear(); },
+  get length() { return storage.size; },
+  key: (i: number) => [...storage.keys()][i] ?? null,
+} as Storage;
+
+const windowListeners = new Map<string, EventListener[]>();
+(globalThis as unknown as { window: { addEventListener: (t: string, h: EventListener) => void; removeEventListener: (t: string, h: EventListener) => void; dispatchEvent: (e: Event) => boolean } }).window = {
+  addEventListener: (type: string, handler: EventListener) => {
+    const list = windowListeners.get(type) ?? [];
+    list.push(handler);
+    windowListeners.set(type, list);
+  },
+  removeEventListener: (type: string, handler: EventListener) => {
+    const list = windowListeners.get(type) ?? [];
+    windowListeners.set(type, list.filter(h => h !== handler));
+  },
+  dispatchEvent: (e: Event) => {
+    for (const h of windowListeners.get(e.type) ?? []) h(e);
+    return true;
+  },
+};
+
+class StubCE<T = unknown> extends (class {} as unknown as typeof Event) {
+  type: string;
+  detail: T | undefined;
+  constructor(type: string, init?: { detail?: T }) {
+    super();
+    this.type = type;
+    this.detail = init?.detail;
+  }
+}
+(globalThis as unknown as { CustomEvent: unknown }).CustomEvent = StubCE;
+
+const docListeners = new Map<string, EventListener[]>();
+(globalThis as unknown as { document: { dispatchEvent: (e: Event) => boolean; addEventListener: (t: string, h: EventListener) => void } }).document = {
+  dispatchEvent: (e: Event) => {
+    for (const h of docListeners.get(e.type) ?? []) h(e);
+    return true;
+  },
+  addEventListener: (type: string, handler: EventListener) => {
+    const list = docListeners.get(type) ?? [];
+    list.push(handler);
+    docListeners.set(type, list);
+  },
+};
+
+// ── Imports ────────────────────────────────────────────────────────────────────
+
+import {
+  isLlmEgressDisclosed,
+  setLlmEgressDisclosed,
+  isLocalModelOnly,
+  setLocalModelOnly,
+} from '../ai-flow-settings.ts';
+
+// ── ai-flow-settings tests ─────────────────────────────────────────────────────
+
+test('llmEgressDisclosed defaults to false', () => {
+  storage.clear();
+  assert.equal(isLlmEgressDisclosed(), false);
+});
+
+test('setLlmEgressDisclosed persists to localStorage', () => {
+  storage.clear();
+  setLlmEgressDisclosed(true);
+  assert.equal(isLlmEgressDisclosed(), true);
+  // Survives "reload" (fresh read from localStorage)
+  assert.equal(storage.get('crystalball-llm-egress-disclosed'), 'true');
+});
+
+test('setLlmEgressDisclosed(false) clears the flag', () => {
+  storage.clear();
+  setLlmEgressDisclosed(true);
+  setLlmEgressDisclosed(false);
+  assert.equal(isLlmEgressDisclosed(), false);
+  assert.equal(storage.get('crystalball-llm-egress-disclosed'), 'false');
+});
+
+test('localModelOnly defaults to false', () => {
+  storage.clear();
+  assert.equal(isLocalModelOnly(), false);
+});
+
+test('setLocalModelOnly persists to localStorage', () => {
+  storage.clear();
+  setLocalModelOnly(true);
+  assert.equal(isLocalModelOnly(), true);
+  assert.equal(storage.get('crystalball-local-model-only'), 'true');
+});
+
+test('settings survive simulated reload (read fresh from storage)', () => {
+  storage.clear();
+  setLlmEgressDisclosed(true);
+  setLocalModelOnly(true);
+  // Simulate a fresh module read from the same localStorage
+  assert.equal(isLlmEgressDisclosed(), true);
+  assert.equal(isLocalModelOnly(), true);
+});
+
+// ── llm-adapter gate tests ─────────────────────────────────────────────────────
+// We test the gates indirectly by importing generateText and checking its
+// return value when the cloud path would otherwise be taken.
+// The cloud path requires runClaudeAgent which is not available in tests,
+// but the gates fire BEFORE reserveCloudCall so we never reach it.
+
+// Stub llm-budget so reserveCloudCall always returns false (belt-and-suspenders;
+// gates should fire before we get there).
+const budgetStorage = new Map<string, string>();
+(globalThis as unknown as { performance: { now: () => number } }).performance = { now: () => Date.now() };
+
+import { resetBudget, setCloudCap } from '../llm-budget.ts';
+
+test('localModelOnly blocks cloud call before reserveCloudCall', async () => {
+  storage.clear();
+  resetBudget();
+  setCloudCap(100);
+
+  setLocalModelOnly(true);
+  setLlmEgressDisclosed(true); // disclosed so only localModelOnly gate fires
+
+  // Import after stubs are in place
+  const { generateText } = await import('../llm-adapter.ts');
+
+  // Stub tryLocal to always fail (return null) so cloud path is attempted
+  // We can't easily stub the module internals, but we can verify the
+  // returned provider is 'none' — meaning the cloud gate fired.
+  const result = await generateText('test prompt', { preferCloud: true });
+  assert.equal(result.provider, 'none');
+  assert.equal(result.text, '');
+});
+
+test('undisclosed egress blocks cloud call and emits disclosure event', async () => {
+  storage.clear();
+  resetBudget();
+  setCloudCap(100);
+
+  setLocalModelOnly(false);
+  setLlmEgressDisclosed(false);
+
+  let disclosureEventFired = false;
+  docListeners.set('cb:llm-egress-disclosure-needed', [() => { disclosureEventFired = true; }]);
+
+  const { generateText } = await import('../llm-adapter.ts');
+  const result = await generateText('test prompt', { preferCloud: true });
+
+  assert.equal(result.provider, 'none');
+  assert.equal(result.text, '');
+  assert.equal(disclosureEventFired, true);
+});
+
+test('disclosed + not local-only allows cloud path to proceed', async () => {
+  storage.clear();
+  resetBudget();
+  setCloudCap(0); // exhaust the budget so we get 'none' without a real cloud call
+
+  setLocalModelOnly(false);
+  setLlmEgressDisclosed(true);
+
+  const { generateText } = await import('../llm-adapter.ts');
+  // With cap=0, reserveCloudCall returns false → provider:none.
+  // The key assertion is that we reach reserveCloudCall (not blocked earlier).
+  // We verify by checking that the disclosure event was NOT fired.
+  let disclosureEventFired = false;
+  docListeners.set('cb:llm-egress-disclosure-needed', [() => { disclosureEventFired = true; }]);
+
+  const result = await generateText('test prompt', { preferCloud: true });
+  assert.equal(disclosureEventFired, false, 'disclosure event should not fire when egress is disclosed');
+  assert.equal(result.provider, 'none'); // cap=0 → exhausted
+});

--- a/src/services/ai-flow-settings.ts
+++ b/src/services/ai-flow-settings.ts
@@ -10,8 +10,11 @@ const STORAGE_KEY_BROWSER_MODEL = 'wm-ai-flow-browser-model';
 const STORAGE_KEY_CLOUD_LLM = 'wm-ai-flow-cloud-llm';
 const STORAGE_KEY_MAP_NEWS_FLASH = 'wm-map-news-flash';
 const STORAGE_KEY_STREAM_QUALITY = 'wm-stream-quality';
+const STORAGE_KEY_LLM_EGRESS_DISCLOSED = 'crystalball-llm-egress-disclosed';
+const STORAGE_KEY_LOCAL_MODEL_ONLY = 'crystalball-local-model-only';
 const EVENT_NAME = 'ai-flow-changed';
 const STREAM_QUALITY_EVENT = 'stream-quality-changed';
+const LLM_EGRESS_EVENT = 'crystalball-llm-egress-changed';
 
 export interface AiFlowSettings {
   browserModel: boolean;
@@ -74,6 +77,34 @@ export function subscribeAiFlowChange(cb: (changedKey?: keyof AiFlowSettings) =>
   };
   window.addEventListener(EVENT_NAME, handler);
   return () => window.removeEventListener(EVENT_NAME, handler);
+}
+
+// ── LLM Egress Disclosure + Local-Model-Only ──
+
+export function isLlmEgressDisclosed(): boolean {
+  return readBool(STORAGE_KEY_LLM_EGRESS_DISCLOSED, false);
+}
+
+export function setLlmEgressDisclosed(value: boolean): void {
+  writeBool(STORAGE_KEY_LLM_EGRESS_DISCLOSED, value);
+  try { window.dispatchEvent(new CustomEvent(LLM_EGRESS_EVENT, { detail: { key: 'llmEgressDisclosed' } })); }
+  catch { /* not in browser context */ }
+}
+
+export function isLocalModelOnly(): boolean {
+  return readBool(STORAGE_KEY_LOCAL_MODEL_ONLY, false);
+}
+
+export function setLocalModelOnly(value: boolean): void {
+  writeBool(STORAGE_KEY_LOCAL_MODEL_ONLY, value);
+  try { window.dispatchEvent(new CustomEvent(LLM_EGRESS_EVENT, { detail: { key: 'localModelOnly' } })); }
+  catch { /* not in browser context */ }
+}
+
+export function subscribeLlmEgressChange(cb: () => void): () => void {
+  const handler = (): void => { cb(); };
+  window.addEventListener(LLM_EGRESS_EVENT, handler);
+  return () => window.removeEventListener(LLM_EGRESS_EVENT, handler);
 }
 
 // ── Stream Quality ──

--- a/src/services/llm-adapter.ts
+++ b/src/services/llm-adapter.ts
@@ -21,6 +21,7 @@ import { getRuntimeConfigSnapshot } from './runtime-config';
 import { recordCall, reserveCloudCall } from './llm-budget';
 import { logDebug } from './reasoning-debug';
 import { recordLatency, incrementCounter } from './reasoning-metrics';
+import { isLocalModelOnly, isLlmEgressDisclosed } from './ai-flow-settings';
 
 export type LlmProvider = 'local' | 'cloud-agent' | 'cloud-chat' | 'none';
 
@@ -166,6 +167,22 @@ export async function generateText(prompt: string, options: LlmOptions = {}): Pr
       recordCall(local.provider);
       return local;
     }
+  }
+  // Block cloud egress if the user has enabled local-only mode.
+  if (isLocalModelOnly()) {
+    logDebug({ level: 'info', category: 'llm', source: 'llm-adapter',
+      message: 'cloud call blocked: local-model-only mode active' });
+    incrementCounter('llm.cloud-agent.blocked.local-only');
+    return { text: '', provider: 'none' };
+  }
+  // Block cloud egress until the user has acknowledged the disclosure notice.
+  if (!isLlmEgressDisclosed()) {
+    try { document.dispatchEvent(new CustomEvent('cb:llm-egress-disclosure-needed')); }
+    catch { /* non-browser test environment */ }
+    logDebug({ level: 'warn', category: 'llm', source: 'llm-adapter',
+      message: 'cloud call blocked: LLM egress not yet disclosed to user' });
+    incrementCounter('llm.cloud-agent.blocked.undisclosed');
+    return { text: '', provider: 'none' };
   }
   // Atomically reserve a cloud-call slot before issuing the request.
   // If reserveCloudCall returns false, the cap is already hit; fail soft.


### PR DESCRIPTION
## Summary

Implements T3-A from the security fix plan (audit finding M-4).

`hypothesis-skeptic.ts` and `auto-brief.ts` silently sent hypothesis summaries to cloud LLMs when no local model was available. Users had no visibility and no off-switch.

## Changes

### `src/services/ai-flow-settings.ts`
- `isLlmEgressDisclosed()` / `setLlmEgressDisclosed()` — one-time user acknowledgment flag (localStorage key `crystalball-llm-egress-disclosed`, default `false`)
- `isLocalModelOnly()` / `setLocalModelOnly()` — hard block on all cloud LLM calls (key `crystalball-local-model-only`, default `false`)
- `subscribeLlmEgressChange()` — for HUD re-render on toggle

### `src/services/llm-adapter.ts`
Two new gates in `generateText()`, checked before `reserveCloudCall()`:
1. `isLocalModelOnly()` → returns `{ text: '', provider: 'none' }` immediately, logs + increments counter
2. `!isLlmEgressDisclosed()` → dispatches `cb:llm-egress-disclosure-needed`, returns `{ text: '', provider: 'none' }`

### `src/components/AnalystHUD.ts`
- Disclosure banner in the Auto-Briefs section (only rendered while `!isLlmEgressDisclosed()`)  
  Text: *"When no local model is available, hypothesis summaries and evidence may be sent to your configured cloud LLM provider (Anthropic, Groq, or OpenRouter). Enable 'Local model only' below to disable this fallback."*  
  Acknowledge button sets `llmEgressDisclosed = true` and re-renders.
- **Local model only** toggle added to the settings card (⌘,)
- HUD auto-opens on first `cb:llm-egress-disclosure-needed` event (first attempted cloud call)

### `src/services/__tests__/llm-egress-settings.test.mts`
9 tests: settings defaults, persistence, reload survival, all three adapter gate scenarios (local-only blocks, undisclosed blocks + fires event, disclosed allows through to `reserveCloudCall`).

## Test results
```
✔ llmEgressDisclosed defaults to false
✔ setLlmEgressDisclosed persists to localStorage
✔ setLlmEgressDisclosed(false) clears the flag
✔ localModelOnly defaults to false
✔ setLocalModelOnly persists to localStorage
✔ settings survive simulated reload
✔ localModelOnly blocks cloud call before reserveCloudCall
✔ undisclosed egress blocks cloud call and emits disclosure event
✔ disclosed + not local-only allows cloud path to proceed
pass 9, fail 0
```

## Cross-agent review

This is a `claude/*` branch — Codex review required per cross-agent policy. Running review below.
