### PR TITLE
perf: single-flight cache dedupe + async/auth-gated /gps/nmea

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -15893,6 +15893,14 @@ export async function createLocalApiServer(options = {}) {
  const reqStartedAt = Date.now();
 
  if (requestUrl.pathname === '/gps/nmea') {
+ // CORS preflight carries no Authorization header, so answer it before the
+ // auth gate — otherwise the browser preflight 401s and the real GET (which
+ // does carry the token) is never sent.
+ if (req.method === 'OPTIONS') {
+ res.writeHead(204, makeCorsHeaders(req));
+ res.end();
+ return;
+ }
  const authHeader = req.headers['authorization'] || '';
  if (!isValidToken(authHeader)) {
  warnUnauthorizedOnce(context, requestUrl.pathname);

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -3920,6 +3920,24 @@ function setCached(key, data, ttlMs) {
   _ensureSidecarCacheSweep();
 }
 
+// Single-flight de-duplication for cold-cache fetches. Without this, N callers
+// that all miss the cache for the same key each fire their own upstream fetch.
+// This collapses the concurrent-miss window: the first caller's promise is held
+// in `_sidecarInflight` and subsequent callers await it instead of issuing a
+// duplicate request. The TTL cache (getCached/setCached) remains the source of
+// truth for completed results — the fetcher still reads/writes it as before; the
+// inflight map only spans the in-progress fetch and is cleared once it settles.
+const _sidecarInflight = new Map(); // key -> Promise
+function dedupeInflight(key, fetcher) {
+  const existing = _sidecarInflight.get(key);
+  if (existing) return existing;
+  const promise = Promise.resolve()
+    .then(() => fetcher())
+    .finally(() => { _sidecarInflight.delete(key); });
+  _sidecarInflight.set(key, promise);
+  return promise;
+}
+
 // ── ProMED snapshot helper (shared by /api/promed and /api/disease-intel) ──
 const PROMED_RSS_URL = 'https://promedmail.org/feed/';
 const PROMED_TTL_MS = 15 * 60 * 1000;
@@ -3927,43 +3945,49 @@ const PROMED_TTL_MS = 15 * 60 * 1000;
 async function getOrFetchPromedSnapshot() {
   const cached = getCached('promed', PROMED_TTL_MS);
   if (cached) return cached;
-  try {
-    const resp = await fetchWithTimeout(
-      PROMED_RSS_URL,
-      { headers: { Accept: 'application/rss+xml, application/xml, text/xml', 'User-Agent': CHROME_UA } },
-      15_000,
-    );
-    if (!resp.ok) {
+  // Concurrent cold-cache callers (e.g. /api/promed and /api/disease-intel
+  // firing together) share one upstream fetch instead of each hitting ProMED.
+  return dedupeInflight('promed', async () => {
+    try {
+      const resp = await fetchWithTimeout(
+        PROMED_RSS_URL,
+        { headers: { Accept: 'application/rss+xml, application/xml, text/xml', 'User-Agent': CHROME_UA } },
+        15_000,
+      );
+      if (!resp.ok) {
+        return {
+          alerts: [],
+          lastFetch: new Date().toISOString(),
+          novelCount: 0,
+          outbreakCount: 0,
+          degraded: true,
+          reason: `ProMED upstream returned HTTP ${resp.status}`,
+        };
+      }
+      const xml = await resp.text();
+      const alerts = parseProMedRss(xml);
+      const { novelCount, outbreakCount } = summarizeProMedAlerts(alerts);
+      const result = {
+        alerts,
+        lastFetch: new Date().toISOString(),
+        novelCount,
+        outbreakCount,
+      };
+      // Only successful snapshots are cached; degraded results stay uncached so
+      // the next caller retries rather than serving a stale failure for the TTL.
+      setCached('promed', result);
+      return result;
+    } catch (error) {
       return {
         alerts: [],
         lastFetch: new Date().toISOString(),
         novelCount: 0,
         outbreakCount: 0,
         degraded: true,
-        reason: `ProMED upstream returned HTTP ${resp.status}`,
+        reason: `promed fetch error: ${error.message ?? error}`,
       };
     }
-    const xml = await resp.text();
-    const alerts = parseProMedRss(xml);
-    const { novelCount, outbreakCount } = summarizeProMedAlerts(alerts);
-    const result = {
-      alerts,
-      lastFetch: new Date().toISOString(),
-      novelCount,
-      outbreakCount,
-    };
-    setCached('promed', result);
-    return result;
-  } catch (error) {
-    return {
-      alerts: [],
-      lastFetch: new Date().toISOString(),
-      novelCount: 0,
-      outbreakCount: 0,
-      degraded: true,
-      reason: `promed fetch error: ${error.message ?? error}`,
-    };
-  }
+  });
 }
 
 // ── Local IDS log helpers ─────────────────────────────────────────────────
@@ -15869,22 +15893,35 @@ export async function createLocalApiServer(options = {}) {
  const reqStartedAt = Date.now();
 
  if (requestUrl.pathname === '/gps/nmea') {
+ const authHeader = req.headers['authorization'] || '';
+ if (!isValidToken(authHeader)) {
+ warnUnauthorizedOnce(context, requestUrl.pathname);
+ res.writeHead(401, { 'content-type': 'application/json', ...makeCorsHeaders(req) });
+ res.end(JSON.stringify({ error: 'Unauthorized' }));
+ return;
+ }
  try {
- const { execFileSync } = await import('node:child_process');
+ const { execFile } = await import('node:child_process');
+ const { readFile } = await import('node:fs/promises');
+ const { promisify } = await import('node:util');
+ const execFileAsync = promisify(execFile);
  const configPath = path.join(os.homedir(), '.crystalball-gps.json');
  let port = '/dev/tty.usbserial-0001';
 
  try {
- const config = JSON.parse(readFileSync(configPath, 'utf8'));
+ const config = JSON.parse(await readFile(configPath, 'utf8'));
  port = config.port || port;
  } catch {
  // Use defaults
  }
 
- const line = execFileSync('head', ['-n', '5', port], {
+ // Async exec so a slow/absent serial device can't block the event loop
+ // for up to the 3s timeout while every other sidecar request stalls.
+ const { stdout } = await execFileAsync('head', ['-n', '5', port], {
  encoding: 'utf8',
  timeout: 3000,
- }).trim();
+ });
+ const line = stdout.trim();
 
  if (!line || !line.startsWith('$')) {
  res.writeHead(404, { 'content-type': 'application/json', ...makeCorsHeaders(req) });

--- a/src/services/gps-tracker.ts
+++ b/src/services/gps-tracker.ts
@@ -184,9 +184,18 @@ export class GpsTracker {
   private async _tryTier3(): Promise<boolean> {
     try {
       const base = getApiBaseUrl();
-      const headers = await this._nmeaHeaders();
-      const res = await fetch(`${base}/gps/nmea`, { headers, signal: AbortSignal.timeout(3000) });
-      if (!res.ok) return false;
+      // The local API token can be transiently unavailable at desktop cold
+      // start, which now yields a 401 from the auth-gated route. Treat that as
+      // retryable (re-acquiring the token each attempt) so a startup race
+      // doesn't leave Tier 3 permanently disabled until the user toggles GPS.
+      let res: Response | null = null;
+      for (let attempt = 0; attempt < 4; attempt++) {
+        const headers = await this._nmeaHeaders();
+        res = await fetch(`${base}/gps/nmea`, { headers, signal: AbortSignal.timeout(3000) });
+        if (res.status !== 401) break;
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+      if (!res || !res.ok) return false;
       const text = await res.text();
       const pos = parseNmea(text.trim());
       if (!pos || pos.latitude === 0 || pos.longitude === 0) return false;

--- a/src/services/gps-tracker.ts
+++ b/src/services/gps-tracker.ts
@@ -172,10 +172,20 @@ export class GpsTracker {
     });
   }
 
+  private async _nmeaHeaders(): Promise<Record<string, string>> {
+    // The /gps/nmea route is auth-gated like the other sidecar endpoints, but
+    // it lives outside the /api/ prefix the global fetch patch authorizes, so
+    // attach the local API token here. Tier 3 is desktop-only; in the browser
+    // build the token is absent and the fetch simply fails back to no Tier 3.
+    const token = await tryInvokeTauri<string>('get_local_api_token').catch(() => null);
+    return token ? { Authorization: `Bearer ${token.trim()}` } : {};
+  }
+
   private async _tryTier3(): Promise<boolean> {
     try {
       const base = getApiBaseUrl();
-      const res = await fetch(`${base}/gps/nmea`, { signal: AbortSignal.timeout(3000) });
+      const headers = await this._nmeaHeaders();
+      const res = await fetch(`${base}/gps/nmea`, { headers, signal: AbortSignal.timeout(3000) });
       if (!res.ok) return false;
       const text = await res.text();
       const pos = parseNmea(text.trim());
@@ -194,7 +204,10 @@ export class GpsTracker {
 
       this._pollId = setInterval(async () => {
         try {
-          const r = await fetch(`${base}/gps/nmea`, { signal: AbortSignal.timeout(3000) });
+          const r = await fetch(`${base}/gps/nmea`, {
+            headers: await this._nmeaHeaders(),
+            signal: AbortSignal.timeout(3000),
+          });
           if (!r.ok) return;
           const t = await r.text();
           const p = parseNmea(t.trim());


### PR DESCRIPTION
## Summary

Two performance/correctness fixes from the Crystal Ball audit.

**Fix A — single-flight cache dedupe.** Adds a `Map<string, Promise>` in-flight tracker (`dedupeInflight`) so concurrent cold-cache callers for the same key await the first request's promise instead of firing duplicate upstream fetches. Adopted in the genuinely-shared `getOrFetchPromedSnapshot()` (backs `/api/promed` + `/api/disease-intel`). TTL stays separate from the in-flight window; degraded results remain uncached.

**Fix B — `/gps/nmea` async + auth gate.** The handler now runs the serial read via async `execFile` (a slow/absent serial device no longer blocks the event loop), and the route is auth-gated with the same `isValidToken` Bearer check as the other sidecar endpoints.

### Codex-flagged follow-ups (both fixed in this PR)
- **P2 — keep the route reachable.** The auth gate would 401 the browser CORS preflight (no `Authorization` header) and the renderer never sent the token. Now: the `/gps/nmea` route answers the `OPTIONS` preflight before the auth check, and `GpsTracker` attaches the local API token to both NMEA fetches.
- **P2 — transient cold-start 401.** `get_local_api_token` can be briefly unavailable at desktop cold start; `_tryTier3()` now retries the initial fetch up to 4× (re-acquiring the token each attempt) on a 401 before disabling Tier 3.

## Testing
- `npm run typecheck:all` — both `tsconfig.json` and `tsconfig.api.json` pass (zero errors).

Cross-agent review: Codex reviewed on 2026-06-12; outcome: clean — "No actionable correctness issues were found in the changed code."