### PR TITLE
security(routing): use strict-origin referrer for map provider keys

### DIFF
--- a/src/services/routing-engine.ts
+++ b/src/services/routing-engine.ts
@@ -75,7 +75,7 @@ async function tryMapbox(from: RouteCoord, to: RouteCoord, profile: RoutingProfi
   const mbProfile = profile === 'driving' ? 'driving-traffic' : profile;
   const url = `https://api.mapbox.com/directions/v5/mapbox/${mbProfile}/${from.lon},${from.lat};${to.lon},${to.lat}?access_token=${key}&geometries=geojson&steps=true&overview=full`;
 
-  const res = await fetch(url, { referrerPolicy: 'no-referrer', signal: AbortSignal.timeout(3000) });
+  const res = await fetch(url, { referrerPolicy: 'strict-origin-when-cross-origin', signal: AbortSignal.timeout(3000) });
   if (!res.ok) return null;
 
   const data = (await res.json()) as Record<string, unknown>;
@@ -124,7 +124,7 @@ async function tryGoogle(from: RouteCoord, to: RouteCoord): Promise<RouteResult 
 
   const url = `https://maps.googleapis.com/maps/api/directions/json?origin=${from.lat},${from.lon}&destination=${to.lat},${to.lon}&key=${key}`;
 
-  const res = await fetch(url, { referrerPolicy: 'no-referrer', signal: AbortSignal.timeout(3000) });
+  const res = await fetch(url, { referrerPolicy: 'strict-origin-when-cross-origin', signal: AbortSignal.timeout(3000) });
   if (!res.ok) return null;
 
   const data = (await res.json()) as Record<string, unknown>;
@@ -176,7 +176,7 @@ async function tryValhalla(from: RouteCoord, to: RouteCoord, profile: RoutingPro
 
   const res = await fetch('https://valhalla1.openstreetmap.de/route', {
     method: 'POST',
-    referrerPolicy: 'no-referrer',
+    referrerPolicy: 'strict-origin-when-cross-origin',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       locations: [{ lat: from.lat, lon: from.lon }, { lat: to.lat, lon: to.lon }],
@@ -226,7 +226,7 @@ async function tryValhalla(from: RouteCoord, to: RouteCoord, profile: RoutingPro
 async function tryOsrm(from: RouteCoord, to: RouteCoord): Promise<RouteResult | null> {
   const url = `https://router.project-osrm.org/route/v1/driving/${from.lon},${from.lat};${to.lon},${to.lat}?overview=full&geometries=geojson&steps=true`;
 
-  const res = await fetch(url, { referrerPolicy: 'no-referrer', signal: AbortSignal.timeout(3000) });
+  const res = await fetch(url, { referrerPolicy: 'strict-origin-when-cross-origin', signal: AbortSignal.timeout(3000) });
   if (!res.ok) return null;
 
   const data = (await res.json()) as Record<string, unknown>;


### PR DESCRIPTION
## Follow-up to #1169 — switch routing referrer policy to strict-origin

PR #1169 auto-merged its `no-referrer` variant before the referrer-policy decision was finalized. Forcing `referrerPolicy: 'no-referrer'` strips the `Referer` header that **referrer-restricted** Mapbox/Google keys validate against, so a user who locks their key to an origin would see routing silently fail (Codex review P2).

**Fix:** switch all four provider fetches (Mapbox, Google, Valhalla, OSRM) to `strict-origin-when-cross-origin`. The `Referer` can then only ever carry the *origin* — never the key-bearing path/query — so the key still can't leak via a cross-origin redirect, while referrer-restricted keys keep working. This matches the document-wide default already set at `index.html:8`.

Net effect on `main`: reverts the 4 `no-referrer` lines merged via #1169 (`428ec499`) to `strict-origin-when-cross-origin`.

---
Cross-agent review: Codex reviewed on 2026-06-15; outcome: pass (no actionable regressions).

Codex `codex exec review --base origin/main` reviewed this change on branch `claude/sec-routing-strict-origin` (session `019ecc11`) and on its predecessor (session `019ecc0d`, commit `53c7a6e7`): no actionable regressions. Codex independently ran `npx eslint src/services/routing-engine.ts` and `tsc --noEmit`, both passing.
