### PR TITLE
security: close XSS→IPC API-key exfil chain (live news XSS + ungated privileged IPC)

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1225,12 +1225,14 @@ fn open_sidecar_log_impl(app: &AppHandle) -> Result<PathBuf, String> {
 }
 
 #[tauri::command]
-fn open_logs_folder(app: AppHandle) -> Result<String, String> {
+fn open_logs_folder(webview: Webview, app: AppHandle) -> Result<String, String> {
+ require_trusted_window(webview.label())?;
  open_logs_folder_impl(&app).map(|path| path.display().to_string())
 }
 
 #[tauri::command]
-fn open_sidecar_log_file(app: AppHandle) -> Result<String, String> {
+fn open_sidecar_log_file(webview: Webview, app: AppHandle) -> Result<String, String> {
+ require_trusted_window(webview.label())?;
  open_sidecar_log_impl(&app).map(|path| path.display().to_string())
 }
 
@@ -1770,7 +1772,18 @@ fn open_live_channels_window(app: &AppHandle, base_url: Option<String>) -> Resul
  Some(ref origin) if !origin.is_empty() => {
  let path = origin.trim_end_matches('/');
  let full_url = format!("{}/live-channels.html", path);
- WebviewUrl::External(Url::parse(&full_url).map_err(|_| "Invalid base URL".to_string())?)
+ let parsed = Url::parse(&full_url).map_err(|_| "Invalid base URL".to_string())?;
+ // This window holds the same IPC trust as `main`, so it must never be
+ // navigated to an attacker-supplied origin. Only loopback dev origins are
+ // honored; anything else falls back to the bundled app asset.
+ let host = parsed.host_str().unwrap_or("");
+ let is_loopback_dev = matches!(parsed.scheme(), "http" | "https")
+ && matches!(host, "localhost" | "127.0.0.1" | "::1" | "[::1]");
+ if is_loopback_dev {
+ WebviewUrl::External(parsed)
+ } else {
+ WebviewUrl::App("live-channels.html".into())
+ }
  }
  _ => WebviewUrl::App("live-channels.html".into()),
  };
@@ -2936,7 +2949,8 @@ fn start_local_api(app: &AppHandle) -> Result<(), String> {
 /// unhandledrejection, and key event handlers so renderer-side errors land
 /// in desktop.log instead of dying in WebInspector.
 #[tauri::command]
-fn log_frontend(app: AppHandle, level: String, message: String, context: Option<String>) {
+fn log_frontend(webview: Webview, app: AppHandle, level: String, message: String, context: Option<String>) -> Result<(), String> {
+ require_trusted_window(webview.label())?;
  let lvl = match level.to_uppercase().as_str() {
  "ERROR" | "WARN" | "INFO" | "DEBUG" => level.to_uppercase(),
  _ => "INFO".to_string(),
@@ -2952,12 +2966,14 @@ fn log_frontend(app: AppHandle, level: String, message: String, context: Option<
  &lvl,
  &format!("[FRONTEND] {truncated_msg}{}", if truncated_ctx.is_empty() { String::new() } else { format!(" | {truncated_ctx}") }),
  );
+ Ok(())
 }
 
 /// Returns a diagnostics bundle (last N log lines + sidecar /api/diag) as a
 /// single string suitable for copying to the clipboard. Triggered by Cmd+Shift+D.
 #[tauri::command]
-async fn copy_diagnostics(app: AppHandle) -> Result<String, String> {
+async fn copy_diagnostics(webview: Webview, app: AppHandle) -> Result<String, String> {
+ require_trusted_window(webview.label())?;
  let mut out = String::new();
  out.push_str(&format!(
  "=== Crystal Ball diagnostics ===\nversion: v{}+{}\ntime: {}\n\n",

--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -3,6 +3,7 @@ import { fetchLiveVideoInfo } from '@/services/live-news';
 import { isDesktopRuntime, getRemoteApiBaseUrl, getApiBaseUrl, getLocalApiPort } from '@/services/runtime';
 import { tryInvokeTauri } from '@/services/tauri-bridge';
 import { t } from '../services/i18n';
+import { escapeHtml } from '@/utils/sanitize';
 import { loadFromStorage, rafSchedule, saveToStorage } from '@/utils';
 import { STORAGE_KEYS, SITE_VARIANT } from '@/config';
 import { getStreamQuality } from '@/services/ai-flow-settings';
@@ -912,10 +913,13 @@ export class LiveNewsPanel extends Panel {
 
   private showOfflineMessage(channel: LiveChannel): void {
  this.destroyPlayer();
+ // channel.name is pre-escaped via escapeHtml() (belt-and-suspenders that holds even
+ // if the global i18next escape is ever disabled); escapeValue:false on the t() calls
+ // below avoids double-encoding names containing &, <, etc.
  this.content.innerHTML = `
  <div class="live-offline">
  <div class="offline-icon">📺</div>
- <div class="offline-text">${t('components.liveNews.notLive', { name: channel.name })}</div>
+ <div class="offline-text">${t('components.liveNews.notLive', { name: escapeHtml(channel.name), interpolation: { escapeValue: false } })}</div>
  <button class="offline-retry" type="button">${t('common.retry')}</button>
  </div>
  `;
@@ -933,7 +937,7 @@ export class LiveNewsPanel extends Panel {
  this.content.innerHTML = `
  <div class="live-offline">
  <div class="offline-icon">!</div>
- <div class="offline-text">${t('components.liveNews.cannotEmbed', { name: channel.name, code: String(errorCode) })}</div>
+ <div class="offline-text">${t('components.liveNews.cannotEmbed', { name: escapeHtml(channel.name), code: String(errorCode), interpolation: { escapeValue: false } })}</div>
  <a class="offline-retry" href="${watchUrl}" target="_blank" rel="noopener noreferrer">${t('components.liveNews.openOnYouTube')}</a>
  </div>
  `;

--- a/src/services/i18n.ts
+++ b/src/services/i18n.ts
@@ -20,7 +20,7 @@ const localeModules = import.meta.glob<TranslationDictionary>(
 const RTL_LANGUAGES = new Set(['ar']);
 
 function normalizeLanguage(lng: string): SupportedLanguage {
-  const base = (lng || 'en').split('-')[0]?.toLowerCase() || 'en';
+  const base = (lng || 'en').split('-')[0]?.toLowerCase() ?? 'en';
   if (SUPPORTED_LANGUAGE_SET.has(base as SupportedLanguage)) {
  return base as SupportedLanguage;
   }
@@ -28,7 +28,7 @@ function normalizeLanguage(lng: string): SupportedLanguage {
 }
 
 function applyDocumentDirection(lang: string): void {
-  const base = lang.split('-')[0] || lang;
+  const base = lang.split('-')[0] ?? lang;
   document.documentElement.setAttribute('lang', base === 'zh' ? 'zh-CN' : base);
   if (RTL_LANGUAGES.has(base)) {
  document.documentElement.setAttribute('dir', 'rtl');
@@ -51,6 +51,7 @@ async function ensureLanguageLoaded(lng: string): Promise<SupportedLanguage> {
  if (loader) {
  translation = await loader();
  } else {
+ // eslint-disable-next-line no-console
  console.warn(`No locale file for "${normalized}", falling back to English`);
  translation = enTranslation as TranslationDictionary;
  }
@@ -126,7 +127,7 @@ export function isRTL(): boolean {
 export function getLocale(): string {
   const lang = getCurrentLanguage();
   const map: Record<string, string> = { en: 'en-US', el: 'el-GR', zh: 'zh-CN', pt: 'pt-BR', ja: 'ja-JP', ko: 'ko-KR', tr: 'tr-TR', th: 'th-TH', vi: 'vi-VN' };
-  return map[lang] || lang;
+  return map[lang] ?? lang;
 }
 
 export const LANGUAGES = [

--- a/src/services/i18n.ts
+++ b/src/services/i18n.ts
@@ -83,7 +83,7 @@ export async function initI18n(): Promise<void> {
  fallbackLng: 'en',
  debug: import.meta.env.DEV,
  interpolation: {
- escapeValue: false, // not needed for these simple strings
+ escapeValue: true, // HTML-escape interpolated values; HTML-bearing strings render via safeHtml()
  },
  detection: {
  order: ['localStorage', 'navigator'],


### PR DESCRIPTION
## Summary

Closes a chained exploit that could lead to **full API-key exfiltration**:

1. **XSS sink** — i18next ran with `escapeValue: false` globally, so any `t()` result interpolated into `innerHTML` was an injection point. `LiveNewsPanel` interpolated `channel.name` into `innerHTML` at two sites.
2. **Ungated privileged IPC** — `open_live_channels_window_command` opened an attacker-controllable `base_url` into the trusted `live-channels` window, and several other commands ran without window-trust checks.

## Changes

- **`src/services/i18n.ts`** — enable HTML escaping of interpolated values (`escapeValue: true`). HTML-bearing translation strings already render via `safeHtml()`, so no call-site migration was needed (audited).
- **`src/components/LiveNewsPanel.ts`** — `escapeHtml(channel.name)` at both `innerHTML` sites as a belt-and-suspenders layer that holds even if the global escape is ever disabled. Those two `t()` calls pass `interpolation: { escapeValue: false }` so the pre-escaped value is not double-encoded (the only interpolated user value is `name`; `code` is numeric).
- **`src/components/S2UndergroundPanel.ts`** — gate the Patreon OAuth `postMessage` handler on the loopback sidecar origin **and** the popup we opened (`ev.source`), rejecting token injection from any other frame.
- **`src-tauri/src/main.rs`** — add `require_trusted_window()` to `open_live_channels_window_command`, `open_logs_folder`, `open_sidecar_log_file`, `log_frontend`, and `copy_diagnostics`; and restrict the live-channels window URL to loopback dev origins (otherwise it falls back to the bundled app asset).

## Verification

- TypeScript: pre-change typecheck clean (exit 0). Post-change edit only adds an `interpolation: {...}` key to `t()` options (param type `Record<string, unknown>`), which cannot introduce a type error. CI `typecheck:all` is the authoritative gate.
- Rust: `cargo check` compiles `main.rs` cleanly (local run only failed on a missing `dist/` frontend artifact, unrelated to code). CI desktop build validates end-to-end.

Cross-agent review: Codex reviewed on 2026-06-13; outcome: issues fixed (flagged a P2 double-escape of pre-sanitized interpolation values, resolved by `interpolation: { escapeValue: false }` on the two affected `t()` calls).