### PR TITLE
Dedupe concurrent NWS fetches and raise poweroutage cache TTL

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -7066,7 +7066,7 @@ async function dispatch(requestUrl, req, routes, context) {
   // upstream is unreachable so the panel can render an empty-state.
 
   if (requestUrl.pathname === '/api/infrarisks/power') {
-    const cached = getCached('infrarisks-power', 60_000);
+    const cached = getCached('infrarisks-power', 15 * 60 * 1000);
     if (cached) return json(cached);
     try {
       const r = await fetchWithTimeout('https://poweroutage.us/api/stat/county', {
@@ -7074,7 +7074,7 @@ async function dispatch(requestUrl, req, routes, context) {
       }, 15_000);
       if (!r.ok) throw new Error(`poweroutage.us HTTP ${r.status}`);
       const data = await r.json();
-      setCached('infrarisks-power', data, 60_000);
+      setCached('infrarisks-power', data, 15 * 60 * 1000);
       return json(data);
     } catch (error) {
       return json({ CountyOutages: [], degraded: true, reason: `poweroutage.us error: ${error.message ?? error}` });

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -7073,7 +7073,10 @@ async function dispatch(requestUrl, req, routes, context) {
         headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
       }, 15_000);
       if (!r.ok) throw new Error(`poweroutage.us HTTP ${r.status}`);
-      const data = await r.json();
+      const raw = await r.json();
+      // cachedAt lets consumers show true source-data age while the
+      // 15-min cache amortizes the panel's 60s poll.
+      const data = { ...raw, cachedAt: Date.now() };
       setCached('infrarisks-power', data, 15 * 60 * 1000);
       return json(data);
     } catch (error) {

--- a/src/components/InfraRiskMatrixPanel.ts
+++ b/src/components/InfraRiskMatrixPanel.ts
@@ -95,7 +95,8 @@ export class InfraRiskMatrixPanel extends Panel {
     if (!power) return emptyState('Loading power-grid data…');
     if (power.records.length === 0) return emptyState('No active power outages reported.');
     const rows = power.records.slice(0, 30).map((r) => renderPowerRow(r)).join('');
-    return `<div style="font-size:12px;opacity:0.75;margin-bottom:4px">${escapeHtml(power.score.headline)}</div>
+    const asOf = power.dataAsOf ? ` · source data ${timeAgo(power.dataAsOf)}` : '';
+    return `<div style="font-size:12px;opacity:0.75;margin-bottom:4px">${escapeHtml(power.score.headline)}${asOf}</div>
       <table class="eq-table" style="width:100%;font-size:12px">
         <thead><tr><th>County</th><th>State</th><th style="text-align:right">Customers Out</th><th style="text-align:right">%</th><th>Severity</th></tr></thead>
         <tbody>${rows}</tbody>

--- a/src/services/infrarisks/infra-risk-service.ts
+++ b/src/services/infrarisks/infra-risk-service.ts
@@ -75,7 +75,7 @@ export interface DomainScore {
 }
 
 export interface InfraRiskState {
-  power: { records: PowerOutageRecord[]; score: DomainScore; alerts: UnifiedAlert[] };
+  power: { records: PowerOutageRecord[]; score: DomainScore; alerts: UnifiedAlert[]; dataAsOf?: number };
   kev: { entries: CisaKevEntry[]; score: DomainScore; alerts: UnifiedAlert[] };
   bgp: { records: BgpAnomalyRecord[]; score: DomainScore; alerts: UnifiedAlert[] };
   acled: { events: AcledEvent[]; score: DomainScore; alerts: UnifiedAlert[] };
@@ -404,7 +404,7 @@ export function acledAlertsFor(events: readonly AcledEvent[], now: number): Unif
 const DOMAIN_WEIGHTS = { power: 0.3, kev: 0.25, bgp: 0.2, acled: 0.25 };
 
 export function composeInfraRiskState(input: {
-  power: { records: PowerOutageRecord[]; score: DomainScore; alerts: UnifiedAlert[] };
+  power: { records: PowerOutageRecord[]; score: DomainScore; alerts: UnifiedAlert[]; dataAsOf?: number };
   kev: { entries: CisaKevEntry[]; score: DomainScore; alerts: UnifiedAlert[] };
   bgp: { records: BgpAnomalyRecord[]; score: DomainScore; alerts: UnifiedAlert[] };
   acled: { events: AcledEvent[]; score: DomainScore; alerts: UnifiedAlert[] };
@@ -461,9 +461,12 @@ export async function fetchInfraRisks(opts: FetchInfraRisksOptions = {}): Promis
   const kevEntries = parseCisaKev(kevRaw, now);
   const bgpRecords = parseBgpAnomalies(bgpRaw);
   const acledEvents = parseAcledEvents(acledRaw);
+  const powerDataAsOf = typeof (powerRaw as { cachedAt?: unknown } | null)?.cachedAt === 'number'
+    ? (powerRaw as { cachedAt: number }).cachedAt
+    : undefined;
 
   const state = composeInfraRiskState({
-    power: { records: powerRecords, score: scorePowerOutages(powerRecords), alerts: powerAlertsFor(powerRecords, now) },
+    power: { records: powerRecords, score: scorePowerOutages(powerRecords), alerts: powerAlertsFor(powerRecords, now), dataAsOf: powerDataAsOf },
     kev: { entries: kevEntries, score: scoreCisaKev(kevEntries, now), alerts: kevAlertsFor(kevEntries, now) },
     bgp: { records: bgpRecords, score: scoreBgpAnomalies(bgpRecords), alerts: bgpAlertsFor(bgpRecords, now) },
     acled: { events: acledEvents, score: scoreAcled(acledEvents), alerts: acledAlertsFor(acledEvents, now) },

--- a/src/services/nws-alerts.ts
+++ b/src/services/nws-alerts.ts
@@ -22,9 +22,16 @@ export interface NWSAlert {
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
 let cache: { data: NWSAlert[]; ts: number } | null = null;
+let inflight: Promise<NWSAlert[]> | null = null;
 
 export async function fetchNWSAlerts(): Promise<NWSAlert[]> {
   if (cache && Date.now() - cache.ts < CACHE_TTL_MS) return cache.data;
+  if (inflight) return inflight;
+  inflight = doFetchNWSAlerts().finally(() => { inflight = null; });
+  return inflight;
+}
+
+async function doFetchNWSAlerts(): Promise<NWSAlert[]> {
   try {
     const res = await fetch(`${getApiBaseUrl()}/api/nws-alerts`, {
       signal: AbortSignal.timeout(12_000),


### PR DESCRIPTION
## Summary

Two targeted fixes from the 2026-06-11 performance audit (`docs/PERFORMANCE_AUDIT_2026-06-11.md`).

### Fix A — NWS in-flight dedupe (`src/services/nws-alerts.ts`)

Investigation found NWS pulls are **already coordinated**: all three data-loader call sites go through the shared `fetchNWSAlerts()`, which has a 5-minute module-level cache. The remaining gap was concurrent callers during a cache miss — each issued its own HTTP request. An in-flight promise now coalesces them, so N concurrent callers share one request. Error semantics are unchanged (stale-cache fallback, freshness recording).

### Fix B — Poweroutage cache TTL (`src-tauri/sidecar/local-api-server.mjs`)

The `/api/infrarisks/power` route already had a sidecar cache, but its 60s TTL exactly matched `InfraRiskMatrixPanel`'s 60s poll interval, so nearly every poll missed the cache and hit poweroutage.us upstream. Raised to 15 minutes, matching the TTL-band of the sibling infrarisks routes (KEV is 30 min).

### Review follow-up — honest source-data age

Codex flagged (P2) that the panel restamps `fetchedAt` on every 60s poll, so cached power data could look fresh for up to 15 minutes. The sidecar now stamps `cachedAt` when it actually hits poweroutage.us, the service surfaces it as `power.dataAsOf`, and the power tab shows the real source-data age next to the headline.

## Testing

- `node --check` on the sidecar passes
- `npm run typecheck:all` — zero errors
- Secret scan passed on push

Cross-agent review: Codex reviewed on 2026-06-12; outcome: issues fixed (P2 stale-age display addressed by surfacing cachedAt/dataAsOf).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>