### PR TITLE
sec(sidecar): harden Node sidecar spawn — env strip, atomic 0600 token, debug-gated node-bin override

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2723,9 +2723,11 @@ fn start_local_api(app: &AppHandle) -> Result<(), String> {
  }
  let local_api_token = token_slot.clone().unwrap();
  // Write token to file so MCP server and other local tools can authenticate.
- // Create the file with 0600 atomically (O_CREAT|O_TRUNC + mode) so there is
- // no world-readable window between creation and permission hardening that a
- // co-resident process could exploit to read the bearer token.
+ // Create the file with 0600 atomically (O_CREAT|O_TRUNC + mode) so a freshly
+ // created inode is never world-readable. mode() only governs newly created
+ // inodes, so when sidecar.token already exists we also re-assert 0600 on the
+ // open handle while it is still truncated/empty — before the bearer token is
+ // written — so a stale, permissively-moded file can't leak the new secret.
  let token_file = logs_dir_path(app)?.join("sidecar.token");
  let write_token = || -> std::io::Result<()> {
  let mut opts = std::fs::OpenOptions::new();
@@ -2736,6 +2738,11 @@ fn start_local_api(app: &AppHandle) -> Result<(), String> {
  opts.mode(0o600);
  }
  let mut file = opts.open(&token_file)?;
+ #[cfg(unix)]
+ {
+ use std::os::unix::fs::PermissionsExt;
+ file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+ }
  file.write_all(local_api_token.as_bytes())?;
  Ok(())
  };

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2515,6 +2515,11 @@ fn local_api_paths(app: &AppHandle) -> (PathBuf, PathBuf) {
 }
 
 fn resolve_node_binary(app: &AppHandle) -> Option<PathBuf> {
+ // The LOCAL_API_NODE_BIN override is honored in debug builds only. In a
+ // release build, an attacker who can set this env var could redirect the
+ // sidecar to an arbitrary executable that inherits the injected keychain
+ // secrets, so the override must be ignored outside development.
+ #[cfg(debug_assertions)]
  if let Ok(explicit) = env::var("LOCAL_API_NODE_BIN") {
  let explicit_path = PathBuf::from(explicit);
  if explicit_path.is_file() {
@@ -2717,20 +2722,39 @@ fn start_local_api(app: &AppHandle) -> Result<(), String> {
  *token_slot = Some(generate_local_token());
  }
  let local_api_token = token_slot.clone().unwrap();
- // Write token to file so MCP server and other local tools can authenticate
+ // Write token to file so MCP server and other local tools can authenticate.
+ // Create the file with 0600 atomically (O_CREAT|O_TRUNC + mode) so there is
+ // no world-readable window between creation and permission hardening that a
+ // co-resident process could exploit to read the bearer token.
  let token_file = logs_dir_path(app)?.join("sidecar.token");
- if let Err(e) = fs::write(&token_file, &local_api_token) {
- append_desktop_log(app, "WARN", &format!("failed to write token file: {e}"));
- } else {
+ let write_token = || -> std::io::Result<()> {
+ let mut opts = std::fs::OpenOptions::new();
+ opts.write(true).create(true).truncate(true);
  #[cfg(unix)]
  {
- use std::os::unix::fs::PermissionsExt;
- let _ = fs::set_permissions(&token_file, fs::Permissions::from_mode(0o600));
+ use std::os::unix::fs::OpenOptionsExt;
+ opts.mode(0o600);
  }
+ let mut file = opts.open(&token_file)?;
+ file.write_all(local_api_token.as_bytes())?;
+ Ok(())
+ };
+ if let Err(e) = write_token() {
+ append_desktop_log(app, "WARN", &format!("failed to write token file: {e}"));
  }
  drop(token_slot);
 
  let mut cmd = Command::new(&node_binary);
+ // Strip dangerous Node runtime env vars inherited from the parent process so
+ // a co-resident attacker who controls the app's environment can't inject
+ // code into the sidecar (which receives the keychain secrets). We do NOT
+ // env_clear() because PATH-based Node resolution still relies on the
+ // inherited environment.
+ cmd.env_remove("NODE_OPTIONS")
+ .env_remove("NODE_PATH")
+ .env_remove("NODE_REPL_EXTERNAL_MODULE")
+ .env_remove("NODE_REPL_HISTORY")
+ .env_remove("NODE_EXTRA_CA_CERTS");
  #[cfg(windows)]
  cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW — hide the node.exe console
  // Sanitize paths for Node.js on Windows: strip \\?\ UNC prefix and set


### PR DESCRIPTION
## Summary

Sidecar process hardening (Security Review Pass 9, P2 findings). All three changes are in `src-tauri/src/main.rs`; no behavior change for normal operation.

1. **Strip dangerous Node env vars before spawn** — `env_remove` for `NODE_OPTIONS`, `NODE_PATH`, `NODE_REPL_EXTERNAL_MODULE`, `NODE_REPL_HISTORY`, `NODE_EXTRA_CA_CERTS` on the sidecar `Command`. A co-resident process that controls the app's environment could otherwise inject code into the sidecar, which receives the injected keychain secrets. PATH is preserved (no `env_clear()`), so Node resolution is unaffected.
2. **Atomic 0600 token file** — `sidecar.token` is now created with `OpenOptions` `create(true).truncate(true)` + `mode(0o600)` so there is no world-readable window between creation and permission hardening. Non-fatal WARN-on-failure behavior preserved.
3. **Debug-gate `LOCAL_API_NODE_BIN`** — the node-binary override is honored only under `#[cfg(debug_assertions)]`. In a release build an attacker-set value could redirect the secret-bearing sidecar to an arbitrary executable.

## Verification

- `cargo check` clean (exit 0) on the rebased tree.
- No TypeScript changes — diff is `src-tauri/src/main.rs` only.

Rebased onto current `origin/main` (picks up the backup-exclusion + notifier-redaction commits; no overlap with these hunks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Cross-agent review: Codex reviewed on 2026-06-14; outcome: issues fixed

---

## Cross-agent review

Cross-agent review: Codex reviewed on 2026-06-14; outcome: issues fixed

**Detail:** Codex (`codex exec review --base origin/main`, gpt-5.5) reviewed commit `c980b5a3` and found **1 × P2** — the atomic `mode(0o600)` only governs newly-created inodes, so a pre-existing `sidecar.token` kept its old permissions on rewrite. Fixed in `db1b7226` by re-asserting `0o600` on the open handle (while truncated/empty, before the secret is written). `cargo check` clean (exit 0).

The confirming re-review of `db1b7226` is **blocked by Codex's usage quota (resets 3:15 AM CDT)**; the fix directly addresses the only finding and compiles cleanly. Arming auto-merge per maintainer direction; see the review-trail comment for the full transcript.
