### PR TITLE
fix: extend LLM egress gate into runClaudeAgent() — covers all direct callers (M-4 follow-up)

### DIFF
--- a/src/services/__tests__/llm-egress-settings.test.mts
+++ b/src/services/__tests__/llm-egress-settings.test.mts
@@ -61,6 +61,7 @@ import {
   setLlmEgressDisclosed,
   isLocalModelOnly,
   setLocalModelOnly,
+  subscribeLlmEgressChange,
 } from '../ai-flow-settings.ts';
 
 // ── ai-flow-settings tests ─────────────────────────────────────────────────────
@@ -176,4 +177,105 @@ test('disclosed + not local-only allows cloud path to proceed', async () => {
   const result = await generateText('test prompt', { preferCloud: true });
   assert.equal(disclosureEventFired, false, 'disclosure event should not fire when egress is disclosed');
   assert.equal(result.provider, 'none'); // cap=0 → exhausted
+});
+
+// ── runClaudeAgent() gate tests ───────────────────────────────────────────────
+// These prove that direct callers (ClaudeAgentPanel, intel-provider, etc.) are
+// protected by the gate inside runClaudeAgent() itself — not only via
+// generateText(). The gate must throw before any fetch() call.
+
+import { runClaudeAgent } from '../claude-agent.ts';
+
+test('runClaudeAgent throws when localModelOnly is true', async () => {
+  storage.clear();
+  setLocalModelOnly(true);
+  setLlmEgressDisclosed(true);
+
+  await assert.rejects(
+    () => runClaudeAgent('test query'),
+    (err: Error) => {
+      assert.ok(err.message.includes('local-model-only'), `unexpected message: ${err.message}`);
+      return true;
+    },
+  );
+});
+
+test('runClaudeAgent throws and fires disclosure event when egress not acknowledged', async () => {
+  storage.clear();
+  setLocalModelOnly(false);
+  setLlmEgressDisclosed(false);
+
+  let disclosureEventFired = false;
+  docListeners.set('cb:llm-egress-disclosure-needed', [() => { disclosureEventFired = true; }]);
+
+  await assert.rejects(
+    () => runClaudeAgent('test query'),
+    (err: Error) => {
+      assert.ok(err.message.includes('egress not yet acknowledged'), `unexpected message: ${err.message}`);
+      return true;
+    },
+  );
+  assert.equal(disclosureEventFired, true, 'disclosure event must fire when egress is undisclosed');
+});
+
+test('runClaudeAgent bypasses gate when both conditions pass (reaches fetch)', async () => {
+  storage.clear();
+  setLocalModelOnly(false);
+  setLlmEgressDisclosed(true);
+
+  // Stub fetch so we can prove the gate was cleared without a real network call.
+  const FETCH_SENTINEL = new Error('stub-fetch-reached');
+  const origFetch = (globalThis as unknown as { fetch?: unknown }).fetch;
+  (globalThis as unknown as { fetch: () => Promise<never> }).fetch = () => Promise.reject(FETCH_SENTINEL);
+
+  try {
+    await assert.rejects(
+      () => runClaudeAgent('test query'),
+      (err: Error) => {
+        // Must be our stub sentinel — not a gate error.
+        assert.equal(err, FETCH_SENTINEL, 'should have reached fetch, not a gate error');
+        return true;
+      },
+    );
+  } finally {
+    if (origFetch === undefined) {
+      delete (globalThis as unknown as { fetch?: unknown }).fetch;
+    } else {
+      (globalThis as unknown as { fetch: unknown }).fetch = origFetch;
+    }
+  }
+});
+
+// ── subscribeLlmEgressChange() lifecycle tests ────────────────────────────────
+
+test('subscribeLlmEgressChange fires callback when llmEgressDisclosed changes', () => {
+  storage.clear();
+  windowListeners.clear();
+
+  let callCount = 0;
+  const unsub = subscribeLlmEgressChange(() => { callCount++; });
+
+  setLlmEgressDisclosed(true);
+  assert.equal(callCount, 1, 'callback should fire on setLlmEgressDisclosed');
+
+  setLocalModelOnly(true);
+  assert.equal(callCount, 2, 'callback should fire on setLocalModelOnly too');
+
+  unsub();
+});
+
+test('subscribeLlmEgressChange unsub stops further callbacks', () => {
+  storage.clear();
+  windowListeners.clear();
+
+  let callCount = 0;
+  const unsub = subscribeLlmEgressChange(() => { callCount++; });
+
+  setLlmEgressDisclosed(true);
+  assert.equal(callCount, 1);
+
+  unsub();
+
+  setLlmEgressDisclosed(false);
+  assert.equal(callCount, 1, 'callback must not fire after unsubscribe');
 });

--- a/src/services/claude-agent.ts
+++ b/src/services/claude-agent.ts
@@ -7,6 +7,7 @@
  */
 
 import { getApiBaseUrl } from './runtime';
+import { isLocalModelOnly, isLlmEgressDisclosed } from './ai-flow-settings';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -80,6 +81,14 @@ export async function runClaudeAgent(
   query: string,
   signal?: AbortSignal,
 ): Promise<AgentResponse> {
+  if (isLocalModelOnly()) {
+    throw new Error('cloud LLM is disabled: local-model-only mode is active');
+  }
+  if (!isLlmEgressDisclosed()) {
+    try { document.dispatchEvent(new CustomEvent('cb:llm-egress-disclosure-needed')); }
+    catch { /* non-browser context */ }
+    throw new Error('cloud LLM is disabled: egress not yet acknowledged by user');
+  }
   const baseUrl = getApiBaseUrl();
   const url = `${baseUrl}/api/claude-agent`;
 

--- a/src/services/supply-chain-impact.ts
+++ b/src/services/supply-chain-impact.ts
@@ -11,6 +11,7 @@
 import { getApiBaseUrl } from './runtime';
 import { haversineKm } from './proximity-filter';
 import { dataFreshness } from './data-freshness';
+import { runClaudeAgent } from './claude-agent';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -449,20 +450,13 @@ async function generateNarrative(disruption: {
 }): Promise<string> {
   const prompt = buildNarrativePrompt(disruption);
 
-  // Try Claude Agent first
+  // Try Claude Agent first — routes through the gated runClaudeAgent() path
+  // so localModelOnly and llmEgressDisclosed controls are honoured.
   try {
- const res = await fetch(`${getApiBaseUrl()}/api/claude-agent`, {
- method: 'POST',
- headers: { 'Content-Type': 'application/json' },
- body: JSON.stringify({ query: prompt }),
- signal: AbortSignal.timeout(15000),
- });
- if (res.ok) {
- const data = (await res.json()) as { response?: string };
- if (data.response) return data.response;
- }
+ const agentRes = await runClaudeAgent(prompt, AbortSignal.timeout(15000));
+ if (agentRes.response) return agentRes.response;
   } catch {
- // Claude unavailable — try Ollama
+ // Claude unavailable or gate blocked — try Ollama
   }
 
   // Ollama fallback


### PR DESCRIPTION
## Summary

Follow-up to [PR #1113](https://github.com/bradleybond512/crystal-ball/pull/1113) (T3-A), addressing findings from Codex cross-agent review.

## Changes (2 commits on top of main)

### `src/services/claude-agent.ts`
Gate added at top of `runClaudeAgent()` — the single cloud boundary for all callers:
```typescript
if (isLocalModelOnly()) throw new Error('cloud LLM is disabled: local-model-only mode is active');
if (!isLlmEgressDisclosed()) {
  document.dispatchEvent(new CustomEvent('cb:llm-egress-disclosure-needed'));
  throw new Error('cloud LLM is disabled: egress not yet acknowledged by user');
}
```
Covers all callers: ClaudeAgentPanel, intel-provider, survival-advisor, scenario-simulator, intelligence-briefing, financial-contagion, threat-synthesis, supply-chain-impact.

### `src/services/supply-chain-impact.ts`
`generateNarrative()` was doing a raw `fetch('/api/claude-agent')` that bypassed both gates. Replaced with `runClaudeAgent()`.

## Test results (14/14 pass)
`runClaudeAgent` throws on localModelOnly, throws + fires disclosure event on undisclosed, passes gate and reaches fetch when both clear. `subscribeLlmEgressChange` lifecycle verified.

---

## Cross-agent review record

| Pass | Reviewer | Verdict | Finding |
|------|----------|---------|---------|
| 1 | Codex | REQUEST CHANGES | Gates only in generateText(); 6 direct callers bypassed |
| 2 | Codex | REQUEST CHANGES | supply-chain-impact.ts raw fetch still bypassed |
| 3 | Codex | **APPROVED** (no blocking findings) | Gate confirmed as single choke-point; all callers verified; 14/14 tests pass |

✅ **Cross-agent Codex review: APPROVED — no blocking findings (pass 3)**
