### PR TITLE
Privacy fix H3/M12: redact traffic log query strings and SSRF URLs

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -12175,7 +12175,8 @@ async function dispatch(requestUrl, req, routes, context) {
  // SSRF protection: block private IPs, reserved ranges, and DNS rebinding
  const safety = await isSafeUrl(feedUrl);
  if (!safety.safe) {
- context.logger.warn(`[local-api] rss-proxy SSRF blocked: ${safety.reason} (url=${feedUrl})`);
+ const blockedHost = (() => { try { return new URL(feedUrl).hostname; } catch { return 'invalid-url'; } })();
+ context.logger.warn(`[local-api] rss-proxy SSRF blocked: ${safety.reason} (host=${blockedHost})`);
  return json({ error: safety.reason }, 403);
  }
 
@@ -12211,7 +12212,8 @@ async function dispatch(requestUrl, req, routes, context) {
  const next = new URL(location, currentUrl).href;
  const nextSafety = await isSafeUrl(next);
  if (!nextSafety.safe) {
- context.logger.warn(`[local-api] rss-proxy SSRF blocked on redirect: ${nextSafety.reason} (url=${next})`);
+ const blockedRedirectHost = (() => { try { return new URL(next).hostname; } catch { return 'invalid-url'; } })();
+ context.logger.warn(`[local-api] rss-proxy SSRF blocked on redirect: ${nextSafety.reason} (host=${blockedRedirectHost})`);
  return json({ error: nextSafety.reason }, 403, makeCorsHeaders(req));
  }
  currentUrl = next;
@@ -16012,7 +16014,7 @@ export async function createLocalApiServer(options = {}) {
  recordTraffic({
  timestamp: new Date().toISOString(),
  method: req.method,
- path: requestUrl.pathname + (requestUrl.search || ''),
+ path: requestUrl.pathname,
  status: response.status,
  durationMs,
  });
@@ -16045,7 +16047,7 @@ export async function createLocalApiServer(options = {}) {
  recordTraffic({
  timestamp: new Date().toISOString(),
  method: req.method,
- path: requestUrl.pathname + (requestUrl.search || ''),
+ path: requestUrl.pathname,
  status: errorStatus,
  durationMs,
  error: error.message,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1082,6 +1082,11 @@ fn open_sidecar_log_impl(app: &AppHandle) -> Result<PathBuf, String> {
  if !log_path.exists() {
  File::create(&log_path)
  .map_err(|e| format!("Failed to create sidecar log {}: {e}", log_path.display()))?;
+ #[cfg(unix)]
+ {
+ use std::os::unix::fs::PermissionsExt;
+ let _ = fs::set_permissions(&log_path, fs::Permissions::from_mode(0o600));
+ }
  }
  open_path_in_shell(&log_path)?;
  Ok(log_path)

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2417,6 +2417,11 @@ fn start_local_api(app: &AppHandle) -> Result<(), String> {
  .append(true)
  .open(&log_path)
  .map_err(|e| format!("Failed to open local API log {}: {e}", log_path.display()))?;
+ #[cfg(unix)]
+ {
+ use std::os::unix::fs::PermissionsExt;
+ let _ = fs::set_permissions(&log_path, fs::Permissions::from_mode(0o600));
+ }
  let log_file_err = log_file
  .try_clone()
  .map_err(|e| format!("Failed to clone local API log handle: {e}"))?;


### PR DESCRIPTION
## Summary

Addresses audit findings H3 (verbose traffic log leaks query strings) and M12 (SSRF block logs private RSS URLs verbatim).

## Changes

### `src-tauri/sidecar/local-api-server.mjs`

- **H3 — traffic log sinks**: Strip query string from `entry.path` at record time (two call sites in the request handler's success and error paths). The ring buffer, the verbose `[traffic]` console.log (stdout → `local-api.log`), and the `/api/local-traffic-log` endpoint all now see only the pathname. The existing endpoint-level sanitization (`entry.path?.split('?')[0]`) becomes a harmless double-safety net.

- **M12 — SSRF block logging**: Replace `url=${feedUrl}` / `url=${next}` with `host=${hostname}` in both the initial and redirect SSRF block log messages. Private RSS feed URLs (watchlist terms, lat/lon) no longer appear in `local-api.log`.

### `src-tauri/src/main.rs`

- **H3 — log file permissions (sidecar startup path)**: Set `local-api.log` to `0600` (owner-read-only) immediately after `OpenOptions::new().create(true).append(true).open()`. Follows the same `#[cfg(unix)]` pattern used for `sidecar.token`. Rotated backups inherit 0600 via `fs::rename`.

- **H3 — log file permissions (create-if-missing path)**: `open_sidecar_log_impl` (UI 'Open log file' action) now also sets 0600 when creating a new file.

## Tests

- `traffic log strips query strings from entries to protect privacy` — passes
- SSRF regression matrix (13 tests) — all pass
- `npm run typecheck:all` — zero errors

## Cross-agent review

Cross-agent review: Codex reviewed on 2026-06-12; outcome: pass