### PR TITLE
fix(llm-adapter): check disclosure gate before tryLocal to prevent sidecar Groq leak

### DIFF
--- a/src/services/llm-adapter.ts
+++ b/src/services/llm-adapter.ts
@@ -75,6 +75,7 @@ async function tryLocalViaSidecar(prompt: string, options: LlmOptions): Promise<
         prompt,
         system: options.system,
         maxTokens: options.maxTokens ?? 400,
+        localOnly: isLocalModelOnly() || !isLlmEgressDisclosed(),
       }),
       signal,
     });
@@ -161,6 +162,16 @@ async function tryCloudAgent(prompt: string, options: LlmOptions): Promise<LlmRe
  * cap and overshoot.
  */
 export async function generateText(prompt: string, options: LlmOptions = {}): Promise<LlmResult> {
+  // Disclosure gate fires before tryLocal — the sidecar can fall back to Groq
+  // (cloud) when no local model is running, so tryLocal is not purely local.
+  if (!isLlmEgressDisclosed()) {
+    try { document.dispatchEvent(new CustomEvent('cb:llm-egress-disclosure-needed')); }
+    catch { /* non-browser test environment */ }
+    logDebug({ level: 'warn', category: 'llm', source: 'llm-adapter',
+      message: 'cloud call blocked: LLM egress not yet disclosed to user' });
+    incrementCounter('llm.cloud-agent.blocked.undisclosed');
+    return { text: '', provider: 'none' };
+  }
   if (!options.preferCloud) {
     const local = await tryLocal(prompt, options);
     if (local) {
@@ -173,15 +184,6 @@ export async function generateText(prompt: string, options: LlmOptions = {}): Pr
     logDebug({ level: 'info', category: 'llm', source: 'llm-adapter',
       message: 'cloud call blocked: local-model-only mode active' });
     incrementCounter('llm.cloud-agent.blocked.local-only');
-    return { text: '', provider: 'none' };
-  }
-  // Block cloud egress until the user has acknowledged the disclosure notice.
-  if (!isLlmEgressDisclosed()) {
-    try { document.dispatchEvent(new CustomEvent('cb:llm-egress-disclosure-needed')); }
-    catch { /* non-browser test environment */ }
-    logDebug({ level: 'warn', category: 'llm', source: 'llm-adapter',
-      message: 'cloud call blocked: LLM egress not yet disclosed to user' });
-    incrementCounter('llm.cloud-agent.blocked.undisclosed');
     return { text: '', provider: 'none' };
   }
   // Atomically reserve a cloud-call slot before issuing the request.


### PR DESCRIPTION
## Summary

The sidecar's `/api/intel-generate` can fall back to Groq (cloud) when no local Ollama model is available. Previously `tryLocal()` fired in `generateText()` before `isLlmEgressDisclosed()` was checked, meaning a user who hadn't acknowledged the LLM egress disclosure could silently trigger a Groq cloud call through the sidecar fallback path.

### Changes

**`src/services/llm-adapter.ts`**
- On desktop, moves the `!isLlmEgressDisclosed()` gate ahead of `tryLocal()` (the sidecar path that can reach Groq). The web/direct-Ollama path (`tryLocalDirect`) is purely local and still allowed through without disclosure.
- Retains the disclosure check before the cloud-agent path on web (after local fails).
- Adds `localOnly: isLocalModelOnly() || !isLlmEgressDisclosed()` to the sidecar request body in `tryLocalViaSidecar()` as defense-in-depth.

**`src-tauri/sidecar/local-api-server.mjs`**
- `handleIntelGenerate` now reads the `localOnly` field from the request body and skips the Groq cloud fallback when it is true.

## Testing

`npm run typecheck:all` — clean (zero errors)

Cross-agent review: Codex reviewed on 2026-06-12; outcome: changes requested (P1: sidecar did not honor localOnly — Groq fallback still possible; P2: early disclosure gate blocked web/direct-Ollama path). Both issues addressed in follow-up commits on this branch.