### PR TITLE
security: remove ALLOW_UNAUTHENTICATED_RELAY auth bypass from relay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,10 +118,6 @@ RELAY_SHARED_SECRET=
 # Header name used to send the relay secret (must match on both platforms)
 RELAY_AUTH_HEADER=x-relay-key
 
-# Emergency production override to allow unauthenticated relay traffic.
-# Leave unset/false in production.
-ALLOW_UNAUTHENTICATED_RELAY=false
-
 # Rolling window size (seconds) used by relay /metrics endpoint.
 RELAY_METRICS_WINDOW_SECONDS=60
 

--- a/docs/RELAY_PARAMETERS.md
+++ b/docs/RELAY_PARAMETERS.md
@@ -40,7 +40,6 @@ Set these before enabling strict relay auth.
 | `VITE_WS_RELAY_URL` | Browser (local dev) | none | No | Localhost fallback path for direct browser calls in development only. |
 | `RELAY_SHARED_SECRET` | Railway + Vercel | empty | Yes in production | Shared secret for non-public relay routes. |
 | `RELAY_AUTH_HEADER` | Railway + Vercel | `x-relay-key` | No (but recommended explicit) | Header name carrying relay secret. |
-| `ALLOW_UNAUTHENTICATED_RELAY` | Railway | `false` | No | Emergency override. If `true`, production can start without secret. Keep `false`. |
 | `ALLOW_VERCEL_PREVIEW_ORIGINS` | Railway | `false` | No | If `true`, allows `*.vercel.app` origins in relay CORS checks. |
 
 ## Relay-Adjacent Feature Flags
@@ -108,7 +107,6 @@ These are safe starting points for a busy relay:
 RELAY_SHARED_SECRET=<strong-random-secret>
 RELAY_AUTH_HEADER=x-relay-key
 WS_RELAY_URL=https://<your-railway-relay>.up.railway.app
-ALLOW_UNAUTHENTICATED_RELAY=false
 
 # OpenSky cache/cardinality
 OPENSKY_CACHE_MAX_ENTRIES=256

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -62,7 +62,6 @@ const IS_PRODUCTION_RELAY = process.env.NODE_ENV === 'production'
   || !!process.env.RAILWAY_ENVIRONMENT
   || !!process.env.RAILWAY_PROJECT_ID
   || !!process.env.RAILWAY_STATIC_URL;
-const ALLOW_UNAUTHENTICATED_RELAY = process.env.ALLOW_UNAUTHENTICATED_RELAY === 'true' && !IS_PRODUCTION_RELAY;
 const RELAY_RATE_LIMIT_WINDOW_MS = Math.max(1000, Number(process.env.RELAY_RATE_LIMIT_WINDOW_MS || 60000));
 const RELAY_RATE_LIMIT_MAX = Number.isFinite(Number(process.env.RELAY_RATE_LIMIT_MAX))
   ? Number(process.env.RELAY_RATE_LIMIT_MAX) : 1200;
@@ -82,15 +81,10 @@ const OREF_ENABLED = !!OREF_PROXY_AUTH;
 const RELAY_OREF_RATE_LIMIT_MAX = Number.isFinite(Number(process.env.RELAY_OREF_RATE_LIMIT_MAX))
   ? Number(process.env.RELAY_OREF_RATE_LIMIT_MAX) : 600;
 
-if (IS_PRODUCTION_RELAY && !RELAY_SHARED_SECRET && !ALLOW_UNAUTHENTICATED_RELAY) {
-  console.error('[Relay] Error: RELAY_SHARED_SECRET is required in production');
+if (!RELAY_SHARED_SECRET) {
+  console.error('[Relay] Error: RELAY_SHARED_SECRET is required');
   console.error('[Relay] Set RELAY_SHARED_SECRET on Railway and Vercel to secure relay endpoints');
-  console.error('[Relay] To bypass temporarily, set ALLOW_UNAUTHENTICATED_RELAY=true (non-production only)');
   process.exit(1);
-}
-if (ALLOW_UNAUTHENTICATED_RELAY) {
-  console.warn('[Relay] WARNING: ALLOW_UNAUTHENTICATED_RELAY is enabled — all auth checks are bypassed');
-  console.warn('[Relay] This flag is blocked in production (IS_PRODUCTION_RELAY=false required)');
 }
 
 let upstreamSocket = null;
@@ -626,7 +620,6 @@ function getRelaySecretFromRequest(req) {
 }
 
 function isAuthorizedRequest(req) {
-  if (!RELAY_SHARED_SECRET) return true;
   const provided = getRelaySecretFromRequest(req);
   if (!provided) return false;
   return safeTokenEquals(provided, RELAY_SHARED_SECRET);
@@ -2752,7 +2745,6 @@ const server = http.createServer(async (req, res) => {
  auth: {
  sharedSecretEnabled: !!RELAY_SHARED_SECRET,
  authHeader: RELAY_AUTH_HEADER,
- allowUnauthenticated: ALLOW_UNAUTHENTICATED_RELAY,
  allowVercelPreviewOrigins: ALLOW_VERCEL_PREVIEW_ORIGINS,
  },
  rateLimit: {


### PR DESCRIPTION
## Summary

Removes the `ALLOW_UNAUTHENTICATED_RELAY` escape hatch from `scripts/ais-relay.cjs` rather than gating it more tightly.

### Changes

**`scripts/ais-relay.cjs`**
- Deleted `const ALLOW_UNAUTHENTICATED_RELAY` — the variable no longer exists
- Collapsed the startup guard: relay now exits(1) unconditionally when `RELAY_SHARED_SECRET` is missing (was only enforced in production; non-production could bypass via the flag)
- Removed the `if (!RELAY_SHARED_SECRET) return true` short-circuit in `isAuthorizedRequest()` — that line allowed every request through when no secret was configured, regardless of the flag
- Dropped `allowUnauthenticated` from the `/health` endpoint response

**`.env.example`**
- Removed the `ALLOW_UNAUTHENTICATED_RELAY=false` entry

**`docs/RELAY_PARAMETERS.md`**
- Removed the table row and the example line

## Testing

`npx tsc --noEmit` — exit 0 (no TypeScript files affected; relay is plain CJS)

Cross-agent review: Codex reviewed on 2026-06-13; outcome: approved (P2 only: local-dev browser fallback paths now require RELAY_SHARED_SECRET to be set — expected and intended behavior; no P0/P1 issues)