### PR TITLE
docs: sync CHANGELOG and README for recent sprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to Crystal Ball are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **Phase 4B — Epistemic intelligence wiring**: bias scan cadence, the epistemic
+  calibration loop (outcome-graded, wired to boot), and the epistemic bridge
+  connecting meta-confidence, counterfactuals, and the bias detector to the live
+  data path (PRs #1131, #1132, #1133).
+- **Phase 3 (start) — Feed resilience P0**: rolled `fetchWithFallback` to 5 P0
+  feeds (GDACS, NHC, disease, tsunami, FIRMS), added the BDI live feed and the
+  earthquake mission bridge, and completed the daily PDF brief (PRs #1140, #1139,
+  #1143, #1142).
+
+### Performance
+
+- **NWS in-flight dedupe** and **poweroutage cache TTL**: collapse concurrent
+  duplicate NWS requests and bound poweroutage payload lifetime (PRs #1129, #1130).
+
+### Fixed
+
+- **Performance sprint**: panel lifecycle teardown on `destroy()` and the Groq
+  egress-disclosure gate (scoped to desktop, honors local-only in the sidecar)
+  (PRs #1135, #1136).
+- **Tooling**: ESLint scope fix and sidecar routes classification (PRs #1145, #1146).
+
+### Security
+
+- **Security sprint (2026-06-12)**: Privacy Fix 1 — secret-in-query tripwire that
+  warns when an API key would be sent in a query string to a non-allowlisted host
+  — and removal of the `RELAY_ALLOW_ANON` anonymous-relay bypass (PRs #1138, #1144).
+
 ## [2.25.143] - 2026-06-08
 
 ### Fixed


### PR DESCRIPTION
Populates the empty `## [Unreleased]` section of `CHANGELOG.md` with the work merged since v2.25.143, using the file's existing Keep-a-Changelog format (bold lead-ins, `(PR #N)` citations, standard category headers).

## Entries added
- **Added** — Phase 4B epistemic intelligence wiring (bias scan cadence, epistemic calibration loop, epistemic bridge) (PRs #1131, #1132, #1133); Phase 3 start: feed resilience P0 (5 feeds), BDI live feed, earthquake mission bridge, daily PDF brief (PRs #1140, #1139, #1143, #1142).
- **Performance** — NWS in-flight dedupe, poweroutage cache TTL (PRs #1129, #1130).
- **Fixed** — perf-sprint lifecycle teardown + Groq disclosure gate (PRs #1135, #1136); ESLint scope fix + sidecar routes classification (PRs #1145, #1146).
- **Security** — security sprint 2026-06-12: Privacy Fix 1 secret-in-query tripwire + `RELAY_ALLOW_ANON` removal (PRs #1138, #1144).

## README
No change needed — the version badge is a dynamic shields.io `github/v/release` badge that auto-tracks the latest release; there is no hardcoded version string to update.

Docs-only; single file (`CHANGELOG.md`) staged.

Cross-agent review: Codex reviewed on 2026-06-13; outcome: no actionable issues found (docs-only change, no executable/behavior changes). Approved.
