### PR TITLE
fix: exclude .worktrees/ from ESLint scope

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,9 +12,12 @@ export default tseslint.config(
  'src-tauri/target/**',
  '.agent/**',
  // Nested checkouts created by the git-worktree workflow live inside
- // `.claude/worktrees/<name>/` and contain a full copy of the tree.
- // Linting them from the canonical repo would report thousands of
- // duplicate errors against unrelated branches.
+ // `.worktrees/<name>/` (and historically `.claude/worktrees/<name>/`) and
+ // contain a full copy of the tree. Linting them from the canonical repo
+ // reports thousands of duplicate errors against unrelated branches.
+ // NOTE: `**/worktrees/**` does NOT match `.worktrees/` — the leading dot is
+ // a distinct path segment — so the `.worktrees/**` entry is required.
+ '.worktrees/**',
  '.claude/worktrees/**',
  '**/worktrees/**',
  'src/workers/ml.worker.ts',


### PR DESCRIPTION
## Problem
`npm run lint` traverses nested git worktrees under `.worktrees/` (created by `git worktree add`) and emits thousands of false ESLint errors against unrelated branches.

## Root cause
The global-ignores block already had `**/worktrees/**`, but that glob only matches a path segment named exactly `worktrees` — it does **not** match `.worktrees/` (the leading dot is a distinct segment). The non-anchored `files: ['**/*.test.*']` block therefore matched every test file under sibling worktrees and linted them.

## Fix
Add `.worktrees/**` to the global `ignores` in `eslint.config.mjs`, and update the stale comment (worktrees now live in `.worktrees/`, not `.claude/worktrees/`).

`.claude/` was checked and contains **no** JS/TS files (only `.claude/worktrees/**`, already ignored), so no `.claude/` entry was added.

## Verification
Via ESLint's `isPathIgnored` API (cwd = canonical repo):

| Path | Old config | New config |
|------|-----------|-----------|
| `.worktrees/…/foo.test.ts` | **LINTED** (bug) | IGNORED |
| `.worktrees/…/x.ts` | IGNORED | IGNORED |
| `.claude/worktrees/…/bar.ts` | IGNORED | IGNORED |
| `src/…/truth-score.ts` (real source) | LINTED | LINTED |
| `src/…/foo.test.ts` (real test) | LINTED | LINTED |

Real source and test files are unaffected; only nested-worktree paths flipped to ignored. `eslint --print-config` on a real file loads cleanly.

### Cross-agent review
Cross-agent review: Codex reviewed on 2026-06-13; outcome: pass