### PR TITLE
sec: gate pre-dispatch state-mutation routes behind isValidToken

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -16478,6 +16478,12 @@ export async function createLocalApiServer(options = {}) {
      return;
    }
    if (req.method === 'POST') {
+     const authHeader = req.headers['authorization'] || '';
+     if (!isValidToken(authHeader)) {
+       res.writeHead(401, { 'content-type': 'application/json', ...makeCorsHeaders(req) });
+       res.end(JSON.stringify({ error: 'Unauthorized' }));
+       return;
+     }
      let bodyText = '';
      try {
        const _rb1 = await readBody(req); bodyText = _rb1 ? _rb1.toString('utf-8') : '';
@@ -16560,6 +16566,12 @@ export async function createLocalApiServer(options = {}) {
      return;
    }
    if (req.method === 'POST') {
+     const authHeader = req.headers['authorization'] || '';
+     if (!isValidToken(authHeader)) {
+       res.writeHead(401, { 'content-type': 'application/json', ...makeCorsHeaders(req) });
+       res.end(JSON.stringify({ error: 'Unauthorized' }));
+       return;
+     }
      let bodyText = '';
      try { const _rb2 = await readBody(req); bodyText = _rb2 ? _rb2.toString('utf-8') : ''; } catch { bodyText = ''; }
      let parsed = null;
@@ -16589,6 +16601,12 @@ export async function createLocalApiServer(options = {}) {
      return;
    }
    if (req.method === 'POST') {
+     const authHeader = req.headers['authorization'] || '';
+     if (!isValidToken(authHeader)) {
+       res.writeHead(401, { 'content-type': 'application/json', ...makeCorsHeaders(req) });
+       res.end(JSON.stringify({ error: 'Unauthorized' }));
+       return;
+     }
      let bodyText = '';
      try { const _rb2 = await readBody(req); bodyText = _rb2 ? _rb2.toString('utf-8') : ''; } catch { bodyText = ''; }
      let parsed = null;
@@ -16616,6 +16634,12 @@ export async function createLocalApiServer(options = {}) {
      res.end(JSON.stringify({ error: 'method not allowed' }));
      return;
    }
+   const authHeader = req.headers['authorization'] || '';
+   if (!isValidToken(authHeader)) {
+     res.writeHead(401, { 'content-type': 'application/json', ...makeCorsHeaders(req) });
+     res.end(JSON.stringify({ error: 'Unauthorized' }));
+     return;
+   }
    let bodyText = '';
    try { const _rb3 = await readBody(req); bodyText = _rb3 ? _rb3.toString('utf-8') : ''; } catch { bodyText = ''; }
    let parsed = null;
@@ -16632,6 +16656,12 @@ export async function createLocalApiServer(options = {}) {
  }
  const ruleDetailMatch = requestUrl.pathname.match(/^\/api\/intelligence\/rules\/([^/]+)$/);
  if (ruleDetailMatch && req.method === 'DELETE') {
+   const authHeader = req.headers['authorization'] || '';
+   if (!isValidToken(authHeader)) {
+     res.writeHead(401, { 'content-type': 'application/json', ...makeCorsHeaders(req) });
+     res.end(JSON.stringify({ error: 'Unauthorized' }));
+     return;
+   }
    const removed = deleteRuleSidecar(ruleDetailMatch[1]);
    res.writeHead(removed ? 200 : 404,
      { 'content-type': 'application/json', ...makeCorsHeaders(req) });
@@ -16715,6 +16745,12 @@ export async function createLocalApiServer(options = {}) {
       return sendJson({ watchboards: getWatchboards() });
     }
     if (req.method === 'POST') {
+      const authHeader = req.headers['authorization'] || '';
+      if (!isValidToken(authHeader)) {
+        res.writeHead(401, { 'content-type': 'application/json', ...makeCorsHeaders(req) });
+        res.end(JSON.stringify({ error: 'Unauthorized' }));
+        return;
+      }
       const raw = await readBody(req);
       const body = raw ? JSON.parse(raw.toString()) : null;
       if (!body || typeof body !== 'object') return sendJson({ error: 'invalid body' }, 400);
@@ -16735,6 +16771,12 @@ export async function createLocalApiServer(options = {}) {
       return sendJson({ templates: getWatchboardTemplates() });
     }
     if (req.method === 'PUT') {
+      const authHeader = req.headers['authorization'] || '';
+      if (!isValidToken(authHeader)) {
+        res.writeHead(401, { 'content-type': 'application/json', ...makeCorsHeaders(req) });
+        res.end(JSON.stringify({ error: 'Unauthorized' }));
+        return;
+      }
       const raw = await readBody(req);
       const body = raw ? JSON.parse(raw.toString()) : null;
       if (!body || typeof body !== 'object') return sendJson({ error: 'invalid body' }, 400);
@@ -16743,6 +16785,12 @@ export async function createLocalApiServer(options = {}) {
       return sendJson({ watchboard: updated });
     }
     if (req.method === 'DELETE') {
+      const authHeader = req.headers['authorization'] || '';
+      if (!isValidToken(authHeader)) {
+        res.writeHead(401, { 'content-type': 'application/json', ...makeCorsHeaders(req) });
+        res.end(JSON.stringify({ error: 'Unauthorized' }));
+        return;
+      }
       const deleted = deleteWatchboard(wbId);
       if (!deleted) return sendJson({ error: 'not found' }, 404);
       return sendJson({ ok: true });


### PR DESCRIPTION
## Summary

8 POST/PUT/DELETE handlers in the `createServer` callback ran before `dispatch()` and had no auth check. Via DNS-rebinding to 127.0.0.1:46123, a malicious page could inject forged situations/entities, upsert/delete rules, and create/modify/delete watchboards without a bearer token.

## Routes fixed

| Route | Method(s) | Function |
|---|---|---|
| `/api/intelligence/situations` | POST | `createSituationSidecar` |
| `/api/intelligence/entities` | POST | `upsertEntitySidecar` |
| `/api/intelligence/rules` | POST | `upsertRuleSidecar` |
| `/api/intelligence/rules/evaluate` | POST | `evaluateRulesAgainstEventSidecar` |
| `/api/intelligence/rules/:id` | DELETE | `deleteRuleSidecar` |
| `/api/watchboards` | POST | `createWatchboard` |
| `/api/watchboards/:id` | PUT | `updateWatchboard` |
| `/api/watchboards/:id` | DELETE | `deleteWatchboard` |

## Fix

Added the same inline `isValidToken(req.headers['authorization'])` guard already used by `/api/health`, `/api/diag`, `/api/ollama-stream`, `/api/intel-generate`, and `/api/intel-embed` — inserted at the top of each POST/PUT/DELETE handler block, before any body is read or state is mutated.

Read-only GET handlers in the pre-dispatch block are unchanged (no state mutation risk).

## Testing

- 48 lines added, all auth guards, no logic changes
- sidecar is pure JS; TypeScript typecheck unaffected
- Pattern mirrors existing production guards in the same file

Cross-agent review: Codex reviewed on 2026-06-13; outcome: pass