### PR TITLE
docs: privacy fix plan (5 High findings) + perf fixes beyond quick wins

### DIFF
--- a/docs/PERFORMANCE_AUDIT_2026-06-11.md
+++ b/docs/PERFORMANCE_AUDIT_2026-06-11.md
@@ -1,0 +1,300 @@
+# Crystal Ball — Performance Audit (2026-06-11)
+
+**Scope:** Read-only analysis. No source files were modified.
+**Method:** Five parallel investigation passes (sidecar routes/caching, SQLite event store, panel refresh/memory, Cesium/startup, external feeds), followed by hand-verification of contested claims. All findings carry `file:line` references against the working tree as of 2026-06-11.
+
+> This report supersedes an earlier same-day draft at this path. Two of that draft's claims were re-verified against source: (1) the `dispose()`-vs-`destroy()` naming hazard is **real** (55 components, confirmed below); (2) the claim that Cesium ships in the main bundle is **contradicted by source** — `GodsVisionView` is dynamically imported at `App.ts:511` and is the only static importer of `CesiumGlobe`, so Cesium lives in a lazy chunk.
+
+---
+
+## Performance Summary
+
+| Component | Current behavior | Risk | Recommendation |
+|---|---|---|---|
+| Sidecar concurrency model | Single Node process, single event loop, ~293-route linear if-chain; sync SQLite (`node:sqlite` DatabaseSync), sync file tails, `execFileSync` on `/gps/nmea` | **High** | Move sync work (SQLite, OFAC XML parse, log tails) off the event loop; replace `execFileSync` with async |
+| Uncached external routes | 68 of 185 outbound routes have no cache; `/api/market-quotes` fans out N Finnhub calls per request; `/api/weather/alerts` fetches multi-MB NWS GeoJSON per request | **High** | Short-TTL caches + in-flight dedupe on the hot uncached routes |
+| Event store ingestion | Every push mints a fresh `randomUUID()`, bypassing the PK dedupe — live DB shows 3.6× row duplication; inserts un-transactioned; prune runs only at sidecar startup | **High** | Derive id from `obs.id`; wrap insert loop in a transaction; add periodic prune timer |
+| OpenSky `states/all` | Full ~2 MB global snapshot fetched by 3 independent routes under 3 cache keys ≈ 85 downloads/h (~150–250 MB/h) | **High** | One shared fetcher/TTL for all 3 routes |
+| FRED full-history CSVs | `/api/freight-stress` + `/api/macro-stress` uncached; full series history downloaded, last 13–30 rows used; ~3,700 upstream hits/day driven by a 60 s panel timer | **High** | 6–24 h cache; FRED data is daily/monthly |
+| Raw `setInterval` sprawl | 375 raw intervals in 349 files bypass the RefreshScheduler's ghost/hidden/jitter/backoff protections; only 5 loops use the `recurring-loops` registry | **Medium-High** | Migrate panel timers to `recurring-loops` or the scheduler |
+| Panel instantiation | 398 registered panels, ~471 instantiated eagerly at boot, never destroyed; all DOM trees exist for app lifetime; hidden panels keep ticking | **Medium** | Lazy instantiation, or at minimum pause timers for disabled/hidden panels |
+| `dispose()` vs `destroy()` naming | 55 components put their `clearInterval` in a `dispose()` method that nothing ever calls and base `Panel.destroy()` doesn't invoke | **Medium** (latent) | Rename to `override destroy()` so any future teardown pass actually cleans them |
+| EEWStatusBar | Sidecar fetch every **5 s**, always-on from boot | **Medium** | 30–60 s with hidden-pause |
+| `aisState.darkHistory` | 24 h TTL but pruned only inside the `/api/dark-vessels` handler; global AIS bounding box can accumulate 100k+ MMSI entries/day if the route is never called | **Medium** | Prune in the message or snapshot path |
+| NASA FIRMS | 6 parallel global VIIRS CSVs (3–15 MB), zero sidecar cache; source updates every 3 h | **Medium** | 30 min cache (the repo's own `feed-latency-config.mjs` already prescribes it) |
+| NWS `alerts/active` | Four uncoordinated full-US GeoJSON pulls (one renderer-direct with no timeout); no `If-Modified-Since` anywhere in the codebase | **Medium** | One shared, conditionally-revalidated sidecar route |
+| poweroutage.us | ~0.5–3 MB county JSON; TTL 60 s == panel poll 60 s → near-every-poll cache miss, around the clock | **Medium** | Raise TTL to 5 min; decouple panel cadence |
+| Cesium globe | Lazy-init, `requestRenderMode`, thorough teardown — but a 50 ms render tick makes active sessions ~20 fps, and `GlobeSeismicWaves` polls the sidecar every 5 s | **Low-Medium** | Gate the 50 ms tick on pulse-layer visibility; seismic poll → 60 s |
+| Startup | Two-wave boot fetch (concurrency 12), single keychain vault read, jittered refreshes — well remediated. Largest remaining cost: synchronous ~471-panel DOM construction before data load | **Low-Medium** | Chunk/idle-defer panel construction |
+| Memory-leak hygiene (renderer) | No `innerHTML +=` anywhere; interval-driven stores are capped; listeners paired | **Low** | None — hygiene is good; cost is churn, not growth |
+
+---
+
+## 1. Sidecar API performance
+
+### 1.1 Route handling & concurrency model
+
+The sidecar is a **single Node process with a single event loop** — no `cluster`, no `worker_threads`. `createServer` at [local-api-server.mjs:15568](../src-tauri/sidecar/local-api-server.mjs) binds to `127.0.0.1`. Dispatch is two-tiered:
+
+1. A handful of routes handled inline in the server callback (`/gps/nmea` :15575, `/api/health` :15626, intelligence situations :15678–15917, `/api/ollama-stream` :15965).
+2. Everything else funnels into `dispatch()` at line 4984 — a **~10,500-line sequential if-chain of ~293 exact-match `pathname ===` comparisons** (lines 4990–15241). Routes near the bottom pay ~290 string comparisons per request. Cheap individually, but O(routes), not a table.
+
+Responses are **fully buffered** (`Buffer.from(await response.arrayBuffer())` at :16004) then optionally brotli/gzip compressed (:16021). Only `/api/ollama-stream` streams. Unknown routes fall through to dynamic `api/*.js` handler modules (`pickModule` :1550, `moduleCache` :1562) and then an optional cloud proxy (:1532, 15 s timeout).
+
+A heartbeat `setInterval` (10 s) at :16124 measures event-loop lag and writes `sidecar.health.json` — loop stalls are already a recognized risk class.
+
+**Synchronous work that blocks the entire sidecar:**
+
+| Location | Blocker |
+|---|---|
+| local-api-server.mjs:15588 | `/gps/nmea` runs **`execFileSync('head', …, {timeout: 3000})`** on a serial device — can stall the event loop **up to 3 s per request**. Worst single blocker. |
+| local-api-server.mjs:3895–3908 | `_tailFile` uses `statSync`/`readSync`; called by `/api/local-ids` (:13380) **on every request, uncached**, reading up to ~500 KB of Suricata/Zeek logs and regexing every line. |
+| event-store.mjs:9 | `node:sqlite` `DatabaseSync` — every query is synchronous on the loop (see §4). |
+| ofac-cache.mjs:80–95 | Weekly SDN refresh parses the **entire multi-MB sdn.xml synchronously** in-process, plus `JSON.stringify` of all entries to disk. Once per 7 days (or first boot). |
+| local-api-server.mjs:743 | AIS websocket: `JSON.parse` per message on a **global bounding box** firehose (`[[-90,-180],[90,180]]`, :781) — constant background CPU; snapshot `JSON.stringify` (~1,500 reports) at :726, invalidated on every message (:762). |
+| :16004 + JSON.parse sites | Whole-body buffering + sync `JSON.parse` of multi-MB upstream payloads (NWS GeoJSON, Celestrak GP). |
+
+Request bodies are capped at 16 MB (`MAX_REQUEST_BODY_BYTES`, :1479) — good. But `fetchWithTimeout` (:3613, 277 call sites) **buffers upstream bodies with no size cap** (:3634–3637) — a misbehaving upstream can balloon memory.
+
+### 1.2 Slowest likely routes
+
+**Fan-out routes** (one request → many upstream calls):
+
+| Route | Line | Fan-out | Cached? |
+|---|---|---|---|
+| `/api/sitrep-bundle` | :6307 | 21 internal sub-requests (each may hit external APIs), 12 s each, parallel | 5 min |
+| `/api/celestrak-gp` | :6455 | 11 parallel Celestrak groups incl. Starlink (~7k sats) | 4 h, but the cached combined array is multi-MB |
+| `/api/adsb-aggregate` | :12834 | 4 sources (OpenSky + airplanes.live + adsb.fi + adsb.lol), 3 s each | 30 s per query string |
+| `/api/webcams/dot-extended` | :15003 | up to 9 jurisdiction APIs | 5 min |
+| `/api/market-quotes` | :9705 | **N parallel Finnhub calls — one per symbol** + Stooq CSV + FRED VIX | **uncached** |
+| `/api/fred-fallback` | :9832 | 5 parallel sources | **uncached** |
+| `/api/economic-stress` | :12487 | 7 parallel sources | cached |
+| `/api/disease-intel` | :8661 | 4 parallel sources | cached |
+
+**CPU-intensive routes:** `/api/gdelt/summary` (:418 — sleeps 5.5 s between two sequential GDELT calls; first-miss latency 6–18 s, 15 min cache with in-flight dedupe), `/api/local-ids` (:13380 — sync tail + heavy regex per request, uncached), `/api/weather/seaice` (:8292 — full-series CSV median computation), `/api/aviation/flights` (:13834 — classifies every OpenSky state vector, 10 min cache), `/api/faa-cam-analyze` (:8488 — image fetch + in-process base64 + 25 s Ollama vision call, per request, uncached), `/api/intel-generate` (:15981→:4776 — a single request can hold **90 s**: 60 s local + 30 s Groq fallback; circuit breaker after 2 failures, :4861).
+
+### 1.3 Cache inventory
+
+**Bounded / well-behaved:**
+
+- `_sidecarCache` (`getCached`/`setCached`, :3810) — the main cache, ~117 routes; per-key TTL 30 s–24 h; **hard cap 500 entries + 5-min sweep** (:3811–3828). ✔ (Minor: the trim sorts on insert at the cap — O(n log n) churn under pressure; an LRU would be cleaner.)
+- `aisState.vessels` (:671) — 30 min TTL, cap 20,000 with oldest-evict (:700–712). ✔
+- `_entities` registry (:2809) — capped 5,000 FIFO (:2855–2858). ✔
+- `trafficLog` (:1651) — fixed ring of 200. ✔
+- `SECURITY_CVE_CACHE` 24 h keyed by severity (:3448–3449, few keys), `securityVulnersCache` 6 h (:3450), space-weather caches 5–15 min (:2353–2356) — single-value or few-key. ✔
+- `feed-resilience.mjs` circuits + last-good cache ([feed-resilience.mjs:9–18](../src-tauri/sidecar/feed-resilience.mjs)) — keyed by feed, no eviction but bounded by feed count.
+- `ofac-cache.mjs` (:34–37) — single SDN dataset, 7-day TTL, on-disk persistence. Large but correct design.
+
+**Unbounded or weakly bounded:**
+
+- **`aisState.darkHistory`** (:675) — 24 h TTL but **pruning happens only inside the `/api/dark-vessels` handler** (:6864–6866). With the global AIS bounding box, if that route is never requested the Map accumulates one entry per MMSI seen worldwide — easily 100k+ entries/day. The biggest unbounded-growth candidate in the sidecar.
+- `_responseCache` (`cachedFetch`, :321–340) — eviction only deletes *expired* entries when size > 200 (:332–334); **no hard cap** on unexpired keys. Practically self-limiting (per-key TTLs 5 min–24 h) but unbounded in principle. Has in-flight dedupe (`_inflight`, :322) — which `getCached`/`setCached` (the other 117 routes) **lacks**: N concurrent cache-miss requests for the same key all fan out upstream simultaneously.
+- `wmHostStats`/`wmHostFailures` (:214/:216) — keyed per upstream host, never pruned; `rss-proxy` targets make this partially user-controlled.
+
+### 1.4 Uncached hot paths (external HTTP on every request)
+
+Scan of all 293 route blocks: **185 make outbound calls; 68 have no caching.** Worst by likely traffic:
+
+1. **`/api/market-quotes`** (:9705) — N Finnhub calls per request, polled by market panels. No cache, no dedupe → concurrent renderer polls multiply upstream calls and burn Finnhub quota.
+2. **`/api/weather/alerts`** (:8068) — full NWS `alerts/active` GeoJSON (1–8 MB) fetched and parsed **per request**, geometry retained (:8102). Its siblings `/api/nws-alerts` (:8027) and `/api/weather/active-warnings` (:8137) are cached; this one isn't.
+3. **`/api/rss-proxy`** (:12170) — pass-through by design, zero caching; every renderer feed refresh is an upstream hit.
+4. `/api/fred-fallback` (:9832), `/api/macro-signals` (:9646), `/api/macro-stress` (:6935), `/api/freight-stress` (:6827), `/api/crypto-quotes` (:9777 — CoinGecko, rate-limit-sensitive), `/api/stablecoin-markets` (:9602), `/api/btc-etf-flows` (:9260).
+5. Cyber feeds fetched fresh each call: `/api/threatfox-iocs` (:7162), `/api/openphish-feed` (:7308), `/api/spamhaus-drop` (:7338), `/api/cisa-kev` (:7374), `/api/otx-iocs` (:7587 — includes per-IP geolocation fan-out at :7628).
+6. Metered news APIs uncached: `/api/newsapi-headlines` (:7780), `/api/newsdata-feed` (:7811).
+7. `/api/nasa-firms` (:11704 — per-area fan-out at :11755), `/api/inpe-fires` (:11867), `/api/wildfire/*` (:11774–11838), `/api/donki-events` (:9039 — 3 NASA calls).
+
+### 1.5 Timeouts and retry behavior
+
+- `fetchWithTimeout` (:3613) default 12 s with destroy-on-timeout — 277 call sites. ✔
+- **Four bare `fetch()` calls with no timeout/abort**: :1956 (Patreon OAuth), :5127 (YouTube channel-feed), :5144 (Patreon audio-RSS), :5162 (Patreon verify) — hung-request risk.
+- GDELT has exemplary exponential backoff 5 s→300 s with stale-serving (:13085–13117). `feed-resilience.mjs` circuit breaker (3 failures/5 min → open 10 min, half-open probe) is solid but **only a handful of routes use it** (nws-alerts, gdacs).
+- AIS websocket reconnects on a **fixed 5 s delay, no backoff** (`AIS_RECONNECT_DELAY_MS`, :796) — a dead upstream gets hit every 5 s indefinitely.
+- Brotli compression of multi-MB JSON runs at default quality 11 (`maybeCompressResponseBody` :1366, no `BROTLI_PARAM_QUALITY` set) — itself CPU-heavy.
+
+---
+
+## 2. Panel refresh rates
+
+### 2.1 Two parallel refresh systems
+
+**A. Central `RefreshScheduler`** ([refresh-scheduler.ts](../src/app/refresh-scheduler.ts)) — self-rescheduling `setTimeout` chains with, per tick: ghost ×5 multiplier (:68), hidden-window ×10 (:6–9), ±10% jitter with 1 s floor (:60–74), no-change/error backoff ×2 up to ×4 (:102, :107), in-flight dedupe (:87), and foreground stale-flush capped at 6 concurrent with 150 ms stagger (:117–158). **53 refreshes are scheduler-managed**, registered in [App.ts:579–730](../src/App.ts). Fastest scheduled task is 60 s (`littleSnitch` :608, `adsb` :688). Nothing scheduled is under 30 s. This is well-designed infrastructure.
+
+**B. Raw `setInterval` — 375 call sites across 349 files**, all bypassing the scheduler: 299 component files + 44 services. None get ghost/hidden/jitter/backoff/dedupe. A third registry, [recurring-loops.ts](../src/services/diagnostics/recurring-loops.ts) (priority-based, `'low'` loops pause when hidden), exists but has **only 5 adopters** ([panel-layout.ts:1872–1899](../src/app/panel-layout.ts)).
+
+### 2.2 Raw-interval distribution
+
+228 panels share the pattern `this.refreshTimer = setInterval(() => this.render(), REFRESH_MS)` — local recompute + debounced render:
+
+| Interval | Panels | | Interval | Panels |
+|---|---|---|---|---|
+| 1 s | 1 | | 5 min | 20 |
+| 5 s | 3 | | 10 min | 7 |
+| 10 s | 21 | | 15 min | 5 |
+| 15 s | 12 | | 30 min | 24 |
+| 20 s | 1 | | 1 h | 35 |
+| 30 s | 53 | | 6 h | 2 |
+| 45 s–3 min | 24 | | 24 h | 24 |
+
+### 2.3 Sub-30 s refreshers — flagged
+
+**Network per tick (the ones that matter):**
+
+| Where | Interval | Hits |
+|---|---|---|
+| [EEWStatusBar.ts:155](../src/components/EEWStatusBar.ts) (`POLL_INTERVAL_MS=5000` :31) | **5 s** | Sidecar fetch, instantiated at boot (panel-layout.ts:841), polls forever. ~12 req/min — the heaviest always-on poller in the app. |
+| [S2UIntelPanel.ts:90](../src/components/S2UIntelPanel.ts) | **10 s** | Sidecar `/api/s2u-xmpp` (:112); TAK at 60 s (:91). |
+| [CorrelationAlertBanner.ts:19](../src/components/CorrelationAlertBanner.ts) (started at panel-layout.ts:863–866) | **15 s** | Sidecar `/api/synthesis/correlations`, app lifetime, bypasses both the scheduler and recurring-loops. |
+| UnifiedSettings.ts:1479 / settings-main.ts:646 | 3 s | Sidecar traffic log — gated: only while settings is open with auto-refresh on. Acceptable. |
+| [clipboard-watcher.ts:26](../src/services/clipboard-watcher.ts) (`POLL_MS=500`) | 500 ms | Tauri IPC clipboard read — gated to the API-key wizard, cleared on stop. Acceptable. |
+| [CorrelationMapPanel.ts:84](../src/components/CorrelationMapPanel.ts), [WhatChangedPanel.ts:34](../src/components/WhatChangedPanel.ts) | 30 s | Sidecar fetches, unconditional from boot. |
+
+**Local-only sub-30 s ticks (compute + render, no network):** 1 s — Globe4D HUD counters (God's Eye only), UTC clock (gated on `isAppActive`), EEWStatusBar subtitle re-render; 5 s — one shared static heartbeat ticker for all panel instances ([Panel.ts:960](../src/components/Panel.ts), good design), JustInRail prune, 3 full-re-render panels; 10 s — 21 panels re-render (CommandCenterPanel :144, FeedHealthDashboardPanel :40, ApiDiagnosticPanel :59, …); 15 s — 12 panels; 20 s — [SeismicSuperpowerPanel.ts:311](../src/components/SeismicSuperpowerPanel.ts) queries 500 events from the observation store per tick.
+
+**Key concern:** only 8 of 299 component files gate their tick on visibility. `Panel.setContent` suppresses *DOM writes* when hidden/off-screen (IntersectionObserver with 200 px rootMargin, Panel.ts:913–926; app-visibility :783), but the per-tick **compute** (store queries, HTML string building) runs regardless — ~38 panels every ≤15 s plus 53 more at 30 s, for the app's lifetime, even when hidden.
+
+### 2.4 Sidecar-calling vs. local panels
+
+Scheduler-managed refreshes are all sidecar/network loads through `data-loader.ts`. The 228-panel raw-interval pattern is overwhelmingly **local recompute** over in-memory stores. The network-on-tick exceptions are the table above plus service pollers: `oref-alerts` 2 min, maritime snapshot 5 min, `grid-intelligence-loader` 5/10/15 min, `intel-channels-bridge` 5/15 min, spaceweather status bar 5 min, and the bare-interval panels in §7 (MaritimeIntelPanel / InfraRiskMatrixPanel at 60 s).
+
+---
+
+## 3. Memory footprint
+
+### 3.1 Panel count and instantiation
+
+- **398 panel configs** in `FULL_PANELS` ([panels.ts:9–412](../src/config/panels.ts)), all `enabled: true`.
+- **~471 `new XPanel(...)` instantiations in panel-layout.ts, all eager at startup**, plus 7 OSINT panels whose *code chunk* is lazy-loaded but which are still instantiated at boot (`loadOsintPanels`, panel-layout.ts:2612–2629, invoked at :1393). [Panel.ts:230](../src/components/Panel.ts) itself documents "473+ panel instances."
+- All panel DOM trees are appended to the grid at boot (:2193, :2513). Disabling a panel is `display:none` (:826) — **the DOM stays and the panel's intervals keep firing**. No virtualization or unmounting.
+- Mitigations in place: per-panel IntersectionObserver skips DOM writes off-screen, 150 ms content debounce + cached-HTML no-op detection (Panel.ts:771–794), one shared heartbeat ticker for all instances, heartbeat animation paused off-screen (:942).
+
+### 3.2 Leak-pattern audit
+
+**Verdict: renderer hygiene is good in the steady state; the risks are (a) lifetime timers by design and (b) a latent teardown bug.**
+
+- **Intervals**: component files with `setInterval` consistently pair it with `clearInterval` in a cleanup method. The dominant pattern stores timer ids and clears them in `override destroy()`; base `Panel.destroy()` (Panel.ts:1280–1374) removes all document/window listeners, disconnects observers, cancels RAFs and debounce timers, and aborts in-flight fetches via `AbortController`.
+- **Latent teardown bug (verified)**: **55 components put their cleanup in a method named `dispose()` instead of `destroy()`** (e.g. [HybridWarfarePanel.ts:26–28](../src/components/HybridWarfarePanel.ts) clears `refreshTimer` in `dispose()`). Nothing in `panel-layout.ts` or `App.ts` calls `.dispose()`, and since the method doesn't override `Panel.destroy()`, even a future teardown pass that calls `destroy()` would not clear these timers. Today this is moot — panel `destroy()` is essentially never called in the full variant anyway (only module teardown at App.ts:488), so **all ~473 panels' timers run for the app lifetime regardless**. That lifetime ticking, not growth, is the dominant idle-CPU cost. But the `dispose()` naming makes any future "destroy panels on disable" fix silently incomplete for 55 panels.
+- **Listeners**: 118 `document/window.addEventListener` across 60 files; sampled hot spots all use bound-handler-in-constructor or paired add/remove. One minor: `AnalystHUD.mount` (:146–168) adds 4 unremovable document listeners — singleton mounted once, harmless. Listeners attached to children inside `render()` are discarded with the innerHTML swap — no accumulation.
+- **DOM accumulation**: **zero `innerHTML +=` and zero `insertAdjacentHTML` in the entire src/ tree.** All rendering funnels through `setContent` or `replaceChildren`.
+- **Unbounded arrays**: all sampled interval-driven stores are capped — `pressure-history.ts:121–122` (splice to HISTORY_MAX), `reasoning-debug.ts:93–94` (200-entry ring), `military-flights.ts:218–220` (20 track points), `alert-correlator.ts:191` (1,000-cap + hourly prune at :589).
+
+The genuine unbounded-growth risks are sidecar-side: `darkHistory` (§1.3) and event-store duplication (§4).
+
+---
+
+## 4. SQLite event store (Temporal World Store)
+
+### 4.1 Driver, schema, pragmas
+
+- **Driver: `node:sqlite` `DatabaseSync`** ([event-store.mjs:9](../src-tauri/sidecar/event-store.mjs)) — fully synchronous; every query blocks the same event loop serving all API traffic. Chosen deliberately to avoid native modules (file header), but a slow query stalls every sidecar route.
+- One table, five secondary indexes (event-store.mjs:57–74): `idx_events_occurred_at`, `idx_events_domain`, `idx_events_partition`, `idx_events_type`, `idx_events_source`. **`occurred_at`, `domain`, and `partition_key` are all indexed.** WAL mode + `synchronous = NORMAL` (:80–81). ✔
+- `idx_events_partition` is near-dead weight: no query filters on `partition_key`; its only consumer is `SELECT DISTINCT partition_key` in `health()` (:186). Six B-trees (incl. PK) are maintained per insert.
+
+### 4.2 Query patterns
+
+`queryEvents()` (:131–160): time/domain/source/type filters all hit single-column indexes; bounded (default LIMIT 1000 :22, HTTP cap 5000 at local-api-server.mjs:5989); no `SELECT *`. Issues:
+
+- `entity_ids LIKE '%"id"%'` (:142–149) — leading-wildcard LIKE over JSON-as-TEXT: **never indexable**; a rare-entity query approaches a full-table reverse scan.
+- `ORDER BY occurred_at DESC, id DESC` is only partially index-satisfied; the common shape `domain = ? ORDER BY occurred_at DESC LIMIT n` has no composite `(domain, occurred_at)` index, forcing either a sort of all domain rows or row-by-row filtering of the time index.
+- `OFFSET` pagination (:158) is O(offset); keyset pagination would be O(1).
+- `health()` (:181–207) does full-table `COUNT(*)` + `GROUP BY domain` **per request** at `/api/events/health` (local-api-server.mjs:6006) — synchronous; at GB scale this becomes the route most likely to stall the sidecar.
+- No N+1 read patterns found; the only query-in-loop is the insert loop below.
+
+### 4.3 Write patterns — the biggest event-store findings
+
+**(a) Inserts are one-at-a-time auto-commit, never transactioned.** local-api-server.mjs:5953 loops up to 200 individual INSERTs (each its own implicit commit) per POST, synchronously on the request path. The prepared statement is reused (event-store.mjs:86–90); per-statement commit is the cost.
+
+**(b) Ingestion duplicates rows — confirmed in the live DB.** The renderer POSTs the most-recent-200 slice of the observation ring ([data-loader.ts:4004–4012](../src/app/data-loader.ts)) from `loadNatural()` (hourly) and `loadAisSignals()` (every 10 min). The store has dedupe — `id TEXT PRIMARY KEY` with a fail-closed append check (event-store.mjs:84–85, :123–128) — but ingestion **bypasses it**: `appendObservationToEventStore` discards the observation's own id and mints a fresh `randomUUID()` per append (local-api-server.mjs:70). Live DB (`~/Library/Logs/com.bradleybond.crystalball/events.db`): **819 rows, only 227 distinct payloads — 3.6× amplification after ~2 days**; one `open-meteo-wind` observation stored 5 times; `open-meteo-forecast` accounts for 720 of 819 rows. An observation that stays in the top-200 ring for 24 h with AIS enabled gets re-inserted up to 144 times. (`appendSituationToEventStore` at :95 has the same `randomUUID()` pattern; its call site is per-mutation, so lower risk.)
+
+**(c)** Open-meteo forecast observations carry **future** `occurred_at` (live rows dated 3 days ahead) — they age out of retention ~3 days late and always sort to the top of default `ORDER BY occurred_at DESC` queries, shadowing real recent events.
+
+### 4.4 Pruning / growth
+
+- Retention: 3 months default (`EVENT_STORE_RETENTION_MONTHS`, :24–29). `pruneOlderThan()` (:175–179) is indexed. ✔
+- **Prune runs only at sidecar startup** (local-api-server.mjs:15556–15561) and via manual `POST /api/events/prune` (:6011). **No periodic timer** — weeks-long uptime means zero pruning.
+- Growth estimate: live rate ~410 rows/day at ~635 B/row all-in (~0.25 MB/day — trivial today). Worst case (all feeds emitting, full ring, no dedupe fix): 168 pushes/day × 200 rows ≈ **34 K rows/day ≈ 21 MB/day → ~1.9 GB steady state at 3-month retention**; ~640 MB/month unbounded if pruning never runs — at which point the synchronous `health()` aggregates and the DELETE itself become loop-blocking operations measured in hundreds of ms.
+- Live file: 520 KB DB + **4.1 MB WAL** + 33 KB SHM — the WAL at ~8× the main DB rides the auto-checkpoint threshold; no explicit `wal_checkpoint`, and `close()` (:209–211) is never called on shutdown.
+- Location: `dataDir/events.db`, where Tauri sets `LOCAL_API_DATA_DIR` to the logs dir ([main.rs:2484–2491](../src-tauri/src/main.rs)) → `~/Library/Logs/com.bradleybond.crystalball/events.db`. Dev fallback is `process.cwd()` (local-api-server.mjs:1730) — hence the stray gitignored `events.db` in the repo root. Size monitoring exists but is pull-only: `health()` reports `dbSizeBytes` (:195–203); nothing polls or alerts on it.
+
+---
+
+## 5. Cesium 3D globe (God's Vision)
+
+### 5.1 Layers
+
+[gods-vision-layers.ts](../src/config/gods-vision-layers.ts) defines **44 layers** (`DEFAULT_GODS_VISION_LAYERS`, :10–279), **21 enabled by default**; `GlobeDataManager.initialize()` registers 42 loadable layers ([GlobeDataManager.ts:631–681](../src/components/GlobeDataManager.ts)). Refresh model: **layers load once per God's Vision session** (`loaded` flag, :753–767); 11 layers are altitude-deferred (:592–604). Pollers inside the globe:
+
+| Poller | Interval | Network? |
+|---|---|---|
+| **GlobeSeismicWaves** ([GlobeSeismicWaves.ts:44](../src/components/GlobeSeismicWaves.ts)) | **5 s** | **yes** — `/api/seismic-globe-overlays`. The only sub-60 s network poller on the globe. |
+| maritimeVessels AIS refresh (GlobeDataManager.ts:1931–1937) | 5 min | yes |
+| Satellite SGP4 worker positions | 1 Hz | no (worker compute) — but `updateSatellitePositions` does `removeAll()` + re-add of the whole `PointPrimitiveCollection` every second (:2933–2950): steady allocation churn with a large catalog |
+| GlobeTrails 5 s, GlobePillars 10 s, Globe4D HUD 1 s, GlobeArcs 30 s, GodsVisionView HUD 100 ms | — | no, local |
+
+### 5.2 Initialization, rendering, caching
+
+- **Lazy-init: yes (verified).** The Cesium chunk is dynamically imported only when the user toggles God's Vision ([App.ts:501–518](../src/App.ts); `await import('@/components/GodsVisionView')` at :511, the sole static importer of `CesiumGlobe`); the viewer is constructed in `enter()`; full teardown on exit frees the WebGL context.
+- **`requestRenderMode: true`** with `maximumRenderTimeChange: Infinity` ([CesiumGlobe.ts:83–84](../src/components/CesiumGlobe.ts)) — not a continuous loop. **However**, a 50 ms render tick for CallbackProperty pulses (:285–292) plus a 1 s heartbeat (:499–506) mean an active, focused session effectively renders **~20 fps**, not the "~1 fps idle" the comment at :93–96 claims. Both ticks are gated on `isAppActive()` (0 fps when hidden/blurred).
+- **`tileCacheSize` is not configured** — Cesium's default 100 tiles applies. No `maximumScreenSpaceError`/`preloadSiblings` tuning. Usually acceptable, but repeated theater-jumping (keys 1–6) re-fetches evicted tiles. `msaaSamples: 2`, `resolutionScale = min(devicePixelRatio, 2)`.
+- **Cleanup on exit: thorough.** `GodsVisionView.exit()` (:390–431) and `GlobeDataManager.destroy()` (:2952–2987) clear the maritime interval, terminate the SGP4 worker, destroy the seismic poller, and remove all data sources. Minor nit: one-shot layer fetches carry no AbortController (except floodAlerts), so exiting mid-load lets in-flight requests complete into removed data sources — wasted bytes, not a leak.
+
+---
+
+## 6. Startup
+
+### 6.1 Launch sequence
+
+`main.ts`: Sentry + analytics + theme synchronously (trivial); heavy modules dynamically imported; on desktop `app.init()` starts **behind the vault intro overlay** (:335–337), overlapping the biometric gate — good. `App.init()` ([App.ts:345–481](../src/App.ts)) is fully sequential: `initDB()` (IDB open) → `initI18n()` → `mlWorker.init()` → `fetchBootstrapData()` (single `/api/bootstrap`, 800 ms timeout) → **`panelLayout.init()` — synchronous all-panels DOM construction** → UI phases → `preloadCountryGeometry()` (214 KB GeoJSON fetch+parse, awaited) → `loadAllData()` → refresh registration.
+
+**The single largest synchronous block is `createPanels()`** ([panel-layout.ts:655–700](../src/app/panel-layout.ts) onward): ~471 panel constructions + DOM appends + dozens of inline `start*()` service boots (:873–984), all before any data loads.
+
+### 6.2 Tauri / Rust side
+
+- `setup()` ([main.rs:2974](../src-tauri/src/main.rs)) loads the PersistentCache from disk **synchronously on the main thread** — a one-time multi-MB JSON read+parse (the comment at :2975–2977 explains it avoids per-IPC file I/O).
+- **Keychain: a single consolidated `secrets-vault` read in steady state** (:186, :253–285), on `spawn_blocking`. Only the one-time migration scans all 73 keys individually; a `migration_done` marker prevents repeats. The frontend's 73 parallel `get_secret` IPC calls ([runtime-config.ts:1326–1337](../src/services/runtime-config.ts)) hit the in-memory Rust cache — IPC chatter, no prompts. **This previously painful path is remediated.**
+- Sidecar spawn is unconditional (:3043–3056) after an orphan-listener kill via `lsof` (:2374–2396). The sidecar starts only light intervals at boot (DNS-cache clear, cache sweep, heartbeat writer).
+
+### 6.3 Boot fetch volume
+
+`loadAllData()` ([data-loader.ts:498–689](../src/app/data-loader.ts)) runs ~105 task groups in **two waves** (11 critical first, :666–671) through a **concurrency limiter capped at 12** (:673) — bounded, not a thundering herd. Some tasks fan out internally (`loadNews` walks a 429-URL feed config 5 categories at a time, :1052–1061). Boot-time interval starts: CorrelationAlertBanner 15 s (network — flagged in §2.3), provider-snapshot bridge 30 s, sidecar health probe 30 s, quality-debt collector 60 s, outcome grading hourly, tuning apply 6 h (panel-layout.ts:863–884, :1868–1930).
+
+---
+
+## 7. External API efficiency
+
+**Conditional requests: confirmed — zero uses of ETag / If-None-Match / If-Modified-Since anywhere** (renderer or sidecar). The only mentions are the app acknowledging the debt ([quality-debt-tracker.ts:192–194](../src/services/intelligence/quality-debt-tracker.ts)). NWS, CISA KEV, and FRED all honor conditional GETs.
+
+[feed-latency-config.mjs](../src-tauri/sidecar/feed-latency-config.mjs) is an honest in-repo self-audit of TTL-vs-source-cadence and **already documents several of the gaps below** — the fixes are pre-specified.
+
+### Worst offenders, ranked by payload × frequency
+
+**#1 — OpenSky `states/all` fetched by three independent routes.** Full global snapshot (~1.5–2.5 MB JSON, 8–12k aircraft) under three cache keys, never shared: `/api/adsb` (local-api-server.mjs:12670, TTL 55 s, renderer polls 60 s, **payload forwarded raw to the renderer and parsed twice**), `/api/adsb-military` (:13754, TTL 3 min, ~99% of payload discarded after military-hex filtering), `/api/aviation/flights` (:13834, TTL 10 min). ≈ **85 full-globe downloads/hour ≈ 150–250 MB/h** from an upstream that rate-limits anonymous users (~100 req/day per feed-latency-config.mjs:29). One shared fetcher would cut this ~3×.
+
+**#2 — poweroutage.us county JSON every 60 s.** `/api/infrarisks/power` (:7066–7080): ~0.5–3 MB, TTL **60 s**, polled by [InfraRiskMatrixPanel.ts:24,42](../src/components/InfraRiskMatrixPanel.ts) every **60 s** via a bare interval — TTL == poll interval means nearly every poll is a cache miss, ~60 upstream hits/h around the clock, full payload re-parsed renderer-side each minute and reduced to aggregate scores.
+
+**#3 — NASA FIRMS: 6 parallel global VIIRS CSVs, zero cache.** `/api/nasa-firms` (:11704–11772): ~3–15 MB total, **no sidecar cache** — the repo's own config admits it (feed-latency-config.mjs:174–178: "No cache — expensive multi-region fetch; 30-min cache would help" — source updates every **3 h**). Triggered every 30 min plus boot plus every `fetchFireIntelSnapshot()` ([fire-intel-service.ts:222](../src/services/wildfires/fire-intel-service.ts)). Same file flags `wildfire-perimeters` (NIFC ArcGIS GeoJSON, :179–183) as uncached.
+
+**#4 — NWS `alerts/active`: four uncoordinated full-US GeoJSON pulls** (1–6 MB each with polygons): (1) renderer-direct in [weather.ts:41–53](../src/services/weather.ts) — bare `fetch`, **no timeout, no `limit` param**, every 10 min, parses everything and keeps the top 50 alerts; (2) `/api/nws-alerts` (:8027), deliberately uncached (feed-latency-config.mjs:48–52 suggests a 90 s cache); (3) `/api/weather/alerts` (:8355); (4) `/api/alerts/active` (:8314), whose only identified poller appears unwired. No conditional revalidation despite api.weather.gov supporting it.
+
+**#5 — FRED full-history CSVs, uncached, driven by a 60 s panel.** `/api/freight-stress` (:6827–6857) and `/api/macro-stress` (:6936–6965) have **no cache**; each call downloads the entire `fredgraph.csv` series history (VIXCLS ≈ 9,000 daily rows) and uses the **last 13** (:2239–2249) or **last 30** (:1974–1988) observations. Drivers: [MaritimeIntelPanel.ts:47,227](../src/components/MaritimeIntelPanel.ts) every **60 s** + [EconomicIntelPanel.ts:75,120](../src/components/EconomicIntelPanel.ts) every 5 min + self-test runs. ≈ **3,700+ upstream FRED hits/day** for daily/monthly data. This is the exact debt item already logged in quality-debt-tracker.ts:192.
+
+**Honorable mentions:** CISA KEV (~3–4 MB) re-downloaded every 30 min via `/api/infrarisks/kev` (:7082) **and the full blob shipped over loopback + reparsed by the renderer every 60 s**; a second KEV entry at feed-latency-config.mjs:136 uses a 24 h TTL — two routes, two policies. SWPC DONKI CME ~1 MB every 5 min, parsed down to a small struct. Celestrak GP (multi-MB, 4 h TTL, boot-only load, circuit-breaker cache) and OFAC SDN (7-day TTL, on-disk) are correctly designed.
+
+**Parse efficiency:** most sidecar routes project upstream payloads to compact DTOs (dod-contracts :12743, wikidata :12800, gdacs-rss regex-parse, wastewater 60-row cap) — good. The bad cases are the five offenders above plus `/api/adsb` forwarding raw OpenSky verbatim.
+
+**Resilience:** 47 renderer services use [circuit-breaker.ts](../src/utils/circuit-breaker.ts) (2 failures → 5 min cooldown, stale-serve); the scheduler backs off ×2→×4. No tight retry loops found — but bare-`setInterval` panels never slow down during outages (poweroutage.us gets a fresh attempt every 60 s for an outage's duration).
+
+---
+
+## Quick Wins — top 5 highest-impact, lowest-effort
+
+1. **Dedupe event-store ingestion** — change local-api-server.mjs:70 to derive the event id from `obs.id` (e.g. `` `obs:${obs.id}` ``) instead of `randomUUID()`. The existing PRIMARY KEY + fail-closed catch then makes re-pushes no-ops, eliminating the confirmed 3.6×+ write amplification at its source. One line. While there, wrap the insert loop at :5953 in a transaction and add a daily prune `setInterval` next to the startup prune at :15556.
+
+2. **Cache the FRED stress routes for 6–24 h** (local-api-server.mjs:6827, :6936) — the data updates daily/monthly; this converts ~3,700 upstream hits/day into ~4–8, using the `getCached`/`setCached` helpers already in the file. The same one-route pattern adds a 30 min cache to `/api/nasa-firms` (:11704), which the repo's own feed-latency-config.mjs:174 already prescribes.
+
+3. **Share one OpenSky `states/all` fetcher across `/api/adsb`, `/api/adsb-military`, and `/api/aviation/flights`** (:12670, :13754, :13834) — a single cached raw snapshot with per-route projections cuts ~100–150 MB/h of upstream transfer ~3× and protects the anonymous rate limit.
+
+4. **Slow the three worst always-on pollers**: EEWStatusBar 5 s → 30–60 s (EEWStatusBar.ts:31), CorrelationAlertBanner 15 s → 60 s with hidden-pause via `registerRecurringLoop` (CorrelationAlertBanner.ts:19), and decouple InfraRiskMatrixPanel's 60 s poll from the 60 s poweroutage.us TTL (raise TTL to 5 min). Constant changes; immediate battery/CPU/upstream relief.
+
+5. **Add short-TTL caches + in-flight dedupe to the two hottest uncached sidecar routes**: `/api/market-quotes` (:9705 — 15–60 s TTL stops per-symbol Finnhub fan-out on every panel poll) and `/api/weather/alerts` (:8068 — 90 s TTL on a multi-MB NWS GeoJSON fetch, matching its already-cached siblings). Adding a generic in-flight dedupe to `getCached`/`setCached` (:3833–3846), mirroring the one `cachedFetch` already has (:322), fixes the thundering-herd-on-cache-miss class across all 117 cached routes at once.
+
+**Runner-up worth a line:** replace `/gps/nmea`'s `execFileSync` (local-api-server.mjs:15588) with async `execFile` — it is a guaranteed up-to-3 s stall of the entire sidecar per request.

--- a/docs/PRIVACY_AUDIT_2026-06-11.md
+++ b/docs/PRIVACY_AUDIT_2026-06-11.md
@@ -1,0 +1,315 @@
+# Crystal Ball — Privacy Audit
+
+**Date:** 2026-06-11
+**Scope:** Sidecar external transmission, data persistence, logging, telemetry, API key privacy, local network exposure, user-generated data lifecycle.
+**Method:** Read-only source audit of `src-tauri/sidecar/*.mjs` (16,165-line `local-api-server.mjs` fully enumerated — all 333 external URL literals traced), `src-tauri/src/main.rs`, `src/services/`, `tools/mcp-server/`, plus on-disk inspection of `~/Library/Application Support/com.bradleybond.crystalball/` and `~/Library/Logs/com.bradleybond.crystalball/`. Four parallel investigation passes with independent re-verification of every High finding against source. This report supersedes and incorporates an earlier same-day audit pass that previously occupied this file (its unique findings — `/gps/nmea`, SMS phone-number exposure, CORS web-origin observation — were re-verified and merged; two of its claims were corrected against source, noted inline). No files modified other than this report. No Keychain access performed.
+
+---
+
+## Privacy Risk Summary
+
+| Data type | Where it goes | User-controlled | Risk |
+|---|---|---|---|
+| API keys (3 providers) | mediastack / aviationstack / geonames over **plain HTTP** during key verification | Yes (verify button) | **High** |
+| Usage analytics (pseudonymous events, 73-key presence profile, `OLLAMA_MODEL` value) | PostHog (`us.i.posthog.com`) — **no opt-out UI exists**; Vercel Analytics on web | No | **High** |
+| Analyst prompts (can embed watchlist terms/entities) | Groq cloud via **silent fallback** on the "local" LLM path; Anthropic (opt-in features) | Partially | **High** |
+| Full request paths + query strings (lat/lon, watchlist terms) | `~/Library/Logs/.../local-api.log` when verbose mode on; exportable via ⌘⇧D clipboard diagnostics | Toggle persists across restarts | **High** |
+| Cached API responses (news/intel bodies, 46 MB observed) | `persistent-cache.json`, plaintext, mode 0644, **no eviction ever** | No | **High** |
+| Real-time GPS coordinates (if USB GPS attached) | `/gps/nmea` — served **before the auth gate**, no token required | No | Medium |
+| Phone numbers + SMS command log | `/api/sms/status` — pre-auth, no token required (SMS off by default) | No | Medium |
+| Saved-place coordinates | Open-Meteo ×4, AirNow, OpenAQ, Windy, ArcGIS, 4 ADS-B flight providers (bounding box) | Yes (per feature) | Medium |
+| Watchlist / search terms / entity names | Reddit, GDELT, SEC EDGAR, OpenSanctions, NewsAPI/NewsData | Yes (per query) | Medium |
+| Portfolio tickers / wallet addresses | Finnhub, Stooq, CoinGecko, blockchain.info | Yes | Medium |
+| User email address | ACLED (legacy path puts it **in a GET query string**) | Yes (ACLED creds) | Medium |
+| All API keys, plaintext | `.env.local` (exists now, 651 B, mode **0644**) + synced to iCloud Drive by backup script | Yes | Medium |
+| Full path + query + **Authorization header** | `crystalball.app` cloud fallback when `LOCAL_API_CLOUD_FALLBACK=1` (default off) | Env opt-in | Medium |
+| Submitted URLs | urlscan.io with **default public visibility** | Yes (feature use) | Medium |
+| Webcam imagery + camera names/locations | Anthropic (camera-analysis cloud fallback) — no UI disclosure | Yes (feature use) | Medium |
+| Intel observations (headlines, coordinates, entity IDs) | `events.db` SQLite **inside ~/Library/Logs**, 3-month retention | No | Medium |
+| Saved places (home/work/school/medical lat/lon), watchlists, geofences, alert rules | localStorage / IndexedDB / `~/.crystal-ball/*.json`, all plaintext | No | Medium |
+| Watched-entity dossiers (full last API response per item) | `~/.crystal-ball/watchlists/*.json`, retained **indefinitely** | Partially | Medium |
+| Error reports (web build only) | Sentry (`sendDefaultPii: false`, desktop excluded) | No | Low |
+| API keys in HTTPS URL query strings | ~17 providers (FRED, EIA, Finnhub, NASA, AirNow, WhoisXML, Mapbox/MapTiler/Google, …) | Inherent to provider APIs | Low |
+| IOC threat-feed IPs (not user IPs) | `ip-api.com` over **plain HTTP** | No | Low |
+| Update check (IP + UA only) | `api.github.com` releases endpoint | No | Informational |
+| Weather location | **None** — NWS alerts are fetched nationwide and matched to saved places locally | — | Informational (good) |
+
+**Overall posture:** The architecture is fundamentally privacy-respecting — loopback-only sidecar with timing-safe bearer auth, fail-closed CORS, keychain-backed secrets with trusted-window IPC gating, no secret values in logs, local-first LLM ordering, an in-memory-only personal profile, and a deliberately privacy-preserving nationwide-NWS design. The high-severity items are all fixable seams: three plain-HTTP verify probes, a dead-code analytics opt-out, a silent Groq fallback, a verbose-log sanitization bypass, and an unbounded plaintext response cache.
+
+---
+
+## High Severity Findings
+
+### H1. API keys transmitted over plain HTTP during verification
+
+`local-api-server.mjs:4335` (MediaStack), `:4466` (AviationStack), `:4541` (GeoNames).
+
+The "verify key" probes for these three providers use `http://` URLs with the secret in the query string:
+
+- `http://api.mediastack.com/v1/news?access_key=<KEY>`
+- `http://api.aviationstack.com/v1/flights?access_key=<KEY>`
+- `http://api.geonames.org/searchJSON?...&username=<VALUE>`
+
+Any on-path observer (coffee-shop Wi-Fi, compromised router) captures the credential in cleartext the moment the user clicks verify. This is the weakest link in an otherwise strong key-storage story (Keychain + AES-GCM web vault + encrypted iCloud backups). All three providers support HTTPS on paid tiers; at minimum the probes should attempt `https://` first.
+
+### H2. No working analytics opt-out; consent defaults to on; Ghost Mode gates are bypassed
+
+`src/services/analytics.ts:32-46, 286, 309-330, 344-348`; `src/main.ts:250`.
+
+- The `wm-analytics-consent` localStorage key absent ⇒ analytics **on by default** (analytics.ts:32-36).
+- `setAnalyticsConsent()` exists but has **zero callers anywhere in `src/`** outside analytics.ts itself — there is no settings UI to opt out. Verified by grep.
+- Ghost Mode suppression is incomplete: `trackEventBeforeUnload` (analytics.ts:344-348) checks neither ghost mode nor consent; the init-time `$pageview` (analytics.ts:286) and the desktop offline-queue replay (`flushOfflineQueue`, analytics.ts:319-330, up to 200 queued events) also bypass the ghost check.
+- On web builds, Vercel Analytics `inject()` runs unconditionally (`src/main.ts:250`) with no consent or ghost gate at all, and Sentry has no opt-out UI (web-only; desktop is excluded at main.ts:22).
+- The `wm_api_keys_configured` event (analytics.ts:354-373) sends a `has_<provider>` boolean for all 73 secret keys plus the **literal `OLLAMA_MODEL` value** — for a security professional, which services they hold accounts with (Shodan, VirusTotal, MISP, OpenCTI, …) is itself a sensitive profile, and it sits in PostHog subject to PostHog's breach surface. `wm_deeplink_opened` sends a `target` string that can include geographic or entity names.
+- Super properties on every event (platform, variant, version, screen/viewport dims, pixel ratio, language, OS, arch — analytics.ts:252-274) are fingerprint-adjacent: sufficient for probabilistic re-identification in aggregate, even though `distinct_id` is a random UUID.
+
+Mitigating factors: no email/name is ever sent, autocapture and session recording are off, properties are allowlisted per event, and a `sanitize_properties` hook redacts strings shaped like secrets (analytics.ts:188-208). The problem is consent and the gate bypasses, not the payload hygiene.
+
+### H3. Verbose traffic log persists full query strings — undoing the endpoint's own sanitization
+
+`local-api-server.mjs:1685` (console write), `:16014/:16046` (`entry.path = pathname + search`), `:6519-6527` (verbose state persists across restarts), `src-tauri/src/main.rs:2497-2498` (sidecar stdout → `local-api.log`), `main.rs:2657-2686` (`copy_diagnostics`).
+
+The HTTP endpoint `/api/local-traffic-log` deliberately strips query strings "to avoid leaking feed URLs and user research patterns" (local-api-server.mjs:16022-16028). But when verbose mode is on, the same entries — full path **including** query string (lat/lon, watchlist terms, tickers, feed URLs) — are written via `console.log` to `~/Library/Logs/.../local-api.log` and persist on disk. Verbose mode is toggleable at runtime via `/api/local-debug-toggle` and **survives restarts** (`verbose-mode.json`). The ⌘⇧D `copy_diagnostics` command then copies the last 200 lines of that log to the clipboard, so coordinates and watchlist queries can leave the machine inside a pasted bug report.
+
+(Correction to the earlier audit pass: it reported the inverse. Verified against source: the `WM_TRACE` `[req]` line logs **pathname only** — correctly sanitized (`:16030`) — while the verbose `[traffic]` line is the one that includes the query string.)
+
+### H4. `persistent-cache.json`: 46 MB of plaintext API responses with zero eviction
+
+`src-tauri/src/main.rs:162, 804-812, 838-860`; `src/utils/proxy.ts:62-91`; `src/services/persistent-cache.ts:99-128`. Observed on disk: 46 MB, mode 0644, at `~/Library/Application Support/com.bradleybond.crystalball/persistent-cache.json`.
+
+Every successful proxied `/api/` response body (full RSS/news content, security-intel feeds, financial data, disease-outbreak data, headers, parsed feeds, risk scores, the Insights world brief) is persisted keyed by URL — with no TTL, no size cap, and no cleanup of stale keys. Entries are only ever overwritten per-URL. This is an unbounded plaintext archive of everything the app has ever read, including content that reflects the user's configured interests. Per-entry limits exist (256 B key / 5 MB value, main.rs:840-845) but nothing bounds the file.
+
+### H5. Silent Groq cloud fallback on the "local" LLM path; bypasses the cloud budget
+
+`local-api-server.mjs:4843-4855`; `src/services/llm-adapter.ts:58-79, 104-106, 166`; `src/services/llm-budget.ts:183`.
+
+`generateText()` is documented local-first, and the sidecar's `/api/intel-generate` does try Ollama (127.0.0.1:11434) then LM Studio (127.0.0.1:1234) — but when both are down and `GROQ_API_KEY` is set, it **silently falls back to `api.groq.com`** (llama-3.1-8b-instant). Consequences:
+
+1. The full prompt (≤8,000 chars + ≤2,000-char system) — which embeds hypothesis statements and up to 6-8 evidence labels, including user watchlist terms and entity names (`watchlist-hypothesis-bridge.ts:156`, `hypothesis-ensemble.ts:102-114`) — leaves the device for Groq's cloud, unscrubbed.
+2. The adapter records the result as `provider: 'local'`, so these calls **never count against the 50/day cloud budget** (`llm-budget.ts`) — the budget only meters the Anthropic path.
+3. There is no user-facing "never use cloud LLMs" switch; the only off-switch is deleting the Groq key. The only signal a fallback occurred is a sidecar log line.
+
+Related: camera-analysis routes fall back to Anthropic — `/api/webcam/analyze` (`local-api-server.mjs:8539`) sends a full base64 webcam JPEG plus an alert-context label (e.g. "near Severe Thunderstorm Warning") and `/api/faa-cam-digest` (`:8574`) sends up to 6 camera names/locations, both revealing the user's monitored geography, with **no UI disclosure** that imagery and location context leave the device.
+
+---
+
+## Medium Severity Findings
+
+### M1. `.env.local` — plaintext shadow copy of API keys, mode 0644, synced to iCloud
+
+`local-api-server.mjs:115-128`; `env-local-loader.mjs:1-12`; `scripts/backup-keys.sh:72`. Confirmed present: 651 bytes, mode 0644, dated 2026-04-07.
+
+The keychain-loss fallback file (created after the 2026-05-08 keychain wipe incident) holds `KEY=value` pairs in plaintext, readable by any process running as the user, and `backup-keys.sh` syncs it to iCloud Drive (`com~apple~CloudDocs/CrystalBall`) — a *separate*, unencrypted artifact from the sanctioned encrypted backup archive. The sidecar token file gets 0600 treatment (main.rs:2459-2467); this far more sensitive file does not. The startup log line reveals only the key count, not names or values. Recommend: delete once keychain is healthy, or chmod 0600 and exclude from iCloud.
+
+### M2. User email address sent to ACLED in a GET query string
+
+`local-api-server.mjs:6809` (legacy `?email=...&key=...`), `:6689-6724` (OAuth path: email as username + password in POST body).
+
+ACLED is the only route transmitting the user's actual email — a direct personal identifier — and the legacy path embeds it in a URL where it lands in ACLED's, CDN edges', and intermediaries' access logs. Prefer the OAuth path exclusively.
+
+### M3. Cloud fallback replays failed requests to `crystalball.app` including the Authorization header
+
+`local-api-server.mjs:1514-1548` (`toHeaders` strips host/origin/referer but **not** Authorization), `:15244-15301`, `:1722`.
+
+With `LOCAL_API_CLOUD_FALLBACK=1` (default **off**), any failed local route is replayed verbatim — full path, query string (lat/lon, watchlist terms), body, and bearer token — to the remote base. A broad, silent re-route of potentially sensitive traffic. Additionally, `/api/military/v1/get-theater-posture` (`:12303`) tries `api.crystalball.app` **unconditionally**, not gated by the fallback flag (low-sensitivity params — see L3).
+
+### M4. urlscan.io submissions default to public visibility
+
+`local-api-server.mjs:14037-14096`. The submit route forwards user URLs without forcing `visibility: 'unlisted'` or `'private'` — anything the user scans becomes publicly browsable on urlscan.io, including internal or personally identifying URLs. Users almost certainly don't expect a "scan this link" feature to publish the link.
+
+### M5. Saved-place coordinates fan out to ~10 independent third parties
+
+Open-Meteo forecast/air-quality/flood/marine (`:9382, :9203, :9480, :9504`), AirNow (`:11808`), ArcGIS hospital lookup (`:13629`), OpenAQ (`:10570`), Windy webcams (`:14478`), four ADS-B providers as a bounding box (OpenSky, airplanes.live, adsb.fi, adsb.lol — `:12905-12962`), and USGS aftershock queries with a bounding box around a quake of interest (`:11345`). Inherent to the features, but collectively these reveal home/work locations to many operators, with no in-app disclosure. Counter-examples done right: the NOAA CO-OPS flood-gauge route computes the nearest station **locally** and sends only a station ID (`:9440`); METAR fetching uses nationwide pulls + local matching (`:577-613`). Where feasible, the station-ID pattern could be extended.
+
+### M6. Watchlist terms, entity names, and tickers go to third-party search APIs
+
+Reddit (`:6882-6908`), GDELT (`:13030-13050`), SEC EDGAR (`:9966-9994`), OpenSanctions (`:7559-7583`), NewsAPI/NewsData (`:7788/:7818`), Finnhub/Stooq tickers (`:9705-9744`), CoinGecko (`:9781`), blockchain.info wallet addresses (`:10493`), GeoNames place searches (`:10634-10669`), haveibeenpwned domains (`:10235`), Censys/SecurityTrails/WhoisXML/pulsedive indicators (`:12005-12121`). The terms a user watches (people, companies, CVEs, wallets) are themselves sensitive intelligence about the user. Inherent to the features — but worth documenting for the user, since no in-app disclosure exists.
+
+### M7. `/gps/nmea` serves real-time GPS coordinates with no authentication
+
+`local-api-server.mjs:15575-15605`. The handler runs **before** the `/api/` path check and before the global auth gate. Any unauthenticated request reads 5 lines from the connected USB GPS serial device (port from `~/.crystalball-gps.json`, default `/dev/tty.usbserial-0001`) and returns the first NMEA sentence — i.e. the user's live position. Exposure is bounded by the loopback bind and fail-closed CORS (a malicious website can fire the request but cannot read the response; a same-user process could read the token anyway), so this is defense-in-depth rather than a remote leak — but it is the single most sensitive datum the sidecar serves, and it is the only personal-data route outside the gate. Move it behind the token.
+
+### M8. SMS routes sit above the auth gate; `/api/sms/status` returns phone numbers; no Twilio signature validation
+
+`local-api-server.mjs:5058, 5077-5091`; `sms-security.mjs`; `sms-command-parser.mjs:66`. `/api/sms/command` and `/api/sms/status` are reachable without the bearer token. `/api/sms/status` returns the recent command log (20 entries), watches, alerts, and the per-phone rate-limit map — **including the phone numbers** of everyone who has texted the app — pre-auth, while the adjacent `/api/sms/config` (`:5094`) correctly requires the token. `/api/sms/command` relies solely on a phone-number allowlist on the `from` field — forgeable by any same-host caller — with **no Twilio request-signature (HMAC) check**. Mitigations: SMS is disabled by default, and the allowlist file is mode 0600. If SMS is ever enabled, add `X-Twilio-Signature` validation and token-gate `/api/sms/status`.
+
+### M9. MCP watchlist files retain the full last API response per watched entity, forever
+
+`tools/mcp-server/tools/stateful.mjs:138-159`; `tools/mcp-server/storage.mjs:5, 21-55`. On every `watchlist_check`, each item's `last_status` is overwritten with the **entire JSON API response** (GreyNoise/AIS/ADS-B/ACLED/market data) in `~/.crystal-ball/watchlists/<name>.json` — a growing plaintext dossier of every tracked IP/vessel/ticker/callsign plus matched intel. `storage.pruneOlderThan` exists but has **zero callers**. (Directory does not currently exist on this machine; risk activates on first use.) Files are not mode-restricted, unlike the SMS allowlist (0600). Related: `~/.crystal-ball/sentinel/alerts.json` is appended indefinitely with no code-level prune — the 7-day history prune exists only as a prompt instruction in `.claude/commands/sentinel.md:27-31`, and retention enforced by an LLM following instructions is not a retention policy.
+
+### M10. The intelligence event database lives inside `~/Library/Logs`
+
+`src-tauri/src/main.rs:2484-2491` sets `LOCAL_API_DATA_DIR` to the **logs** directory; `event-store.mjs:78-81` puts `events.db` there (observed: 520 KB + 4.1 MB WAL), and `ofac-cache.mjs:25` adds a 9.5 MB cache. Users and tooling treat `~/Library/Logs` as shareable/disposable — log cleaners may delete the user's 3-month intel history, and "send me your logs" support flows could ship a database of headlines, coordinates, and entity IDs. The DB belongs in Application Support.
+
+### M11. No user-generated data is encrypted at rest
+
+Saved places — including lat/lon with tags like home/work/medical/school (`src/services/saved-places.ts:41, 212`, key `wm_saved_places_v1`) — watchlist (`watchlist.ts:11, 35`, key `crystalball-watchlist-v1`), multi-location watchlist (`cb-watched-locations`), geofences (`crystalball-geofences`), alert rules (`cb-alert-rules`), CII tier-2 watchlist (`cb-cii-tier2`), webhook configs incl. Slack/Discord URLs and optional secrets (`webhook-dispatcher.ts:3-39`), hypothesis threads, briefing archive, and IDB `crystalball_db` reasoning memory are all plaintext. The only encrypted store is the web key vault. On desktop this sits in the WKWebView container protected only by FileVault. Acceptable for a single-user Mac, but saved-place coordinates are the most sensitive plaintext item in the app.
+
+### M12. User-supplied feed URLs logged verbatim on SSRF block
+
+`local-api-server.mjs:12177, :12213`. Private RSS URLs frequently embed auth tokens (the app itself treats `PATREON_AUDIO_RSS_URL` as a secret) — a blocked fetch writes the full credentialed URL into `local-api.log`.
+
+### M13. IOC IPs geolocated over plain HTTP
+
+`local-api-server.mjs:1120-1160` POSTs IP batches to `http://ip-api.com/batch` (the provider's free tier is HTTP-only). Today the sole caller (`:7628`) sends threat-feed IOC IPs from OTX, not user IPs — but the helper is generic and a future caller could leak user-relevant IPs in cleartext.
+
+---
+
+## Low Severity Findings
+
+### L1. API keys in HTTPS URL query strings for ~17 providers
+
+FRED (`:4030`), EIA (`:4044, :14183`), FMP (`:4266`), NewsData (`:4325`), OpenWeatherMap (`:4346`), NASA (`:4355, :9044`), ICAO (`:4477`), NPS (`:14832`), WhoisXML (`:12047`), AirNow (`:11808`), FIRMS (`:11754`), Finnhub (`:9705`), GeoNames username (`:10634`), ipinfo (`:10732`); renderer-side MapTiler/Google/OWM tile URLs (`runtime-config.ts:1239`, `building-tiles.ts:77`, `owm-weather-tiles.ts:37`). Encrypted in transit but exposed in provider/proxy access logs — inherent to those providers' API designs, not a code bug. Providers that support headers already use them (Anthropic, Groq, OpenRouter, OTX, AbuseIPDB, urlscan, Cesium, ACLED OAuth). The AISStream key travels in a WSS frame body per that provider's protocol (`:775-784`) — visible to TLS-intercepting proxies, otherwise fine.
+
+### L2. Upstream response-body excerpts and full error objects written to log
+
+`local-api-server.mjs:4762` (rejects with 200 chars of provider response body, logged at `:4835/:4850`); `:16038` logs full error objects with stacks. Occasionally echoes request fragments into `local-api.log`.
+
+### L3. `get-theater-posture` contacts `api.crystalball.app` unconditionally
+
+`local-api-server.mjs:12303` — the only first-party cloud call not gated by `LOCAL_API_CLOUD_FALLBACK`. Sends the route's query string (theater identifiers; low sensitivity) before falling back to local computation. Should be gated like everything else.
+
+### L4. XMPP nickname exposure in S2U MUC rooms
+
+`s2u-xmpp-source.mjs:24-38, 186-212`. The JID local-part becomes the visible nick broadcast to all occupants of the 5 rooms. Receive-only otherwise; credentials are user-supplied.
+
+### L5. events.db pruned only at sidecar startup
+
+`local-api-server.mjs:15556-15561`. A long-running session never prunes; retention can exceed the 3-month default until next restart. The 4.1 MB WAL also carries recent payloads. No row-count or size cap. Manual prune exists (`POST /api/events/prune`, `:6011-6020`).
+
+### L6. `local-api.log` rotates only at sidecar spawn
+
+`main.rs:2413-2420`. A long session can exceed the 5 MB cap. (`desktop.log` rotates properly: 5 MB, 3 backups — `main.rs:31-32, 881-930`.)
+
+### L7. Little Snitch baseline file accumulates connection metadata indefinitely
+
+`local-api-server.mjs:11973-11998` (opt-in via `LITTLE_SNITCH_BASELINE_PATH`). `app::remoteHost` pairs are added, never removed.
+
+### L8. Patreon OAuth links the install to a real-world identity
+
+`local-api-server.mjs:1956, 5021-5030, 5160`. Standard OAuth (client ID + code exchange, then bearer identity fetch); noted because it is the one feature tying the app to a named account.
+
+### L9. CORS allowlist includes the production web domains
+
+`local-api-server.mjs:1841-1849`. `crystalball.app` and 4 subdomains are allowed origins, so a browser tab on the production web app can complete CORS requests against the locally running sidecar. The bearer token still blocks unauthorized access, but the surface is wider than the desktop app needs (the Tauri renderer uses `tauri://`, not `crystalball.app`). Defense-in-depth: drop the web origins from the desktop sidecar's allowlist if unneeded.
+
+### L10. No inbound Host-header allowlist (DNS rebinding)
+
+There is no explicit inbound `Host:` validation; the check near `:14072` is an outbound SSRF guard for urlscan submissions. Practical exploitation is blocked anyway by loopback-only bind + fail-closed CORS + the bearer token, and outbound rebinding TOCTOU is closed by resolved-IP pinning in `ipv4Fetch` (`:1036-1049`). Defense-in-depth only.
+
+### L11. Frontend JS errors forwarded into desktop.log
+
+`main.rs:2637-2653` (truncated to 1000/2000 bytes, CR/LF-sanitized). Error strings could embed data fragments; rotation bounds exposure.
+
+### L12. Sidecar analyst-state mirror — low residual exposure
+
+`src/services/sidecar-pusher.ts:44-59, 155-176` pushes analyst snapshot, forecast, hypothesis threads (signature/kind/region/confidence), hot entities, debug log, metrics. **No saved places, no watchlist contents, no coordinates** — and the sidecar whitelists fields on receipt (`local-api-server.mjs:5247-5259`). Thread `region` strings are coarse (country/theater). Reachable only with the bearer token. Note: code comments at `:5692/:5736` claim "No bearer auth: loopback-only," but those routes sit **below** the global gate and do require the token — the comments are misleading and should be fixed.
+
+---
+
+## Informational Findings (including strengths)
+
+### I1. Local network exposure — strong posture (audit scope §6 answer)
+
+- **Bind:** `server.listen(port, '127.0.0.1')` — loopback only (`local-api-server.mjs:16074`); falls back to an OS-assigned port on conflict, never `0.0.0.0`.
+- **Auth:** global bearer gate covering all routes below `:5108-5118`, compared with `timingSafeEqual` (`:170-177`); token is 32 CSPRNG bytes generated per session (`main.rs:574-578`), written to `sidecar.token` mode **0600** (`main.rs:2459-2467`), handed to the renderer only via trusted-window-gated IPC (`main.rs:588-598`), deleted at shutdown.
+- **Can another app call the sidecar without the token?** A different-user process: no (cannot read the 0600 file; rejected at the gate). A same-user process: yes — it can read the token file and then reach everything (analyst state, command queue, quota-spending proxy routes, cached data). That is the documented single-user trust boundary. Token-less pre-auth routes: `/gps/nmea` (M7), `/api/sms/command` + `/api/sms/status` (M8), `/api/service-status`, `/api/youtube-embed`, `/api/feeds/health`, and the Patreon OAuth endpoints (`:4990-5028`) — the latter group intentionally pre-auth and non-sensitive.
+- **CORS:** fail-closed — Origin reflected only against a fixed allowlist, otherwise `tauri://localhost` is returned, which no browser sends (`:1841-1849`). No wildcard, no override env. A malicious website cannot read sidecar responses and cannot obtain the token. (Allowlist breadth: L9.)
+
+### I2. API key storage and handling — clean (audit scope §5 answer)
+
+- Keychain: single `secrets-vault` entry under service `crystal-ball`, 73-key allowlist (`main.rs:42, 563-572`); ACL is per-signed-app. `get_secret`/`set_secret`/`delete_secret` all require trusted-window IPC first (`main.rs:729, 747, 770`; `require_trusted_window` `:580-586`) and perform **no logging at all** — not even key names. Error messages return key names only.
+- Sidecar receives keys as env vars injected at spawn (`main.rs:2504-2517`); the runtime-update route `/api/local-env-update` is token-gated and key-allowlisted, and logs **key names only** (`:12248, :12251`).
+- Both secret-carrying routes are excluded from the traffic ring (`skipRecord`, `:15995-15999`). No sidecar endpoint returns key values; diagnostics expose only **missing-key names** (`:6404-6410`). PostHog strips secret-shaped strings.
+- Web vault verified as documented: AES-GCM-256 / PBKDF2-SHA-256 600k iterations / per-save random IV / AAD-bound / 15-min auto-lock; key material never leaves module closure.
+- Backup scripts write only encrypted archives to iCloud (age/gpg/openssl); the residual issue is `.env.local` (M1), not the backups.
+
+### I3. Weather location privacy — done right
+
+There is **no `api.weather.gov/points/{lat},{lon}` call anywhere** — NWS alerts are pulled nationwide (UA `CrystalBall-NWS/1.0`) and matched to saved places locally, so the most frequent location-sensitive feature leaks nothing. Same pattern for METARs (nationwide station pull, `:577-613`) and NOAA flood gauges (local nearest-station resolution, `:9440`). NASA FIRMS uses 6 static global bboxes, not user location (`:11754-11766`). AISStream subscribes to the entire globe — `BoundingBoxes: [[[-90,-180],[90,180]]]` — and filters locally (`:775-784`), so the provider never learns which area the user watches.
+
+### I4. Personal profile is in-memory only
+
+`local-api-server.mjs:5400-5430`. The profile POSTed to `/api/personal/profile` — saved places (≤500), watchlist (≤200), interests (≤50), travel dates (≤100, with lat/lon) — is sanitized, capped, and held only in `context._personalProfile`. It is never written to `events.db`, `persistent-cache.json`, or any disk location, and never transmitted externally. Token-gated. This is the right pattern for the most sensitive aggregate in the system.
+
+### I5. No telemetry from the sidecar; no other SDKs
+
+No PostHog/Sentry/Segment/Amplitude/Bugsnag/crashpad in any sidecar file or in package.json beyond the three renderer integrations (PostHog, Sentry web-only with `sendDefaultPii: false`, Vercel web-only). The only phone-home besides analytics is the GitHub releases update check (`desktop-updater.ts:119-121` — IP + UA only, 5 s after boot / hourly / on focus; DMG verified via sha256 manifest; no Tauri updater plugin). All internal "telemetry" modules (threshold-telemetry, reasoning-metrics) are local-only.
+
+### I6. Other positives
+
+- **S2U TAK client hardened:** GET-only, SHA-256 cert pinning with explicit opt-in bypass, refuses to run without user creds (`s2u-tak-client.mjs:27-28, 184-197`).
+- **SEC EDGAR UA** uses the project contact address (`contact@crystalball.app`), not the user's email (`:9966`).
+- **Twilio is receive-only** — the sidecar never originates SMS (`:5056`).
+- **Arbitrary-URL routes** (`/api/rss-proxy`, `/api/feed-discovery`) are SSRF-guarded via private-IP blocking and resolved-IP pinning (`:12092-12170`).
+- **Export paths are clean:** `buildSharePacket`, `presentation-export`, `hypothesis-export` serialize only the briefing content handed to them — no code path serializes `wm_saved_places_v1` or raw coordinates into an export (`share-packet.ts:50-106`).
+- **Clipboard watcher** (key-entry wizard) polls the clipboard at 500 ms but only while the wizard is open, matches key shapes only, persists nothing (`clipboard-watcher.ts:48-60`).
+- **Key-verification probes** (~40 providers, `:3990-4570`) use fixed test parameters only (8.8.8.8, AAPL, London, Denver) — never user data.
+- **FAA weathercam header spoofing** (`:8388-8459`) — Origin/Referer set to `weathercams.faa.gov` to pass their referrer check. Not a privacy issue; documented as an undocumented impersonation pattern.
+
+---
+
+## Detailed answers to the audit scope questions
+
+### §1 External data transmission — destination inventory
+
+**~333 external URL literals enumerated.** Categories (full per-route details in findings above):
+
+- **First-party cloud:** `crystalball.app` (opt-in fallback, M3), `api.crystalball.app` (theater posture, L3).
+- **LLM:** Ollama/LM Studio (loopback), Groq (H5), Anthropic (camera routes H5; cloud-agent path via `api/claude-agent.js:430`).
+- **User-query carriers:** Reddit, GDELT, EDGAR, OpenSanctions, NewsAPI/NewsData, Finnhub, Stooq, CoinGecko, GeoNames, blockchain.info, haveibeenpwned, urlscan.io, pulsedive, Censys, SecurityTrails, WhoisXML, ipinfo, user-configured MISP, arbitrary RSS URLs, YouTube channel handles (M6).
+- **Location carriers:** Open-Meteo ×4, AirNow, OpenAQ, Windy, ArcGIS/HIFLD, OpenSky + 3 ADS-B providers, USGS aftershock bboxes, USGS water / EPA SDWIS passthrough proxies (M5).
+- **Identity carriers:** ACLED (email — M2), Patreon OAuth (L8), S2U TAK/XMPP (credentials; nick exposure L4), user-configured Oref relay (shared secret header).
+- **Fixed-destination feeds (no user data):** ~120 government/scientific/OSINT endpoints — NOAA/SWPC/SPC/NHC, USGS, CDC, WHO, ReliefWeb, FEMA, NVD/EPSS, CISA KEV, abuse.ch, Spamhaus, Tor onionoo, Celestrak, World Bank/IMF/FAO, Treasury/OFAC, RIPE, poweroutage.us, EIA, InciWeb/NIFC, ~14 state DOT camera APIs, promedmail, GDACS, FAA TFRs, and others. Constant or nationwide queries only.
+- **Key-verification probes (~40 providers, `:3990-4570`):** fixed test parameters; three over plain HTTP (H1).
+
+### §2 Data persistence — answers
+
+- **dataDir** resolves to the **logs directory** (`main.rs:2484-2491` → `local-api-server.mjs:1730`), see M10. Contents: `events.db` (+WAL/SHM), `data/ofac-cache.json` (public sanctions data, 7-day refresh — third-party PII, not user PII), `sidecar.health.json` (PID/port/memory/AIS state, 10 s overwrite, no user data), `sidecar.port`/`sidecar.token` (deleted at shutdown), `verbose-mode.json`, `desktop.log`/`local-api.log` (+ rotations).
+- **Temporal World Store (`event-store.mjs`):** stores `observation | situation_* | alert_fired | score_updated` events; observations carry full JSON payloads — **headline title, location coordinates, entityIds, tags, sourceId, severity, domain** (`local-api-server.mjs:5940-5953`). Retention: **3 months** default (`EVENT_STORE_RETENTION_MONTHS`, `event-store.mjs:24-29`), pruned at startup + manual endpoint only (L5). No size cap. (`alert_fired` is defined but currently has no writer.)
+- **Watchboard firings:** the literal term "watchboard" does not exist in the repo (verified by case-insensitive grep across .ts/.mjs/.js/.md/.rs). The nearest equivalents and what they retain: MCP `watchlist_check` persists the full last API response per item indefinitely (M9); sentinel sweeps append alert records forever (M9); renderer watchlist matches persist matched titles (first 100 chars) as hypothesis evidence in localStorage/IDB with stale-thread pruning (`hypothesis-threads.ts:137`) and a 12-entry confidence-history cap; and everything flowing through the observation pipeline lands in `events.db` for 3 months.
+- **Cached API responses with sensitive content:** yes — `persistent-cache.json` (H4) holds full news/security-intel/financial/health response bodies; `ofac-cache.json` holds public sanctions PII.
+- **Sidecar in-memory only (not disk):** observation ring mirror (200 cap), analyst state, personal profile (I4), SMS command log (50 cap), traffic ring (200 cap), feed tracker.
+
+### §3 Logging — answers
+
+43 console/logger statements in `local-api-server.mjs`; zero in other non-test sidecar files. `context.logger` **is** `console` (`:1733`) and Rust pipes sidecar stdout/stderr to `local-api.log` (`main.rs:2497-2498`) — so every sidecar log line persists to disk. Problem lines: verbose traffic with query strings (H3), feed URLs on SSRF block (M12), upstream body excerpts (L2). Secrets are never logged (I2). Tauri side uses a custom `append_desktop_log` (CR/LF-sanitized, 5 MB ×3 rotation), not tauri-plugin-log; keychain commands log nothing.
+
+### §4 Telemetry — answers
+
+PostHog (desktop + web, default-on, no working opt-out — H2), Sentry (web only, PII off), Vercel Analytics (web only, ungated). No Segment/Amplitude/crash reporters. Cloud LLM data flows per H5: watchlist-derived hypothesis content can reach Groq (silent fallback, uncounted by the budget) and Anthropic (opt-in skeptic/ensemble/auto-brief, ghost-suppressed, 50/day budget — but the budget only meters the Anthropic path; the MCP-triggered skeptic bypasses the enabled/ghost guards by design, `hypothesis-skeptic.ts:181-185`). Saved-place names/coordinates do **not** enter LLM prompts directly; the personal/insights services are LLM-free. The prompt sanitizer (`sanitizeForPrompt`) is used by the skeptic but **not** by `hypothesis-ensemble.ts:105`.
+
+### §5 API key privacy — answers
+
+Stored in: Keychain (primary, gated, clean), `.env.local` (M1 — plaintext fallback), sidecar process env (runtime), encrypted web vault (browser). Leak vectors found: plain-HTTP verify probes (H1), URL query-string placement at ~17 providers (L1), `.env.local` + iCloud (M1), WSS frame body for AISStream (L1). **Not** leaked via: logs, error messages, diagnostics endpoints, analytics, or any sidecar read route — all verified.
+
+### §6 Local network exposure — answers
+
+`127.0.0.1` only; timing-safe bearer auth on all routes except the enumerated pre-auth set (`/gps/nmea` and `/api/sms/status` being the two that matter — M7/M8); 0600 token file; fail-closed CORS. Same-user processes can use the token by design; different users and websites cannot. See I1, L9, L10.
+
+### §7 User-generated data — answers
+
+Saved places / watchlists / geofences / alert rules / webhooks → plaintext localStorage + IDB (M11). MCP watchlists → plaintext `~/.crystal-ball` (M9). Nothing user-generated is encrypted at rest except web-vault keys. The personal profile pushed to the sidecar is in-memory only (I4). Export/share paths do not auto-include coordinates or watchlist contents (I6); no automatic sync exists for user data — the only cloud flows are the analytics stream (H2) and the explicitly user-invoked encrypted key backup.
+
+---
+
+## Prioritized remediation list
+
+1. **H1** — Switch mediastack/aviationstack/geonames verify probes to HTTPS (or drop the probe and report "Saved" like other unverifiable providers).
+2. **H2** — Wire `setAnalyticsConsent` into Settings (ideally opt-in on first launch); gate `trackEventBeforeUnload`, init `$pageview`, offline replay, and Vercel `inject()` on consent + ghost mode; drop `OLLAMA_MODEL` and the 73-key presence map from `wm_api_keys_configured`.
+3. **H3** — Strip query strings in the verbose `[traffic]` console line (reuse the `/api/local-traffic-log` sanitizer).
+4. **H5** — Make the Groq fallback opt-in (or at least chargeable to the cloud budget and labeled `provider: 'cloud'`); disclose in the webcam-analysis UI that imagery goes to Anthropic.
+5. **H4** — Add TTL/size-cap eviction to `persistent-cache.json`; chmod 0600.
+6. **M7** — Move `/gps/nmea` behind the auth gate.
+7. **M1** — Delete or 0600 `.env.local`; keep it out of iCloud.
+8. **M4** — Force `visibility: 'unlisted'` on urlscan submissions.
+9. **M2** — Remove the ACLED legacy email-in-URL path in favor of OAuth.
+10. **M3/L3** — Strip `Authorization` in `toHeaders` for cloud-fallback replays; gate the theater-posture route on the fallback flag.
+11. **M8** — Token-gate `/api/sms/status`; add Twilio signature validation before ever enabling SMS.
+12. **M9** — Wire up `storage.pruneOlderThan`; add a code-level prune for sentinel `alerts.json`/history; chmod 0600 on `~/.crystal-ball/watchlists/*.json`.
+13. **M10** — Move `events.db` and `ofac-cache.json` out of `~/Library/Logs` into Application Support.
+14. **M11** — Consider encrypting saved-place coordinates at rest (same key-derivation chain as the web vault).
+
+---
+
+*Audit produced by Claude Code on 2026-06-11. Four parallel investigation passes (external transmission, persistence, logging/telemetry, keys/network/user-data) with independent verification of all High findings against source, merged with the unique findings of a prior same-day pass. Read-only: no code, config, or data was modified.*

--- a/docs/PRIVACY_FIX_PLAN_2026-06-12.md
+++ b/docs/PRIVACY_FIX_PLAN_2026-06-12.md
@@ -2,7 +2,9 @@
 
 Implementation plan for the 5 High findings in `docs/PRIVACY_AUDIT_2026-06-11.md`, plus
 the highest-impact performance fixes from `docs/PERFORMANCE_AUDIT_2026-06-11.md` not
-already landed by `claude/perf-quick-wins` (PR #1069, merged).
+already landed by `claude/perf-quick-wins` (PR #1069, merged). Both audit docs are
+committed alongside this plan (they previously existed only as untracked local files),
+so every finding reference below is verifiable in-repo.
 
 **Read this first — overlap with the in-flight security PR stack.** Several security PRs
 already cover slices of these findings. Each Fix section below states exactly what is
@@ -92,8 +94,8 @@ conflicts in the same file (rebase whichever lands second).
 (:344-348) skips the ghost-mode check; the init `$pageview` (:286) and
 `flushOfflineQueue` (:319-330) bypass ghost mode; Vercel Analytics `inject()` at
 `src/main.ts:250` runs unconditionally; `wm_api_keys_configured` (:354-373) sends a
-73-key boolean presence map plus the literal `OLLAMA_MODEL` value; super properties
-(:252-274) are fingerprint-adjacent.
+70-key boolean presence map (`SECRET_ANALYTICS_NAMES`) plus the literal `OLLAMA_MODEL`
+value; super properties (:252-274) are fingerprint-adjacent.
 
 **Files to modify:**
 
@@ -153,9 +155,9 @@ its scope note explicitly excludes `local-api.log` / `sidecar.log` (created by t
 host). The content problem — query strings persisted — is fully open.
 
 **Problem recap:** the verbose console write at `local-api-server.mjs:1685` and the
-traffic-log entries (`entry.path = pathname + search` at :16014 and :16046) record full
-query strings; verbose mode persists across restarts via `verbose-mode.json`
-(:6519-6527). The Rust host pipes sidecar stdout to `local-api.log`
+traffic-log entries (`entry.path = pathname + search` at ~:16015 and ~:16048) record
+full query strings; verbose mode persists across restarts via `verbose-mode.json`
+(state read/write at ~:1658-1668, toggle save near :6570). The Rust host pipes sidecar stdout to `local-api.log`
 (`src-tauri/src/main.rs:2497-2498`), and `copy_diagnostics` (main.rs:2657-2686) exports
 the last 200 lines to the clipboard. The only sanitized surface today is the
 `/api/local-traffic-log` JSON route (:16022-16028).
@@ -192,8 +194,8 @@ the last 200 lines to the clipboard. The only sanitized surface today is the
     short, so the default-deny length rule alone won't catch them. Add `lat`, `lon`,
     `latitude`, `longitude`, `q`, `query`, `address` to `SENSITIVE_QUERY_PARAMS`.
   - route path itself is always preserved (`/api/weather/alerts` stays intact)
-- `npm run test:sidecar` green; `cargo build` (or `npm run desktop:build:full` if
-  touching main.rs warrants it) compiles.
+- `npm run test:sidecar` green; the main.rs change requires a full desktop build to
+  verify: `npm run desktop:build:full` must complete cleanly.
 
 **Risk assessment:** Low-medium. Debugging ergonomics degrade slightly (param values
 gone from verbose logs); acceptable — param *names* remain, which is enough to identify
@@ -244,8 +246,9 @@ responses (which include location-derived data) indefinitely. Renderer side:
   - entry older than TTL ⇒ read miss
   - entry without `stored_at` ⇒ read miss
   - over-cap save evicts oldest entries first and lands under cap
-- Manual verification in PR body: after running the app, `ls -la` shows
-  `persistent-cache.json` mode 0600 and a sane size.
+- Manual verification in PR body: after running the app once, `ls -la` shows
+  `persistent-cache.json` with mode `-rw-------` (0600) and a size ≤ 32 MB (the
+  pre-fix file was 46 MB; the stored_at migration must have shrunk it).
 - `npm run typecheck:all` + desktop build compile.
 
 **Risk assessment:** Medium. The one-time cache flush causes a cold-start burst of API
@@ -291,10 +294,16 @@ Item 3 is the actual privacy hole; 1 and 2 are honesty/metering.
      entirely and return `503 { error: 'no local model available', provider: 'none' }`
      after Ollama and LM Studio fail.
 2. `src/services/llm-adapter.ts`
+   - **Type change first:** `LlmProvider` at `llm-adapter.ts:26` is
+     `'local' | 'cloud-agent' | 'cloud-chat' | 'none'`. Add a new variant
+     `'cloud-groq'` to the union. Then grep for every exhaustive use of the union
+     (`grep -rn "cloud-chat" src/`) and extend each switch/conditional — reasoning
+     metrics, debug log labels, and any provider-display code must handle
+     `'cloud-groq'` or typecheck will fail.
    - Pass `localOnly: isLocalModelOnly()` in the `/api/intel-generate` request body.
-   - Read `provider` from the response. When it is `'groq'`:
-     - record the result with `provider: 'groq'` (not `'local'`)
-     - call `reserveCloudCall('groq-fallback')` *before* using the result; if the
+   - Read `provider` from the sidecar response. When it is `'groq'`:
+     - record the result with `provider: 'cloud-groq'` (not `'local'`)
+     - call `reserveCloudCall('cloud-groq')` *before* using the result; if the
        budget is exhausted, discard the result and fall through to the existing
        no-cloud-budget behavior. Reserve-on-detect (after the response reveals Groq
        served it) is the pragmatic v1 — the alternative, reserving before the request,
@@ -305,8 +314,14 @@ Item 3 is the actual privacy hole; 1 and 2 are honesty/metering.
        `!isLlmEgressDisclosed()`, treat a `provider:'groq'` response as a failure and
        dispatch `cb:llm-egress-disclosure-needed`, same as the direct-cloud path.
 3. `src/services/llm-budget.ts`
-   - No structural change; verify `reserveCloudCall` accepts the new caller tag and that
-     metrics/labels surface it (grep for existing tags).
+   - **Structural change required:** `reserveCloudCall(provider)` at :160-168 and
+     `recordCall` at :184-185 only increment for `'cloud-agent'` and `'cloud-chat'` —
+     any other string is silently unmetered. Add a `cloudGroq` counter to the budget
+     state, increment it in both functions for `'cloud-groq'`, and include it in the
+     daily-cap total (the 50/day cap must cover agent + chat + groq combined, since
+     the cap exists to bound cloud egress, not per-provider usage). Update the budget
+     snapshot/serialization shape and any UI that renders the counters (grep for
+     `cloudChat` consumers).
 4. **Webcam/FAA-cam disclosure (audit-related):** `/api/webcam/analyze` (:8539) and
    `/api/faa-cam-digest` (:8574) send imagery + camera locations to Anthropic with no UI
    disclosure. Minimal v1: route both behind the existing `isLlmEgressDisclosed()`
@@ -322,8 +337,9 @@ Item 3 is the actual privacy hole; 1 and 2 are honesty/metering.
     (mock fetch; assert no call to `api.groq.com`)
   - response always carries `provider`
 - `src/services/__tests__/llm-adapter-groq-labeling.test.mts`:
-  - mocked sidecar response `provider:'groq'` ⇒ result recorded as `groq`, budget
-    reserve called once
+  - mocked sidecar response `provider:'groq'` ⇒ result recorded as `cloud-groq`,
+    `reserveCloudCall('cloud-groq')` called once, and the call counts toward the
+    daily cap total
   - budget exhausted ⇒ groq result discarded
   - `isLocalModelOnly()` true ⇒ request body contains `localOnly: true`
 - `npm run test:sidecar` + `npm run typecheck:all` green.

--- a/docs/PRIVACY_FIX_PLAN_2026-06-12.md
+++ b/docs/PRIVACY_FIX_PLAN_2026-06-12.md
@@ -1,0 +1,437 @@
+# Privacy Fix Plan — 2026-06-12
+
+Implementation plan for the 5 High findings in `docs/PRIVACY_AUDIT_2026-06-11.md`, plus
+the highest-impact performance fixes from `docs/PERFORMANCE_AUDIT_2026-06-11.md` not
+already landed by `claude/perf-quick-wins` (PR #1069, merged).
+
+**Read this first — overlap with the in-flight security PR stack.** Several security PRs
+already cover slices of these findings. Each Fix section below states exactly what is
+already done and what is residual. Before starting any fix, run
+`gh pr list --state all --limit 40` and re-verify the PR states listed here.
+
+| PR | State (2026-06-12) | Overlaps |
+|----|--------------------|----------|
+| #1105 `claude/sec-https-urls` | OPEN | H1 transport (plain HTTP → HTTPS) |
+| #1109 `claude/sec-ci-http-guardrail` | OPEN | H1 regression guard |
+| #1113 + #1115 `claude/sec-llm-egress-disclosure` | MERGED | H5 renderer-side disclosure + local-only toggle |
+| #1104 `claude/sec-db-log-chmod600` | OPEN | H4/H3 file permissions (events.db + heartbeat ONLY — not persistent-cache.json, not local-api.log) |
+| #1069 `claude/perf-quick-wins` | MERGED | Perf quick wins 1–5 (see Performance section) |
+
+General conventions for every fix:
+
+- Branch from `origin/main` in a worktree: `git worktree add .worktrees/<name> -b <branch> origin/main`
+- Sidecar tests: add `.test.mjs` under `src-tauri/sidecar/__tests__/`, runnable via `npm run test:sidecar` (plain `node --test`)
+- Renderer service tests: `.test.mts` next to the module or in `src/services/__tests__/`, runnable via `tsx --test`
+- `npm run typecheck:all` must stay at zero errors
+- Push: `SKIP_STALE_CHECK=1 git push --force-with-lease origin <branch>`
+- Every PR body needs a real cross-agent review marker: `Cross-agent review: Codex reviewed on <date>; outcome: <verdict>.`
+
+---
+
+## Fix 1 — Stop sending API keys over plain HTTP and in query strings (H1)
+
+**Branch:** `claude/priv-https-verify`
+
+**Already done elsewhere:** PR #1105 (OPEN) switches all sidecar plain-HTTP external URLs
+to HTTPS, including the three key-verification probes. PR #1109 (OPEN) adds a CI guard
+that blocks new `http://` external URLs in the sidecar. **Do not duplicate the
+HTTP→HTTPS change.** If #1105 has merged by the time you start, rebase onto main and
+verify the three lines below are HTTPS; if it's still open, base this branch on top of it
+or wait for it.
+
+**Residual problem:** even over HTTPS, the secrets ride in the **query string**:
+
+- `src-tauri/sidecar/local-api-server.mjs:4335` — MediaStack verify: `access_key=<secret>` in query
+- `src-tauri/sidecar/local-api-server.mjs:4466` — AviationStack verify: `access_key=<secret>` in query
+- `src-tauri/sidecar/local-api-server.mjs:4541` — GeoNames verify: `username=<value>` in query
+
+Query strings end up in: the sidecar's own verbose traffic log (see Fix 3), provider-side
+access logs, and any intermediary that logs request lines. MediaStack, AviationStack, and
+GeoNames genuinely do not support header auth on their free tiers — the key-in-query is a
+provider API constraint, so the fix is **containment**, not relocation:
+
+**Files to modify:**
+
+1. `src-tauri/sidecar/local-api-server.mjs`
+   - Locate the traffic-log entry construction (`entry.path = pathname + search` at
+     ~:16014 and ~:16046, and the verbose console write at ~:1685 — exact lines after
+     #1105 merges will shift; grep for `pathname + search`).
+   - Confirm these verify routes are covered by the Fix 3 sanitizer (Fix 3 is the actual
+     mechanism; this fix verifies coverage for the three probe paths specifically).
+   - Add a `SENSITIVE_QUERY_PARAMS` set (`access_key`, `apikey`, `api_key`, `key`,
+     `token`, `username`, `appid`, `client_secret`) used by the Fix 3 sanitizer, exported
+     for tests.
+2. Verification-response hygiene: the three probe handlers must never echo the upstream
+   URL (which contains the key) in their JSON error responses. Audit each handler's catch
+   block; replace any `String(error)` that can embed a URL with a static message like
+   `'mediastack verification failed'` plus the upstream HTTP status code only.
+
+**Test requirements:**
+
+- `src-tauri/sidecar/__tests__/sensitive-query-redaction.test.mjs`:
+  - sanitizer strips `access_key`, `username`, `token` values from a path string while
+    preserving the route path and non-sensitive params
+  - probe error responses for a mocked 401 upstream contain no `access_key=` substring
+- Run: `npm run test:sidecar` green; `npm run secrets:scan` green.
+
+**Risk assessment:** Low. Containment only — no provider request format changes, so
+verification behavior is unchanged. Main risk is missing one of the log sinks; mitigated
+by the Fix 3 shared sanitizer + unit test. Coordinate merge order with #1105 to avoid
+conflicts in the same file (rebase whichever lands second).
+
+---
+
+## Fix 2 — Analytics consent gate + payload minimization (H2)
+
+**Branch:** `claude/priv-posthog-optout`
+
+**Already done elsewhere:** nothing. This finding is fully open.
+
+**Problem recap:** `src/services/analytics.ts:32-46` treats absent consent as consent
+(`setAnalyticsConsent()` exists but has **zero callers**); `trackEventBeforeUnload`
+(:344-348) skips the ghost-mode check; the init `$pageview` (:286) and
+`flushOfflineQueue` (:319-330) bypass ghost mode; Vercel Analytics `inject()` at
+`src/main.ts:250` runs unconditionally; `wm_api_keys_configured` (:354-373) sends a
+73-key boolean presence map plus the literal `OLLAMA_MODEL` value; super properties
+(:252-274) are fingerprint-adjacent.
+
+**Files to modify:**
+
+1. `src/services/analytics.ts`
+   - **Default-off until consent.** Change the consent getter (~:32-46) so that absent
+     stored consent ⇒ analytics disabled. Single gate function
+     `isAnalyticsAllowed(): boolean` = `consentGranted && !isGhostMode()`; every send
+     path calls it: `capture()`, init `$pageview` (:286), `flushOfflineQueue` (:319-330),
+     `trackEventBeforeUnload` (:344-348).
+   - **`trackEventBeforeUnload`** additionally must early-return when
+     `!isAnalyticsAllowed()` — it currently bypasses even the ghost check.
+   - **`wm_api_keys_configured` (:354-373):** remove the per-key boolean map and the
+     literal `OLLAMA_MODEL` value. Replace the payload with a single
+     `configured_key_count: number`. Nothing else.
+   - **Super properties (:252-274):** drop screen resolution / locale-adjacent fields if
+     present; keep app version + platform (`darwin`/`web`) only.
+   - **Offline queue:** when consent is absent or revoked, `flushOfflineQueue` must clear
+     the queue without sending (revocation should not later replay buffered events).
+2. `src/main.ts:250`
+   - Wrap the Vercel `inject()` call: only run when `isAnalyticsAllowed()` returns true
+     at boot. Import the gate from `analytics.ts`. (Vercel inject is web-only; the
+     desktop build should never reach it — preserve any existing runtime guard.)
+3. `src/components/UnifiedSettings.ts` (or wherever the Privacy/General settings tab
+   renders — grep for `SETTINGS_CATEGORIES` usage)
+   - Add an "Share anonymous usage analytics" toggle wired to `setAnalyticsConsent()`.
+     Default unchecked. Toggling off calls PostHog `opt_out_capturing()` if the client is
+     already initialized, and clears the offline queue.
+4. Migration note: existing users have no stored consent key, so this flips analytics
+   off for everyone until they opt in. That is the intended behavior per the audit
+   ("consent-absent ⇒ on" is the finding). Do not add a grandfather path.
+
+**Test requirements:**
+
+- `src/services/__tests__/analytics-consent.test.mts`:
+  - absent consent ⇒ `isAnalyticsAllowed()` false; granted ⇒ true; granted+ghost ⇒ false
+  - `wm_api_keys_configured` payload shape: exactly `{ configured_key_count }`, no key
+    names, no `OLLAMA_MODEL`
+  - revoking consent clears the offline queue (mock localStorage/queue)
+- Manual check in the PR description: with consent off, no `posthog.com` or
+  `vercel-insights` requests appear in devtools network on web build.
+- `npm run typecheck:all` zero errors.
+
+**Risk assessment:** Medium. Analytics volume will drop to near zero until users opt in —
+that is the point, but flag it in the PR body so it isn't mistaken for a regression.
+PostHog client API (`opt_out_capturing`) must match the installed posthog-js version.
+Ghost-mode interaction is already partially implemented; keep `analytics suppressed in
+Ghost Mode` semantics intact (consent AND not-ghost, never OR).
+
+---
+
+## Fix 3 — Stop persisting query strings in the traffic log (H3)
+
+**Branch:** `claude/priv-traffic-log-redaction`
+
+**Already done elsewhere:** PR #1104 (OPEN) chmods `events.db` + heartbeat to 0600 but
+its scope note explicitly excludes `local-api.log` / `sidecar.log` (created by the Rust
+host). The content problem — query strings persisted — is fully open.
+
+**Problem recap:** the verbose console write at `local-api-server.mjs:1685` and the
+traffic-log entries (`entry.path = pathname + search` at :16014 and :16046) record full
+query strings; verbose mode persists across restarts via `verbose-mode.json`
+(:6519-6527). The Rust host pipes sidecar stdout to `local-api.log`
+(`src-tauri/src/main.rs:2497-2498`), and `copy_diagnostics` (main.rs:2657-2686) exports
+the last 200 lines to the clipboard. The only sanitized surface today is the
+`/api/local-traffic-log` JSON route (:16022-16028).
+
+**Files to modify:**
+
+1. `src-tauri/sidecar/local-api-server.mjs`
+   - Extract the existing sanitizer logic from :16022-16028 into a top-level function
+     `sanitizePathForLog(pathname, search)` that:
+     - drops values of params in `SENSITIVE_QUERY_PARAMS` (from Fix 1), replacing with
+       `<redacted>`
+     - for all *other* params, keeps the param **names** but drops values longer than 32
+       chars (location coords, free-text queries) — i.e. default-deny on values, not just
+       known-sensitive keys. Rationale: lat/lon and search terms are the privacy payload
+       here, not only API keys.
+   - Apply it at all three sinks: the console write (:1685), and both `entry.path`
+     assignments (:16014, :16046). The `/api/local-traffic-log` route then serves
+     already-sanitized entries and its inline sanitizer can be deleted.
+   - Export `sanitizePathForLog` for tests.
+2. `src-tauri/src/main.rs`
+   - `local-api.log` creation (~:2497-2498): set file mode 0600 on creation
+     (`OpenOptions` + `PermissionsExt::from_mode(0o600)` on unix). This is the log-file
+     half that #1104 explicitly left out.
+   - `copy_diagnostics` (:2657-2686): no change needed once the sidecar stops emitting
+     query strings — but add a defensive line-level regex strip of
+     `(access_key|api_key|apikey|token|key)=[^&\s]+` before clipboard export, since old
+     log files written before this fix may still contain secrets.
+
+**Test requirements:**
+
+- `src-tauri/sidecar/__tests__/sanitize-path-for-log.test.mjs`:
+  - `?access_key=SECRET` ⇒ `?access_key=<redacted>`
+  - `?lat=41.61&lon=-86.72` ⇒ values ≤32 chars: decide and pin behavior — coords are
+    short, so the default-deny length rule alone won't catch them. Add `lat`, `lon`,
+    `latitude`, `longitude`, `q`, `query`, `address` to `SENSITIVE_QUERY_PARAMS`.
+  - route path itself is always preserved (`/api/weather/alerts` stays intact)
+- `npm run test:sidecar` green; `cargo build` (or `npm run desktop:build:full` if
+  touching main.rs warrants it) compiles.
+
+**Risk assessment:** Low-medium. Debugging ergonomics degrade slightly (param values
+gone from verbose logs); acceptable — param *names* remain, which is enough to identify
+the route variant. The main.rs change is small but touches the Rust host: it needs a
+desktop build to verify, and the 0600 chmod must not break log rotation if any exists
+(grep main.rs for rotation logic first). Merge-order conflict risk with #1104 is nil
+(different lines/files) but rebase after it lands anyway.
+
+---
+
+## Fix 4 — persistent-cache.json: TTL, size cap, eviction, 0600 (H4)
+
+**Branch:** `claude/priv-cache-hygiene`
+
+**Already done elsewhere:** PR #1104 does **not** touch persistent-cache.json. Fully open.
+
+**Problem recap:** `src-tauri/src/main.rs:162, 804-812, 838-860` — the persistent cache
+is a plaintext JSON file, observed at 46 MB, written mode 0644, with per-entry caps only
+(256 B key / 5 MB value), no TTL, no total-size cap, no eviction. It accumulates API
+responses (which include location-derived data) indefinitely. Renderer side:
+`src/services/proxy.ts:62-91`, `src/services/persistent-cache.ts:99-128`.
+
+**Files to modify:**
+
+1. `src-tauri/src/main.rs`
+   - **Entry shape:** add `stored_at: u64` (epoch millis) to each cache entry on write
+     (~:838-860). Entries without `stored_at` (pre-migration) are treated as expired on
+     first load.
+   - **TTL on read** (~:804-812): default TTL 7 days; expired entries return miss and are
+     dropped on the next persist.
+   - **Total-size cap with eviction:** 32 MB serialized. On save, if over cap, evict
+     oldest-`stored_at`-first until under cap. (LRU would need read-tracking; oldest-write
+     is sufficient and simpler — the cache is a freshness cache, not a hot-set cache.)
+   - **File mode:** create/rewrite with 0o600 (`PermissionsExt::from_mode`), same pattern
+     as #1104 / #1103.
+   - **One-time shrink:** the migration (no `stored_at` ⇒ expired) automatically clears
+     the existing 46 MB file on first run after update.
+2. `src/services/persistent-cache.ts:99-128`
+   - No protocol change required if TTL lives in Rust. Verify the TS side tolerates a
+     miss for previously-hot keys (it already must, for first-run). If the TS layer has
+     its own staleness logic, align its default to ≤ the Rust TTL so behavior is
+     explainable.
+
+**Test requirements:**
+
+- Rust unit tests in `main.rs` (or a `cache.rs` module if you extract — extraction is
+  optional, do not refactor beyond the fix):
+  - entry older than TTL ⇒ read miss
+  - entry without `stored_at` ⇒ read miss
+  - over-cap save evicts oldest entries first and lands under cap
+- Manual verification in PR body: after running the app, `ls -la` shows
+  `persistent-cache.json` mode 0600 and a sane size.
+- `npm run typecheck:all` + desktop build compile.
+
+**Risk assessment:** Medium. The one-time cache flush causes a cold-start burst of API
+re-fetches on first launch after update — every cached provider gets re-hit. Acceptable
+once; note it in the PR body. Eviction logic must be deterministic and crash-safe (write
+to temp file + rename, if not already the pattern — check existing save path at
+:838-860). Do not change the IPC surface; renderer code keeps working unmodified.
+
+---
+
+## Fix 5 — Groq fallback: honest labeling, budget metering, sidecar-side gate (H5)
+
+**Branch:** `claude/priv-groq-fallback-honesty`
+
+**Already done elsewhere (substantial):** PRs #1113 + #1115 (MERGED) added the
+cloud-egress disclosure modal, the `Local model only` toggle
+(`src/services/ai-flow-settings.ts`: `isLocalModelOnly()` / `isLlmEgressDisclosed()`),
+and gates in `llm-adapter.generateText()` + `claude-agent.runClaudeAgent()`. **Do not
+rebuild any of that.**
+
+**Residual problem:** the gates live in the renderer, but the silent Groq hop lives in
+the **sidecar**: `/api/intel-generate` (`local-api-server.mjs:4843-4855`) tries Ollama →
+LM Studio → Groq (`llama-3.1-8b-instant`). The renderer treats any `/api/intel-generate`
+success as the *local* path, so:
+
+1. `llm-adapter.ts` records `provider: 'local'` even when Groq (cloud) served the
+   request — the user-facing provenance is wrong.
+2. The 50/day cloud budget (`llm-budget.ts:183`, `reserveCloudCall()`) is bypassed for
+   these calls entirely.
+3. `isLocalModelOnly()` does not stop them, because the renderer believes the call is
+   local. Prompts (≤8000 chars, embedding watchlist terms via
+   `watchlist-hypothesis-bridge.ts:156` and persona context via
+   `hypothesis-ensemble.ts:102-114`) reach Groq with the toggle ON.
+
+Item 3 is the actual privacy hole; 1 and 2 are honesty/metering.
+
+**Files to modify:**
+
+1. `src-tauri/sidecar/local-api-server.mjs` (~:4843-4855)
+   - Response must include which engine served it: add `provider: 'ollama' | 'lmstudio'
+     | 'groq'` to the JSON response of `/api/intel-generate`.
+   - Honor a request flag: when the POST body has `localOnly: true`, skip the Groq leg
+     entirely and return `503 { error: 'no local model available', provider: 'none' }`
+     after Ollama and LM Studio fail.
+2. `src/services/llm-adapter.ts`
+   - Pass `localOnly: isLocalModelOnly()` in the `/api/intel-generate` request body.
+   - Read `provider` from the response. When it is `'groq'`:
+     - record the result with `provider: 'groq'` (not `'local'`)
+     - call `reserveCloudCall('groq-fallback')` *before* using the result; if the
+       budget is exhausted, discard the result and fall through to the existing
+       no-cloud-budget behavior. Reserve-on-detect (after the response reveals Groq
+       served it) is the pragmatic v1 — the alternative, reserving before the request,
+       would burn budget on calls that Ollama ends up serving. Note the small
+       overshoot window (the prompt has already reached Groq by the time the reserve
+       fails) in the PR body.
+     - the egress-disclosure gate from #1113 must also apply: if
+       `!isLlmEgressDisclosed()`, treat a `provider:'groq'` response as a failure and
+       dispatch `cb:llm-egress-disclosure-needed`, same as the direct-cloud path.
+3. `src/services/llm-budget.ts`
+   - No structural change; verify `reserveCloudCall` accepts the new caller tag and that
+     metrics/labels surface it (grep for existing tags).
+4. **Webcam/FAA-cam disclosure (audit-related):** `/api/webcam/analyze` (:8539) and
+   `/api/faa-cam-digest` (:8574) send imagery + camera locations to Anthropic with no UI
+   disclosure. Minimal v1: route both behind the existing `isLlmEgressDisclosed()`
+   acknowledgment — the renderer callers of these two routes must check the flag and
+   show the existing disclosure event flow before first use. Find callers:
+   `grep -rn "webcam/analyze\|faa-cam-digest" src/`. Do not build a new modal; reuse
+   `cb:llm-egress-disclosure-needed`.
+
+**Test requirements:**
+
+- `src-tauri/sidecar/__tests__/intel-generate-local-only.test.mjs`:
+  - with `localOnly: true` and no local engines reachable ⇒ 503, no outbound Groq fetch
+    (mock fetch; assert no call to `api.groq.com`)
+  - response always carries `provider`
+- `src/services/__tests__/llm-adapter-groq-labeling.test.mts`:
+  - mocked sidecar response `provider:'groq'` ⇒ result recorded as `groq`, budget
+    reserve called once
+  - budget exhausted ⇒ groq result discarded
+  - `isLocalModelOnly()` true ⇒ request body contains `localOnly: true`
+- `npm run test:sidecar` + `npm run typecheck:all` green.
+
+**Risk assessment:** Medium. Behavior change: users with no local model and
+local-model-only OFF now consume cloud budget for ensemble/skeptic calls — they may hit
+the 50/day cap sooner. That is correct metering, but call it out in the PR body. The
+sidecar response-shape addition is backward-compatible (new field). The disclosure gate
+on webcam routes may surprise users who used them before; the one-time acknowledgment
+makes this a single extra click.
+
+---
+
+## Performance Fixes Beyond Quick Wins
+
+`claude/perf-quick-wins` (PR #1069, MERGED — verified against the actual diff) already
+landed: event-store dedup IDs **and** the transactioned batch insert **and** the daily
+prune timer; FRED 6 h caches (freight-stress + macro-stress); FIRMS 30 min cache; the
+shared OpenSky `opensky:states:all` snapshot across all three call sites; EEWStatusBar
+and CorrelationAlertBanner poller slowdowns. Do not redo any of those. The
+highest-impact remaining items, in priority order:
+
+### Perf 1 — Hot-route caches + generic in-flight dedupe in `getCached`/`setCached`
+
+**Branch:** `claude/perf-hot-route-caches`
+**Files:** `src-tauri/sidecar/local-api-server.mjs` — `/api/market-quotes` (~:9705),
+`/api/weather/alerts` (~:8068), `getCached`/`setCached` (~:3833-3846); reference the
+existing `_inflight` pattern in `cachedFetch` (~:322).
+**Change:** add short-TTL caches (market-quotes 30 s, weather/alerts 60 s) to the two
+hottest uncached routes, and add in-flight promise dedupe to the `getCached`/`setCached`
+cache family so N concurrent panels asking for the same key produce one upstream fetch
+(mirror the `_inflight` map that `cachedFetch` already has — the two cache systems are
+separate; this closes the gap in the `_sidecarCache` one).
+**Tests:** sidecar test asserting two concurrent requests to a mocked slow route produce
+one upstream call; TTL expiry produces a second call.
+**Risk:** Low. Pure additive caching; TTLs are well under data freshness needs.
+
+### Perf 2 — poweroutage.us TTL 60 s → 5 min + InfraRiskMatrixPanel decoupling
+
+**Branch:** `claude/perf-poweroutage-ttl`
+**Files:** sidecar poweroutage route (grep `poweroutage`), `src/components/InfraRiskMatrixPanel.ts`.
+**Change:** raise the poweroutage cache TTL to 5 min (the upstream updates ~10 min);
+ensure InfraRiskMatrixPanel's own poll interval is ≥ the TTL so it isn't polling a
+guaranteed-stale-miss cycle.
+**Tests:** existing sidecar tests stay green; assert TTL constant via exported value or
+route test.
+**Risk:** Low. Outage counts 5 min stale is well within product tolerance.
+
+### Perf 3 — `/gps/nmea`: execFileSync → async execFile (+ auth gate, privacy M7)
+
+**Branch:** `claude/perf-gps-nmea-async`
+**Files:** `src-tauri/sidecar/local-api-server.mjs` (~:15575-15605, execFileSync at ~:15588).
+**Change:** replace the synchronous `execFileSync` (blocks the entire single-threaded
+sidecar event loop up to 3 s per call) with promisified `execFile`. While in the
+handler, also move the route behind the bearer-auth check — the audit's privacy finding
+M7 flags it as pre-auth; this is a two-line ordering change in the dispatch path.
+**Tests:** sidecar test that the route rejects without the bearer token; mocked execFile
+resolves asynchronously.
+**Risk:** Low-medium. The auth gate is a breaking change for any unauthenticated local
+caller — grep the repo for `/gps/nmea` consumers first and update them to send the
+token.
+
+### Perf 4 — `dispose()` vs `destroy()` lifecycle bug across ~55 components
+
+**Branch:** `claude/perf-dispose-destroy-audit`
+**Files:** ~55 components implementing `dispose()` while the panel host calls
+`destroy()` (audit example: `src/components/HybridWarfarePanel.ts:26-28`); panel
+teardown in `src/app/panel-layout.ts`.
+**Change:** pick ONE canonical teardown name (match what `Panel.ts` base class +
+panel-layout actually invoke — verify before renaming), then rename the orphaned
+`dispose()` implementations so their `clearInterval`/listener cleanup actually runs on
+panel close. This is the root cause behind a chunk of the 375 raw `setInterval` leaks.
+**Tests:** `npm run typecheck:all`; add one regression test asserting a representative
+panel's interval is cleared after teardown if a harness exists (`grep -rn "destroy()"
+src/components/__tests__/` first); otherwise manual verification steps in the PR body
+(open/close panel, observe interval stops via console counter).
+**Risk:** Medium. Wide mechanical change touching 55 files — keep it purely mechanical
+(rename + wire-up, zero logic changes) so Codex review can verify by pattern. Land it as
+its own PR with nothing else mixed in.
+
+### Perf 5 — Coordinate NWS `alerts/active` pulls + add timeout to renderer-direct fetch
+
+**Branch:** `claude/perf-nws-coordination`
+**Files:** `src/services/weather.ts:41-53` (renderer-direct fetch, no timeout); the
+sidecar NWS alert routes (grep `api.weather.gov/alerts`); audit notes 4 uncoordinated
+pulls.
+**Change:** route the renderer-direct call through the sidecar's cached route (or, if
+the renderer must stay direct for web builds, add `AbortSignal.timeout(10_000)` and a
+60 s memory cache); consolidate the sidecar pulls onto one cached fetch with a shared
+TTL so the app issues at most one `alerts/active` request per minute instead of four
+overlapping ones.
+**Tests:** unit test for the renderer cache/timeout; sidecar tests stay green.
+**Risk:** Low-medium. Weather alerts are safety-relevant — keep the TTL at 60 s, never
+higher, and preserve the existing personal-storm-mode bridge behavior
+(`bridgeWeatherAlertsToInsights` consumers in `src/app/data-loader.ts`).
+
+---
+
+## Suggested landing order
+
+1. Fix 2 (analytics consent) — standalone, highest user-facing privacy value
+2. Fix 3 (traffic-log redaction) — unlocks Fix 1's verification step
+3. Fix 1 (probe containment) — after #1105 merges
+4. Fix 5 (Groq honesty) — renderer + sidecar, builds on merged #1113/#1115
+5. Fix 4 (cache hygiene) — Rust-side, needs a desktop build cycle
+6. Perf 1 → Perf 5 in listed order; Perf 4 (mechanical sweep) whenever convenient as an
+   isolated PR
+
+Each fix is one PR, one branch, one Codex cross-agent review. None of them depend on
+each other except where noted (Fix 1 ↔ Fix 3 share `SENSITIVE_QUERY_PARAMS`; if Fix 1
+lands first, define the set there and Fix 3 imports it — or vice versa).

--- a/docs/PRIVACY_FIX_PLAN_2026-06-12.md
+++ b/docs/PRIVACY_FIX_PLAN_2026-06-12.md
@@ -22,7 +22,10 @@ already done and what is residual. Before starting any fix, run
 General conventions for every fix:
 
 - Branch from `origin/main` in a worktree: `git worktree add .worktrees/<name> -b <branch> origin/main`
-- Sidecar tests: add `.test.mjs` under `src-tauri/sidecar/__tests__/`, runnable via `npm run test:sidecar` (plain `node --test`)
+- Sidecar tests: add `.test.mjs` under `src-tauri/sidecar/__tests__/`, runnable via
+  `npm run test:sidecar` (plain `node --test`). **The `test:sidecar` script in
+  `package.json` is an explicit file list, not a glob — every new test file must also
+  be appended to that script or it will never run.**
 - Renderer service tests: `.test.mts` next to the module or in `src/services/__tests__/`, runnable via `tsx --test`
 - `npm run typecheck:all` must stay at zero errors
 - Push: `SKIP_STALE_CHECK=1 git push --force-with-lease origin <branch>`


### PR DESCRIPTION
## Summary

Adds `docs/PRIVACY_FIX_PLAN_2026-06-12.md` — an implementation-ready plan for the 5 High findings in `docs/PRIVACY_AUDIT_2026-06-11.md`, plus a "Performance Fixes Beyond Quick Wins" section covering the highest-impact perf items not landed by PR #1069. Also commits the two audit docs themselves (previously untracked local files) so every finding reference is verifiable in-repo.

Each `## Fix N` section includes branch name, exact files with line numbers, specific code change description, test requirements, and risk assessment, so a Sonnet agent can start coding directly from it.

## Key scoping decisions (verified against live PR states 2026-06-12)

- **H1** (plain-HTTP key probes): PR #1105 (open) already does the HTTP→HTTPS switch; Fix 1 scopes to the residual secret-in-query-string containment only.
- **H5** (silent Groq fallback): PRs #1113/#1115 (merged) already added the egress disclosure + local-model-only toggle; Fix 5 covers the residual sidecar-side hop, provider mislabeling, and budget bypass — via a new `'cloud-groq'` `LlmProvider` variant + `cloudGroq` budget counter.
- **H3/H4**: PR #1104 (open) covers events.db + heartbeat permissions only — `local-api.log` and `persistent-cache.json` remain in Fixes 3/4.
- **Perf**: verified against the actual #1069 diff that event-store dedup, transactioned batch insert, the prune timer, FRED/FIRMS caches, and the shared OpenSky fetcher are all merged — the 5 remaining items start from market-quotes/weather caches + in-flight dedupe.

Docs-only change; no code touched.

## Review history

- Round 1 (Codex): CHANGES REQUESTED — audit docs were untracked (not verifiable in-repo); Fix 5's `reserveCloudCall('groq-fallback')` guidance would fail typecheck and be silently unmetered; 4 nits (stale line refs, key count, vague verification criteria). Addressed in b12c20af.
- Round 2 (Codex): verified both blockers' doc fixes; final round confirmed Fix 5 guidance is now type-correct against `llm-adapter.ts`/`llm-budget.ts` and would correctly meter Groq calls. One nit (test:sidecar explicit file list) addressed in f27b1924.

Cross-agent review: Codex reviewed on 2026-06-12; outcome: approved with nits (all addressed).