### PR TITLE
test(algorithms): sync expected registry + tunings sets with live algos

### DIFF
--- a/src/services/algorithms/__tests__/algorithm-registry.test.mts
+++ b/src/services/algorithms/__tests__/algorithm-registry.test.mts
@@ -28,12 +28,14 @@ test('initial: registers all live algorithms (orphaned algos with no call sites 
   // situation-clustering, watchlist-relevance, what-changed-digest — all had zero live
   // call sites (confirmed by audit 2026-06-07). No recordAlgorithmEvaluation would ever
   // fire for them; keeping them would only pollute the ledger with fabricated entries.
+  // Cognitive Enhancement work registered 4 new live algorithms (2026-06):
+  // bias-detector, cognitive-bias-detector, counterfactual-reasoning, meta-confidence.
   const expected = [
-    'big-event-detector', 'competitive-hypothesis', 'compound-risk', 'confidence-urgency-matrix',
-    'correlation-feedback', 'hypothesis-accuracy', 'negative-evidence',
-    'nws-polygon-match', 'personal-storm-mode', 'relevance-learner',
-    'shortage-diesel', 'shortage-wheat', 'source-feedback',
-    'threat-classifier', 'truth-score', 'weather-urgency',
+    'bias-detector', 'big-event-detector', 'cognitive-bias-detector', 'competitive-hypothesis',
+    'compound-risk', 'confidence-urgency-matrix', 'correlation-feedback', 'counterfactual-reasoning',
+    'hypothesis-accuracy', 'meta-confidence', 'negative-evidence', 'nws-polygon-match',
+    'personal-storm-mode', 'relevance-learner', 'shortage-diesel', 'shortage-wheat',
+    'source-feedback', 'threat-classifier', 'truth-score', 'weather-urgency',
   ];
   assert.deepEqual(ids, expected);
 });

--- a/src/services/algorithms/__tests__/tunable-params-store.test.mts
+++ b/src/services/algorithms/__tests__/tunable-params-store.test.mts
@@ -95,7 +95,7 @@ test('getTunings exposes all declared algorithms', () => {
   _resetTunedParamsForTests();
   const tunings = getTunings();
   const ids = tunings.map((t) => t.algorithmId).sort();
-  assert.deepEqual(ids, ['big-event-detector', 'correlation-feedback', 'hypothesis-feedback', 'negative-evidence']);
+  assert.deepEqual(ids, ['big-event-detector', 'correlation-feedback', 'hypothesis-feedback', 'negative-evidence', 'superforecast']);
   const negEv = tunings.find((t) => t.algorithmId === 'negative-evidence');
   const maxPenalty = negEv!.parameters.find((p) => p.parameterId === 'maxPenalty');
   assert.equal(maxPenalty!.current, 0.6);


### PR DESCRIPTION
## Summary

Fixes 2 pre-existing failures in `npm run test:algorithms` on `main`. The active Cognitive Enhancement work registered new live algorithms, but the registry-coverage tests' expected sets were never updated to match `getAlgorithmDefinitions()` / `getTunings()`.

## Fix (test-only — no production code touched)

- `algorithm-registry.test.mts` — `initial: registers all live algorithms` was missing four newly-registered cognition algorithms: `bias-detector`, `cognitive-bias-detector`, `counterfactual-reasoning`, `meta-confidence`. Added them to the expected set (kept sorted).
- `tunable-params-store.test.mts` — `getTunings exposes all declared algorithms` was missing `superforecast` (it now declares a tunable knob). Added it to the expected set.

Each new id was confirmed against the actual `listAlgorithms()` / `getTunings()` output captured from the test runner's own deep-equal diff, not assumed.

## Verification

- `npm run test:algorithms`: **114 pass / 0 fail** (was 112 / 2).
- `npm run typecheck:all`: clean.

## Cross-agent review
Cross-agent review: Codex reviewed on 2026-06-15; outcome: pass — no P0/P1/P2. Codex independently read `algorithm-registry.ts` and the tunable-params source and confirmed the expected arrays exactly match the live registry (20/20) and tunings (5/5), no extra/missing ids, and that no assertion was loosened. (Codex could not run the suite under its read-only sandbox — `tsx` hit `listen EPERM` on its IPC pipe — so the 114/0 count above is from the local run.)
