### PR TITLE
feat: Promote saved places to global proximity filter

### DIFF
--- a/src/app/layout/html.ts
+++ b/src/app/layout/html.ts
@@ -143,6 +143,7 @@ export function buildDesktopLayout(ctx: AppContext): string {
  <button class="mac-alert-family-btn" id="alertFamilyBtn">⚠ Alert Family</button>
  <button class="mac-ghost-mode-btn${ghostActive}" id="ghostModeBtn" title="Ghost Mode — Reduce polling, suppress notifications (⌘⇧G)">👻 Ghost Mode</button>
  <button class="mac-ghost-mode-btn" id="godsVisionBtn" title="God's Vision — 3D globe view (G)">🌍 God's Vision</button>
+ <button class="mac-ghost-mode-btn" id="savedPlacesFilterBtn" title="Filter all panels by saved place proximity">📍 Proximity: OFF</button>
  </div>
  <div class="mac-situational-mode-section" id="situationalModeSwitcherSection">
  <div class="mac-situational-mode-label">

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -518,6 +518,7 @@ import { tryInvokeTauri, invokeTauri } from '@/services/tauri-bridge';
 import { initModeTransitionCards } from '@/services/mode-transition-card';
 import { initPanelCorrelation } from '@/services/panel-correlation';
 import { getPrimarySavedPlace, getSavedPlace, getSavedPlaces, subscribeSavedPlaces } from '@/services/saved-places';
+import { getSavedPlacesFilterService } from '@/services/intelligence/saved-places-filter';
 import { DataCenterReadinessPanel } from '@/components/DataCenterReadinessPanel';
 import { DataCenterPinnedStrip } from '@/components/DataCenterPinnedStrip';
 import { setDatacenterSite } from '@/services/datacenter/datacenter-state';
@@ -2391,6 +2392,36 @@ export class PanelLayoutManager implements AppModule {
  document.dispatchEvent(new CustomEvent('cb:toggle-gods-vision'));
  }
  });
+
+ // Saved-places proximity filter toggle
+ const syncFilterBtn = () => {
+ const btn = document.getElementById('savedPlacesFilterBtn');
+ if (!btn) return;
+ const ctx = getSavedPlacesFilterService().getContext();
+ if (ctx.isActive && ctx.activePlaceName) {
+ btn.textContent = `📍 ${ctx.activePlaceName}`;
+ btn.classList.add('mac-ghost-mode-active');
+ } else {
+ btn.textContent = '📍 Proximity: OFF';
+ btn.classList.remove('mac-ghost-mode-active');
+ }
+ };
+ document.addEventListener('click', (e) => {
+ const target = (e.target as HTMLElement).closest('#savedPlacesFilterBtn');
+ if (!target) return;
+ const svc = getSavedPlacesFilterService();
+ const ctx = svc.getContext();
+ if (ctx.isActive) {
+ svc.deactivate();
+ } else {
+ const primary = getPrimarySavedPlace();
+ const all = getSavedPlaces();
+ const place = primary ?? all[0];
+ if (place) svc.activate(place.id);
+ }
+ });
+ getSavedPlacesFilterService().subscribe(syncFilterBtn);
+ syncFilterBtn();
  document.addEventListener('wm:toggle-ghost-mode', () => {
  toggleGhostMode();
  });

--- a/src/components/EarthquakesPanel.ts
+++ b/src/components/EarthquakesPanel.ts
@@ -1,10 +1,12 @@
 import { Panel } from './Panel';
 import type { Earthquake } from '@/services/earthquakes';
 import { escapeHtml } from '@/utils/sanitize';
+import { getSavedPlacesFilterService, isNearActivePlace } from '@/services/intelligence/saved-places-filter';
 
 export class EarthquakesPanel extends Panel {
-  private earthquakes: Earthquake[] = [];
+  private allEarthquakes: Earthquake[] = [];
   private lastUpdated: Date | null = null;
+  private filterUnsub: (() => void) | null = null;
 
   constructor() {
  super({
@@ -15,22 +17,44 @@ export class EarthquakesPanel extends Panel {
  infoTooltip: 'USGS earthquake data — M4.5+ events in the past 24 hours.',
  });
  this.showLoading('Fetching seismic data...');
+ this.filterUnsub = getSavedPlacesFilterService().subscribe(() => this.render());
+  }
+
+  public destroy(): void {
+ super.destroy();
+ this.filterUnsub?.();
+ this.filterUnsub = null;
   }
 
   public update(earthquakes: Earthquake[]): void {
- this.earthquakes = [...earthquakes].sort((a, b) => b.magnitude - a.magnitude);
+ this.allEarthquakes = [...earthquakes].sort((a, b) => b.magnitude - a.magnitude);
  this.lastUpdated = new Date();
- this.setCount(this.earthquakes.length);
  this.render();
   }
 
   private render(): void {
- if (this.earthquakes.length === 0) {
+ const ctx = getSavedPlacesFilterService().getContext();
+ const earthquakes = ctx.isActive
+ ? this.allEarthquakes.filter(eq => !eq.location || isNearActivePlace(eq.location.latitude, eq.location.longitude))
+ : this.allEarthquakes;
+ const hiddenCount = this.allEarthquakes.length - earthquakes.length;
+ this.setCount(earthquakes.length);
+
+ if (earthquakes.length === 0 && this.allEarthquakes.length === 0) {
  this.setContent('<div class="panel-empty">No earthquakes reported in the past 24 hours.</div>');
  return;
  }
 
- const rows = this.earthquakes.map(eq => {
+ const filterBanner = ctx.isActive
+ ? `<div class="spf-proximity-banner">📍 ${escapeHtml(ctx.activePlaceName ?? '')} · ${ctx.radiusKm} km · ${hiddenCount > 0 ? `${hiddenCount} hidden` : 'showing all'}</div>`
+ : '';
+
+ if (earthquakes.length === 0) {
+ this.setContent(`${filterBanner}<div class="panel-empty">No earthquakes within ${ctx.radiusKm} km of ${escapeHtml(ctx.activePlaceName ?? 'saved place')}.</div>`);
+ return;
+ }
+
+ const rows = earthquakes.map(eq => {
  const mag = eq.magnitude.toFixed(1);
  const depth = eq.depthKm == undefined ? '—' : `${Math.round(eq.depthKm)} km`;
  const ago = timeAgo(eq.occurredAt);
@@ -47,6 +71,7 @@ export class EarthquakesPanel extends Panel {
 
  this.setContent(`
  <div class="eq-panel-content">
+ ${filterBanner}
  <table class="eq-table">
  <thead>
  <tr>

--- a/src/components/FloodMonitorPanel.ts
+++ b/src/components/FloodMonitorPanel.ts
@@ -1,5 +1,6 @@
 import { Panel } from './Panel';
 import { escapeHtml } from '@/utils/sanitize';
+import { getSavedPlacesFilterService, isNearActivePlace } from '@/services/intelligence/saved-places-filter';
 
 interface StateFloodEntry {
   state: string;
@@ -51,6 +52,7 @@ export class FloodMonitorPanel extends Panel {
   private gaugeData: GaugeData | null = null;
   private warningData: WarningData | null = null;
   private lastUpdated: Date | null = null;
+  private filterUnsub: (() => void) | null = null;
 
   constructor() {
     super({
@@ -61,6 +63,13 @@ export class FloodMonitorPanel extends Panel {
       infoTooltip: 'USGS stream gauge readings at flood stage + NWS active flood watches and warnings.',
     });
     this.showLoading('Fetching flood data...');
+    this.filterUnsub = getSavedPlacesFilterService().subscribe(() => this.render());
+  }
+
+  public destroy(): void {
+    super.destroy();
+    this.filterUnsub?.();
+    this.filterUnsub = null;
   }
 
   public updateGauges(data: GaugeData): void {
@@ -89,8 +98,20 @@ export class FloodMonitorPanel extends Panel {
       return;
     }
 
+    const ctx = getSavedPlacesFilterService().getContext();
+    const allTop10 = this.gaugeData?.top10 ?? [];
+    const filteredTop10 = ctx.isActive
+      ? allTop10.filter(g => g.lat != null && g.lon != null ? isNearActivePlace(g.lat!, g.lon!) : true)
+      : allTop10;
+    const hiddenGauges = allTop10.length - filteredTop10.length;
+
+    const filterBanner = ctx.isActive
+      ? `<div class="spf-proximity-banner">📍 ${escapeHtml(ctx.activePlaceName ?? '')} · ${ctx.radiusKm} km · ${hiddenGauges > 0 ? `${hiddenGauges} gauges hidden` : 'showing all'}</div>`
+      : '';
+
     const updatedStr = this.lastUpdated ? timeAgo(this.lastUpdated) : 'never';
     const sections: string[] = [];
+    if (filterBanner) sections.push(filterBanner);
 
     // Summary row
     const gaugeCount = this.gaugeData?.atFloodStage ?? '—';
@@ -134,9 +155,9 @@ export class FloodMonitorPanel extends Panel {
       sections.push('<div class="panel-empty flood-empty">No active NWS flood alerts.</div>');
     }
 
-    // Top 10 gauges
-    if (this.gaugeData && this.gaugeData.top10.length > 0) {
-      const rows = this.gaugeData.top10.map(g => {
+    // Top 10 gauges (proximity-filtered when filter is active)
+    if (this.gaugeData && filteredTop10.length > 0) {
+      const rows = filteredTop10.map(g => {
         const stageClass = stageRowClass(g.stage);
         return `<tr class="${stageClass}">
           <td class="flood-gauge-name">${escapeHtml(g.siteName)}</td>
@@ -155,6 +176,8 @@ export class FloodMonitorPanel extends Panel {
           </table>
         </div>
       `);
+    } else if (this.gaugeData && filteredTop10.length === 0 && allTop10.length > 0) {
+      sections.push(`<div class="panel-empty flood-empty">No flood-stage gauges within ${ctx.radiusKm} km of ${escapeHtml(ctx.activePlaceName ?? 'saved place')}.</div>`);
     } else if (this.gaugeData && !this.gaugeData.degraded) {
       sections.push('<div class="panel-empty flood-empty">No gauges currently at flood stage.</div>');
     }

--- a/src/components/FloodMonitorPanel.ts
+++ b/src/components/FloodMonitorPanel.ts
@@ -120,16 +120,16 @@ export class FloodMonitorPanel extends Panel {
       <div class="flood-summary-row">
         <div class="flood-stat">
           <span class="flood-stat-value ${this.gaugeData?.atFloodStage ? 'flood-stat-alert' : ''}">${gaugeCount}</span>
-          <span class="flood-stat-label">Gauges at flood stage</span>
+          <span class="flood-stat-label">Gauges at flood stage${ctx.isActive ? ' (US total)' : ''}</span>
         </div>
         <div class="flood-stat">
           <span class="flood-stat-value ${this.warningData?.total ? 'flood-stat-alert' : ''}">${warningCount}</span>
-          <span class="flood-stat-label">NWS flood alerts</span>
+          <span class="flood-stat-label">NWS flood alerts${ctx.isActive ? ' (US total)' : ''}</span>
         </div>
       </div>
     `);
 
-    // NWS warnings by state
+    // NWS warnings by state (state-level data — no per-alert coordinates, shown nationwide when filter active)
     if (this.warningData && this.warningData.byState.length > 0) {
       const rows = this.warningData.byState.slice(0, 10).map(s => {
         const badge = severityBadge(s.maxSeverity ?? 'Unknown');
@@ -142,9 +142,10 @@ export class FloodMonitorPanel extends Panel {
         </tr>`;
       }).join('');
 
+      const stateNote = ctx.isActive ? ' <span style="font-size:10px;opacity:0.5;font-weight:400;">(state-level, not proximity filtered)</span>' : '';
       sections.push(`
         <div class="flood-section">
-          <div class="flood-section-header">NWS Active Alerts by State</div>
+          <div class="flood-section-header">NWS Active Alerts by State${stateNote}</div>
           <table class="flood-table">
             <thead><tr><th>State</th><th>#</th><th>Severity</th><th>Alert Type</th></tr></thead>
             <tbody>${rows}</tbody>

--- a/src/components/SevereWeatherPanel.ts
+++ b/src/components/SevereWeatherPanel.ts
@@ -2,10 +2,12 @@ import { Panel } from './Panel';
 import type { SevereWeatherStatus, ActiveWarning } from '@/services/severe-weather';
 import { riskLabelForCode, riskBadgeStyle, warningColor } from '@/services/severe-weather';
 import { escapeHtml } from '@/utils/sanitize';
+import { getSavedPlacesFilterService, isNearActivePlace } from '@/services/intelligence/saved-places-filter';
 
 export class SevereWeatherPanel extends Panel {
   private status: SevereWeatherStatus | null = null;
   private onWarningClick: ((lat: number, lon: number) => void) | null = null;
+  private filterUnsub: (() => void) | null = null;
 
   constructor() {
     super({
@@ -16,6 +18,13 @@ export class SevereWeatherPanel extends Panel {
       infoTooltip: 'SPC Day 1–2 convective outlook risk level + NWS active tornado and severe thunderstorm warnings.',
     });
     this.showLoading('Fetching SPC outlook...');
+    this.filterUnsub = getSavedPlacesFilterService().subscribe(() => this.render());
+  }
+
+  public destroy(): void {
+    super.destroy();
+    this.filterUnsub?.();
+    this.filterUnsub = null;
   }
 
   public setWarningClickHandler(fn: (lat: number, lon: number) => void): void {
@@ -35,7 +44,23 @@ export class SevereWeatherPanel extends Panel {
       return;
     }
 
-    const { outlook, warnings, tornadoWarningCount, thunderstormWarningCount, watchCount } = this.status;
+    const ctx = getSavedPlacesFilterService().getContext();
+    const allWarnings = this.status.warnings;
+    const warnings = ctx.isActive
+      ? allWarnings.filter(w => !w.centroid || isNearActivePlace(w.centroid.lat, w.centroid.lon))
+      : allWarnings;
+    const hiddenCount = allWarnings.length - warnings.length;
+
+    const filterBanner = ctx.isActive
+      ? `<div class="spf-proximity-banner">📍 ${escapeHtml(ctx.activePlaceName ?? '')} · ${ctx.radiusKm} km · ${hiddenCount > 0 ? `${hiddenCount} hidden` : 'showing all'}</div>`
+      : '';
+
+    const { outlook, tornadoWarningCount, thunderstormWarningCount, watchCount } = this.status;
+    const filteredTornado = ctx.isActive ? warnings.filter(w => w.warnType === 'tornado').length : tornadoWarningCount;
+    const filteredThunder = ctx.isActive ? warnings.filter(w => w.warnType === 'thunderstorm').length : thunderstormWarningCount;
+    const filteredWatch = ctx.isActive ? warnings.filter(w => w.warnType === 'watch').length : watchCount;
+    const count = filteredTornado + filteredThunder + filteredWatch;
+    this.setCount(count);
     const riskLabel = riskLabelForCode(outlook.maxRisk);
 
     const outlookHtml = `
@@ -48,9 +73,9 @@ export class SevereWeatherPanel extends Panel {
           </div>
         </div>
         <div style="margin-left:auto;text-align:right;font-size:11px">
-          <div style="color:#ef4444;font-weight:600">${tornadoWarningCount} Tornado Warn.</div>
-          <div style="color:#f97316">${thunderstormWarningCount} Thunder. Warn.</div>
-          <div style="color:#eab308">${watchCount} Watch${watchCount === 1 ? '' : 'es'}</div>
+          <div style="color:#ef4444;font-weight:600">${filteredTornado} Tornado Warn.</div>
+          <div style="color:#f97316">${filteredThunder} Thunder. Warn.</div>
+          <div style="color:#eab308">${filteredWatch} Watch${filteredWatch === 1 ? '' : 'es'}</div>
         </div>
       </div>`;
 
@@ -64,7 +89,7 @@ export class SevereWeatherPanel extends Panel {
         </table>`;
 
     this.setContent(
-      `<div class="ct-panel-content">${outlookHtml}${tableHtml}<div class="fires-footer"><span class="fires-source">NWS SPC · NWS CAP</span></div></div>`,
+      `<div class="ct-panel-content">${filterBanner}${outlookHtml}${tableHtml}<div class="fires-footer"><span class="fires-source">NWS SPC · NWS CAP</span></div></div>`,
     );
 
     this.getContentElement().addEventListener('click', (e) => {

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -1154,12 +1154,12 @@ export class UnifiedSettings {
  const places = getSavedPlaces();
  const MAX = 20;
  let html = `<div class="us-proximity-filter-section" style="padding:10px 0 12px;border-bottom:1px solid rgba(255,255,255,0.08);margin-bottom:10px;">
-   <div style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;opacity:0.6;margin-bottom:6px;">Proximity Filter Default Radius</div>
+   <div style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;opacity:0.6;margin-bottom:6px;">Proximity Filter Fallback Radius</div>
    <div style="display:flex;align-items:center;gap:8px;">
      <input id="us-spf-radius" type="number" min="50" max="5000" step="50" value="${currentRadius}" style="width:80px;padding:4px 6px;background:var(--bg-secondary,#1e1e1e);border:1px solid var(--border-color,#333);border-radius:4px;color:var(--text-primary,#eee);font-size:12px;">
      <span style="font-size:12px;opacity:0.7;">km</span>
-     <span style="font-size:11px;opacity:0.5;">(50–5000 km, default 500)</span>
    </div>
+   <div style="font-size:11px;opacity:0.5;margin-top:4px;">Applies to places with no per-place radius set. Each place&apos;s own radius takes precedence — edit a place to set its radius.</div>
  </div>`;
  html += `<div class="us-places-header"><span class="us-places-count">${places.length} / ${MAX} places</span><button class="spm-btn spm-btn--primary spm-btn--sm" data-places-action="add" type="button">+ Add Place</button></div>`;
 

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -28,6 +28,7 @@ import {
   setPrimarySavedPlace,
   subscribeSavedPlaces,
 } from '@/services/saved-places';
+import { getSavedPlacesFilterService } from '@/services/intelligence/saved-places-filter';
 import {
   loadProximityConfig,
   saveProximityConfig,
@@ -422,6 +423,9 @@ export class UnifiedSettings {
  } else if (target.id === 'us-analytics-consent') {
  setAnalyticsConsent(target.checked);
  if (target.checked) void initAnalytics();
+ } else if (target.id === 'us-spf-radius') {
+ const km = Number.parseInt(target.value, 10);
+ if (Number.isFinite(km)) getSavedPlacesFilterService().setDefaultRadius(km);
  }
  });
 
@@ -1144,9 +1148,20 @@ export class UnifiedSettings {
  const container = this.overlay.querySelector('#usPlacesContent');
  if (!container) return;
 
+ const filterSvc = getSavedPlacesFilterService();
+ const currentRadius = filterSvc.getDefaultRadius();
+
  const places = getSavedPlaces();
  const MAX = 20;
- let html = `<div class="us-places-header"><span class="us-places-count">${places.length} / ${MAX} places</span><button class="spm-btn spm-btn--primary spm-btn--sm" data-places-action="add" type="button">+ Add Place</button></div>`;
+ let html = `<div class="us-proximity-filter-section" style="padding:10px 0 12px;border-bottom:1px solid rgba(255,255,255,0.08);margin-bottom:10px;">
+   <div style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;opacity:0.6;margin-bottom:6px;">Proximity Filter Default Radius</div>
+   <div style="display:flex;align-items:center;gap:8px;">
+     <input id="us-spf-radius" type="number" min="50" max="5000" step="50" value="${currentRadius}" style="width:80px;padding:4px 6px;background:var(--bg-secondary,#1e1e1e);border:1px solid var(--border-color,#333);border-radius:4px;color:var(--text-primary,#eee);font-size:12px;">
+     <span style="font-size:12px;opacity:0.7;">km</span>
+     <span style="font-size:11px;opacity:0.5;">(50–5000 km, default 500)</span>
+   </div>
+ </div>`;
+ html += `<div class="us-places-header"><span class="us-places-count">${places.length} / ${MAX} places</span><button class="spm-btn spm-btn--primary spm-btn--sm" data-places-action="add" type="button">+ Add Place</button></div>`;
 
  if (places.length === 0) {
  html += `<div class="us-places-empty">No saved places yet. Add your home, work, and other key locations.</div>`;

--- a/src/services/intelligence/saved-places-filter.ts
+++ b/src/services/intelligence/saved-places-filter.ts
@@ -252,21 +252,37 @@ export class SavedPlacesFilterService {
     try { raw = store.getItem(STORAGE_KEY); } catch { return; }
     if (!raw) return;
     try {
-      const parsed = JSON.parse(raw) as { activeId?: string | null } | null;
+      const parsed = JSON.parse(raw) as { activeId?: string | null; defaultRadius?: number } | null;
       const candidate = parsed?.activeId;
       if (typeof candidate === 'string' && this.adapter.get(candidate)) {
         this.activeId = candidate;
+      }
+      const r = parsed?.defaultRadius;
+      if (typeof r === 'number' && r >= 50 && r <= 5000) {
+        this.defaultRadiusKm = r;
       }
     } catch {
       // corrupt — leave defaults
     }
   }
 
+  setDefaultRadius(km: number): void {
+    const clamped = Math.max(50, Math.min(5000, Math.round(km)));
+    if (clamped === this.defaultRadiusKm) return;
+    this.defaultRadiusKm = clamped;
+    this.persist();
+    this.notify();
+  }
+
+  getDefaultRadius(): number {
+    return this.defaultRadiusKm;
+  }
+
   private persist(): void {
     const store = safeStorage();
     if (!store) return;
     try {
-      store.setItem(STORAGE_KEY, JSON.stringify({ activeId: this.activeId }));
+      store.setItem(STORAGE_KEY, JSON.stringify({ activeId: this.activeId, defaultRadius: this.defaultRadiusKm }));
     } catch {
       // best effort
     }
@@ -294,6 +310,14 @@ export function getSavedPlacesFilterService(): SavedPlacesFilterService {
 export function __resetSavedPlacesFilterSingleton(): void {
   _singleton?.resetForTesting();
   _singleton = null;
+}
+
+/** Convenience: returns true if (lat, lon) falls within the active saved-place
+ *  filter radius, or if no filter is active. Panels use this for per-item gating. */
+export function isNearActivePlace(lat: number, lon: number): boolean {
+  const ctx = getSavedPlacesFilterService().getContext();
+  if (!ctx.isActive || !ctx.center) return true;
+  return haversineKm(ctx.center.lat, ctx.center.lon, lat, lon) <= ctx.radiusKm;
 }
 
 export const __internals = {

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -806,3 +806,14 @@
 .neo-prob { color: #f97316; }
 .neo-row-sub { font-size: 10px; color: var(--text-faint, #888); margin-top: 1px; }
 .neo-degraded { padding: 4px 8px; font-size: 10px; color: #ffb74d; }
+
+/* Saved Places proximity filter banner (shown inside panels when filter is active) */
+.spf-proximity-banner {
+  padding: 4px 8px;
+  font-size: 10px;
+  background: rgba(74, 158, 255, 0.1);
+  border-left: 2px solid #4a9eff;
+  border-radius: 2px;
+  color: #4a9eff;
+  margin-bottom: 6px;
+}


### PR DESCRIPTION
## Summary

Adds a first-class proximity filter that pins all domain panels to events within the active saved place's radius. When active, every panel that has per-event coordinates filters its data and shows a blue banner with the place name, radius, and count of hidden items.

## Changes

### Core service
- `saved-places-filter.ts` — added `setDefaultRadius(km)` + `getDefaultRadius()` methods with persistence, added `isNearActivePlace(lat, lon)` convenience export for panels

### UI toggle
- `html.ts` — added `📍 Proximity: OFF / [Place Name]` button in the `mac-mode-section` sidebar alongside Ghost Mode / God's Vision
- `panel-layout.ts` — wires the toggle: click activates/deactivates first saved place; subscribes to filter service to keep button label in sync

### Panel wiring (3 diverse domain panels)
- `EarthquakesPanel.ts` — filters by `eq.location.latitude/longitude` (passthrough when `eq.location` is null); shows proximity banner
- `SevereWeatherPanel.ts` — filters by `warning.centroid` (passthrough when centroid is null); updates tornado/thunderstorm/watch counts to reflect filtered set
- `FloodMonitorPanel.ts` — filters top flood-stage gauges by `gauge.lat/lon` (passthrough when coords are null); NWS state-level alert table annotated as "(state-level, not proximity filtered)"

### Settings
- `UnifiedSettings.ts` — adds a "Fallback Radius" number input (50–5000 km) in the Places tab with explanatory note that per-place radius takes precedence; persists via `setDefaultRadius()`

### CSS
- `panels.css` — adds `.spf-proximity-banner` style (blue left-border banner)

## Behavior

- Filter OFF: all panels unaffected, button shows "📍 Proximity: OFF"
- Filter ON: button shows "📍 [Place Name]", each wired panel re-renders filtered, shows banner with `N hidden`
- Events without coordinates always pass through (never silently hidden)
- Radius defaults to 500 km; per-place radius overrides the default (already stored on `SavedPlace.radiusKm`)
- Filter state persists across reloads via `wm-saved-places-filter` localStorage key

---

Cross-agent review: Codex reviewed on 2026-06-12; outcome: 2 P2s fixed (fallback-radius label clarified + flood NWS section annotated as state-level), 1 P3 acknowledged (no panel-level regression tests — deferred, service layer has full coverage), release approved
