### PR TITLE
fix(lint): wrap ShadowFleetPanel map callbacks in arrow fns

### DIFF
--- a/src/components/ShadowFleetPanel.ts
+++ b/src/components/ShadowFleetPanel.ts
@@ -162,7 +162,7 @@ export class ShadowFleetPanel extends Panel {
           <th style="padding:4px 6px;text-align:right;">Capacity</th>
           <th style="padding:4px 6px;">Flag States</th>
         </tr></thead>
-        <tbody>${data.stats.map(statRow).join('')}</tbody>
+        <tbody>${data.stats.map((s) => statRow(s)).join('')}</tbody>
       </table>
     </div>`;
 
@@ -179,7 +179,7 @@ export class ShadowFleetPanel extends Panel {
           <th style="padding:4px 6px;text-align:right;">Det.</th>
           <th style="padding:4px 6px;text-align:right;">Risk</th>
         </tr></thead>
-        <tbody>${sortedVessels.map(vesselRow).join('')}</tbody>
+        <tbody>${sortedVessels.map((v) => vesselRow(v)).join('')}</tbody>
       </table>
     </div>`;
 


### PR DESCRIPTION
## Summary

Two `unicorn/no-array-callback-reference` ESLint errors in `src/components/ShadowFleetPanel.ts` merged onto `main` via #1071 (ESLint is a non-required check, so they landed). `npm run lint:ci` only lints files changed vs the base ref, so they don't fail CI today — but the next PR that touches this file would fail the ESLint gate.

- L165: `${data.stats.map(statRow).join('')}` → `${data.stats.map((s) => statRow(s)).join('')}`
- L182: `${sortedVessels.map(vesselRow).join('')}` → `${sortedVessels.map((v) => vesselRow(v)).join('')}`

## Verification

`npx eslint src/components/ShadowFleetPanel.ts` → 0 errors (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Cross-agent review: Codex reviewed on 2026-06-14; outcome: pass

**Detail:** Codex (`codex exec review --base origin/main`, gpt-5.5) reviewed the diff and found no introduced correctness issues — the change only wraps the existing row renderer callbacks in arrow functions without changing behavior.
