### PR TITLE
feat: complete daily PDF brief (sidecar endpoints + synthesis + Tauri save)

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -924,6 +924,35 @@ fn write_cache_entry(webview: Webview, app: AppHandle, cache: tauri::State<'_, P
  Ok(())
 }
 
+/// Save a PDF brief to ~/Documents/Crystal Ball Briefs/<filename>.
+/// Creates the directory if absent. Restricted to the trusted window list.
+#[tauri::command]
+fn save_brief(webview: Webview, filename: String, bytes: Vec<u8>) -> Result<String, String> {
+ require_trusted_window(webview.label())?;
+ if filename.is_empty() || filename.contains('/') || filename.contains('\\') {
+  return Err("Invalid filename".into());
+ }
+ if bytes.len() > 64 * 1024 * 1024 {
+  return Err("Brief exceeds 64 MB limit".into());
+ }
+ let home = std::env::var_os("HOME")
+  .map(PathBuf::from)
+  .ok_or_else(|| "Cannot determine home directory".to_string())?;
+ let dir = home.join("Documents").join("Crystal Ball Briefs");
+ fs::create_dir_all(&dir)
+  .map_err(|e| format!("Failed to create briefs directory: {e}"))?;
+ let path = dir.join(&filename);
+ fs::write(&path, &bytes)
+  .map_err(|e| format!("Failed to write brief: {e}"))?;
+ #[cfg(unix)]
+ {
+  use std::os::unix::fs::PermissionsExt;
+  let perms = fs::Permissions::from_mode(0o644);
+  fs::set_permissions(&path, perms).ok();
+ }
+ Ok(path.display().to_string())
+}
+
 fn logs_dir_path(app: &AppHandle) -> Result<PathBuf, String> {
  let dir = app
  .path()
@@ -3135,6 +3164,7 @@ fn main() {
  read_cache_entry,
  write_cache_entry,
  delete_cache_entry,
+ save_brief,
  open_logs_folder,
  open_sidecar_log_file,
  log_frontend,

--- a/src/components/IntelligenceBriefingPanel.ts
+++ b/src/components/IntelligenceBriefingPanel.ts
@@ -74,9 +74,13 @@ export class IntelligenceBriefingPanel extends Panel {
  title: 'Intelligence Briefing',
  });
 
- this._scheduler = new BriefingScheduler(async () => {
- await this.handleDownloadReport();
- });
+ this._scheduler = new BriefingScheduler(
+ async () => { await this.handleDownloadReport(); },
+ async () => {
+ const blob = await this.buildReportBlob();
+ return new Uint8Array(await blob.arrayBuffer());
+ },
+ );
  this._scheduler.start();
 
  this._unsub = subscribeBriefing(() => this.render());

--- a/src/services/export/enhanced-brief-generator.ts
+++ b/src/services/export/enhanced-brief-generator.ts
@@ -111,6 +111,14 @@ export interface PersonalizedAlertEntry {
   topSeverity: number;   // 0–10
 }
 
+export interface CrossDomainSynthesisInput {
+  overallAssessment: string;
+  escalationRisk: string;
+  causalHypotheses: string[];
+  recommendedActions: string[];
+  clusterCount: number;
+}
+
 export interface EnhancedBriefingInput {
   /** Optional pre-built executive summary (e.g. from AI brief). When
    *  absent, the renderer derives one from the threat matrix. */
@@ -124,6 +132,7 @@ export interface EnhancedBriefingInput {
   correlations?: CorrelationEntry[];
   shortageRadar?: ShortageRadarEntry[];
   personalizedAlerts?: PersonalizedAlertEntry[];
+  crossDomainSynthesis?: CrossDomainSynthesisInput;
   /** Wall-clock data-current-as-of timestamp shown in the footer. */
   dataCurrentAt: number;
   /** Crystal Ball app version, shown in the footer. */
@@ -196,7 +205,8 @@ export function renderEnhancedBriefingPdf(
   y = renderFeedHealth(doc, input.feedHealth, y, onPageBreak);
   y = renderCorrelations(doc, input.correlations ?? [], y, onPageBreak);
   y = renderShortageRadar(doc, input.shortageRadar ?? [], y, onPageBreak);
-  renderPersonalizedAlerts(doc, input.personalizedAlerts ?? [], y, onPageBreak);
+  y = renderPersonalizedAlerts(doc, input.personalizedAlerts ?? [], y, onPageBreak);
+  renderCrossDomainSynthesis(doc, input.crossDomainSynthesis ?? null, y, onPageBreak);
 
   // Stamp footer + page numbers across every page.
   const pageCount = doc.getNumberOfPages();
@@ -758,6 +768,94 @@ function renderPersonalizedAlerts(
     }
     y += 2;
   }
+  return y + 8;
+}
+
+function renderCrossDomainSynthesis(
+  doc: jsPDF,
+  synthesis: CrossDomainSynthesisInput | null,
+  startY: number,
+  onPageBreak: () => number,
+): number {
+  let y = ensureRoomFor(doc, startY, 50, onPageBreak);
+  y = drawSectionHeader(doc, 'CROSS-DOMAIN THREAT SYNTHESIS', y);
+  if (!synthesis) {
+    return drawEmptyLine(doc, 'Synthesis data unavailable — no active cross-domain situations detected.', y) + 14;
+  }
+
+  // Overall assessment paragraph.
+  if (synthesis.overallAssessment) {
+    y = ensureRoomFor(doc, y, 14, onPageBreak);
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(10);
+    doc.setTextColor(20, 20, 20);
+    doc.text('Assessment:', MARGIN, y);
+    y += 14;
+    y = renderWrappedText(doc, synthesis.overallAssessment, y, onPageBreak);
+    y += 6;
+  }
+
+  // Escalation risk badge.
+  const riskColors: Record<string, [number, number, number]> = {
+    critical: [194, 0, 0], high: [217, 86, 0], moderate: [186, 137, 0], low: [70, 113, 70],
+  };
+  const [rr, rg, rb] = riskColors[synthesis.escalationRisk.toLowerCase()] ?? [80, 80, 80];
+  y = ensureRoomFor(doc, y, 14, onPageBreak);
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(10);
+  doc.setTextColor(20, 20, 20);
+  doc.text(`Escalation Risk: `, MARGIN, y);
+  doc.setTextColor(rr, rg, rb);
+  doc.text(synthesis.escalationRisk.toUpperCase(), MARGIN + 100, y);
+  doc.setTextColor(20, 20, 20);
+  doc.text(`  |  Clusters: ${synthesis.clusterCount}`, MARGIN + 160, y);
+  y += 16;
+
+  // Causal hypotheses list.
+  if (synthesis.causalHypotheses.length > 0) {
+    y = ensureRoomFor(doc, y, 14, onPageBreak);
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(10);
+    doc.setTextColor(20, 20, 20);
+    doc.text('Causal Hypotheses:', MARGIN, y);
+    y += 14;
+    for (const hyp of synthesis.causalHypotheses.slice(0, 4)) {
+      const wrapped = doc.splitTextToSize(`• ${hyp}`, CONTENT_WIDTH) as string[];
+      for (const wline of wrapped) {
+        y = ensureRoomFor(doc, y, 13, onPageBreak);
+        doc.setFont('helvetica', 'normal');
+        doc.setFontSize(10);
+        doc.setTextColor(40, 40, 40);
+        doc.text(wline, MARGIN, y);
+        y += 13;
+      }
+      y += 2;
+    }
+    y += 4;
+  }
+
+  // Recommended actions list.
+  if (synthesis.recommendedActions.length > 0) {
+    y = ensureRoomFor(doc, y, 14, onPageBreak);
+    doc.setFont('helvetica', 'bold');
+    doc.setFontSize(10);
+    doc.setTextColor(20, 20, 20);
+    doc.text('Recommended Actions:', MARGIN, y);
+    y += 14;
+    for (const action of synthesis.recommendedActions.slice(0, 5)) {
+      const wrapped = doc.splitTextToSize(`→ ${action}`, CONTENT_WIDTH) as string[];
+      for (const wline of wrapped) {
+        y = ensureRoomFor(doc, y, 13, onPageBreak);
+        doc.setFont('helvetica', 'normal');
+        doc.setFontSize(10);
+        doc.setTextColor(40, 40, 40);
+        doc.text(wline, MARGIN, y);
+        y += 13;
+      }
+      y += 2;
+    }
+  }
+
   return y + 8;
 }
 

--- a/src/services/export/enhanced-brief-snapshot.ts
+++ b/src/services/export/enhanced-brief-snapshot.ts
@@ -23,9 +23,11 @@ import { getCachedBriefing } from '../intelligence-briefing';
 import { getFeatureHealthRegistry } from '../diagnostics/diagnostics-state';
 import type { ThreatSeverity } from '../intelligence-briefing';
 import { getApiBaseUrl } from '../runtime';
+import { getCachedSynthesis } from '../threat-synthesis';
 import {
   type AlertEntry,
   type CorrelationEntry,
+  type CrossDomainSynthesisInput,
   type EconomicIndicator,
   type EnhancedBriefingInput,
   type FeedHealthRow,
@@ -60,7 +62,7 @@ export async function collectEnhancedBriefing(
 
   // All collectors are independently try/catch'd — never let one section
   // sink the whole snapshot.
-  const [executiveSummary, threatMatrix, activeAlerts, spaceWeather, topWildfires, economicIndicators, feedHealth, correlations, shortageRadar, personalizedAlerts] =
+  const [executiveSummary, threatMatrix, activeAlerts, spaceWeather, topWildfires, economicIndicators, feedHealth, correlations, shortageRadar, personalizedAlerts, crossDomainSynthesis] =
     await Promise.all([
       Promise.resolve().then(() => collectExecutiveSummary()),
       Promise.resolve().then(() => collectThreatMatrix()),
@@ -72,12 +74,13 @@ export async function collectEnhancedBriefing(
       collectCorrelations(apiBase),
       collectShortageRadar(apiBase),
       collectPersonalizedAlerts(apiBase),
+      Promise.resolve().then(() => collectCrossDomainSynthesis()),
     ]);
 
   return {
     executiveSummary, threatMatrix, activeAlerts, spaceWeather,
     topWildfires, economicIndicators, feedHealth,
-    correlations, shortageRadar, personalizedAlerts,
+    correlations, shortageRadar, personalizedAlerts, crossDomainSynthesis,
     dataCurrentAt: now(), appVersion,
   };
 }
@@ -337,6 +340,20 @@ function readAppVersion(): string {
     const v = (globalThis as unknown as { __APP_VERSION__?: string }).__APP_VERSION__;
     return typeof v === 'string' && v.length > 0 ? v : 'dev';
   } catch { return 'dev'; }
+}
+
+export function collectCrossDomainSynthesis(): CrossDomainSynthesisInput | undefined {
+  try {
+    const report = getCachedSynthesis();
+    if (!report) return undefined;
+    return {
+      overallAssessment: report.overallAssessment,
+      escalationRisk: report.escalationRisk,
+      causalHypotheses: report.causalHypotheses,
+      recommendedActions: report.recommendedActions,
+      clusterCount: report.clusters.length,
+    };
+  } catch { return undefined; }
 }
 
 export {mapHealthStatusToFeedStatus, topScenarioSeverity} from './enhanced-brief-mappers';

--- a/src/services/intelligence/briefing-scheduler.ts
+++ b/src/services/intelligence/briefing-scheduler.ts
@@ -1,3 +1,6 @@
+import { isDesktopRuntime } from '../runtime';
+import { invokeTauri } from '../tauri-bridge';
+
 export interface BriefingSchedule {
   enabled: boolean;
   hour: number;       // 0-23
@@ -100,10 +103,15 @@ export class BriefingScheduler {
   private schedule: BriefingSchedule;
   private timerId: ReturnType<typeof setTimeout> | null = null;
   private onFire: () => Promise<void>;
+  private buildPdfBytes?: () => Promise<Uint8Array | null>;
 
-  constructor(onFire: () => Promise<void>) {
+  constructor(
+    onFire: () => Promise<void>,
+    buildPdfBytes?: () => Promise<Uint8Array | null>,
+  ) {
     this.schedule = loadSchedule();
     this.onFire = onFire;
+    this.buildPdfBytes = buildPdfBytes;
   }
 
   getSchedule(): BriefingSchedule { return { ...this.schedule }; }
@@ -134,11 +142,23 @@ export class BriefingScheduler {
 
   private async fire(): Promise<void> {
     try {
-      await this.onFire();
+      if (this.buildPdfBytes && isDesktopRuntime()) {
+        await this.fireTauri();
+      } else {
+        await this.onFire();
+      }
       this.schedule.lastGeneratedAt = Date.now();
       saveSchedule(this.schedule);
     } finally {
       this.reschedule();
     }
+  }
+
+  private async fireTauri(): Promise<void> {
+    const bytes = await this.buildPdfBytes!();
+    if (!bytes) return;
+    const iso = new Date().toISOString().slice(0, 10);
+    const filename = `brief-${iso}.pdf`;
+    await invokeTauri<string>('save_brief', { filename, bytes: Array.from(bytes) });
   }
 }


### PR DESCRIPTION
## Summary

Closes the three remaining gaps from Phase 3 PR 1 (see `docs/PHASE3_NEXT_WAVE_PLAN.md`):

### Gap 1 — Existing sidecar routes verified
The three routes the snapshot collector calls (`/api/intelligence/correlations`, `/api/shortage/summary`, `/api/intelligence/nearby`) already exist in `local-api-server.mjs` and return well-formed JSON matching what the snapshot collector expects. No 404s.

### Gap 2 — Cross-domain synthesis section
- `enhanced-brief-snapshot.ts`: Added `collectCrossDomainSynthesis()` calling `getCachedSynthesis()` from `threat-synthesis.ts`; wired into `collectEnhancedBriefing()` via `Promise.all`
- `enhanced-brief-generator.ts`: Added `CrossDomainSynthesisInput` interface, `crossDomainSynthesis?` field to `EnhancedBriefingInput`, and `renderCrossDomainSynthesis()` section (renders assessment, escalation risk badge, causal hypotheses, recommended actions; shows placeholder when null); inserted as final section after Personalized Alerts

### Gap 3 — Daily Tauri save path
- `main.rs`: Added `save_brief` Tauri command — writes `~/Documents/Crystal Ball Briefs/<filename>`, auto-creates directory, 64 MB cap, trusted-window restriction, 0644 permissions
- `briefing-scheduler.ts`: Added optional `buildPdfBytes` constructor param; `fire()` routes to `fireTauri()` when `isDesktopRuntime() && buildPdfBytes` is provided (Tauri path), otherwise calls `onFire()` (browser download fallback)
- `IntelligenceBriefingPanel.ts`: Passes `buildPdfBytes` callback that builds the enhanced PDF blob and returns `Uint8Array` for Tauri saves

## Verification
- `npm run typecheck:all` → exit 0 (both tsconfig.json and tsconfig.api.json)
- `cargo check` → exit 0
- Secret scan passed (3650 files)

## Cross-agent review
Cross-agent review: Codex reviewed on 2026-06-13; outcome: No actionable correctness issues were found in the diff. The changes appear consistent with existing patterns and should not break existing behavior.