### PR TITLE
fix(privacy): make analytics consent opt-in, not opt-out

### DIFF
--- a/src/components/AnalyticsConsentBanner.ts
+++ b/src/components/AnalyticsConsentBanner.ts
@@ -1,0 +1,98 @@
+/**
+ * First-run analytics consent banner (opt-in).
+ *
+ * Shown once for brand-new installs that have no recorded consent choice. The
+ * user must explicitly Accept to enable PostHog/Vercel analytics — declining (or
+ * dismissing) leaves analytics off. Either choice records 'wm-analytics-consent'
+ * and marks the prompt as seen so this never re-appears.
+ *
+ * Migrated / already-decided installs never reach here (migrateAnalyticsConsent
+ * marks the prompt seen), so mounting is gated on hasSeenConsentPrompt().
+ */
+
+import {
+  hasSeenConsentPrompt,
+  markConsentPromptSeen,
+  setAnalyticsConsent,
+  initAnalytics,
+} from '@/services/analytics';
+
+const BANNER_ID = 'analytics-consent-banner';
+
+function decide(banner: HTMLElement, allow: boolean): void {
+  setAnalyticsConsent(allow);
+  markConsentPromptSeen();
+  if (allow) void initAnalytics();
+  banner.remove();
+}
+
+export function mountAnalyticsConsentBanner(): void {
+  if (hasSeenConsentPrompt()) return;
+  if (document.getElementById(BANNER_ID)) return;
+
+  const banner = document.createElement('div');
+  banner.id = BANNER_ID;
+  banner.setAttribute('role', 'dialog');
+  banner.setAttribute('aria-live', 'polite');
+  banner.setAttribute('aria-label', 'Analytics consent');
+  Object.assign(banner.style, {
+    position: 'fixed',
+    bottom: '16px',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    zIndex: '10000',
+    maxWidth: 'min(560px, calc(100vw - 32px))',
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: '12px',
+    padding: '14px 18px',
+    borderRadius: '14px',
+    border: '1px solid rgba(120, 170, 255, 0.35)',
+    background: 'rgba(14, 18, 28, 0.94)',
+    boxShadow: '0 18px 48px rgba(0, 0, 0, 0.4)',
+    color: '#e9eefc',
+    font: '500 13px/1.45 "SF Pro Text", -apple-system, BlinkMacSystemFont, sans-serif',
+    backdropFilter: 'blur(12px)',
+  } as CSSStyleDeclaration);
+
+  const text = document.createElement('span');
+  text.style.flex = '1 1 240px';
+  text.textContent =
+    'Share anonymous usage analytics? Aggregate counts only — no key names, no personal data. Off unless you opt in.';
+
+  const actions = document.createElement('div');
+  Object.assign(actions.style, { display: 'flex', gap: '8px', flex: '0 0 auto' } as CSSStyleDeclaration);
+
+  const decline = document.createElement('button');
+  decline.type = 'button';
+  decline.textContent = 'No thanks';
+  Object.assign(decline.style, {
+    padding: '8px 14px',
+    borderRadius: '10px',
+    border: '1px solid rgba(255, 255, 255, 0.18)',
+    background: 'transparent',
+    color: '#c4ccdd',
+    font: 'inherit',
+    cursor: 'pointer',
+  } as CSSStyleDeclaration);
+  decline.addEventListener('click', () => decide(banner, false));
+
+  const accept = document.createElement('button');
+  accept.type = 'button';
+  accept.textContent = 'Allow';
+  Object.assign(accept.style, {
+    padding: '8px 16px',
+    borderRadius: '10px',
+    border: '1px solid rgba(120, 170, 255, 0.6)',
+    background: 'rgba(70, 120, 235, 0.9)',
+    color: '#fff',
+    font: '600 13px/1.45 "SF Pro Text", -apple-system, BlinkMacSystemFont, sans-serif',
+    cursor: 'pointer',
+  } as CSSStyleDeclaration);
+  accept.addEventListener('click', () => decide(banner, true));
+
+  actions.append(decline, accept);
+  banner.append(text, actions);
+  document.body.append(banner);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -165,7 +165,7 @@ import { debugGetCells, getCellCount } from '@/services/geo-convergence';
 import { initMetaTags } from '@/services/meta-tags';
 import { installRuntimeFetchPatch, installWebApiRedirect, isDesktopRuntime } from '@/services/runtime';
 import { loadDesktopSecrets } from '@/services/runtime-config';
-import { initAnalytics, isAnalyticsAllowed, trackApiKeysSnapshot } from '@/services/analytics';
+import { initAnalytics, isAnalyticsAllowed, migrateAnalyticsConsent, trackApiKeysSnapshot } from '@/services/analytics';
 import { applyStoredTheme } from '@/utils/theme-manager';
 import { SITE_VARIANT } from '@/config/variant';
 import { clearChunkReloadGuard, installChunkReloadGuard } from '@/bootstrap/chunk-reload';
@@ -250,6 +250,12 @@ function showDesktopRuntimeDebugNotice(snapshot: DesktopRuntimeSnapshot): void {
 // send-time so consent revocation mid-session takes effect immediately without
 // a reload (inject() itself has no shutdown path).
 if (!isDesktopRuntime()) inject({ beforeSend: (e) => isAnalyticsAllowed() ? e : null });
+
+// Migrate pre-consent-gate installs once, then surface a first-run opt-in banner
+// for brand-new installs that have no recorded choice. Must run before
+// initAnalytics() so migration's consent write is visible to the gate.
+migrateAnalyticsConsent();
+import('./components/AnalyticsConsentBanner').then(({ mountAnalyticsConsentBanner }) => { mountAnalyticsConsentBanner(); }).catch((error: unknown) => console.warn('[boot] AnalyticsConsentBanner failed to mount', error));
 
 // Initialize PostHog product analytics
 void initAnalytics();

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -4,11 +4,15 @@
  * Active when VITE_POSTHOG_KEY is set AND the user has explicitly opted in.
  * All exports are no-ops when the key is absent (dev/local) or user has not consented.
  *
- * Consent model:
+ * Consent model (opt-in):
  * - localStorage key 'wm-analytics-consent':
  * 'true'  → user explicitly opted in (analytics enabled)
  * 'false' → user explicitly opted out
  * absent  → not consented (analytics disabled by default)
+ * - A one-time consent prompt is surfaced on first boot for new installs
+ * (see AnalyticsConsentBanner); 'wm-analytics-consent-prompt-seen' records it.
+ * - Installs that predate consent gating are migrated once to 'true' so their
+ * prior (opt-out-era) behaviour is preserved — see migrateAnalyticsConsent().
  * - Ghost Mode always suppresses analytics regardless of consent.
  *
  * Data safety:
@@ -51,6 +55,42 @@ export function setAnalyticsConsent(allow: boolean): void {
     posthogInstance = null;
     initPromise = null;
   }
+}
+
+const CONSENT_PROMPT_SEEN_KEY = 'wm-analytics-consent-prompt-seen';
+
+/** True once the first-run consent prompt has been shown (or migration ran). */
+export function hasSeenConsentPrompt(): boolean {
+  return localStorage.getItem(CONSENT_PROMPT_SEEN_KEY) === 'true';
+}
+
+export function markConsentPromptSeen(): void {
+  localStorage.setItem(CONSENT_PROMPT_SEEN_KEY, 'true');
+}
+
+/**
+ * One-time consent migration. Runs at boot before initAnalytics().
+ *
+ * - Already prompted/migrated → no-op.
+ * - Explicit choice already on file (key present) → just mark prompt seen.
+ * - Pre-consent-gate install (no choice, but a prior installation id exists) →
+ *   migrate to 'true' to preserve the opt-out-era behaviour these users had.
+ * - Brand-new install (no choice, no installation id) → leave unconsented so the
+ *   first-run banner can ask. markConsentPromptSeen() is the banner's job here.
+ */
+export function migrateAnalyticsConsent(): void {
+  try {
+    if (hasSeenConsentPrompt()) return;
+    if (localStorage.getItem(CONSENT_KEY) !== null) {
+      markConsentPromptSeen();
+      return;
+    }
+    const isExistingInstall = localStorage.getItem('wm-installation-id') !== null;
+    if (isExistingInstall) {
+      localStorage.setItem(CONSENT_KEY, 'true');
+      markConsentPromptSeen();
+    }
+  } catch { /* localStorage unavailable — treat as unconsented */ }
 }
 
 // ── Installation identity ──
@@ -164,7 +204,7 @@ const EVENT_SCHEMAS: Record<string, Set<string>> = {
   wm_search_used: new Set(['query_length', 'result_count']),
   // Phase 2 — additional interaction events
   wm_map_view_changed: new Set(['view']),
-  wm_country_selected: new Set(['country_code', 'country_name', 'source']),
+  wm_country_selected: new Set(['country_code', 'source']),
   wm_search_result_selected: new Set(['result_type']),
   wm_panel_toggled: new Set(['panel_id', 'enabled']),
   wm_finding_clicked: new Set(['finding_id', 'finding_source', 'finding_type', 'priority']),


### PR DESCRIPTION
## What

Switch PostHog/Vercel analytics from an opt-out to an opt-in consent model.

- **`hasAnalyticsConsent()`** now returns `false` when the consent key is absent — analytics is off by default until the user explicitly opts in (this was already on `main`; this PR builds the rest of the model around it).
- **Migration** (`migrateAnalyticsConsent()`, runs once at boot before `initAnalytics()`): installs that predate the consent gate — identified by an existing `wm-installation-id` — are migrated to `'true'` so their prior behaviour is preserved. Brand-new installs (no id, no choice) stay unconsented.
- **First-run banner** (`AnalyticsConsentBanner.ts`): new installs see a one-time Allow / No-thanks prompt. Either choice records `wm-analytics-consent` and marks the prompt seen so it never re-appears. The existing Settings → Privacy toggle remains the durable control.
- **Data minimization**: drop `country_name` from the `wm_country_selected` event allowlist — `country_code` is sufficient. `sanitizeProps()` silently drops the now-unlisted property.

## Files

- `src/services/analytics.ts` — consent-prompt key + `hasSeenConsentPrompt` / `markConsentPromptSeen` / `migrateAnalyticsConsent`; allowlist trim.
- `src/components/AnalyticsConsentBanner.ts` — new first-run opt-in banner.
- `src/main.ts` — run migration then mount the banner at boot, before `initAnalytics()`.

## Verification

- `npm run typecheck:all` — clean (exit 0).

---

Cross-agent review: Codex reviewed on 2026-06-15; outcome: pass