### PR TITLE
fix(memory): AnalystHUD teardown + boot bridge promise rejection gaps

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -612,6 +612,7 @@ export class PanelLayoutManager implements AppModule {
   private criticalBannerEl: HTMLElement | null = null;
   private dcStrip: DataCenterPinnedStrip | null = null;
   private unsubDcPlaces: (() => void) | null = null;
+  private analystHud: AnalystHUD | null = null;
   private readonly applyTimeRangeFilterDebounced: () => void;
   private readonly _onUpdateState = () => { this.renderSidebarUpdateBtn(); };
 
@@ -686,6 +687,7 @@ export class PanelLayoutManager implements AppModule {
  this.stalenessBanner.destroy();
  this.stalenessBanner = null;
  }
+ if (this.analystHud) { this.analystHud.destroy(); this.analystHud = null; }
  // Clean up datacenter strip + saved-places subscription
  if (this.unsubDcPlaces) { this.unsubDcPlaces(); this.unsubDcPlaces = null; }
  if (this.dcStrip) { this.dcStrip.destroy(); this.dcStrip = null; }
@@ -955,15 +957,15 @@ export class PanelLayoutManager implements AppModule {
  // Emitters last.
  startModeForecast();
  startAnalystLoop();
- const analystHud = new AnalystHUD();
- analystHud.mount(document.body);
+ this.analystHud = new AnalystHUD();
+ this.analystHud.mount(document.body);
  ensureReasoningDebugCss();
  const debugOverlay = new ReasoningDebugOverlay();
  debugOverlay.mount(document.body);
  document.addEventListener('keydown', (e: KeyboardEvent) => {
    if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === 'A' || e.key === 'a')) {
      e.preventDefault();
-     analystHud.toggle();
+     this.analystHud?.toggle();
    }
  });
  document.addEventListener('keydown', (e: KeyboardEvent) => {
@@ -1995,7 +1997,7 @@ export class PanelLayoutManager implements AppModule {
  30_000,
  { priority: 'normal', runImmediately: true },
  );
- });
+ }).catch((err) => { console.error('[boot] sidecar-health-probe failed:', err); });
  // Periodic quality-debt collector. Priority='low' so it pauses
  // when the document is hidden (the export bundle and System
  // Diagnostic catch up on next tick once visible again).

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -613,6 +613,8 @@ export class PanelLayoutManager implements AppModule {
   private dcStrip: DataCenterPinnedStrip | null = null;
   private unsubDcPlaces: (() => void) | null = null;
   private analystHud: AnalystHUD | null = null;
+  private _onAnalystHudKey: ((e: KeyboardEvent) => void) | null = null;
+  private _onBriefExportKey: ((e: KeyboardEvent) => void) | null = null;
   private readonly applyTimeRangeFilterDebounced: () => void;
   private readonly _onUpdateState = () => { this.renderSidebarUpdateBtn(); };
 
@@ -688,6 +690,8 @@ export class PanelLayoutManager implements AppModule {
  this.stalenessBanner = null;
  }
  if (this.analystHud) { this.analystHud.destroy(); this.analystHud = null; }
+ if (this._onAnalystHudKey) { document.removeEventListener('keydown', this._onAnalystHudKey); this._onAnalystHudKey = null; }
+ if (this._onBriefExportKey) { document.removeEventListener('keydown', this._onBriefExportKey); this._onBriefExportKey = null; }
  // Clean up datacenter strip + saved-places subscription
  if (this.unsubDcPlaces) { this.unsubDcPlaces(); this.unsubDcPlaces = null; }
  if (this.dcStrip) { this.dcStrip.destroy(); this.dcStrip = null; }
@@ -962,18 +966,20 @@ export class PanelLayoutManager implements AppModule {
  ensureReasoningDebugCss();
  const debugOverlay = new ReasoningDebugOverlay();
  debugOverlay.mount(document.body);
- document.addEventListener('keydown', (e: KeyboardEvent) => {
+ this._onAnalystHudKey = (e: KeyboardEvent) => {
    if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === 'A' || e.key === 'a')) {
      e.preventDefault();
      this.analystHud?.toggle();
    }
- });
- document.addEventListener('keydown', (e: KeyboardEvent) => {
+ };
+ document.addEventListener('keydown', this._onAnalystHudKey);
+ this._onBriefExportKey = (e: KeyboardEvent) => {
    if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'H') {
      e.preventDefault();
      exportBriefingToClipboard();
    }
- });
+ };
+ document.addEventListener('keydown', this._onBriefExportKey);
  const cbSays = new CrystalBallSays();
  cbSays.mount(document.body);
  const relatedStrip = new RelatedStrip();

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1880,7 +1880,7 @@ export class PanelLayoutManager implements AppModule {
  const sync = () => bridgeSavedPlacesToProfile(getSavedPlaces().map((p) => adaptExistingSavedPlace(p)));
  sync();
  if (typeof subscribeSavedPlaces === 'function') subscribeSavedPlaces(sync);
- });
+ }).catch((err) => { console.error('[boot] saved-places bridge failed:', err); });
  // Periodic provider-snapshot bridge so Command Center's "Provider
  // Stress" + System Diagnostic's redundancy view stay current.
  // All recurring loops here go through registerRecurringLoop() so
@@ -1905,7 +1905,7 @@ export class PanelLayoutManager implements AppModule {
  30_000,
  { priority: 'normal', runImmediately: true },
  );
- });
+ }).catch((err) => { console.error('[boot] provider bridge failed:', err); });
  // 60 s degradation alerting — compare consecutive system-health snapshots
  // and route transitions through the notification trace registry.
  void Promise.all([
@@ -2031,7 +2031,7 @@ export class PanelLayoutManager implements AppModule {
  }).catch((error) => {
  console.warn('[quality-debt] failed to wire collector:', error);
  });
- });
+ }).catch((err) => { console.error('[boot] bridge load failed:', err); });
  this.ctx.panels['cascade-simulator'] = new CascadeSimulatorPanel();
  this.ctx.panels['emergency-broadcast'] = new EmergencyBroadcastPanel();
  this.ctx.panels['satellite-change'] = new SatelliteChangePanel();

--- a/src/components/AnalystHUD.ts
+++ b/src/components/AnalystHUD.ts
@@ -189,6 +189,7 @@ export class AnalystHUD {
   }
 
   destroy(): void {
+    this.visible = false;
     for (const fn of this._cleanups) fn();
     this._cleanups.length = 0;
   }

--- a/src/components/AnalystHUD.ts
+++ b/src/components/AnalystHUD.ts
@@ -192,6 +192,7 @@ export class AnalystHUD {
     this.visible = false;
     for (const fn of this._cleanups) fn();
     this._cleanups.length = 0;
+    this.root.remove();
   }
 
   private handleKeydown(e: KeyboardEvent): void {

--- a/src/components/AnalystHUD.ts
+++ b/src/components/AnalystHUD.ts
@@ -103,6 +103,7 @@ export class AnalystHUD {
   private selectedHypothesisIndex = 0;
   private settingsOpen = false;
   private renderScheduled = false;
+  private readonly _cleanups: Array<() => void> = [];
 
   constructor() {
     this.root = document.createElement('div');
@@ -122,61 +123,74 @@ export class AnalystHUD {
     // All event-driven re-renders go through scheduleRender() to coalesce
     // bursts (e.g. analyst-hypotheses + auto-brief + question-answered all
     // arriving in the same tick) into a single rAF-aligned render.
-    subscribeAnalyst((snap) => {
+    this._cleanups.push(subscribeAnalyst((snap) => {
       this.snapshot = snap;
       // Record recurrence ONCE per snapshot (not once per render) —
       // otherwise event bursts cause recurrenceCount to balloon by 10-30×
       // per actual cycle, polluting playbooks + hammering IDB writes.
       for (const h of snap.hypotheses.slice(0, MAX_VISIBLE)) noteRecurrence(h);
       this.scheduleRender();
-    });
-    subscribeModeAdvisory((f) => {
+    }));
+    this._cleanups.push(subscribeModeAdvisory((f) => {
       this.forecast = f;
       this.scheduleRender();
-    });
-    subscribeAutoBrief((brief) => {
+    }));
+    this._cleanups.push(subscribeAutoBrief((brief) => {
       this.briefs[brief.domain] = brief;
       this.scheduleRender();
-    });
-    subscribePressureHistory((h) => {
+    }));
+    this._cleanups.push(subscribePressureHistory((h) => {
       this.pressure = h;
       this.scheduleRender();
-    });
-    subscribeSkeptic(() => { this.scheduleRender(); });
-    subscribeAlternatives(() => { this.scheduleRender(); });
-    subscribeQuestionAnswered(() => { this.scheduleRender(); });
-    subscribeBriefingArchive(() => { this.scheduleRender(); });
-    subscribeProjection(() => { this.scheduleRender(); });
-    document.addEventListener('cb:hypothesis-export-copied', (e: Event) => {
+    }));
+    this._cleanups.push(subscribeSkeptic(() => { this.scheduleRender(); }));
+    this._cleanups.push(subscribeAlternatives(() => { this.scheduleRender(); }));
+    this._cleanups.push(subscribeQuestionAnswered(() => { this.scheduleRender(); }));
+    this._cleanups.push(subscribeBriefingArchive(() => { this.scheduleRender(); }));
+    this._cleanups.push(subscribeProjection(() => { this.scheduleRender(); }));
+    const onExportCopied = (e: Event) => {
       const ce = e as CustomEvent<{ hypothesisId: string }>;
       this.exportedFlash = { id: ce.detail.hypothesisId, at: Date.now() };
       this.scheduleRender();
-    });
-    subscribeBudget(() => { this.scheduleRender(); });
-    subscribeDebug((entry) => {
+    };
+    document.addEventListener('cb:hypothesis-export-copied', onExportCopied);
+    this._cleanups.push(() => document.removeEventListener('cb:hypothesis-export-copied', onExportCopied));
+    this._cleanups.push(subscribeBudget(() => { this.scheduleRender(); }));
+    this._cleanups.push(subscribeDebug((entry) => {
       // Only re-render on errors (to refresh the footer counter) — info
       // and warn entries are too chatty.
       if (entry.level === 'error') this.scheduleRender();
-    });
-    subscribeSnapshotArchive(() => {
+    }));
+    this._cleanups.push(subscribeSnapshotArchive(() => {
       // Only scroll the view on new archived snapshots when we're live.
       // When replayed, the user's anchor timestamp resolves to the same
       // snapshot regardless, so no re-render is needed.
       if (this.replayAtTimestamp === null) this.scheduleRender();
-    });
-    subscribeEnsemble(() => { this.scheduleRender(); });
-    subscribeLlmEgressChange(() => { this.scheduleRender(); });
+    }));
+    this._cleanups.push(subscribeEnsemble(() => { this.scheduleRender(); }));
+    this._cleanups.push(subscribeLlmEgressChange(() => { this.scheduleRender(); }));
     // When llm-adapter blocks a cloud call because disclosure hasn't been
     // acknowledged yet, show the disclosure banner in the HUD.
-    document.addEventListener('cb:llm-egress-disclosure-needed', () => {
+    const onEgressDisclosure = () => {
       if (this.visible) this.scheduleRender();
       else this.show();
-    });
-    document.addEventListener('cb:toggle-analyst-hud', () => this.toggle());
-    document.addEventListener('cb:hypothesis-feedback', () => {
-      if (this.visible) this.render();
-    });
-    document.addEventListener('keydown', (e: KeyboardEvent) => this.handleKeydown(e));
+    };
+    document.addEventListener('cb:llm-egress-disclosure-needed', onEgressDisclosure);
+    this._cleanups.push(() => document.removeEventListener('cb:llm-egress-disclosure-needed', onEgressDisclosure));
+    const onToggle = () => this.toggle();
+    document.addEventListener('cb:toggle-analyst-hud', onToggle);
+    this._cleanups.push(() => document.removeEventListener('cb:toggle-analyst-hud', onToggle));
+    const onFeedback = () => { if (this.visible) this.render(); };
+    document.addEventListener('cb:hypothesis-feedback', onFeedback);
+    this._cleanups.push(() => document.removeEventListener('cb:hypothesis-feedback', onFeedback));
+    const onKeydown = (e: KeyboardEvent) => this.handleKeydown(e);
+    document.addEventListener('keydown', onKeydown);
+    this._cleanups.push(() => document.removeEventListener('keydown', onKeydown));
+  }
+
+  destroy(): void {
+    for (const fn of this._cleanups) fn();
+    this._cleanups.length = 0;
   }
 
   private handleKeydown(e: KeyboardEvent): void {


### PR DESCRIPTION
## What

Closes four async/memory safety bugs identified in security review passes 1–5.

### Fix 1 — StrikePackagesPanel listener (already in branch from prior work)
Stores the `wm:strike-packages` handler as `onStrikePackages` class field; `destroy()` removes it. Each layout rebuild previously accumulated one more orphaned listener.

### Fix 2 — AnalystHUD teardown
`mount()` previously discarded the return value of every `subscribe*()` call and passed anonymous closures to document event listeners with no corresponding `removeEventListener`. Added:
- `private readonly _cleanups: Array<() => void>` field
- All 14 `subscribe*()` calls wrapped with `this._cleanups.push(...)`
- Named document handler closures; push removal lambdas to `_cleanups`
- `destroy(): void` that sets `this.visible = false` (guards pending rAF), drains `_cleanups`, and calls `this.root.remove()` to detach the .analyst-hud node from document.body (prevents click listener closure from keeping the HUD instance alive)

Covers: `subscribeAnalyst`, `subscribeModeAdvisory`, `subscribeAutoBrief`, `subscribePressureHistory`, `subscribeSkeptic`, `subscribeAlternatives`, `subscribeQuestionAnswered`, `subscribeBriefingArchive`, `subscribeProjection`, `subscribeBudget`, `subscribeDebug`, `subscribeSnapshotArchive`, `subscribeEnsemble`, `subscribeLlmEgressChange`, plus `cb:hypothesis-export-copied`, `cb:llm-egress-disclosure-needed`, `cb:toggle-analyst-hud`, `cb:hypothesis-feedback`, `keydown`.

### Fix 3 — Boot-bridge promise rejection gaps
Four dynamic imports in `panel-layout.ts` had no `.catch()`:
- `import('@/services/insights/data-bridge').then(...)` — outer chain
- `import('@/services/saved-places').then(...)` — inner saved-places bridge
- `Promise.all([api-diagnostic, recurring-loops, live-diagnostics-snapshot]).then(...)` — provider bridge
- `Promise.all([sidecar-probe, recurring-loops]).then(...)` — sidecar health probe

### Fix 4 — Cache stampede (already in branch from prior work)
`dedupeInflight(key, fetcher)` added adjacent to `getCached`/`setCached`. First cold-cache caller stores the in-flight `Promise` in `_sidecarInflight`; subsequent concurrent callers await the same promise.

### Fix 5 — PanelLayoutManager keydown handler leaks (Codex P2)
Two anonymous `keydown` listeners added during boot (⌘⇧A HUD toggle, ⌘⇧H brief export) were never removed. Stored as `_onAnalystHudKey` / `_onBriefExportKey` instance fields; `destroy()` removes both.

### Fix 6 — analystHud local variable unreachable from destroy() (Codex P2)
`analystHud` was a `const` inside the boot async closure, making `PanelLayoutManager.destroy()` unable to call `analystHud.destroy()`. Promoted to `private analystHud: AnalystHUD | null = null` instance field; `destroy()` nulls it after tearing down.

## Testing
- `tsc --noEmit` — zero errors (verified on commit a6b6d56d before rebase; rebase was clean/no conflicts)
- `tsc -p tsconfig.api.json --noEmit` — zero errors
- No behaviour change in production paths; purely additive teardown hooks and rejection handlers

## Cross-agent review
Round 1 (2026-06-13): Codex found two P2s — anonymous keydown listener accumulation (fix 5 above) and root node leak after destroy() (fix 6/AnalystHUD). Both fixed in commit 89f4e3b3.
Round 2 (2026-06-13): Codex review running against rebased HEAD.