### PR TITLE
fix(security): close sidecar auth bypass + OAuth token injection; repair hung routes

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -16378,17 +16378,27 @@ export async function createLocalApiServer(options = {}) {
  // before dispatch()'s global auth gate, so they were reachable without a
  // LOCAL_API_TOKEN — an unauthenticated local caller could read and mutate
  // sidecar state (POST situations/entities/rules, DELETE rules/watchboards).
- // Gate them here. OPTIONS preflight carries no auth header, and the few
- // intentionally-public routes served pre-auth by dispatch() (iframe embed,
- // service status, Patreon authorize-url, SMS webhook) must fall through.
+ // Gate them here. The few intentionally-public routes served pre-auth by
+ // dispatch() (iframe embed, service status, Patreon authorize-url, SMS
+ // webhook) must fall through.
  const PUBLIC_API_ROUTES = new Set([
  '/api/service-status',
  '/api/youtube-embed',
  '/api/patreon/authorize-url',
  '/api/sms/command',
  ]);
- if (req.method !== 'OPTIONS'
- && !PUBLIC_API_ROUTES.has(requestUrl.pathname)
+ // Answer CORS preflight for every inline /api/ route here. Preflight
+ // (OPTIONS) carries no Authorization header, and the inline handlers below
+ // only branch on GET/POST/PUT/DELETE — merely exempting OPTIONS from the
+ // auth check would let it fall through to a 405/401 (or, before sendJson,
+ // a hung request), so the real request's preflight would never succeed.
+ // Mirrors the /gps/nmea handler above and dispatch()'s OPTIONS handler.
+ if (req.method === 'OPTIONS') {
+ res.writeHead(204, makeCorsHeaders(req));
+ res.end();
+ return;
+ }
+ if (!PUBLIC_API_ROUTES.has(requestUrl.pathname)
  && !isValidToken(req.headers['authorization'] || '')) {
  warnUnauthorizedOnce(context, requestUrl.pathname);
  res.writeHead(401, { 'content-type': 'application/json', ...makeCorsHeaders(req) });

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -16302,6 +16302,16 @@ export async function createLocalApiServer(options = {}) {
  if (aliasTarget) requestUrl.pathname = aliasTarget;
  const reqStartedAt = Date.now();
 
+ // Inline routes below write directly to `res`. The module-level json()
+ // helper returns a Response object, which dispatch() converts to `res` at
+ // the end of this callback — but an inline `return json(...)` here just
+ // discards that Response and hangs the request. Use sendJson() for inline
+ // routes so they always flush.
+ const sendJson = (data, status = 200) => {
+ res.writeHead(status, { 'content-type': 'application/json', ...makeCorsHeaders(req) });
+ res.end(JSON.stringify(data));
+ };
+
  if (requestUrl.pathname === '/gps/nmea') {
  // CORS preflight carries no Authorization header, so answer it before the
  // auth gate — otherwise the browser preflight 401s and the real GET (which
@@ -16362,15 +16372,39 @@ export async function createLocalApiServer(options = {}) {
  return;
  }
 
+ // ── Shared auth gate for inline /api/ routes ──────────────────────────
+ // The inline handlers below (feeds health, diagnostics self-test, the
+ // intelligence mirror, command-center, timeline, watchboards) return
+ // before dispatch()'s global auth gate, so they were reachable without a
+ // LOCAL_API_TOKEN — an unauthenticated local caller could read and mutate
+ // sidecar state (POST situations/entities/rules, DELETE rules/watchboards).
+ // Gate them here. OPTIONS preflight carries no auth header, and the few
+ // intentionally-public routes served pre-auth by dispatch() (iframe embed,
+ // service status, Patreon authorize-url, SMS webhook) must fall through.
+ const PUBLIC_API_ROUTES = new Set([
+ '/api/service-status',
+ '/api/youtube-embed',
+ '/api/patreon/authorize-url',
+ '/api/sms/command',
+ ]);
+ if (req.method !== 'OPTIONS'
+ && !PUBLIC_API_ROUTES.has(requestUrl.pathname)
+ && !isValidToken(req.headers['authorization'] || '')) {
+ warnUnauthorizedOnce(context, requestUrl.pathname);
+ res.writeHead(401, { 'content-type': 'application/json', ...makeCorsHeaders(req) });
+ res.end(JSON.stringify({ error: 'Unauthorized' }));
+ return;
+ }
+
  // ── /api/feeds/health — per-feed resilience status ────────────────────
  if (requestUrl.pathname === '/api/feeds/health') {
-   return json({ feeds: getAllFeedStatuses(), asOf: new Date().toISOString() });
+   return sendJson({ feeds: getAllFeedStatuses(), asOf: new Date().toISOString() });
  }
 
  if (requestUrl.pathname.startsWith('/api/feeds/health/')) {
    const feedId = requestUrl.pathname.slice('/api/feeds/health/'.length);
-   if (!feedId || !/^[\w\-.:]+$/.test(feedId)) return json({ error: 'invalid feedId' }, 400);
-   return json(getFeedStatus(feedId));
+   if (!feedId || !/^[\w\-.:]+$/.test(feedId)) return sendJson({ error: 'invalid feedId' }, 400);
+   return sendJson(getFeedStatus(feedId));
  }
 
  // ── /api/health — lightweight liveness probe ──────────────────────
@@ -16668,16 +16702,16 @@ export async function createLocalApiServer(options = {}) {
   // ── /api/watchboards — geofenced standing queries (tripwires) ─────
   if (requestUrl.pathname === '/api/watchboards' || requestUrl.pathname === '/api/watchboards/') {
     if (req.method === 'GET') {
-      return json({ watchboards: getWatchboards() }, 200, makeCorsHeaders(req));
+      return sendJson({ watchboards: getWatchboards() });
     }
     if (req.method === 'POST') {
       const raw = await readBody(req);
       const body = raw ? JSON.parse(raw.toString()) : null;
-      if (!body || typeof body !== 'object') return json({ error: 'invalid body' }, 400, makeCorsHeaders(req));
+      if (!body || typeof body !== 'object') return sendJson({ error: 'invalid body' }, 400);
       const created = createWatchboard(body);
-      return json({ watchboard: created }, 201, makeCorsHeaders(req));
+      return sendJson({ watchboard: created }, 201);
     }
-    return json({ error: 'Method not allowed' }, 405, makeCorsHeaders(req));
+    return sendJson({ error: 'Method not allowed' }, 405);
   }
 
   const wbIdMatch = requestUrl.pathname.match(/^\/api\/watchboards\/([^/]+)$/);
@@ -16685,25 +16719,25 @@ export async function createLocalApiServer(options = {}) {
     const wbId = wbIdMatch[1];
     if (wbId === 'firings' && req.method === 'GET') {
       const limit = Math.min(Number(requestUrl.searchParams.get('limit') || '50'), 200);
-      return json({ firings: getRecentFirings(limit) }, 200, makeCorsHeaders(req));
+      return sendJson({ firings: getRecentFirings(limit) });
     }
     if (wbId === 'templates' && req.method === 'GET') {
-      return json({ templates: getWatchboardTemplates() }, 200, makeCorsHeaders(req));
+      return sendJson({ templates: getWatchboardTemplates() });
     }
     if (req.method === 'PUT') {
       const raw = await readBody(req);
       const body = raw ? JSON.parse(raw.toString()) : null;
-      if (!body || typeof body !== 'object') return json({ error: 'invalid body' }, 400, makeCorsHeaders(req));
+      if (!body || typeof body !== 'object') return sendJson({ error: 'invalid body' }, 400);
       const updated = updateWatchboard(wbId, body);
-      if (!updated) return json({ error: 'not found' }, 404, makeCorsHeaders(req));
-      return json({ watchboard: updated }, 200, makeCorsHeaders(req));
+      if (!updated) return sendJson({ error: 'not found' }, 404);
+      return sendJson({ watchboard: updated });
     }
     if (req.method === 'DELETE') {
       const deleted = deleteWatchboard(wbId);
-      if (!deleted) return json({ error: 'not found' }, 404, makeCorsHeaders(req));
-      return json({ ok: true }, 200, makeCorsHeaders(req));
+      if (!deleted) return sendJson({ error: 'not found' }, 404);
+      return sendJson({ ok: true });
     }
-    return json({ error: 'Method not allowed' }, 405, makeCorsHeaders(req));
+    return sendJson({ error: 'Method not allowed' }, 405);
   }
 
  // ── /api/diag — full diagnostics snapshot for bug reports ─────────

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -615,9 +615,16 @@ test('inline /api routes: gated route requires auth, public route does not', asy
  const authedBody = await authed.json();
  assert.ok(Array.isArray(authedBody.feeds));
 
- // Allowlisted public route stays reachable without auth.
- const pub = await fetch(`http://127.0.0.1:${port}/api/service-status`);
- assert.notEqual(pub.status, 401);
+ // Every allowlisted public route stays reachable without auth (a non-401
+ // status — 200/400/405 are all fine; the point is the gate doesn't 401 them).
+ for (const route of ['/api/service-status', '/api/youtube-embed', '/api/patreon/authorize-url']) {
+ const pub = await fetch(`http://127.0.0.1:${port}${route}`);
+ assert.notEqual(pub.status, 401, `${route} should not be auth-gated`);
+ }
+
+ // /api/health is NOT on the allowlist and keeps its own token check.
+ const healthUnauth = await fetch(`http://127.0.0.1:${port}/api/health`);
+ assert.equal(healthUnauth.status, 401, '/api/health must stay gated');
   } finally {
  process.env.LOCAL_API_TOKEN = originalToken;
  await app.close();

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -566,6 +566,65 @@ test('responds to OPTIONS preflight with CORS headers', async () => {
   }
 });
 
+test('inline /api routes: OPTIONS preflight returns 204 (not 401/405)', async () => {
+  // Regression: the inline-route auth preamble must answer CORS preflight
+  // before the route handlers, otherwise an authenticated cross-origin GET to
+  // an inline route (e.g. /api/feeds/health) fails because its preflight 401s
+  // or 405s and the browser never sends the real request.
+  const localApi = await setupApiDir({});
+  const app = await createLocalApiServer({
+ port: 0,
+ apiDir: localApi.apiDir,
+ logger: { log() {}, warn() {}, error() {} },
+  });
+  const { port } = await app.start();
+  try {
+ for (const route of ['/api/feeds/health', '/api/watchboards']) {
+ const response = await fetch(`http://127.0.0.1:${port}${route}`, { method: 'OPTIONS' });
+ assert.equal(response.status, 204, `${route} OPTIONS should be 204`);
+ assert.ok(response.headers.get('access-control-allow-methods'), `${route} OPTIONS should carry CORS headers`);
+ }
+  } finally {
+ await app.close();
+ await localApi.cleanup();
+  }
+});
+
+test('inline /api routes: gated route requires auth, public route does not', async () => {
+  const localApi = await setupApiDir({});
+  const originalToken = process.env.LOCAL_API_TOKEN;
+  process.env.LOCAL_API_TOKEN = 'secret-inline-token';
+  const app = await createLocalApiServer({
+ port: 0,
+ apiDir: localApi.apiDir,
+ logger: { log() {}, warn() {}, error() {} },
+  });
+  const { port } = await app.start();
+  try {
+ // Gated inline route without auth → 401.
+ const unauth = await fetch(`http://127.0.0.1:${port}/api/feeds/health`);
+ assert.equal(unauth.status, 401);
+ const unauthBody = await unauth.json();
+ assert.equal(unauthBody.error, 'Unauthorized');
+
+ // Same route with the token → reachable.
+ const authed = await fetch(`http://127.0.0.1:${port}/api/feeds/health`, {
+ headers: { Authorization: 'Bearer secret-inline-token' },
+ });
+ assert.equal(authed.status, 200);
+ const authedBody = await authed.json();
+ assert.ok(Array.isArray(authedBody.feeds));
+
+ // Allowlisted public route stays reachable without auth.
+ const pub = await fetch(`http://127.0.0.1:${port}/api/service-status`);
+ assert.notEqual(pub.status, 401);
+  } finally {
+ process.env.LOCAL_API_TOKEN = originalToken;
+ await app.close();
+ await localApi.cleanup();
+  }
+});
+
 test('preserves Origin in Vary when gzip compression is applied', async () => {
   const localApi = await setupApiDir({
  'large.js': `

--- a/src/components/S2UndergroundPanel.ts
+++ b/src/components/S2UndergroundPanel.ts
@@ -17,6 +17,7 @@ const REFRESH_MS = 30 * 60 * 1000;
 export class S2UndergroundPanel extends Panel {
   private refreshTimer: ReturnType<typeof setInterval> | null = null;
   private activeVideoId: string | null = null;
+  private oauthWindow: Window | null = null;
 
   constructor() {
     super({
@@ -134,7 +135,7 @@ export class S2UndergroundPanel extends Panel {
         return;
       }
       window.addEventListener('message', this.onOAuthMessage);
-      window.open(j.url, 'patreon-oauth', 'width=600,height=800');
+      this.oauthWindow = window.open(j.url, 'patreon-oauth', 'width=600,height=800');
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       this.setContent(`<div style="padding:12px;font-size:12px;color:#f44336">Could not start Patreon connect: ${msg}</div>`);
@@ -142,9 +143,16 @@ export class S2UndergroundPanel extends Panel {
   }
 
   private readonly onOAuthMessage = (ev: MessageEvent): void => {
+    // Only trust the OAuth callback served by our own sidecar, and only the
+    // popup window we opened. Without these checks any page/frame able to
+    // postMessage to this window could inject an attacker-controlled
+    // access_token that we'd persist to the keychain.
+    if (ev.origin !== `http://127.0.0.1:${getLocalApiPort()}`) return;
+    if (ev.source !== this.oauthWindow) return;
     const m = ev.data as { type?: string; ok?: boolean; access_token?: string; refresh_token?: string };
     if (m?.type !== 'patreon-oauth') return;
     window.removeEventListener('message', this.onOAuthMessage);
+    this.oauthWindow = null;
     if (m.ok && m.access_token) {
       setPatreonSessionTokens(m.access_token, m.refresh_token);
     }

--- a/src/components/S2UndergroundPanel.ts
+++ b/src/components/S2UndergroundPanel.ts
@@ -1,4 +1,5 @@
 import { Panel } from './Panel';
+import { isTrustedOAuthMessage } from './s2-underground-helpers';
 import { escapeHtml } from '@/utils/sanitize';
 import { getLocalApiPort } from '@/services/runtime';
 import {
@@ -147,10 +148,8 @@ export class S2UndergroundPanel extends Panel {
     // popup window we opened. Without these checks any page/frame able to
     // postMessage to this window could inject an attacker-controlled
     // access_token that we'd persist to the keychain.
-    if (ev.origin !== `http://127.0.0.1:${getLocalApiPort()}`) return;
-    if (ev.source !== this.oauthWindow) return;
-    const m = ev.data as { type?: string; ok?: boolean; access_token?: string; refresh_token?: string };
-    if (m?.type !== 'patreon-oauth') return;
+    if (!isTrustedOAuthMessage(ev, `http://127.0.0.1:${getLocalApiPort()}`, this.oauthWindow)) return;
+    const m = ev.data as { ok?: boolean; access_token?: string; refresh_token?: string };
     window.removeEventListener('message', this.onOAuthMessage);
     this.oauthWindow = null;
     if (m.ok && m.access_token) {

--- a/src/components/__tests__/s2-underground-helpers.test.mts
+++ b/src/components/__tests__/s2-underground-helpers.test.mts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isTrustedOAuthMessage } from '../s2-underground-helpers.ts';
+
+const ORIGIN = 'http://127.0.0.1:46123';
+const POPUP = { name: 'patreon-oauth' }; // stands in for the opened window
+const GOOD_DATA = { type: 'patreon-oauth', ok: true, access_token: 'tok' };
+
+test('accepts a message from the right origin, right source, right type', () => {
+  assert.equal(
+    isTrustedOAuthMessage({ origin: ORIGIN, source: POPUP, data: GOOD_DATA }, ORIGIN, POPUP),
+    true,
+  );
+});
+
+test('rejects a message from a foreign origin (token-injection guard)', () => {
+  assert.equal(
+    isTrustedOAuthMessage(
+      { origin: 'https://evil.example', source: POPUP, data: GOOD_DATA },
+      ORIGIN,
+      POPUP,
+    ),
+    false,
+  );
+});
+
+test('rejects a message from a different window/source even if origin matches', () => {
+  const otherFrame = { name: 'attacker-frame' };
+  assert.equal(
+    isTrustedOAuthMessage({ origin: ORIGIN, source: otherFrame, data: GOOD_DATA }, ORIGIN, POPUP),
+    false,
+  );
+});
+
+test('rejects when the expected source is null (no popup opened yet)', () => {
+  assert.equal(
+    isTrustedOAuthMessage({ origin: ORIGIN, source: POPUP, data: GOOD_DATA }, ORIGIN, null),
+    false,
+  );
+});
+
+test('rejects a message without the patreon-oauth type tag', () => {
+  assert.equal(
+    isTrustedOAuthMessage(
+      { origin: ORIGIN, source: POPUP, data: { ok: true, access_token: 'tok' } },
+      ORIGIN,
+      POPUP,
+    ),
+    false,
+  );
+});
+
+test('rejects malformed / null data without throwing', () => {
+  assert.equal(isTrustedOAuthMessage({ origin: ORIGIN, source: POPUP, data: null }, ORIGIN, POPUP), false);
+  assert.equal(isTrustedOAuthMessage({ origin: ORIGIN, source: POPUP, data: 'oops' }, ORIGIN, POPUP), false);
+});

--- a/src/components/s2-underground-helpers.ts
+++ b/src/components/s2-underground-helpers.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure helpers for S2UndergroundPanel, extracted so the security-critical
+ * OAuth message gate is unit-testable without a DOM.
+ */
+
+export interface OAuthMessageLike {
+  origin: string;
+  source: unknown;
+  data: unknown;
+}
+
+/**
+ * Decide whether a postMessage event may carry the Patreon OAuth tokens we
+ * persist. A message is trusted only when it comes from our own sidecar
+ * origin AND from the exact popup window we opened AND is tagged as the
+ * Patreon callback. Any of these failing means a foreign page/frame is
+ * posting to us and the message must be ignored — otherwise an attacker
+ * could inject an access_token we'd save to the keychain.
+ */
+export function isTrustedOAuthMessage(
+  ev: OAuthMessageLike,
+  expectedOrigin: string,
+  expectedSource: unknown,
+): boolean {
+  if (ev.origin !== expectedOrigin) return false;
+  if (ev.source !== expectedSource) return false;
+  const data = ev.data as { type?: string } | null | undefined;
+  return data?.type === 'patreon-oauth';
+}

--- a/src/services/intelligence/__tests__/baseline-deviation.test.mts
+++ b/src/services/intelligence/__tests__/baseline-deviation.test.mts
@@ -126,6 +126,32 @@ test('deviation: confidence rises with sample count, falls with zero variance', 
   assert.ok(variedHigh > 0.5);
 });
 
+// ── Warmup mode ─────────────────────────────────────────────────────────
+
+test('warmup: confidence is non-zero and ramps within the warmup window', () => {
+  // 5 varied samples: above WARMUP_MIN_SAMPLES (3), below minSamplesForZ (12).
+  const early = createBaselineStore({ minSamplesForZ: 12, warmupMode: true });
+  fillRandom(early, 'm', 5, 100, 10);
+  const r5 = early.deviation('m', 130);
+  // Regression guard: the pre-fix code multiplied a floored-to-0 confidence by
+  // the warmup scale, pinning warmup confidence to 0 forever.
+  assert.notEqual(r5.label, 'insufficient_data');
+  assert.ok(r5.confidence > 0, `expected >0, got ${r5.confidence}`);
+  assert.ok(r5.confidence <= 0.5, `expected <=0.5 cap, got ${r5.confidence}`);
+
+  // More samples (still in warmup) → higher confidence.
+  const later = createBaselineStore({ minSamplesForZ: 12, warmupMode: true });
+  fillRandom(later, 'm', 10, 100, 10);
+  const r10 = later.deviation('m', 130);
+  assert.ok(r10.confidence > r5.confidence, `expected ramp ${r10.confidence} > ${r5.confidence}`);
+});
+
+test('warmup: flat history still yields zero confidence (no variance)', () => {
+  const s = createBaselineStore({ minSamplesForZ: 12, warmupMode: true });
+  fillFlat(s, 'm', 6, 100);
+  assert.equal(s.deviation('m', 100).confidence, 0);
+});
+
 test('deviation: summary string mentions sigma direction', () => {
   const s = createBaselineStore();
   fillRandom(s, 'm', 50, 100, 10);

--- a/src/services/intelligence/baseline-deviation.ts
+++ b/src/services/intelligence/baseline-deviation.ts
@@ -176,12 +176,17 @@ export function createBaselineStore(options: BaselineStoreOptions = {}): Baselin
     const z = stats.stdDev > 0 ? (value - stats.mean) / stats.stdDev : 0;
     const percentile = computePercentile(samples, value);
     // In warmup mode, scale confidence linearly from 0 at WARMUP_MIN_SAMPLES
-    // to the normal value at minSamplesForZ so early deviations are usable
-    // but clearly discounted.
+    // to a 0.5 cap as we approach minSamplesForZ so early deviations are
+    // usable but clearly discounted.
     let confidence = computeConfidence(samples.length, stats.stdDev, opts.minSamplesForZ);
     if (opts.warmupMode && samples.length < opts.minSamplesForZ) {
+      // computeConfidence() floors to 0 below minSamplesForZ (its sample-count
+      // term goes negative), so multiplying it by the warmup scale always
+      // yielded 0 and defeated warmup mode. Derive the discounted confidence
+      // directly from the warmup ramp, gated on there being variance to read.
       const warmupScale = (samples.length - WARMUP_MIN_SAMPLES) / Math.max(1, opts.minSamplesForZ - WARMUP_MIN_SAMPLES);
-      confidence = confidence * warmupScale * 0.5; // cap at 50% during warmup
+      const varianceConfidence = stats.stdDev > 0 ? 1 : 0;
+      confidence = varianceConfidence * warmupScale * 0.5; // cap at 50% during warmup
     }
     const label = labelFor(z);
     const summary = buildSummary(z, stats, samples.length);


### PR DESCRIPTION
## Summary

3× bug + security scan of Crystal Ball, then fixes. Three live security issues, one latent correctness bug, plus the regression tests to lock them in. One scan candidate was investigated and **reverted as a false positive** (kept honest below).

## Fixes

### 1. Sidecar inline-route auth bypass (HIGH) — `local-api-server.mjs`
The inline `/api/*` handlers (feeds/health, watchboards CRUD: POST situations/entities/rules, DELETE rules/watchboards) ran **before** `dispatch()`'s global auth gate, so an unauthenticated local caller could read and mutate sidecar state without a `LOCAL_API_TOKEN`. Added a shared auth preamble that gates every inline route, with an explicit `PUBLIC_API_ROUTES` allowlist for the routes intentionally served pre-auth (`service-status`, `youtube-embed`, `patreon/authorize-url`, `sms/command`). `/api/health` keeps its own existing token check.

### 2. OAuth token-injection via postMessage (HIGH) — `S2UndergroundPanel.ts`
`onOAuthMessage` consumed `ev.data.access_token` and persisted it (→ `/api/patreon/verify` → keychain) **without validating the message origin or source**. Any open page/frame could `postMessage` an attacker token. Now validates both `ev.origin === http://127.0.0.1:<sidecarPort>` **and** `ev.source === the popup we opened` before trusting the message. Logic extracted to a pure `isTrustedOAuthMessage()` helper for testability.

### 3. Hung inline routes (BUG) — `local-api-server.mjs`
Several inline routes did `return json(...)` inside the `http.createServer` async callback, whose return value is **ignored** — the `Response` was discarded and the request hung. Replaced with a `sendJson()` helper that writes the response directly.

### 4. OPTIONS preflight (P1, from cross-agent review) — `local-api-server.mjs`
The first cut of the auth preamble exempted `OPTIONS` from the token check but let it fall through to handlers that only branch on GET/POST/PUT/DELETE → 405/401, so browser CORS preflight for authenticated cross-origin requests failed. Now short-circuits `OPTIONS → 204 + CORS` before the auth check, mirroring `/gps/nmea` and `dispatch()`.

### 5. Baseline-deviation warmup confidence stuck at 0 (LATENT correctness) — `baseline-deviation.ts`
In warmup mode `computeConfidence` floors to 0 below `minSamplesForZ`, so warmup confidence was `0 × scale = 0` forever. Now derives confidence from the warmup ramp (capped at 0.5). Module is currently dormant (no live callers) — fix + tests land ahead of wiring.

## Investigated and reverted (false positive — kept for honesty)
`negative-evidence.ts` aftershock signal `domain: 'space'` *looked* wrong, but the existing fixture matches `'space'`, the module is dormant, and the earthquake adapter uses a different (`ObservationEvent`) vocabulary. Changing it broke 2 tests; reverted to origin/main.

## Tests
- New: `s2-underground-helpers.test.mts` (6 cases — origin/source/type gate).
- Sidecar: inline-route OPTIONS preflight → 204; gated route 401 vs authed 200; full public allowlist un-gated; `/api/health` stays 401 unauth.
- `baseline-deviation.test.mts`: warmup ramp non-zero + flat-history-stays-zero.
- `npm run test:sidecar` (289), `npm run typecheck:all`, full intelligence suite — all green.

## Cross-agent review
Cross-agent review: Codex reviewed on 2026-06-15; outcome: pass — no high-confidence P0/P1/P2 issues. Codex independently confirmed all three fix invariants and re-ran test:sidecar (289), baseline-deviation (19), and typecheck:all (all passing). Its two flagged test gaps (OAuth-message rejection, full allowlist + `/api/health` 401) are closed by commit `78820ce8`. The earlier P1 (OPTIONS preflight) it found is fixed in `db980179`.

## Out of scope (pre-existing on main, flagged not fixed)
`npm run test:algorithms` has 2 pre-existing failures (`registers all live algorithms`, `getTunings exposes all declared algorithms`) — the registry gained `'superforecast'` from the active Cognitive Enhancement work and those tests weren't updated. Not touched by this branch.
