### PR TITLE
Fix CoreLocation use-after-release + trust-weight situation severity rollup

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1128,6 +1128,8 @@ fn get_native_location_impl() -> Result<(f64, f64), String> {
  fn objc_getClass(name: *const u8) -> *mut c_void;
  fn sel_registerName(name: *const u8) -> *mut c_void;
  fn objc_msgSend(receiver: *mut c_void, sel: *mut c_void, ...) -> *mut c_void;
+ fn objc_retain(obj: *mut c_void) -> *mut c_void;
+ fn objc_release(obj: *mut c_void);
  }
 
  #[repr(C)]
@@ -1157,6 +1159,12 @@ fn get_native_location_impl() -> Result<(f64, f64), String> {
   std::thread::sleep(Duration::from_millis(100));
  }
 
+ // The manager owns `loc`; retain it before releasing the manager so the
+ // coordinate read below is not a use-after-free.
+ if !loc.is_null() {
+  objc_retain(loc);
+ }
+
  let stop = sel_registerName(b"stopUpdatingLocation\0".as_ptr());
  objc_msgSend(mgr, stop);
  let release = sel_registerName(b"release\0".as_ptr());
@@ -1166,10 +1174,12 @@ fn get_native_location_impl() -> Result<(f64, f64), String> {
   return Err("Location not available — ensure Location Services is enabled for Crystal Ball in System Settings".into());
  }
 
- // On ARM64, CLLocationCoordinate2D (16 bytes) is returned in registers
+ // On ARM64, CLLocationCoordinate2D (16 bytes) is returned in registers.
+ // We hold our own retain on `loc`, so this is safe after the manager release.
  let coord_fn: unsafe extern "C" fn(*mut c_void, *mut c_void) -> CLLocationCoordinate2D =
   std::mem::transmute(objc_msgSend as *const ());
  let coord = coord_fn(loc, coord_sel);
+ objc_release(loc);
 
  if coord.latitude == 0.0 && coord.longitude == 0.0 {
   return Err("Location returned 0,0 — GPS may not have a fix yet".into());

--- a/src/services/intelligence/situation-store-v2.ts
+++ b/src/services/intelligence/situation-store-v2.ts
@@ -26,6 +26,8 @@ import { CorrelateEngine, type CorrelatedPair, type EdgeType } from './correlate
 import { builtInCorrelationRules } from './built-in-correlation-rules';
 import { resolve as resolveEntity } from './entity-registry';
 import type { ObservationEvent } from './observation-adapters';
+import { getSourceTrust } from '../source-trust';
+import type { AlertSource } from '../unified-alerts';
 
 // ── Public types ──────────────────────────────────────────────────────
 
@@ -140,18 +142,48 @@ function dedupeStrings(values: readonly string[]): string[] {
 
 // ── Severity + confidence rollups ─────────────────────────────────────
 
+/**
+ * Map an observation adapter's `sourceId` onto the AlertSource trust
+ * vocabulary so the severity rollup can weight by source reliability.
+ * Unmapped sources fall through to getSourceTrust's own default (0.7).
+ */
+const OBSERVATION_SOURCE_TO_ALERT_SOURCE: Record<string, AlertSource> = {
+  'usgs-earthquake': 'earthquake',
+  'nws-alerts': 'nws',
+  'aviation-track': 'aviation-hazard',
+  'ais-disruption': 'maritime',
+  'inciweb-wildfire': 'fire',
+  'swpc-space-weather': 'space-weather',
+};
+
+/** Minimum source trust for a lone CRITICAL observation to escalate a Situation. */
+const CRITICAL_TRUST_FLOOR = 0.7;
+
+function trustForObservation(o: ObservationEvent): number {
+  const mapped = OBSERVATION_SOURCE_TO_ALERT_SOURCE[o.sourceId];
+  return mapped ? getSourceTrust(mapped) : 0.7;
+}
+
 function severityFromObservations(observations: readonly ObservationEvent[]): SituationSeverity {
   if (observations.length === 0) return 'low';
-  let hasCritical = false;
   let hasHigh = false;
   let hasMedium = false;
+  const criticalObs: ObservationEvent[] = [];
   for (const o of observations) {
-    if (o.severity === 'CRITICAL') hasCritical = true;
+    if (o.severity === 'CRITICAL') criticalObs.push(o);
     else if (o.severity === 'HIGH') hasHigh = true;
     else if (o.severity === 'MEDIUM') hasMedium = true;
   }
-  if (hasCritical) return 'critical';
-  if (hasHigh) return 'high';
+  // Source-trust-weighted CRITICAL rollup: a single CRITICAL observation only
+  // escalates the whole Situation when it comes from a high-trust source.
+  // Otherwise require independent corroboration (≥2 CRITICAL observations) so a
+  // lone low-trust feed can't unilaterally drive a Situation to critical.
+  if (criticalObs.length >= 2) return 'critical';
+  if (criticalObs.length === 1 && trustForObservation(criticalObs[0]!) >= CRITICAL_TRUST_FLOOR) {
+    return 'critical';
+  }
+  // A single low-trust CRITICAL (or any HIGH) falls through to 'high'.
+  if (hasHigh || criticalObs.length === 1) return 'high';
   if (hasMedium || observations.length >= 2) return 'medium';
   return 'low';
 }

--- a/src/services/intelligence/situation-store-v2.ts
+++ b/src/services/intelligence/situation-store-v2.ts
@@ -174,16 +174,19 @@ function severityFromObservations(observations: readonly ObservationEvent[]): Si
     else if (o.severity === 'HIGH') hasHigh = true;
     else if (o.severity === 'MEDIUM') hasMedium = true;
   }
-  // Source-trust-weighted CRITICAL rollup: a single CRITICAL observation only
-  // escalates the whole Situation when it comes from a high-trust source.
-  // Otherwise require independent corroboration (≥2 CRITICAL observations) so a
-  // lone low-trust feed can't unilaterally drive a Situation to critical.
-  if (criticalObs.length >= 2) return 'critical';
-  if (criticalObs.length === 1 && trustForObservation(criticalObs[0]!) >= CRITICAL_TRUST_FLOOR) {
+  // Source-trust-weighted CRITICAL rollup. Escalate the whole Situation to
+  // critical only when there is genuine corroboration or a trusted source:
+  //   - ≥2 CRITICAL observations from DISTINCT sources (independent agreement), or
+  //   - any CRITICAL observation from a high-trust source (trust ≥ floor).
+  // Counting observations alone is not enough — a single noisy low-trust feed
+  // can emit multiple CRITICALs, so we key independence on distinct sourceIds.
+  const distinctCriticalSources = new Set(criticalObs.map((o) => o.sourceId));
+  if (distinctCriticalSources.size >= 2) return 'critical';
+  if (criticalObs.some((o) => trustForObservation(o) >= CRITICAL_TRUST_FLOOR)) {
     return 'critical';
   }
-  // A single low-trust CRITICAL (or any HIGH) falls through to 'high'.
-  if (hasHigh || criticalObs.length === 1) return 'high';
+  // Remaining low-trust single-source CRITICALs (or any HIGH) fall through to 'high'.
+  if (hasHigh || criticalObs.length >= 1) return 'high';
   if (hasMedium || observations.length >= 2) return 'medium';
   return 'low';
 }


### PR DESCRIPTION
## Summary

Two security fixes from the latest review passes.

### Fix 1 — CoreLocation use-after-release (`src-tauri/src/main.rs`)
`get_native_location_impl` released the `CLLocationManager` and *then* read the
coordinate off the `CLLocation`. Since the manager owns the location object,
releasing it could deallocate the location first — a use-after-free.

Now: retain the location before releasing the manager, read the coordinate while
holding our own retain, then release the location.

### Fix 2 — Situation severity ignored source trust (`src/services/intelligence/situation-store-v2.ts`)
`severityFromObservations` escalated a whole Situation to `critical` from *any*
single observation marked CRITICAL, regardless of how trustworthy the source was.
A lone low-trust feed could unilaterally drive the situation to critical.

Now escalation to `critical` requires either:
- **≥2 independent CRITICAL observations**, or
- **1 CRITICAL from a source whose trust ≥ 0.7** (mapped onto the existing
  `AlertSource` trust table in `source-trust.ts`).

A lone low-trust CRITICAL now falls through to `high`.

## Verification
- `cargo check` — clean (`Finished dev profile`)
- `tsc --noEmit` — clean, zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Cross-agent review: codex reviewed on 2026-06-14; outcome: issues fixed (1 P2 — count-only critical escalation could be satisfied by a single noisy source; now keyed on distinct sourceIds + high-trust source, addressed in a276ea9e). Re-verification run blocked by Codex usage limit (resets ~03:15); will re-run if requested.
