### PR TITLE
sec: redact hypothesis notifications + exclude cache from backup

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -870,6 +870,25 @@ fn cache_file_path(app: &AppHandle) -> Result<PathBuf, String> {
  Ok(dir.join("persistent-cache.json"))
 }
 
+// Exclude the app data directory from Time Machine / iCloud backups.
+// The persistent-cache.json contains plaintext intelligence data that should
+// not leave the machine. Uses the com.apple.metadata:com_apple_backup_excludeItem
+// xattr, which is the same mechanism Xcode uses for DerivedData.
+#[cfg(target_os = "macos")]
+fn exclude_app_data_from_backup(dir: &std::path::Path) {
+ let _ = std::process::Command::new("xattr")
+ .args([
+ "-w",
+ "com.apple.metadata:com_apple_backup_excludeItem",
+ "com.apple.backup.excludeItem",
+ &dir.to_string_lossy(),
+ ])
+ .output();
+}
+
+#[cfg(not(target_os = "macos"))]
+fn exclude_app_data_from_backup(_dir: &std::path::Path) {}
+
 #[tauri::command]
 fn read_cache_entry(webview: Webview, cache: tauri::State<'_, PersistentCache>, key: String) -> Result<Option<Value>, String> {
  require_trusted_window(webview.label())?;
@@ -3191,6 +3210,11 @@ fn main() {
  // Load persistent cache into memory (avoids 14MB file I/O on every IPC call)
  let cache_path = cache_file_path(&app.handle()).unwrap_or_default();
  app.manage(PersistentCache::load(&cache_path));
+ // Mark the app data dir as excluded from Time Machine / iCloud so
+ // persistent-cache.json (plaintext intelligence data) doesn't leave the machine.
+ if let Ok(data_dir) = app.handle().path().app_data_dir() {
+ exclude_app_data_from_backup(&data_dir);
+ }
 
  // Apply native macOS vibrancy (HudWindow material, 12pt rounded corners).
  // Pairs with `transparent: true` + `macOSPrivateApi: true` in tauri.conf.json

--- a/src/services/hypothesis-notifier.ts
+++ b/src/services/hypothesis-notifier.ts
@@ -43,7 +43,6 @@ function buildAlert(h: Hypothesis, count: number): UnifiedAlert {
 }
 
 function handleSnapshot(snapshot: AnalystSnapshot): void {
-  if (isGhostMode()) return; // Ghost Mode: suppress all notifications
   if (hudVisible) return; // user is looking — no need to nudge
   const now = Date.now();
   // Prune old entries.
@@ -54,10 +53,13 @@ function handleSnapshot(snapshot: AnalystSnapshot): void {
     if (h.risk !== 'critical') continue;
     const sig = signatureFor(h);
     if (notified.has(sig)) continue;
+    // Always record the signature even in Ghost Mode so hypotheses seen during
+    // Ghost Mode don't re-fire as "fresh" once the mode is turned off.
     notified.set(sig, now);
     fresh.push(h);
   }
   if (fresh.length === 0) return;
+  if (isGhostMode()) return; // Ghost Mode: signatures recorded above, but no banner
 
   // Pick the highest-confidence fresh hypothesis as the notification headline.
   const lead = [...fresh].sort((a, b) => b.confidence - a.confidence)[0];

--- a/src/services/hypothesis-notifier.ts
+++ b/src/services/hypothesis-notifier.ts
@@ -16,6 +16,7 @@ import { notificationDispatcher } from './notification-dispatcher';
 import type { UnifiedAlert } from './unified-alerts';
 import type { AnalystSnapshot, Hypothesis } from './analyst-loop';
 import { signatureFor } from './hypothesis-feedback';
+import { isGhostMode } from './mode-manager';
 
 const NOTIFY_WINDOW_MS = 60 * 60 * 1000; // Don't re-notify the same signature within an hour.
 
@@ -33,7 +34,7 @@ function buildAlert(h: Hypothesis, count: number): UnifiedAlert {
     source: 'correlation',
     severity: 'critical',
     title: `Analyst: critical hypothesis${suffix}`,
-    body: h.statement.slice(0, 240),
+    body: 'Open Crystal Ball to review new critical hypothesis',
     timestamp: Date.now(),
     relevanceScore: 95,
     acknowledged: false,
@@ -42,6 +43,7 @@ function buildAlert(h: Hypothesis, count: number): UnifiedAlert {
 }
 
 function handleSnapshot(snapshot: AnalystSnapshot): void {
+  if (isGhostMode()) return; // Ghost Mode: suppress all notifications
   if (hudVisible) return; // user is looking — no need to nudge
   const now = Date.now();
   // Prune old entries.


### PR DESCRIPTION
## Security fixes (P1)

### Finding 1 — Hypothesis text on macOS lock screen
**File:** `src/services/hypothesis-notifier.ts`

Previously `body: h.statement.slice(0, 240)` put full intelligence hypothesis text into the macOS Notification Center banner, which appears on the lock screen unredacted.

**Fix:** Replace with generic `'Open Crystal Ball to review new critical hypothesis'`. Add `isGhostMode()` guard — signatures are always recorded in `notified` (so Ghost Mode hypotheses don't re-fire on mode exit), but the banner is suppressed. Consistent with how `notificationDispatcher` and `analytics.ts` suppress in Ghost Mode.

### Finding 2 — Intelligence cache not excluded from Time Machine backup
**File:** `src-tauri/src/main.rs`

`persistent-cache.json` in `~/Library/Application Support/com.bradleybond.crystalball/` contains plaintext intelligence data and was not excluded from Time Machine or iCloud Drive backups.

**Fix:** Add `exclude_app_data_from_backup()` — sets the `com.apple.metadata:com_apple_backup_excludeItem` xattr on the app data directory at startup. This is the same mechanism Xcode uses for DerivedData. No-op on non-macOS targets via `#[cfg]`.

---
> cross-agent-review: codex — approved with P2 (ghost-mode dedup regression) addressed in follow-up commit 670842f9