### PR TITLE
fix(survival): Codex review fixes for Storm Posture engine (follow-up to #1183)

### DIFF
--- a/docs/superpowers/plans/2026-06-14-storm-posture-engine-core.md
+++ b/docs/superpowers/plans/2026-06-14-storm-posture-engine-core.md
@@ -46,6 +46,7 @@ Tests live in `src/services/survival/__tests__/<name>.test.mts`.
 ## Task 1: Shared contract — `survival-types.ts`
 
 **Files:**
+
 - Create: `src/services/survival/survival-types.ts`
 - Test: `src/services/survival/__tests__/survival-types.test.mts`
 
@@ -268,6 +269,7 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 ## Task 2: Threat projection — `threat-projection.ts`
 
 **Files:**
+
 - Create: `src/services/survival/threat-projection.ts`
 - Test: `src/services/survival/__tests__/threat-projection.test.mts`
 
@@ -397,6 +399,7 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 ## Task 3: Posture engine — `survival-posture.ts`
 
 **Files:**
+
 - Create: `src/services/survival/survival-posture.ts`
 - Test: `src/services/survival/__tests__/survival-posture.test.mts`
 
@@ -572,6 +575,7 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 ## Task 4: Moves + effect modeling — `survival-moves.ts`
 
 **Files:**
+
 - Create: `src/services/survival/survival-moves.ts`
 - Test: `src/services/survival/__tests__/survival-moves.test.mts`
 
@@ -707,6 +711,7 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 ## Task 5: Plan + the commit→improve loop — `survival-plan.ts`
 
 **Files:**
+
 - Create: `src/services/survival/survival-plan.ts`
 - Test: `src/services/survival/__tests__/survival-plan.test.mts`
 
@@ -848,6 +853,7 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 ## Task 6: Snapshot spine + grid-down projection — `world-snapshot.ts`
 
 **Files:**
+
 - Create: `src/services/survival/world-snapshot.ts`
 - Test: `src/services/survival/__tests__/world-snapshot.test.mts`
 
@@ -1010,6 +1016,7 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 ## Task 7: End-to-end loop proof + test script + typecheck
 
 **Files:**
+
 - Create: `src/services/survival/__tests__/survival-loop.test.mts`
 - Modify: `package.json` (add `test:survival` script next to the other `test:*` scripts)
 
@@ -1089,6 +1096,7 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 ## Self-Review (completed by plan author)
 
 **Spec coverage (Part III engine pieces):**
+
 - World Snapshot (Layer 0 spine) → Task 6. ✓
 - Threat projection (Layer 1) → Task 2. ✓
 - Survival posture, multi-axis, explainable (Layer 3) → Task 3. ✓

--- a/docs/superpowers/specs/2026-06-14-grand-strategy-survival-os-design.md
+++ b/docs/superpowers/specs/2026-06-14-grand-strategy-survival-os-design.md
@@ -125,6 +125,7 @@ does, how you use it, what it depends on.*
 1. **`world-snapshot.ts`** (pure)
    - *Does:* defines the on-device save-file and pure build/serialize/project fns.
    - *Interface:*
+
      ```ts
      interface WorldSnapshot {
        version: number;            // schema version for migration
@@ -140,6 +141,7 @@ does, how you use it, what it depends on.*
      deserializeSnapshot(json): WorldSnapshot;
      projectView(s): StormPostureViewModel;  // pure projection the UI renders
      ```
+
    - *Depends on:* the type modules only. **No IDB/DOM here.**
 
 2. **`snapshot-store.ts`** (adapter — IDB/DOM allowed)
@@ -150,6 +152,7 @@ does, how you use it, what it depends on.*
 3. **`survival-posture.ts`** (pure)
    - *Does:* defines the posture model and computes it from a snapshot.
    - *Interface:*
+
      ```ts
      type Axis = 'physical_safety' | 'supply' | 'financial' | 'mobility'
                | 'comms' | 'health' | 'energy_water' | 'security';
@@ -165,6 +168,7 @@ does, how you use it, what it depends on.*
      interface SurvivalPosture { axes: AxisState[]; overall: AxisState; capturedAt: string }
      computePosture(s: WorldSnapshot): SurvivalPosture;
      ```
+
    - *E1 scope:* `physical_safety` computed fully from weather threats; the other
      seven axes present-but-flat (so the multi-axis UI is real but only one axis
      moves). This makes E2 generalization a fill-in, not a rebuild.
@@ -172,6 +176,7 @@ does, how you use it, what it depends on.*
 4. **`threat-projection.ts`** (pure)
    - *Does:* turns a matched weather alert into posture threats.
    - *Interface:*
+
      ```ts
      interface PostureThreat {
        sourceEventId: string;
@@ -184,11 +189,13 @@ does, how you use it, what it depends on.*
      }
      projectWeatherThreats(matched: PolygonMatchResult[], places: SavedPlace[]): PostureThreat[];
      ```
+
    - *Depends on:* `nws-polygon-match`, `weather-urgency`, `personal-storm-mode`.
 
 5. **`survival-moves.ts`** (pure)
    - *Does:* the move library + effect modeling.
    - *Interface:*
+
      ```ts
      interface SurvivalMove {
        id: string;
@@ -203,6 +210,7 @@ does, how you use it, what it depends on.*
      availableMoves(p: SurvivalPosture, s: WorldSnapshot): SurvivalMove[];
      projectMoveEffect(m: SurvivalMove, p: SurvivalPosture): PostureDelta[];
      ```
+
    - *E1 scope:* storm-relevant moves only (shelter-in-place, evacuate via route,
      secure property, charge devices / fill water / fuel up, pre-position go-bag),
      seeded from `storm-preparedness` + `action-cards`.

--- a/src/services/survival/__tests__/survival-plan.test.mts
+++ b/src/services/survival/__tests__/survival-plan.test.mts
@@ -2,7 +2,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { emptyPlan, commitMove, moveStatus, applyPlanToPosture } from '../survival-plan.ts';
-import type { SurvivalMove, SurvivalPosture, AxisState } from '../survival-types.ts';
+import type { SurvivalMove, SurvivalPlan, SurvivalPosture, AxisState } from '../survival-types.ts';
 
 const NOW = 1_700_000_000_000;
 
@@ -45,4 +45,14 @@ test('applyPlanToPosture lowers the affected axis level and marks it improving',
   assert.equal(phys.trend, 'improving');
   assert.equal(improved.overallLevel, 60);
   assert.ok(improved.headline.includes('high'), 'headline should reflect the new (improved) band');
+  assert.equal(phys.confidence.total, 60);
+  assert.equal(phys.confidence.total, phys.confidence.items.reduce((s, i) => s + i.value, 0));
+  assert.ok(phys.explanation.headline.includes('high'));
+});
+
+test('applyPlanToPosture ignores skipped moves', () => {
+  const posture = postureWithPhysical(90);
+  const plan: SurvivalPlan = { committed: [{ moveId: 'move-shelter', committedAtMs: NOW, status: 'skipped' }] };
+  const result = applyPlanToPosture(posture, plan, [SHELTER]);
+  assert.equal(result.axes.find((a) => a.axis === 'physical_safety')!.level, 90);
 });

--- a/src/services/survival/__tests__/world-snapshot.test.mts
+++ b/src/services/survival/__tests__/world-snapshot.test.mts
@@ -31,6 +31,7 @@ test('GRID-DOWN: serialize -> deserialize -> project yields full posture with no
   assert.equal(view.posture.worstAxis, 'physical_safety');
   assert.equal(view.isStale, true); // 3h old > 15min threshold
   assert.ok(view.weatherAgeMs >= 3 * 3_600_000);
+  assert.equal(view.worstAxisLabel, 'Physical safety');
 });
 
 test('recomputing posture from the deserialized snapshot equals the stored posture', () => {

--- a/src/services/survival/__tests__/world-snapshot.test.mts
+++ b/src/services/survival/__tests__/world-snapshot.test.mts
@@ -3,6 +3,8 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { buildSnapshot, serializeSnapshot, deserializeSnapshot, projectView, SNAPSHOT_VERSION } from '../world-snapshot.ts';
 import { computePosture } from '../survival-posture.ts';
+import { availableMoves } from '../survival-moves.ts';
+import { commitMove, emptyPlan } from '../survival-plan.ts';
 import type { NwsAlertMinimal, AlertPolygon, SavedPlace } from '../../weather/weather-threat-types.ts';
 
 const NOW = 1_700_000_000_000;
@@ -32,6 +34,7 @@ test('GRID-DOWN: serialize -> deserialize -> project yields full posture with no
   assert.equal(view.isStale, true); // 3h old > 15min threshold
   assert.ok(view.weatherAgeMs >= 3 * 3_600_000);
   assert.equal(view.worstAxisLabel, 'Physical safety');
+  assert.ok(view.posture.staleInputs.some((s) => s.includes('weather')), 'projected stale snapshot must surface stale weather input');
 });
 
 test('recomputing posture from the deserialized snapshot equals the stored posture', () => {
@@ -44,4 +47,13 @@ test('recomputing posture from the deserialized snapshot equals the stored postu
 
 test('deserialize rejects an unknown version', () => {
   assert.throws(() => deserializeSnapshot(JSON.stringify({ version: 999 })), /Unsupported snapshot version/);
+});
+
+test('buildSnapshot applies a committed plan so the persisted posture is mitigated', () => {
+  const base = buildSnapshot({ weatherAlerts: ALERTS, savedPlaces: [HOME], weatherFetchedAtMs: NOW - 60_000 }, { now: NOW });
+  const moves = availableMoves(base.posture, base, { now: NOW });
+  assert.ok(moves.length >= 2);
+  const plan = commitMove(commitMove(emptyPlan(), moves[0]!, NOW), moves[1]!, NOW);
+  const withPlan = buildSnapshot({ weatherAlerts: ALERTS, savedPlaces: [HOME], weatherFetchedAtMs: NOW - 60_000, plan }, { now: NOW });
+  assert.ok(withPlan.posture.overallLevel < base.posture.overallLevel, 'committed plan should lower the persisted posture');
 });

--- a/src/services/survival/survival-plan.ts
+++ b/src/services/survival/survival-plan.ts
@@ -2,7 +2,7 @@
 import type {
   AxisState, CommittedMove, SurvivalAxis, SurvivalMove, SurvivalPlan, SurvivalPosture,
 } from './survival-types.ts';
-import { bandForLevel, buildHeadline } from './survival-types.ts';
+import { axisLabel, bandForLevel, buildHeadline } from './survival-types.ts';
 
 export function emptyPlan(): SurvivalPlan {
   return { committed: [] };
@@ -26,6 +26,7 @@ export function applyPlanToPosture(
 ): SurvivalPosture {
   const deltaByAxis = new Map<SurvivalAxis, number>();
   for (const c of plan.committed) {
+    if (c.status === 'skipped') continue;
     const move = moves.find((m) => m.id === c.moveId);
     if (!move) continue;
     for (const d of move.effect) {
@@ -37,12 +38,19 @@ export function applyPlanToPosture(
     const delta = deltaByAxis.get(a.axis) ?? 0;
     if (delta === 0) return a;
     const level = Math.max(0, Math.min(100, a.level + delta));
+    const band = bandForLevel(level);
     return {
       ...a,
       level,
-      band: bandForLevel(level),
+      band,
       trend: level < a.level ? 'improving' : a.trend,
       drivers: [...a.drivers, `Planned moves change exposure by ${delta}`],
+      confidence: {
+        total: level,
+        max: 100,
+        items: [{ label: a.threats[0]?.hazardLabel ?? 'Mitigated exposure', value: level, max: 100, polarity: 'negative' as const }],
+      },
+      explanation: { ...a.explanation, headline: `${axisLabel(a.axis)}: ${band}` },
     };
   });
 

--- a/src/services/survival/world-snapshot.ts
+++ b/src/services/survival/world-snapshot.ts
@@ -1,6 +1,7 @@
 // src/services/survival/world-snapshot.ts
 import type { NwsAlertMinimal, SavedPlace } from '../weather/weather-threat-types.ts';
 import type { DomainFreshness, SurvivalPlan, SurvivalPosture, WorldSnapshot } from './survival-types.ts';
+import { axisLabel } from './survival-types.ts';
 import { emptyPlan } from './survival-plan.ts';
 import { computePosture } from './survival-posture.ts';
 
@@ -74,6 +75,6 @@ export function projectView(snapshot: WorldSnapshot, options: { now?: number } =
     posture: snapshot.posture,
     weatherAgeMs,
     isStale: weather ? weatherAgeMs > DEFAULT_STALE_AFTER_MS : true,
-    worstAxisLabel: snapshot.posture.worstAxis,
+    worstAxisLabel: axisLabel(snapshot.posture.worstAxis),
   };
 }

--- a/src/services/survival/world-snapshot.ts
+++ b/src/services/survival/world-snapshot.ts
@@ -3,7 +3,9 @@ import type { NwsAlertMinimal, SavedPlace } from '../weather/weather-threat-type
 import type { DomainFreshness, SurvivalPlan, SurvivalPosture, WorldSnapshot } from './survival-types.ts';
 import { axisLabel } from './survival-types.ts';
 import { emptyPlan } from './survival-plan.ts';
+import { applyPlanToPosture } from './survival-plan.ts';
 import { computePosture } from './survival-posture.ts';
+import { availableMoves } from './survival-moves.ts';
 
 export const SNAPSHOT_VERSION = 1;
 const DEFAULT_STALE_AFTER_MS = 15 * 60_000;
@@ -33,17 +35,23 @@ export function buildSnapshot(inputs: SnapshotInputs, options: SnapshotOptions =
 
   const weatherAlerts = [...inputs.weatherAlerts];
   const savedPlaces = [...inputs.savedPlaces];
-  const posture: SurvivalPosture = computePosture({ weatherAlerts, savedPlaces, freshness, capturedAtMs: now }, { now });
-
-  return {
+  const basePosture: SurvivalPosture = computePosture({ weatherAlerts, savedPlaces, freshness, capturedAtMs: now }, { now });
+  const plan = inputs.plan ?? emptyPlan();
+  const baseSnapshot: WorldSnapshot = {
     version: SNAPSHOT_VERSION,
     capturedAtMs: now,
     freshness,
     weatherAlerts,
     savedPlaces,
-    posture,
-    plan: inputs.plan ?? emptyPlan(),
+    posture: basePosture,
+    plan,
   };
+
+  if (plan.committed.length === 0) return baseSnapshot;
+
+  const moves = availableMoves(basePosture, baseSnapshot, { now });
+  const posture = applyPlanToPosture(basePosture, plan, moves);
+  return { ...baseSnapshot, posture };
 }
 
 export function serializeSnapshot(snapshot: WorldSnapshot): string {
@@ -71,10 +79,17 @@ export function projectView(snapshot: WorldSnapshot, options: { now?: number } =
   const now = options.now ?? snapshot.capturedAtMs;
   const weather = snapshot.freshness.find((f) => f.domain === 'weather');
   const weatherAgeMs = weather ? now - weather.fetchedAtMs : 0;
+  const isStale = weather ? weatherAgeMs > DEFAULT_STALE_AFTER_MS : true;
+
+  const staleNote = `weather feed stale (${Math.round(weatherAgeMs / 60_000)} min old)`;
+  const posture = isStale && !snapshot.posture.staleInputs.some((s) => s.includes('weather'))
+    ? { ...snapshot.posture, staleInputs: [...snapshot.posture.staleInputs, staleNote] }
+    : snapshot.posture;
+
   return {
-    posture: snapshot.posture,
+    posture,
     weatherAgeMs,
-    isStale: weather ? weatherAgeMs > DEFAULT_STALE_AFTER_MS : true,
+    isStale,
     worstAxisLabel: axisLabel(snapshot.posture.worstAxis),
   };
 }


### PR DESCRIPTION
Follow-up to #1183, which auto-merged at an earlier head before these review fixes landed (auto-merge race). Ships the stragglers.

## What

Codex cross-agent review of the survival engine core found 5 correctness/consistency issues; this lands the fixes that didn't make the #1183 merge:

- **Ignore `skipped` moves** in `applyPlanToPosture` (a skipped action no longer improves posture).
- **Resync adjusted-axis scoring**: after a plan lowers an axis, recompute its `confidence` + `explanation.headline` so a critical→high axis no longer exposes stale critical scoring (`total === sum(items.value)` preserved).
- **Humanize `worstAxisLabel`** in `projectView` (`axisLabel()` instead of the raw `physical_safety` enum).
- **Persist plan mitigation**: `buildSnapshot` now applies a committed plan so the saved posture reflects committed moves (the loop persists).
- **Surface staleness on the grid-down path**: `projectView` injects a stale-weather note into the returned `posture.staleInputs` when projecting an offline snapshot past the threshold.
- Markdown formatting fixes for the spec + plan docs (CI static-lint).

## Test plan
- [x] `npm run test:survival` — 25 deterministic tests pass (new tests lock each fix)
- [x] `npm run typecheck:all` — 0 errors

Cross-agent review: Codex reviewed on 2026-06-14; outcome: pass.
(Re-reviewed the follow-up diff — no actionable correctness issues; the Date.now default param matches the existing datacenter/weather pure-service idiom, determinism preserved via injected `now`.)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>