### PR TITLE
security: validate live-channels URL + add on_navigation guards

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1245,9 +1245,19 @@ fn close_settings_window(app: AppHandle) -> Result<(), String> {
 
 #[tauri::command]
 async fn open_live_channels_window_command(
+ webview: Webview,
  app: AppHandle,
  base_url: Option<String>,
 ) -> Result<(), String> {
+ require_trusted_window(webview.label())?;
+ // The live-channels window loads `base_url` directly. Only permit the local
+ // sidecar origin so a compromised renderer cannot point this trusted window at
+ // an attacker-controlled host. Absent/empty falls through to bundled app content.
+ if let Some(ref origin) = base_url {
+ if !origin.is_empty() && !origin.starts_with("http://127.0.0.1:46123/") {
+ return Err("Refusing live-channels base URL outside the local sidecar origin".to_string());
+ }
+ }
  open_live_channels_window(&app, base_url)
 }
 
@@ -1729,6 +1739,13 @@ async fn fetch_polymarket(webview: Webview, path: String, params: String) -> Res
 }
 
 
+/// Navigation guard for trusted windows. Only same-origin bundled app content
+/// (`tauri://` scheme) or the local sidecar (`127.0.0.1` host) may be loaded;
+/// any attempt to navigate the window to an external origin is blocked.
+fn is_trusted_window_navigation(url: &Url) -> bool {
+ url.scheme() == "tauri" || url.host_str() == Some("127.0.0.1")
+}
+
 fn open_live_channels_window(app: &AppHandle, base_url: Option<String>) -> Result<(), String> {
  if let Some(window) = app.get_webview_window("live-channels") {
  let _ = window.show();
@@ -1754,6 +1771,7 @@ fn open_live_channels_window(app: &AppHandle, base_url: Option<String>) -> Resul
  .inner_size(680.0, 760.0)
  .min_inner_size(520.0, 600.0)
  .resizable(true)
+ .on_navigation(is_trusted_window_navigation)
  .background_color(tauri::webview::Color(26, 28, 30, 255))
  .build()
  .map_err(|e| format!("Failed to create live channels window: {e}"))?;


### PR DESCRIPTION
## Findings addressed

### FINDING 1 (P1) — unvalidated `base_url` into a trusted window
`open_live_channels_window_command` accepted `base_url: Option<String>` and loaded it into the **live-channels** trusted window with no validation. A compromised renderer could point the window at an attacker-controlled origin.

Fix:
- Added `require_trusted_window(webview.label())?` at the start of the command (injected `webview: Webview`), so only `main` / `settings` / `live-channels` may invoke it.
- Reject any non-empty `base_url` that does not start with `http://127.0.0.1:46123/` (the local sidecar origin). Absent/empty still falls through to bundled app content (`WebviewUrl::App`).

### FINDING 2 (P2) — no `on_navigation` guard on the trusted window
Added a navigation guard so the live-channels window can only ever navigate to same-origin bundled content or the local sidecar:

```rust
fn is_trusted_window_navigation(url: &Url) -> bool {
    url.scheme() == "tauri" || url.host_str() == Some("127.0.0.1")
}
```
wired via `.on_navigation(is_trusted_window_navigation)` on the `live-channels` `WebviewWindowBuilder`. Any external navigation is blocked.

**Scope note:** the only `WebviewWindowBuilder` calls in `src-tauri/src/main.rs` are `live-channels` (trusted — now guarded) and `youtube-login` (an intentional external OAuth window, not in `TRUSTED_WINDOWS`, left permissive by design). The `main` window is created from `tauri.conf.json` and `settings` has no builder in the codebase, so there is no builder-level `on_navigation` hook to attach for those without restructuring window creation (out of scope for this focused patch; main is already covered by CSP with no `unsafe-inline` on script-src + devtools disabled in production).

## Verification
- `cargo check --manifest-path src-tauri/Cargo.toml` — clean (exit 0, no warnings).

---

Cross-agent review: Codex review attempted 2026-06-14; hit OpenAI usage limit (resets 3:15 AM CDT) before producing findings; outcome: rate-limited, re-run pending. Auto-merge armed per maintainer pre-authorization.
