### PR TITLE
style(cognition): clear lint errors stranded by PR4 reland merge

### DIFF
--- a/src/services/cognition/operator-model.ts
+++ b/src/services/cognition/operator-model.ts
@@ -133,7 +133,7 @@ const STOPWORDS = new Set<string>([
 // ── Default model ─────────────────────────────────────────────────────────────
 
 function emptyRhythm(): number[] {
-  return new Array<number>(168).fill(1);
+  return Array.from({length: 168}, () => 1);
 }
 
 function defaultModel(): OperatorModel {
@@ -160,7 +160,7 @@ let _ackWindow: number[] = [];
 // ── Persistence ───────────────────────────────────────────────────────────────
 
 function applyLoaded(parsed: Partial<OperatorModel> | null): void {
-  if (!parsed || parsed.version !== 1) return;
+  if (parsed?.version !== 1) return;
   if (Array.isArray(parsed.interests)) _model.interests = parsed.interests;
   if (parsed.domainAffinity && typeof parsed.domainAffinity === 'object') {
     _model.domainAffinity = parsed.domainAffinity;
@@ -268,14 +268,12 @@ function updateAffinity(domain: string, positive: boolean): void {
  * Pin + export + panel-jump → expert signal.
  * Accumulate a running counter per domain; cross thresholds determine level.
  */
-type ExpertiseCounter = { fastDismiss: number; deep: number; total: number };
+interface ExpertiseCounter { fastDismiss: number; deep: number; total: number }
 const _expertiseCounts: Record<string, ExpertiseCounter> = {};
 
 function updateExpertise(domain: string, wentDeep: boolean, fastDismiss: boolean): void {
   if (!domain) return;
-  if (!_expertiseCounts[domain]) {
-    _expertiseCounts[domain] = { fastDismiss: 0, deep: 0, total: 0 };
-  }
+  _expertiseCounts[domain] ??= { fastDismiss: 0, deep: 0, total: 0 };
   const c = _expertiseCounts[domain]!;
   c.total += 1;
   if (wentDeep) c.deep += 1;
@@ -402,9 +400,12 @@ export function preferredDepth(domain: string): DepthPreference {
   ensureLoaded();
   const expertise = _model.expertise[domain] ?? 'familiar';
   switch (expertise) {
-    case 'novice': return 'headline';
-    case 'expert': return 'deep';
-    default: return 'standard';
+    case 'novice': { return 'headline';
+    }
+    case 'expert': { return 'deep';
+    }
+    default: { return 'standard';
+    }
   }
 }
 

--- a/src/services/insights/notification-ladder.ts
+++ b/src/services/insights/notification-ladder.ts
@@ -188,29 +188,8 @@ export function routeBigEventToLadder(
   // guard is the structural guarantee: the safety path physically cannot
   // reach the deferral code.
   if (options.applyAttentionDeferral && !safetyCritical) {
-    const threshold = options.attentionDeferralThreshold ?? 0.3;
-    const currentAttention = attentionWeight(at);
-    if (currentAttention < threshold) {
-      const nextWindow = nextActiveHour(at, threshold);
-      registry.recordEvent(candidateId, {
-        kind: 'urgency_check',
-        reason: `Attention-rhythm deferral: weight ${currentAttention.toFixed(2)} < threshold ${threshold}.${nextWindow ? ` Next active window: ${new Date(nextWindow).toISOString()}.` : ' No active window found in 24h — dispatching now.'}`,
-        detail: { currentAttention, threshold, nextWindow },
-      });
-      if (nextWindow !== undefined) {
-        // Defer: record as silent now; host is responsible for re-routing at nextWindow.
-        registry.suppress(candidateId, 'quiet-hours-no-bypass', at);
-        return {
-          candidateId,
-          rung: 'silent',
-          dispatched: false,
-          reason: `Deferred — low attention weight (${currentAttention.toFixed(2)}). Next active window: ${new Date(nextWindow).toISOString()}.`,
-          unsafeSuppression: false,
-          deferredUntil: nextWindow,
-        };
-      }
-      // If no active window in 24h, fall through and dispatch now.
-    }
+    const deferral = maybeDeferForAttention(registry, candidateId, options, at);
+    if (deferral) return deferral;
   }
 
   const rung = pickRung(result.deliveryPriority, safetyCritical);
@@ -222,6 +201,43 @@ export function routeBigEventToLadder(
     reason: `Dispatched at rung "${rung}" (priority ${result.deliveryPriority}).`,
     unsafeSuppression: false,
     explanation: options.explanation,
+  };
+}
+
+/** Attention-rhythm deferral for non-safety-critical events. Returns a silent
+ *  decision when the current attention weight is below threshold and a later
+ *  active window exists; returns null to let the caller dispatch now. */
+function maybeDeferForAttention(
+  registry: NotificationTraceRegistry,
+  candidateId: string,
+  options: RouteToLadderOptions,
+  at: number,
+): LadderDecision | null {
+  const threshold = options.attentionDeferralThreshold ?? 0.3;
+  const currentAttention = attentionWeight(at);
+  if (currentAttention >= threshold) return null;
+
+  const nextWindow = nextActiveHour(at, threshold);
+  const windowNote = nextWindow
+    ? ` Next active window: ${new Date(nextWindow).toISOString()}.`
+    : ' No active window found in 24h — dispatching now.';
+  registry.recordEvent(candidateId, {
+    kind: 'urgency_check',
+    reason: `Attention-rhythm deferral: weight ${currentAttention.toFixed(2)} < threshold ${threshold}.${windowNote}`,
+    detail: { currentAttention, threshold, nextWindow },
+  });
+
+  if (nextWindow === undefined) return null; // No active window in 24h — dispatch now.
+
+  // Defer: record as silent now; host is responsible for re-routing at nextWindow.
+  registry.suppress(candidateId, 'quiet-hours-no-bypass', at);
+  return {
+    candidateId,
+    rung: 'silent',
+    dispatched: false,
+    reason: `Deferred — low attention weight (${currentAttention.toFixed(2)}). Next active window: ${new Date(nextWindow).toISOString()}.`,
+    unsafeSuppression: false,
+    deferredUntil: nextWindow,
   };
 }
 


### PR DESCRIPTION
## Why

PR #1176 (PR4 operator-model reland) auto-merged before its ESLint cleanup push landed (the auto-merge fired on the pre-lint commit). The merged code is functional and typechecks, but two files carry the 9 ESLint errors CI flagged on #1176. They lie dormant in `main` (lint:ci only checks a PR's changed files) but would block the next PR that touches them.

## What

- `operator-model.ts` — `??=` over if-assign; `Array.from({length:168}, () => 1)` (typed `number[]`); switch-case braces; optional chain.
- `notification-ladder.ts` — extract `maybeDeferForAttention` helper to drop `routeBigEventToLadder` cognitive complexity 16→below limit and remove the nested template literal.

Behavior-preserving: notification-ladder (7/7, incl. safety-override + impossible-suppression guards) and operator-model tests pass; `tsc` 0 errors.

Cross-agent review: CodeRabbit reviewed on 2026-06-14; outcome: approved — mechanical lint-only delta, behavior verified by passing tests (the substantive logic was already reviewed on #1176).