### PR TITLE
fix(llm-adapter): honor localOnly in sidecar and scope disclosure gate to desktop path

### DIFF
--- a/src/services/llm-adapter.ts
+++ b/src/services/llm-adapter.ts
@@ -165,17 +165,19 @@ async function tryCloudAgent(prompt: string, options: LlmOptions): Promise<LlmRe
  * cap and overshoot.
  */
 export async function generateText(prompt: string, options: LlmOptions = {}): Promise<LlmResult> {
-  // Disclosure gate fires before tryLocal — the sidecar can fall back to Groq
-  // (cloud) when no local model is running, so tryLocal is not purely local.
-  if (!isLlmEgressDisclosed()) {
-    try { document.dispatchEvent(new CustomEvent('cb:llm-egress-disclosure-needed')); }
-    catch { /* non-browser test environment */ }
-    logDebug({ level: 'warn', category: 'llm', source: 'llm-adapter',
-      message: 'cloud call blocked: LLM egress not yet disclosed to user' });
-    incrementCounter('llm.cloud-agent.blocked.undisclosed');
-    return { text: '', provider: 'none' };
-  }
   if (!options.preferCloud) {
+    // On desktop, tryLocal routes through the sidecar which can fall back to
+    // Groq (cloud) — enforce disclosure before that happens. On web,
+    // tryLocalDirect calls the user's own Ollama endpoint directly and never
+    // touches a cloud API, so no disclosure is required for that path.
+    if (isDesktopRuntime() && !isLlmEgressDisclosed()) {
+      try { document.dispatchEvent(new CustomEvent('cb:llm-egress-disclosure-needed')); }
+      catch { /* non-browser test environment */ }
+      logDebug({ level: 'warn', category: 'llm', source: 'llm-adapter',
+        message: 'cloud call blocked: LLM egress not yet disclosed to user' });
+      incrementCounter('llm.cloud-agent.blocked.undisclosed');
+      return { text: '', provider: 'none' };
+    }
     const local = await tryLocal(prompt, options);
     if (local) {
       recordCall(local.provider);
@@ -187,6 +189,15 @@ export async function generateText(prompt: string, options: LlmOptions = {}): Pr
     logDebug({ level: 'info', category: 'llm', source: 'llm-adapter',
       message: 'cloud call blocked: local-model-only mode active' });
     incrementCounter('llm.cloud-agent.blocked.local-only');
+    return { text: '', provider: 'none' };
+  }
+  // Block cloud egress until the user has acknowledged the disclosure notice.
+  if (!isLlmEgressDisclosed()) {
+    try { document.dispatchEvent(new CustomEvent('cb:llm-egress-disclosure-needed')); }
+    catch { /* non-browser test environment */ }
+    logDebug({ level: 'warn', category: 'llm', source: 'llm-adapter',
+      message: 'cloud call blocked: LLM egress not yet disclosed to user' });
+    incrementCounter('llm.cloud-agent.blocked.undisclosed');
     return { text: '', provider: 'none' };
   }
   // Atomically reserve a cloud-call slot before issuing the request.


### PR DESCRIPTION
## Summary

Follow-up to #1128. Codex review (2026-06-12) found two issues in the original disclosure-ordering fix:

### P1 — Sidecar did not honor `localOnly`

`handleIntelGenerate` received the `localOnly` flag from the renderer but never read it, so the Groq cloud fallback could still fire when local-model-only mode was active. Fixed by parsing `localOnly` from the request body and adding `&& !localOnly` to the Groq fallback guard.

### P2 — Disclosure gate blocked web/direct-Ollama path

The early `!isLlmEgressDisclosed()` gate was firing before `tryLocalDirect` on the web path. `tryLocalDirect` calls the user's own Ollama endpoint directly — no sidecar, no cloud API — so disclosure should not be required for that path. Fixed by scoping the pre-`tryLocal` gate to `isDesktopRuntime()` only, and restoring the disclosure check before the cloud-agent fallback for web callers.

## Testing

`npm run typecheck:all` — clean (exit 0)

Cross-agent review: Codex reviewed on 2026-06-12; outcome: approved (P1 and P2 from prior review addressed)