### PR TITLE
fix(sms): move CSRF check before enabled gate; add route-level integration tests

### DIFF
--- a/src-tauri/sidecar/__tests__/sms-auth.test.mjs
+++ b/src-tauri/sidecar/__tests__/sms-auth.test.mjs
@@ -1,12 +1,103 @@
 /**
  * Tests for SMS route auth hardening:
  *   - validateTwilioSignature (sms-security.mjs) — HMAC-SHA1 correctness
- *   - /api/sms/status auth gate
- *   - /api/sms/command CSRF Origin rejection
+ *   - /api/sms/status auth gate (integration)
+ *   - /api/sms/command CSRF Origin rejection (integration)
  */
 import { strict as assert } from 'node:assert';
 import test from 'node:test';
 import { createHmac } from 'node:crypto';
+
+// ── Integration test helpers ────────────────────────────────────────────────
+
+const TEST_TOKEN = 'sms-auth-test-token-xyz';
+process.env.LOCAL_API_TOKEN ??= TEST_TOKEN;
+import { createLocalApiServer } from '../local-api-server.mjs';
+
+const silentLogger = { log() {}, warn() {}, error() {} };
+
+async function withServer(fn) {
+  const app = await createLocalApiServer({ port: 0, logger: silentLogger });
+  const { port } = await app.start();
+  const base = `http://127.0.0.1:${port}`;
+  try {
+    await fn(base);
+  } finally {
+    await app.close();
+  }
+}
+
+// ── /api/sms/status — bearer-auth gate ──────────────────────────────────────
+
+test('/api/sms/status: returns 401 without bearer token', async () => {
+  await withServer(async (base) => {
+    const res = await fetch(`${base}/api/sms/status`);
+    assert.equal(res.status, 401);
+    const body = await res.json();
+    assert.ok(body.error);
+  });
+});
+
+test('/api/sms/status: returns 200 with valid bearer token', async () => {
+  await withServer(async (base) => {
+    const res = await fetch(`${base}/api/sms/status`, {
+      headers: { authorization: `Bearer ${process.env.LOCAL_API_TOKEN}` },
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(typeof body.enabled === 'boolean');
+    assert.ok(typeof body.uptimeMs === 'number');
+  });
+});
+
+// ── /api/sms/command — CSRF Origin rejection ────────────────────────────────
+
+test('/api/sms/command: rejects request with Origin header and no bearer token (CSRF)', async () => {
+  await withServer(async (base) => {
+    const res = await fetch(`${base}/api/sms/command`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'origin': 'http://evil.example.com',
+      },
+      body: JSON.stringify({ from: '+15551234567', body: 'STATUS' }),
+    });
+    assert.equal(res.status, 403);
+    const body = await res.json();
+    assert.ok(body.error);
+  });
+});
+
+test('/api/sms/command: allows request with Origin header when bearer token is valid', async () => {
+  await withServer(async (base) => {
+    // Trusted local caller (bearer token) bypasses CSRF check;
+    // SMS is disabled by default so the next gate returns 503.
+    const res = await fetch(`${base}/api/sms/command`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'origin': 'http://127.0.0.1',
+        'authorization': `Bearer ${process.env.LOCAL_API_TOKEN}`,
+      },
+      body: JSON.stringify({ from: '+15551234567', body: 'STATUS' }),
+    });
+    // 503 means it passed CSRF and reached the enabled check (SMS disabled by default)
+    assert.equal(res.status, 503);
+  });
+});
+
+test('/api/sms/command: allows request with no Origin header (Twilio webhook pattern)', async () => {
+  await withServer(async (base) => {
+    // No Origin header — should reach the enabled check, not be blocked by CSRF
+    const res = await fetch(`${base}/api/sms/command`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ from: '+15551234567', body: 'STATUS' }),
+    });
+    // 503 means it passed CSRF and reached the enabled check (SMS disabled by default)
+    assert.equal(res.status, 503);
+  });
+});
 
 import { validateTwilioSignature } from '../sms-security.mjs';
 

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -5295,6 +5295,14 @@ async function dispatch(requestUrl, req, routes, context) {
   // gateway webhooks (Twilio, etc.) can POST without a LOCAL_API_TOKEN.
   // Security is enforced by the phone-number allowlist in sms-config.json.
   if (requestUrl.pathname === '/api/sms/command' && req.method === 'POST') {
+    // Reject browser-originated requests (CSRF protection) before touching the
+    // body. Real Twilio webhooks are server-to-server and never carry an Origin
+    // header; the in-app test caller is trusted via bearer token.
+    const trustedLocalCaller = isValidToken(req.headers.authorization || '');
+    if (req.headers.origin && !trustedLocalCaller) {
+      return json({ error: 'Forbidden' }, 403);
+    }
+
     if (!_smsConfig.enabled) return json({ error: 'SMS command interface is disabled.' }, 503);
 
     const rawBodyBuf = await readBody(req);
@@ -5308,14 +5316,6 @@ async function dispatch(requestUrl, req, routes, context) {
       params = Object.fromEntries(new URLSearchParams(rawBody));
     } else {
       try { params = JSON.parse(rawBody || '{}'); } catch { return json({ error: 'Invalid JSON' }, 400); }
-    }
-
-    // Reject browser-originated requests (CSRF protection). Real Twilio
-    // webhooks are server-to-server and never carry an Origin header; the
-    // in-app test caller is trusted via bearer token.
-    const trustedLocalCaller = isValidToken(req.headers.authorization || '');
-    if (req.headers.origin && !trustedLocalCaller) {
-      return json({ error: 'Forbidden' }, 403);
     }
 
     // Caller-ID (From) is spoofable. When a TWILIO_AUTH_TOKEN is configured we


### PR DESCRIPTION
## Summary

Follow-up to #1154. Codex cross-agent review identified that `sms-auth.test.mjs` only tested `validateTwilioSignature` (pure function), not the actual route-level auth boundaries.

### Changes

**Route reorder in `local-api-server.mjs`**

Moved the CSRF Origin check to fire *before* the `_smsConfig.enabled` check. This is the correct security posture (reject unauthorized requests before any business logic runs) and makes it possible to test the CSRF gate without toggling module-level config state.

**5 new integration tests in `sms-auth.test.mjs`**

Tests use `createLocalApiServer` with a live HTTP server to verify the exact route boundaries:
- `GET /api/sms/status` without token → 401
- `GET /api/sms/status` with token → 200
- `POST /api/sms/command` + Origin (no token) → **403** (CSRF rejected)
- `POST /api/sms/command` + Origin + token → 503 (CSRF passed, SMS disabled)
- `POST /api/sms/command` + no Origin → 503 (Twilio pattern, CSRF passed)

### Verification
- `npm run test:sms` — 101/101 pass
- `npm run typecheck:all` — 0 errors

---

Cross-agent review: Codex reviewed on 2026-06-13; outcome: pass