### PR TITLE
sec: tighten all runtime-created files from 0644 to 0600

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -1704,7 +1704,7 @@ function loadVerboseState(dataDir) {
 
 function saveVerboseState() {
   if (!_verboseStatePath) return;
-  try { writeFileSync(_verboseStatePath, JSON.stringify({ verboseMode })); } catch { /* ignore */ }
+  try { writeFileSync(_verboseStatePath, JSON.stringify({ verboseMode })); chmodSync(_verboseStatePath, 0o600); } catch { /* ignore */ }
 }
 
 function _getTrafficEntries() {
@@ -12649,7 +12649,7 @@ async function dispatch(requestUrl, req, routes, context) {
       return out;
     });
     if (baselinePath) {
-      try { writeFileSync(baselinePath, JSON.stringify(baseline)); } catch { /* non-fatal */ }
+      try { writeFileSync(baselinePath, JSON.stringify(baseline)); chmodSync(baselinePath, 0o600); } catch { /* non-fatal */ }
     }
     return json({ available: true, generatedAt: raw.generatedAt, entries: sanitized, summary: { totalConnections: sanitized.length } });
   }
@@ -16943,7 +16943,7 @@ export async function createLocalApiServer(options = {}) {
 
  const portFile = process.env.LOCAL_API_PORT_FILE;
  if (portFile) {
- try { writeFileSync(portFile, String(boundPort)); } catch {}
+ try { writeFileSync(portFile, String(boundPort)); chmodSync(portFile, 0o600); } catch {}
  }
 
  context.logger.log(`[local-api] listening on http://127.0.0.1:${boundPort} (apiDir=${context.apiDir}, routes=${routes.length}, cloudFallback=${context.cloudFallback})`);

--- a/src-tauri/sidecar/sidecar-logger.mjs
+++ b/src-tauri/sidecar/sidecar-logger.mjs
@@ -13,7 +13,7 @@
  *    os.tmpdir() elsewhere.
  */
 
-import { appendFileSync, renameSync, unlinkSync, existsSync, statSync, mkdirSync } from 'node:fs';
+import { appendFileSync, chmodSync, renameSync, unlinkSync, existsSync, statSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
 import { homedir, tmpdir } from 'node:os';
 
@@ -44,6 +44,7 @@ export function createSidecarLogger(opts = {}) {
   const now = opts.now ?? (() => Date.now());
 
   const logPath = join(dir, 'sidecar.log');
+  let logPermsSet = false;
 
   function rotate() {
     // Delete overflow: sidecar.log.{keep}
@@ -60,6 +61,7 @@ export function createSidecarLogger(opts = {}) {
 
     // Rename current log to .1
     try { if (existsSync(logPath)) renameSync(logPath, join(dir, 'sidecar.log.1')); } catch { /* ignore */ }
+    logPermsSet = false;
   }
 
   function appendLine(line) {
@@ -71,6 +73,10 @@ export function createSidecarLogger(opts = {}) {
         if (size >= maxBytes) rotate();
       } catch { /* file doesn't exist yet, skip */ }
       appendFileSync(logPath, line, 'utf8');
+      if (!logPermsSet) {
+        try { chmodSync(logPath, 0o600); } catch { /* best effort */ }
+        logPermsSet = true;
+      }
       // Post-write rotation: if the file grew past maxBytes after append,
       // rotate now so the log can never grow unbounded. Concurrent-instance
       // races may cause slightly early/late rotation — that is acceptable.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -969,7 +969,7 @@ fn save_brief(webview: Webview, filename: String, bytes: Vec<u8>) -> Result<Stri
  #[cfg(unix)]
  {
   use std::os::unix::fs::PermissionsExt;
-  let perms = fs::Permissions::from_mode(0o644);
+  let perms = fs::Permissions::from_mode(0o600);
   fs::set_permissions(&path, perms).ok();
  }
  Ok(path.display().to_string())
@@ -1020,6 +1020,11 @@ fn append_desktop_log(app: &AppHandle, level: &str, message: &str) {
  let Ok(mut file) = OpenOptions::new().create(true).append(true).open(&path) else {
  return;
  };
+ #[cfg(unix)]
+ {
+  use std::os::unix::fs::PermissionsExt;
+  let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
+ }
 
  // Replace embedded CR/LF so frontend-supplied content can't inject forged
  // log entries into subsequent lines. Each `append_desktop_log` call MUST
@@ -3084,6 +3089,8 @@ fn main() {
  if let Ok(mut f) = OpenOptions::new().create(true).append(true).open(&log) {
  let ts = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0);
  let _ = writeln!(f, "[{ts}][v{}+{}][PANIC] {msg} at {location}", env!("CARGO_PKG_VERSION"), BUILD_SHA);
+ #[cfg(unix)]
+ { use std::os::unix::fs::PermissionsExt; let _ = fs::set_permissions(&log, fs::Permissions::from_mode(0o600)); }
  }
  }
  }));


### PR DESCRIPTION
## Security — file permission hardening

Every file the sidecar/app creates at runtime was world-readable (0644). Only `sidecar.token` was 0600. This closes the gap for all remaining creation sites.

### Files changed

| File | Site | Fix |
|---|---|---|
| `src-tauri/src/main.rs` | PDF brief (`save_brief`): `0o644` | Changed to `0o600` |
| `src-tauri/src/main.rs` | `desktop.log` (`append_desktop_log`): no chmod | Added `#[cfg(unix)]` `set_permissions(0o600)` after `open()` |
| `src-tauri/src/main.rs` | `desktop.log` (panic handler): no chmod | Added best-effort chmod after write |
| `src-tauri/sidecar/sidecar-logger.mjs` | `sidecar.log`: no chmod | Added `chmodSync(0o600)` on first write + after rotation (`logPermsSet` flag avoids per-write syscall) |
| `src-tauri/sidecar/local-api-server.mjs` | `verbose-mode.json` | `chmodSync` after `writeFileSync` |
| `src-tauri/sidecar/local-api-server.mjs` | `portFile` (`LOCAL_API_PORT_FILE`) | `chmodSync` after `writeFileSync` |
| `src-tauri/sidecar/local-api-server.mjs` | Little Snitch baseline JSON | `chmodSync` after `writeFileSync` |

**Already correct (no change):** `sidecar.token` (0o600), `sidecar.health.json` (uses `{ mode: 0o600 }` + `chmodSync`), event-store SQLite (`chmodSync` in constructor), sidecar log file (fixed above), tmp cache file (0o600).

### Pattern

Matches the existing `#[cfg(unix)]` block at `main.rs:2638` and the `chmodSync` pattern in `event-store.mjs:82`.

Cross-agent review: Codex reviewed on 2026-06-13; outcome: pass