### PR TITLE
Shortage feeds signal failure + per-commodity fail-closed supply cache

### DIFF
--- a/src/services/data-freshness.ts
+++ b/src/services/data-freshness.ts
@@ -37,7 +37,8 @@ export type DataSourceId =
   | 'giving' // Global giving activity data
   | 'bis' // BIS central bank data
   | 'wto_trade' // WTO trade policy data
-  | 'supply_chain' // Supply chain disruption intelligence
+  | 'supply_chain' // Supply chain disruption intelligence (shipping + minerals aggregate)
+  | 'chokepoint-status' // Maritime chokepoint status — distinct from supply_chain so a shipping/minerals refresh can't mask a chokepoint outage
   | 'security_advisories'  // Government travel/security advisories
   | 'gpsjam' // GPS/GNSS interference
   | 'acled_airstrikes' // ACLED air/drone strikes & missile attacks
@@ -194,6 +195,7 @@ const SOURCE_METADATA: Record<DataSourceId, { name: string; requiredForRisk: boo
   bis: { name: 'BIS Central Banks', requiredForRisk: false, panelId: 'economic' },
   wto_trade: { name: 'WTO Trade Policy', requiredForRisk: false, panelId: 'trade-policy' },
   supply_chain: { name: 'Supply Chain Intelligence', requiredForRisk: false, panelId: 'supply-chain' },
+  'chokepoint-status': { name: 'Maritime Chokepoint Status', requiredForRisk: false, panelId: 'supply-chain' },
   security_advisories: { name: 'Security Advisories', requiredForRisk: false, panelId: 'security-advisories' },
   gpsjam: { name: 'GPS/GNSS Interference', requiredForRisk: false, panelId: 'map' },
   acled_airstrikes: { name: 'Air Strikes & Drones (ACLED)', requiredForRisk: false, panelId: 'airstrikes' },
@@ -555,6 +557,7 @@ const INTELLIGENCE_GAP_MESSAGES: Record<DataSourceId, string> = {
   bis: 'Central bank policy data may be stale—BIS feed unavailable',
   wto_trade: 'Trade policy intelligence unavailable—WTO data not updating',
   supply_chain: 'Supply chain disruption status unavailable—chokepoint monitoring offline',
+  'chokepoint-status': 'Maritime chokepoint status unavailable—corridor disruption may be missed',
   security_advisories: 'Government travel advisory data unavailable—security alerts may be missed',
   gpsjam: 'GPS/GNSS interference data unavailable—jamming zones undetected',
   acled_airstrikes: 'Air strike & drone event data unavailable—ACLED feed not responding',

--- a/src/services/drought-monitor.ts
+++ b/src/services/drought-monitor.ts
@@ -212,11 +212,15 @@ export async function fetchDroughtMonitor(): Promise<DroughtSummary> {
   try {
  const res = await fetch(DROUGHT_API_URL, { signal: AbortSignal.timeout(12_000) });
  if (!res.ok) {
+ dataFreshness.recordError('drought-monitor', `HTTP ${res.status}`);
  return cache?.summary ?? emptyDroughtSummary();
  }
 
  const json = await res.json() as RawDroughtRow[];
- if (!Array.isArray(json)) return cache?.summary ?? emptyDroughtSummary();
+ if (!Array.isArray(json)) {
+ dataFreshness.recordError('drought-monitor', 'unexpected payload shape');
+ return cache?.summary ?? emptyDroughtSummary();
+ }
 
  let validDate: Date | null = null;
  const collected: DroughtState[] = [];

--- a/src/services/power-grid-alerts.ts
+++ b/src/services/power-grid-alerts.ts
@@ -79,16 +79,20 @@ function extractRegion(title: string, description: string): string {
   return states?.[0] ?? 'North America';
 }
 
-async function fetchRssFeed(feedUrl: string, source: PowerGridAlert['source']): Promise<PowerGridAlert[]> {
+// Returns the parsed alerts on success (possibly an empty array when the feed
+// has no grid-relevant items), or `null` when the fetch itself failed (HTTP
+// error, parse error, timeout). The null/empty distinction is what lets
+// fetchPowerGridAlerts tell a real outage apart from a quiet-but-healthy feed.
+async function fetchRssFeed(feedUrl: string, source: PowerGridAlert['source']): Promise<PowerGridAlert[] | null> {
   try {
  const proxyUrl = `/api/rss-proxy?url=${encodeURIComponent(feedUrl)}`;
  const res = await fetch(proxyUrl, { signal: AbortSignal.timeout(12_000) });
- if (!res.ok) return [];
+ if (!res.ok) return null;
 
  const text = await res.text();
  const parser = new DOMParser();
  const doc = parser.parseFromString(text, 'text/xml');
- if (doc.querySelector('parsererror')) return [];
+ if (doc.querySelector('parsererror')) return null;
 
  const items = doc.querySelectorAll('item');
  const alerts: PowerGridAlert[] = [];
@@ -118,24 +122,21 @@ async function fetchRssFeed(feedUrl: string, source: PowerGridAlert['source']): 
 
  return alerts;
   } catch {
- return [];
+ return null;
   }
 }
 
 export async function fetchPowerGridAlerts(): Promise<PowerGridAlert[]> {
   if (cache && Date.now() - cache.fetchedAt < CACHE_TTL_MS) return cache.alerts;
 
-  const [nercResult, doeResult, oeResult] = await Promise.allSettled([
+  const settled = await Promise.allSettled([
  fetchRssFeed(NERC_ALERTS_RSS, 'NERC'),
  fetchRssFeed(DOE_CESER_RSS, 'DOE'),
  fetchRssFeed(DOE_OE_RSS, 'DOE'),
   ]);
-
-  const combined = [
- ...(nercResult.status === 'fulfilled' ? nercResult.value : []),
- ...(doeResult.status === 'fulfilled' ? doeResult.value : []),
- ...(oeResult.status === 'fulfilled' ? oeResult.value : []),
-  ];
+  // null = the sub-feed failed to fetch; [] = fetched OK but no grid-relevant items.
+  const feedResults = settled.map((r) => (r.status === 'fulfilled' ? r.value : null));
+  const combined = feedResults.flatMap((v) => v ?? []);
 
   // Dedupe by title similarity
   const seen = new Set<string>();
@@ -155,7 +156,14 @@ export async function fetchPowerGridAlerts(): Promise<PowerGridAlert[]> {
  .slice(0, 40);
 
   cache = { alerts: recent, fetchedAt: Date.now() };
-  dataFreshness.recordUpdate('power-grid-alerts', recent.length);
+  // Honest freshness signal: only a real success advances dataFreshness. Each
+  // fetchRssFeed catches its own errors and returns null on failure (vs [] for a
+  // healthy-but-quiet feed), so if every sub-feed is null the empty result is an
+  // outage, not "no alerts" — record an error so downstream fail-closed logic can
+  // tell the difference.
+  const anyFeedOk = feedResults.some((v) => v !== null);
+  if (anyFeedOk) dataFreshness.recordUpdate('power-grid-alerts', recent.length);
+  else dataFreshness.recordError('power-grid-alerts', 'all grid RSS feeds failed');
   return recent;
 }
 

--- a/src/services/shortage/__tests__/shortage-input-bridge.test.mts
+++ b/src/services/shortage/__tests__/shortage-input-bridge.test.mts
@@ -10,6 +10,7 @@ import test from 'node:test';
 import {
   buildShortageInputsFromSources,
   mergeShortageEntriesByFeedStatus,
+  healthyCommodities,
   COMMODITY_SOURCE_FEEDS,
   type ChokepointSignal,
   type ShortageFeedId,

--- a/src/services/shortage/__tests__/shortage-input-bridge.test.mts
+++ b/src/services/shortage/__tests__/shortage-input-bridge.test.mts
@@ -27,7 +27,7 @@ import type { PowerGridAlert } from '@/services/power-grid-alerts';
 const ALL_FEEDS_OK: Record<ShortageFeedId, boolean> = {
   'drought-monitor': true,
   'power-grid-alerts': true,
-  'supply_chain': true,
+  'chokepoint-status': true,
 };
 
 function summaryEntry(commodity: FullSetCommodity, riskLevel: RiskLevel): ShortageSummaryEntry {
@@ -273,15 +273,15 @@ test('output is JSON-serializable', () => {
 // ── Per-commodity feed map + fail-closed merge ──────────────────────────────
 
 test('COMMODITY_SOURCE_FEEDS covers every commodity with valid feed ids', () => {
-  const validFeeds: ShortageFeedId[] = ['drought-monitor', 'power-grid-alerts', 'supply_chain'];
+  const validFeeds: ShortageFeedId[] = ['drought-monitor', 'power-grid-alerts', 'chokepoint-status'];
   for (const commodity of ALL_FULLSET_COMMODITIES) {
     const deps = COMMODITY_SOURCE_FEEDS[commodity];
     assert.ok(deps, `${commodity} missing from COMMODITY_SOURCE_FEEDS`);
     for (const f of deps) assert.ok(validFeeds.includes(f), `${commodity} has invalid feed ${f}`);
   }
   // Matches what buildShortageInputsFromSources actually wires.
-  assert.deepEqual([...COMMODITY_SOURCE_FEEDS.wheat].sort(), ['drought-monitor', 'supply_chain']);
-  assert.deepEqual(COMMODITY_SOURCE_FEEDS.rice, ['supply_chain']);
+  assert.deepEqual([...COMMODITY_SOURCE_FEEDS.wheat].sort(), ['chokepoint-status', 'drought-monitor']);
+  assert.deepEqual(COMMODITY_SOURCE_FEEDS.rice, ['chokepoint-status']);
   assert.deepEqual(COMMODITY_SOURCE_FEEDS['natural-gas'], ['power-grid-alerts']);
   assert.deepEqual(COMMODITY_SOURCE_FEEDS['jet-fuel'], []);
 });
@@ -294,16 +294,16 @@ test('merge with all feeds OK takes every fresh entry', () => {
 });
 
 test('merge keeps cached entry only for commodities whose feed is down', () => {
-  // Chokepoint (supply_chain) feed down, drought + grid healthy.
+  // Chokepoint-status feed down, drought + grid healthy.
   const feedsOk: Record<ShortageFeedId, boolean> = {
     'drought-monitor': true,
     'power-grid-alerts': true,
-    'supply_chain': false,
+    'chokepoint-status': false,
   };
   const fresh = [
-    summaryEntry('rice', 'LOW'),      // deps supply_chain (down)  -> keep cached
-    summaryEntry('diesel', 'LOW'),    // deps supply_chain (down)  -> keep cached
-    summaryEntry('wheat', 'LOW'),     // deps drought + supply_chain (down) -> keep cached
+    summaryEntry('rice', 'LOW'),      // deps chokepoint-status (down)  -> keep cached
+    summaryEntry('diesel', 'LOW'),    // deps chokepoint-status (down)  -> keep cached
+    summaryEntry('wheat', 'LOW'),     // deps drought + chokepoint-status (down) -> keep cached
     summaryEntry('corn', 'LOW'),      // deps drought (up)         -> take fresh
     summaryEntry('natural-gas', 'LOW'), // deps grid (up)          -> take fresh
     summaryEntry('jet-fuel', 'LOW'),  // no deps                   -> take fresh
@@ -328,11 +328,11 @@ test('merge keeps cached entry only for commodities whose feed is down', () => {
 });
 
 test('merge falls back to fresh when a down-feed commodity has no cached entry', () => {
-  // Cold-ish merge: supply_chain down, but no prior rice entry to preserve.
+  // Cold-ish merge: chokepoint-status down, but no prior rice entry to preserve.
   const feedsOk: Record<ShortageFeedId, boolean> = {
     'drought-monitor': true,
     'power-grid-alerts': true,
-    'supply_chain': false,
+    'chokepoint-status': false,
   };
   const merged = mergeShortageEntriesByFeedStatus([summaryEntry('rice', 'LOW')], [], feedsOk);
   assert.deepEqual(merged.map((e) => e.riskLevel), ['LOW']);

--- a/src/services/shortage/__tests__/shortage-input-bridge.test.mts
+++ b/src/services/shortage/__tests__/shortage-input-bridge.test.mts
@@ -9,10 +9,30 @@ import test from 'node:test';
 
 import {
   buildShortageInputsFromSources,
+  mergeShortageEntriesByFeedStatus,
+  COMMODITY_SOURCE_FEEDS,
   type ChokepointSignal,
+  type ShortageFeedId,
 } from '../shortage-input-bridge.ts';
+import {
+  ALL_FULLSET_COMMODITIES,
+  type FullSetCommodity,
+  type RiskLevel,
+  type ShortageSummaryEntry,
+} from '../shortage-fullset.ts';
 import type { DroughtState, DroughtSummary } from '@/services/drought-monitor';
 import type { PowerGridAlert } from '@/services/power-grid-alerts';
+
+const ALL_FEEDS_OK: Record<ShortageFeedId, boolean> = {
+  'drought-monitor': true,
+  'power-grid-alerts': true,
+  'supply_chain': true,
+};
+
+function summaryEntry(commodity: FullSetCommodity, riskLevel: RiskLevel): ShortageSummaryEntry {
+  // The merge only reads `commodity`; `riskLevel` is the marker we assert on.
+  return { commodity, riskLevel, riskScore: 0, primaryDrivers: [], timeToImpact: '', trend: 'stable' } as unknown as ShortageSummaryEntry;
+}
 
 const NOW = Date.parse('2026-05-12T12:00:00Z');
 
@@ -247,4 +267,72 @@ test('output is JSON-serializable', () => {
   );
   const round = JSON.parse(JSON.stringify(r));
   assert.deepEqual(round, r);
+});
+
+// ── Per-commodity feed map + fail-closed merge ──────────────────────────────
+
+test('COMMODITY_SOURCE_FEEDS covers every commodity with valid feed ids', () => {
+  const validFeeds: ShortageFeedId[] = ['drought-monitor', 'power-grid-alerts', 'supply_chain'];
+  for (const commodity of ALL_FULLSET_COMMODITIES) {
+    const deps = COMMODITY_SOURCE_FEEDS[commodity];
+    assert.ok(deps, `${commodity} missing from COMMODITY_SOURCE_FEEDS`);
+    for (const f of deps) assert.ok(validFeeds.includes(f), `${commodity} has invalid feed ${f}`);
+  }
+  // Matches what buildShortageInputsFromSources actually wires.
+  assert.deepEqual([...COMMODITY_SOURCE_FEEDS.wheat].sort(), ['drought-monitor', 'supply_chain']);
+  assert.deepEqual(COMMODITY_SOURCE_FEEDS.rice, ['supply_chain']);
+  assert.deepEqual(COMMODITY_SOURCE_FEEDS['natural-gas'], ['power-grid-alerts']);
+  assert.deepEqual(COMMODITY_SOURCE_FEEDS['jet-fuel'], []);
+});
+
+test('merge with all feeds OK takes every fresh entry', () => {
+  const fresh = [summaryEntry('rice', 'LOW'), summaryEntry('corn', 'LOW')];
+  const cached = [summaryEntry('rice', 'CRITICAL'), summaryEntry('corn', 'HIGH')];
+  const merged = mergeShortageEntriesByFeedStatus(fresh, cached, ALL_FEEDS_OK);
+  assert.deepEqual(merged.map((e) => e.riskLevel), ['LOW', 'LOW']);
+});
+
+test('merge keeps cached entry only for commodities whose feed is down', () => {
+  // Chokepoint (supply_chain) feed down, drought + grid healthy.
+  const feedsOk: Record<ShortageFeedId, boolean> = {
+    'drought-monitor': true,
+    'power-grid-alerts': true,
+    'supply_chain': false,
+  };
+  const fresh = [
+    summaryEntry('rice', 'LOW'),      // deps supply_chain (down)  -> keep cached
+    summaryEntry('diesel', 'LOW'),    // deps supply_chain (down)  -> keep cached
+    summaryEntry('wheat', 'LOW'),     // deps drought + supply_chain (down) -> keep cached
+    summaryEntry('corn', 'LOW'),      // deps drought (up)         -> take fresh
+    summaryEntry('natural-gas', 'LOW'), // deps grid (up)          -> take fresh
+    summaryEntry('jet-fuel', 'LOW'),  // no deps                   -> take fresh
+  ];
+  const cached = [
+    summaryEntry('rice', 'CRITICAL'),
+    summaryEntry('diesel', 'HIGH'),
+    summaryEntry('wheat', 'CRITICAL'),
+    summaryEntry('corn', 'CRITICAL'),     // stale; corn's feed is up so this is dropped
+    summaryEntry('natural-gas', 'CRITICAL'),
+    summaryEntry('jet-fuel', 'CRITICAL'),
+  ];
+  const byCommodity = new Map(
+    mergeShortageEntriesByFeedStatus(fresh, cached, feedsOk).map((e) => [e.commodity, e.riskLevel]),
+  );
+  assert.equal(byCommodity.get('rice'), 'CRITICAL');     // preserved through outage
+  assert.equal(byCommodity.get('diesel'), 'HIGH');       // preserved
+  assert.equal(byCommodity.get('wheat'), 'CRITICAL');    // any dead dep preserves
+  assert.equal(byCommodity.get('corn'), 'LOW');          // refreshed (feed up)
+  assert.equal(byCommodity.get('natural-gas'), 'LOW');   // refreshed (feed up)
+  assert.equal(byCommodity.get('jet-fuel'), 'LOW');      // no deps -> always fresh
+});
+
+test('merge falls back to fresh when a down-feed commodity has no cached entry', () => {
+  // Cold-ish merge: supply_chain down, but no prior rice entry to preserve.
+  const feedsOk: Record<ShortageFeedId, boolean> = {
+    'drought-monitor': true,
+    'power-grid-alerts': true,
+    'supply_chain': false,
+  };
+  const merged = mergeShortageEntriesByFeedStatus([summaryEntry('rice', 'LOW')], [], feedsOk);
+  assert.deepEqual(merged.map((e) => e.riskLevel), ['LOW']);
 });

--- a/src/services/shortage/shortage-fullset.ts
+++ b/src/services/shortage/shortage-fullset.ts
@@ -73,6 +73,12 @@ export interface ShortageFullSetOptions {
   region?: string;
   /** Optional clock epoch ms for deterministic tests. */
   now?: number;
+  /** When provided, only these commodities are computed; the rest are skipped
+   *  entirely so their module-level trend memory is left untouched. The
+   *  partial-outage supply merge uses this to avoid writing a discarded baseline
+   *  score into trend state (which would show a false trend on recovery). Omit to
+   *  compute the full set. */
+  only?: ReadonlySet<FullSetCommodity>;
 }
 
 // ── Trend tracking ─────────────────────────────────────────────────────────
@@ -189,6 +195,7 @@ export function computeShortageFullSet(
   const entries: ShortageSummaryEntry[] = [];
 
   for (const commodity of ALL_FULLSET_COMMODITIES) {
+    if (options.only && !options.only.has(commodity)) continue;
     const bag = inputs[commodity] ?? {};
     const forecast = runCommodity(commodity, bag, region, now);
     if (!forecast) continue;

--- a/src/services/shortage/shortage-input-bridge.ts
+++ b/src/services/shortage/shortage-input-bridge.ts
@@ -22,7 +22,7 @@
 import type { DroughtState, DroughtSummary } from '@/services/drought-monitor';
 import type { PowerGridAlert } from '@/services/power-grid-alerts';
 import type { ShortageInput, ShortageInputBag } from './shortage-types';
-import type { FullSetCommodity } from './shortage-fullset';
+import type { FullSetCommodity, ShortageSummaryEntry } from './shortage-fullset';
 
 // Concrete `fetch*` modules are loaded lazily inside `loadShortageInputs`
 // below — they transitively pull in i18n.ts (which uses Vite's
@@ -81,56 +81,54 @@ export function buildShortageInputsFromSources(
   options: ShortageInputBridgeOptions = {},
 ): Partial<Record<FullSetCommodity, ShortageInputBag>> {
   const now = options.now ?? Date.now();
-  const out: Partial<Record<FullSetCommodity, ShortageInputBag>> = {};
-
-  const droughtFreshness = sources.drought ? sources.drought.fetchedAt.getTime() : now;
-
-  // ── Grains: drought-monitor drives the production drivers ──────────────
-  if (sources.drought?.states.length) {
-    const wheatBag = buildGrainBag(sources.drought.states, WHEAT_BELT, droughtFreshness, 'us-drought-monitor');
-    const cornBag  = buildGrainBag(sources.drought.states, CORN_BELT, droughtFreshness, 'us-drought-monitor');
-    const soyBag   = buildGrainBag(sources.drought.states, SOYBEAN_BELT, droughtFreshness, 'us-drought-monitor');
-    if (Object.keys(wheatBag).length) out.wheat    = { ...(out.wheat ?? {}),    ...wheatBag };
-    if (Object.keys(cornBag).length)  out.corn     = { ...(out.corn ?? {}),     ...cornBag };
-    if (Object.keys(soyBag).length)   out.soybeans = { ...(out.soybeans ?? {}), ...soyBag };
-  }
-
-  // ── Chokepoints: maritime export-corridor stress ───────────────────────
-  if (sources.chokepoints?.length) {
-    for (const cp of sources.chokepoints) {
-      const stress = corridorStressScore(cp);
-      const source = `chokepoint:${cp.key}`;
-      if (cp.key === 'bosphorus') {
-        out.wheat = {
-          ...(out.wheat ?? {}),
-          export_corridor_status: { value: stress, source, observedAt: now },
-        };
-      } else if (cp.key === 'suez') {
-        out.rice = {
-          ...(out.rice ?? {}),
-          export_corridor_status: { value: stress, source, observedAt: now },
-        };
-      } else if (cp.key === 'hormuz') {
-        // Hormuz disruption proxies for crude-import stress on both
-        // diesel and gasoline. Mapped onto crude_imports_wow as a
-        // negative delta — 100 stress → -40% WoW imports, which sits at
-        // the floor of the model's inverseLinear(-25, 5) saturation band.
-        const inp: ShortageInput = { value: -stress * 0.4, source, observedAt: now };
-        out.diesel   = { ...(out.diesel ?? {}),   crude_imports_wow: inp };
-        out.gasoline = { ...(out.gasoline ?? {}), crude_imports_wow: inp };
-      }
-    }
-  }
-
-  // ── Grid alerts: natural-gas demand + curtailment proxies ──────────────
-  if (sources.gridAlerts?.length) {
-    const natGasBag = buildNatGasBag(sources.gridAlerts, now);
-    if (Object.keys(natGasBag).length) {
-      out['natural-gas'] = { ...(out['natural-gas'] ?? {}), ...natGasBag };
-    }
-  }
-
+  const out: InputAccumulator = {};
+  const { drought, chokepoints, gridAlerts } = sources;
+  if (drought?.states.length) applyDroughtInputs(out, drought);
+  if (chokepoints?.length) applyChokepointInputs(out, chokepoints, now);
+  if (gridAlerts?.length) applyGridInputs(out, gridAlerts, now);
   return out;
+}
+
+type InputAccumulator = Partial<Record<FullSetCommodity, ShortageInputBag>>;
+
+/** Grains: drought-monitor drives the production drivers. observedAt is the
+ *  drought summary's own fetch time so freshness propagates accurately. */
+function applyDroughtInputs(out: InputAccumulator, drought: DroughtSummary): void {
+  const observedAt = drought.fetchedAt.getTime();
+  const wheatBag = buildGrainBag(drought.states, WHEAT_BELT, observedAt, 'us-drought-monitor');
+  const cornBag  = buildGrainBag(drought.states, CORN_BELT, observedAt, 'us-drought-monitor');
+  const soyBag   = buildGrainBag(drought.states, SOYBEAN_BELT, observedAt, 'us-drought-monitor');
+  if (Object.keys(wheatBag).length) out.wheat    = { ...out.wheat,    ...wheatBag };
+  if (Object.keys(cornBag).length)  out.corn     = { ...out.corn,     ...cornBag };
+  if (Object.keys(soyBag).length)   out.soybeans = { ...out.soybeans, ...soyBag };
+}
+
+/** Chokepoints: maritime export-corridor stress mapped to corridor/import drivers. */
+function applyChokepointInputs(out: InputAccumulator, chokepoints: readonly ChokepointSignal[], now: number): void {
+  for (const cp of chokepoints) {
+    const stress = corridorStressScore(cp);
+    const source = `chokepoint:${cp.key}`;
+    if (cp.key === 'bosphorus') {
+      out.wheat = { ...out.wheat, export_corridor_status: { value: stress, source, observedAt: now } };
+    } else if (cp.key === 'suez') {
+      out.rice = { ...out.rice, export_corridor_status: { value: stress, source, observedAt: now } };
+    } else if (cp.key === 'hormuz') {
+      // Hormuz disruption proxies for crude-import stress on both diesel and
+      // gasoline. Mapped onto crude_imports_wow as a negative delta — 100 stress
+      // → -40% WoW imports, at the floor of the model's inverseLinear(-25, 5) band.
+      const inp: ShortageInput = { value: -stress * 0.4, source, observedAt: now };
+      out.diesel   = { ...out.diesel,   crude_imports_wow: inp };
+      out.gasoline = { ...out.gasoline, crude_imports_wow: inp };
+    }
+  }
+}
+
+/** Grid alerts: natural-gas demand + curtailment proxies. */
+function applyGridInputs(out: InputAccumulator, gridAlerts: readonly PowerGridAlert[], now: number): void {
+  const natGasBag = buildNatGasBag(gridAlerts, now);
+  if (Object.keys(natGasBag).length) {
+    out['natural-gas'] = { ...out['natural-gas'], ...natGasBag };
+  }
 }
 
 // ── Grain helpers ─────────────────────────────────────────────────────────
@@ -199,7 +197,88 @@ function round(n: number): number {
   return Math.round(n * 10) / 10;
 }
 
+// ── Per-feed status + per-commodity fail-closed merge ──────────────────────
+// A PARTIAL outage (e.g. the chokepoint feed is down but drought is healthy)
+// must not silently downgrade the commodities that depend on the dead feed.
+// We track which of the three underlying feeds actually refreshed this cycle,
+// then merge fresh-vs-cached entries PER COMMODITY: a commodity keeps its prior
+// (cached) risk whenever ANY feed it depends on failed.
+
+/** The `dataFreshness` source ids for the three wired shortage feeds. Each is a
+ *  valid `DataSourceId` (drought-monitor + power-grid-alerts record under their
+ *  own ids; chokepoint status records under the supply_chain domain id). */
+export type ShortageFeedId = 'drought-monitor' | 'power-grid-alerts' | 'supply_chain';
+
+/** Which feeds each commodity's inputs are derived from in
+ *  `buildShortageInputsFromSources`. Commodities with no wired feed have no
+ *  dependencies — their forecast is always the seasonal baseline, so there is
+ *  no live risk a failed feed could erase. */
+export const COMMODITY_SOURCE_FEEDS: Record<FullSetCommodity, readonly ShortageFeedId[]> = {
+  wheat: ['drought-monitor', 'supply_chain'], // belt drought + Bosphorus corridor
+  corn: ['drought-monitor'],
+  soybeans: ['drought-monitor'],
+  rice: ['supply_chain'],                       // Suez corridor
+  diesel: ['supply_chain'],                     // Hormuz crude imports
+  gasoline: ['supply_chain'],                   // Hormuz crude imports
+  'natural-gas': ['power-grid-alerts'],
+  'jet-fuel': [],
+  fertilizer: [],
+  crude: [],
+  propane: [],
+  electricity: [],
+};
+
+export interface ShortageInputsWithStatus {
+  inputs: Partial<Record<FullSetCommodity, ShortageInputBag>>;
+  /** True iff the feed actually refreshed (or last refreshed) without a pending
+   *  error this cycle — see `loadShortageInputsWithStatus`. */
+  feedsOk: Record<ShortageFeedId, boolean>;
+}
+
+/**
+ * Merges a freshly-computed full set against the prior cached set, per commodity.
+ * A commodity adopts its FRESH entry only when every feed it depends on is OK;
+ * otherwise it keeps its CACHED entry (preserving a known risk through the
+ * outage), falling back to the fresh baseline only when no cached entry exists.
+ * Pure + deterministic — no fetch, no clock.
+ */
+export function mergeShortageEntriesByFeedStatus(
+  fresh: readonly ShortageSummaryEntry[],
+  cached: readonly ShortageSummaryEntry[],
+  feedsOk: Readonly<Record<ShortageFeedId, boolean>>,
+): ShortageSummaryEntry[] {
+  const cachedByCommodity = new Map(cached.map((e) => [e.commodity, e]));
+  return fresh.map((freshEntry) => {
+    const deps = COMMODITY_SOURCE_FEEDS[freshEntry.commodity] ?? [];
+    const allDepsOk = deps.every((f) => feedsOk[f]);
+    if (allDepsOk) return freshEntry;
+    return cachedByCommodity.get(freshEntry.commodity) ?? freshEntry;
+  });
+}
+
 // ── Async shell ───────────────────────────────────────────────────────────
+
+/** Maps a provider's free-text chokepoint name onto one of the three corridors
+ *  the bridge models. Returns null for chokepoints we don't yet wire. */
+function chokepointKeyFromName(name: string): ChokepointKey | null {
+  const n = name.toLowerCase();
+  if (n.includes('bosphorus')) return 'bosphorus';
+  if (n.includes('suez')) return 'suez';
+  if (n.includes('hormuz')) return 'hormuz';
+  return null;
+}
+
+function toChokepointSignals(
+  chokepoints: readonly { name: string; disruptionScore: number; status: string }[],
+): ChokepointSignal[] {
+  const cps: ChokepointSignal[] = [];
+  for (const c of chokepoints) {
+    const key = chokepointKeyFromName(c.name);
+    if (!key) continue;
+    cps.push({ key, disruptionScore: c.disruptionScore, status: (c.status as ChokepointSignal['status']) ?? undefined });
+  }
+  return cps;
+}
 
 /**
  * Fetches the three currently-wired feeds in parallel (best-effort) and
@@ -217,23 +296,38 @@ export async function loadShortageInputs(): Promise<Partial<Record<FullSetCommod
     fetchPowerGridAlerts(),
     fetchChokepointStatus(),
   ]);
-  const cps: ChokepointSignal[] = [];
-  if (chokepoints.status === 'fulfilled') {
-    for (const c of chokepoints.value.chokepoints) {
-      const name = c.name.toLowerCase();
-      const key: ChokepointKey | null =
-        name.includes('bosphorus') ? 'bosphorus' :
-        name.includes('suez')      ? 'suez' :
-        name.includes('hormuz')    ? 'hormuz' :
-        null;
-      if (!key) continue;
-      const status = (c.status as ChokepointSignal['status']) ?? undefined;
-      cps.push({ key, disruptionScore: c.disruptionScore, status });
-    }
-  }
+  const cps = chokepoints.status === 'fulfilled'
+    ? toChokepointSignals(chokepoints.value.chokepoints)
+    : [];
   return buildShortageInputsFromSources({
     drought:     drought.status === 'fulfilled' ? drought.value : undefined,
     gridAlerts:  gridAlerts.status === 'fulfilled' ? gridAlerts.value : undefined,
     chokepoints: cps.length > 0 ? cps : undefined,
   });
+}
+
+/**
+ * Same as `loadShortageInputs`, plus a per-feed health verdict read from
+ * `dataFreshness` AFTER the fetchers have run. A feed is OK when it has a prior
+ * successful update and no pending error — `recordUpdate` clears `lastError`
+ * while `recordError` sets it, so this correctly treats an internal cache-hit
+ * (no new record this cycle) as healthy and only a genuine failure as down.
+ * Callers feed `feedsOk` into `mergeShortageEntriesByFeedStatus` to keep partial
+ * outages from downgrading commodities whose feed is still alive.
+ */
+export async function loadShortageInputsWithStatus(): Promise<ShortageInputsWithStatus> {
+  const inputs = await loadShortageInputs();
+  const { dataFreshness } = await import('@/services/data-freshness');
+  const feedOk = (id: ShortageFeedId): boolean => {
+    const s = dataFreshness.getSource(id);
+    return !!s?.lastUpdate && !s.lastError;
+  };
+  return {
+    inputs,
+    feedsOk: {
+      'drought-monitor': feedOk('drought-monitor'),
+      'power-grid-alerts': feedOk('power-grid-alerts'),
+      'supply_chain': feedOk('supply_chain'),
+    },
+  };
 }

--- a/src/services/shortage/shortage-input-bridge.ts
+++ b/src/services/shortage/shortage-input-bridge.ts
@@ -235,25 +235,60 @@ export interface ShortageInputsWithStatus {
   feedsOk: Record<ShortageFeedId, boolean>;
 }
 
+/** Whether every feed a commodity depends on is healthy this cycle. A commodity
+ *  with no wired feed (empty deps) is always considered satisfiable. */
+export function commodityFeedsOk(
+  commodity: FullSetCommodity,
+  feedsOk: Readonly<Record<ShortageFeedId, boolean>>,
+): boolean {
+  return (COMMODITY_SOURCE_FEEDS[commodity] ?? []).every((f) => feedsOk[f]);
+}
+
+/** The set of commodities whose feeds are all healthy — i.e. the ones safe to
+ *  recompute during a partial outage. Callers pass this as `computeShortageFullSet`'s
+ *  `only` option so down-feed commodities are never recomputed (and so never
+ *  pollute trend memory with a discarded baseline score). */
+export function healthyCommodities(
+  feedsOk: Readonly<Record<ShortageFeedId, boolean>>,
+): Set<FullSetCommodity> {
+  const out = new Set<FullSetCommodity>();
+  for (const commodity of Object.keys(COMMODITY_SOURCE_FEEDS) as FullSetCommodity[]) {
+    if (commodityFeedsOk(commodity, feedsOk)) out.add(commodity);
+  }
+  return out;
+}
+
 /**
- * Merges a freshly-computed full set against the prior cached set, per commodity.
- * A commodity adopts its FRESH entry only when every feed it depends on is OK;
- * otherwise it keeps its CACHED entry (preserving a known risk through the
- * outage), falling back to the fresh baseline only when no cached entry exists.
- * Pure + deterministic — no fetch, no clock.
+ * Merges freshly-computed entries against the prior cached set, per commodity,
+ * over the UNION of both (so `fresh` may be a subset — only the healthy-feed
+ * commodities). A commodity adopts its FRESH entry only when every feed it
+ * depends on is OK and a fresh entry exists; otherwise it keeps its CACHED entry
+ * (preserving a known risk through the outage), falling back to the fresh entry
+ * only when no cached entry exists. Pure + deterministic — no fetch, no clock.
  */
 export function mergeShortageEntriesByFeedStatus(
   fresh: readonly ShortageSummaryEntry[],
   cached: readonly ShortageSummaryEntry[],
   feedsOk: Readonly<Record<ShortageFeedId, boolean>>,
 ): ShortageSummaryEntry[] {
+  const freshByCommodity = new Map(fresh.map((e) => [e.commodity, e]));
   const cachedByCommodity = new Map(cached.map((e) => [e.commodity, e]));
-  return fresh.map((freshEntry) => {
-    const deps = COMMODITY_SOURCE_FEEDS[freshEntry.commodity] ?? [];
-    const allDepsOk = deps.every((f) => feedsOk[f]);
-    if (allDepsOk) return freshEntry;
-    return cachedByCommodity.get(freshEntry.commodity) ?? freshEntry;
-  });
+  const out: ShortageSummaryEntry[] = [];
+  const seen = new Set<FullSetCommodity>();
+  for (const commodity of [...freshByCommodity.keys(), ...cachedByCommodity.keys()]) {
+    if (seen.has(commodity)) continue;
+    seen.add(commodity);
+    const freshEntry = freshByCommodity.get(commodity);
+    const cachedEntry = cachedByCommodity.get(commodity);
+    if (commodityFeedsOk(commodity, feedsOk) && freshEntry) {
+      out.push(freshEntry);
+    } else if (cachedEntry) {
+      out.push(cachedEntry);
+    } else if (freshEntry) {
+      out.push(freshEntry);
+    }
+  }
+  return out;
 }
 
 // ── Async shell ───────────────────────────────────────────────────────────

--- a/src/services/shortage/shortage-input-bridge.ts
+++ b/src/services/shortage/shortage-input-bridge.ts
@@ -205,21 +205,23 @@ function round(n: number): number {
 // (cached) risk whenever ANY feed it depends on failed.
 
 /** The `dataFreshness` source ids for the three wired shortage feeds. Each is a
- *  valid `DataSourceId` (drought-monitor + power-grid-alerts record under their
- *  own ids; chokepoint status records under the supply_chain domain id). */
-export type ShortageFeedId = 'drought-monitor' | 'power-grid-alerts' | 'supply_chain';
+ *  valid `DataSourceId`. The chokepoint feed records under its OWN
+ *  `'chokepoint-status'` id — deliberately NOT the shared `'supply_chain'` source,
+ *  which the supply-chain panel also advances for shipping/minerals; sharing it
+ *  would let a healthy shipping refresh mask a chokepoint outage. */
+export type ShortageFeedId = 'drought-monitor' | 'power-grid-alerts' | 'chokepoint-status';
 
 /** Which feeds each commodity's inputs are derived from in
  *  `buildShortageInputsFromSources`. Commodities with no wired feed have no
  *  dependencies — their forecast is always the seasonal baseline, so there is
  *  no live risk a failed feed could erase. */
 export const COMMODITY_SOURCE_FEEDS: Record<FullSetCommodity, readonly ShortageFeedId[]> = {
-  wheat: ['drought-monitor', 'supply_chain'], // belt drought + Bosphorus corridor
+  wheat: ['drought-monitor', 'chokepoint-status'], // belt drought + Bosphorus corridor
   corn: ['drought-monitor'],
   soybeans: ['drought-monitor'],
-  rice: ['supply_chain'],                       // Suez corridor
-  diesel: ['supply_chain'],                     // Hormuz crude imports
-  gasoline: ['supply_chain'],                   // Hormuz crude imports
+  rice: ['chokepoint-status'],                       // Suez corridor
+  diesel: ['chokepoint-status'],                     // Hormuz crude imports
+  gasoline: ['chokepoint-status'],                   // Hormuz crude imports
   'natural-gas': ['power-grid-alerts'],
   'jet-fuel': [],
   fertilizer: [],
@@ -362,7 +364,7 @@ export async function loadShortageInputsWithStatus(): Promise<ShortageInputsWith
     feedsOk: {
       'drought-monitor': feedOk('drought-monitor'),
       'power-grid-alerts': feedOk('power-grid-alerts'),
-      'supply_chain': feedOk('supply_chain'),
+      'chokepoint-status': feedOk('chokepoint-status'),
     },
   };
 }

--- a/src/services/supply-chain/index.ts
+++ b/src/services/supply-chain/index.ts
@@ -1,6 +1,7 @@
 import { createCircuitBreaker } from '@/utils';
 import { getHydratedData } from '@/services/bootstrap';
 import { getApiBaseUrl } from '@/services/runtime';
+import { dataFreshness } from '@/services/data-freshness';
 
 import type {
   GetShippingRatesResponse,
@@ -21,7 +22,7 @@ export type {
 
 interface SidecarSupplyChain {
   bdi: { value: number; date: string } | null;
-  chokepoints: Array<{ name: string; status: string; throughput_pct: number | null; region: string }>;
+  chokepoints: { name: string; status: string; throughput_pct: number | null; region: string }[];
   fetchedAt: string;
 }
 
@@ -30,7 +31,10 @@ const chokepointBreaker = createCircuitBreaker<GetChokepointStatusResponse>({ na
 const mineralsBreaker = createCircuitBreaker<GetCriticalMineralsResponse>({ name: 'Critical Minerals', cacheTtlMs: 60 * 60 * 1000, persistCache: true });
 
 const emptyShipping: GetShippingRatesResponse = { indices: [], fetchedAt: '', upstreamUnavailable: false };
-const emptyChokepoints: GetChokepointStatusResponse = { chokepoints: [], fetchedAt: '', upstreamUnavailable: false };
+// Distinct fallback for the breaker/catch paths so a real outage is marked
+// `upstreamUnavailable` (and recorded as a dataFreshness error) rather than
+// looking like a healthy "no chokepoints" response.
+const unavailableChokepoints: GetChokepointStatusResponse = { chokepoints: [], fetchedAt: '', upstreamUnavailable: true };
 const emptyMinerals: GetCriticalMineralsResponse = { minerals: [], fetchedAt: '', upstreamUnavailable: false };
 
 async function fetchSidecarData(): Promise<SidecarSupplyChain> {
@@ -69,10 +73,20 @@ export async function fetchShippingRates(): Promise<GetShippingRatesResponse> {
 
 export async function fetchChokepointStatus(): Promise<GetChokepointStatusResponse> {
   const hydrated = getHydratedData('chokepoints') as GetChokepointStatusResponse | undefined;
-  if (hydrated) return hydrated;
+  if (hydrated) {
+    // Bootstrap-hydrated payloads bypass the fetch below, so record their health
+    // here too — otherwise valid hydrated data leaves the supply_chain feed
+    // looking down to the shortage fail-closed merge.
+    if (hydrated.upstreamUnavailable) {
+      dataFreshness.recordError('supply_chain', 'hydrated payload marked upstream unavailable');
+    } else {
+      dataFreshness.recordUpdate('supply_chain', hydrated.chokepoints.length);
+    }
+    return hydrated;
+  }
 
   try {
- return await chokepointBreaker.execute(async () => {
+ const result = await chokepointBreaker.execute(async () => {
  const data = await fetchSidecarData();
  return {
  chokepoints: data.chokepoints.map((c, i) => ({
@@ -80,7 +94,7 @@ export async function fetchChokepointStatus(): Promise<GetChokepointStatusRespon
  name: c.name,
  lat: 0,
  lon: 0,
- disruptionScore: c.throughput_pct != null ? Math.max(0, 100 - c.throughput_pct) : 0,
+ disruptionScore: c.throughput_pct == null ? 0 : Math.max(0, 100 - c.throughput_pct),
  status: c.status,
  activeWarnings: 0,
  congestionLevel: '',
@@ -90,9 +104,16 @@ export async function fetchChokepointStatus(): Promise<GetChokepointStatusRespon
  fetchedAt: data.fetchedAt,
  upstreamUnavailable: false,
  };
- }, emptyChokepoints);
+ }, unavailableChokepoints);
+    if (result.upstreamUnavailable) {
+      dataFreshness.recordError('supply_chain', 'upstream unavailable');
+    } else {
+      dataFreshness.recordUpdate('supply_chain', result.chokepoints.length);
+    }
+    return result;
   } catch {
- return emptyChokepoints;
+    dataFreshness.recordError('supply_chain', 'fetch threw');
+    return unavailableChokepoints;
   }
 }
 
@@ -101,7 +122,7 @@ export async function fetchCriticalMinerals(): Promise<GetCriticalMineralsRespon
   if (hydrated) return hydrated;
 
   try {
- return await mineralsBreaker.execute(async () => emptyMinerals, emptyMinerals);
+ return await mineralsBreaker.execute(() => Promise.resolve(emptyMinerals), emptyMinerals);
   } catch {
  return emptyMinerals;
   }

--- a/src/services/supply-chain/index.ts
+++ b/src/services/supply-chain/index.ts
@@ -75,12 +75,12 @@ export async function fetchChokepointStatus(): Promise<GetChokepointStatusRespon
   const hydrated = getHydratedData('chokepoints') as GetChokepointStatusResponse | undefined;
   if (hydrated) {
     // Bootstrap-hydrated payloads bypass the fetch below, so record their health
-    // here too — otherwise valid hydrated data leaves the supply_chain feed
+    // here too — otherwise valid hydrated data leaves the chokepoint-status feed
     // looking down to the shortage fail-closed merge.
     if (hydrated.upstreamUnavailable) {
-      dataFreshness.recordError('supply_chain', 'hydrated payload marked upstream unavailable');
+      dataFreshness.recordError('chokepoint-status', 'hydrated payload marked upstream unavailable');
     } else {
-      dataFreshness.recordUpdate('supply_chain', hydrated.chokepoints.length);
+      dataFreshness.recordUpdate('chokepoint-status', hydrated.chokepoints.length);
     }
     return hydrated;
   }
@@ -106,13 +106,13 @@ export async function fetchChokepointStatus(): Promise<GetChokepointStatusRespon
  };
  }, unavailableChokepoints);
     if (result.upstreamUnavailable) {
-      dataFreshness.recordError('supply_chain', 'upstream unavailable');
+      dataFreshness.recordError('chokepoint-status', 'upstream unavailable');
     } else {
-      dataFreshness.recordUpdate('supply_chain', result.chokepoints.length);
+      dataFreshness.recordUpdate('chokepoint-status', result.chokepoints.length);
     }
     return result;
   } catch {
-    dataFreshness.recordError('supply_chain', 'fetch threw');
+    dataFreshness.recordError('chokepoint-status', 'fetch threw');
     return unavailableChokepoints;
   }
 }

--- a/src/services/survival/__tests__/supply-contributor.test.mts
+++ b/src/services/survival/__tests__/supply-contributor.test.mts
@@ -266,27 +266,31 @@ test('cold cache: empty base yields no supply threats (no crash, no phantom axis
   assert.deepEqual(contributor.contribute(NOW), []);
 });
 
-// ── Fail-closed shortage cache (feed outage must not clear a known risk) ──────
-// `loadShortageInputs()` is best-effort and drops failed feeds, so a total
-// outage returns an empty input map with no failure signal. `getSupplyEntries`
-// recomputes only when the refresh actually returned feed data — otherwise it
-// preserves the prior cache. `shortageCacheAction(gotFeedData, hasCache)` is the
-// pure decision seam: 'replace' (feed-backed → authoritative), 'keep' (outage +
-// warm cache → preserve prior risk), 'passthrough' (cold start + no feed data →
-// baseline but NOT authoritative, so the hydrated fallback wins).
-
-test('fail-closed: keep prior cache when feeds fail but a cache exists', () => {
-  // Outage (gotFeedData === false) + a prior HIGH/CRITICAL cache -> keep it.
-  assert.equal(shortageCacheAction(false, true), 'keep');
-});
-
-test('cold start + outage: passthrough (do NOT become authoritative)', () => {
-  // No prior cache + no feed data -> baseline but not authoritative, so a hydrated
-  // snapshot's supply threat is preserved by supplyContributorForBase (fail-closed).
-  assert.equal(shortageCacheAction(false, false), 'passthrough');
-});
+// ── Fail-closed shortage cache (a dead feed must not clear a known risk) ──────
+// Each shortage feed (drought / grid / chokepoint) reports its own health, so
+// `shortageCacheAction(gotAnyFeed, allFeedsOk, hasCache)` distinguishes a full
+// refresh from partial and total outages: 'replace' (all feeds healthy →
+// authoritative), 'merge' (partial outage + warm cache → keep cached entries for
+// the dead feed's commodities, refresh the rest), 'keep' (total outage + warm
+// cache → preserve prior risk), 'passthrough' (cold start under anything short of
+// a clean refresh → baseline but NOT authoritative, so the hydrated fallback wins).
 
 test('healthy refresh always replaces, regardless of prior cache', () => {
-  assert.equal(shortageCacheAction(true, true), 'replace');
-  assert.equal(shortageCacheAction(true, false), 'replace');
+  assert.equal(shortageCacheAction(true, true, true), 'replace');
+  assert.equal(shortageCacheAction(true, true, false), 'replace');
+});
+
+test('partial outage + warm cache: merge (keep dead-feed commodities, refresh rest)', () => {
+  assert.equal(shortageCacheAction(true, false, true), 'merge');
+});
+
+test('total outage + warm cache: keep prior cache (preserve known risk)', () => {
+  assert.equal(shortageCacheAction(false, false, true), 'keep');
+});
+
+test('cold start under an incomplete refresh: passthrough (do NOT become authoritative)', () => {
+  // No prior cache: a hydrated snapshot's supply threat must survive, so neither a
+  // total outage nor a partial refresh may seed the cache (only allFeedsOk does).
+  assert.equal(shortageCacheAction(false, false, false), 'passthrough');
+  assert.equal(shortageCacheAction(true, false, false), 'passthrough');
 });

--- a/src/services/survival/storm-posture-state.ts
+++ b/src/services/survival/storm-posture-state.ts
@@ -3,7 +3,11 @@ import { fetchNWSAlerts } from '../nws-alerts.ts';
 import { getSavedPlaces } from '../saved-places.ts';
 import { dataFreshness } from '../data-freshness.ts';
 import { computeShortageFullSet, type ShortageSummaryEntry } from '../shortage/shortage-fullset.ts';
-import { loadShortageInputs } from '../shortage/shortage-input-bridge.ts';
+import {
+  loadShortageInputsWithStatus,
+  mergeShortageEntriesByFeedStatus,
+  type ShortageFeedId,
+} from '../shortage/shortage-input-bridge.ts';
 import { buildSnapshot } from './world-snapshot.ts';
 import { commitMove, applyPlanToPosture } from './survival-plan.ts';
 import { computeMultiAxisPosture } from './survival-posture.ts';
@@ -20,58 +24,90 @@ import type { SurvivalMove, SurvivalPosture, WorldSnapshot } from './survival-ty
 // ── Shortage-entry TTL cache ────────────────────────────────────────────────
 // The three shortage feeds (drought / chokepoint / grid) move slowly, but
 // refreshStormPosture runs ~every 120s. Refetching them on every storm tick is
-// wasteful, so cache the computed entries and only re-`loadShortageInputs()`
-// when older than SHORTAGE_TTL_MS. Last-write-wins; no concurrency guard.
+// wasteful, so cache the computed entries and only re-fetch (via
+// loadShortageInputsWithStatus) when older than SHORTAGE_TTL_MS. Last-write-wins;
+// no concurrency guard.
 const SHORTAGE_TTL_MS = 15 * 60_000;
 let cachedShortageEntries: ShortageSummaryEntry[] = [];
 let cachedShortageAtMs = 0;
 let hasShortageCache = false;
 
-/** Decide whether a refresh result may REPLACE the cached supply entries.
- *  Fail-closed: `loadShortageInputs()` is best-effort (`Promise.allSettled`) and
- *  drops failed feeds, so a total feed outage returns an EMPTY input map with no
- *  failure signal. Recomputing from that empty bag pushes every commodity to
- *  baseline/LOW — which would silently overwrite a known HIGH/CRITICAL cache and
- *  flip the supply axis to an unsafe all-clear purely because feeds failed. So we
- *  only become the authoritative cache when the refresh actually returned feed
- *  data ('replace'); on an outage with a prior cache we keep the prior risk
- *  ('keep'); on a cold start with no feed data we pass through baseline WITHOUT
- *  caching it authoritatively ('passthrough'), so a hydrated snapshot's supply is
- *  preserved by `supplyContributorForBase` (fail-closed). Pure + exported so the
- *  decision is unit-testable. */
-export type ShortageCacheAction = 'replace' | 'keep' | 'passthrough';
-export function shortageCacheAction(gotFeedData: boolean, hasCache: boolean): ShortageCacheAction {
-  if (gotFeedData) return 'replace';
-  return hasCache ? 'keep' : 'passthrough';
+/** Decide how a refresh result interacts with the cached supply entries, now at
+ *  per-feed granularity. Each shortage feed (drought / grid / chokepoint) reports
+ *  its own health via `dataFreshness`, so we distinguish a FULL refresh, a PARTIAL
+ *  outage, and a TOTAL outage:
+ *
+ *  - `'replace'`  — every feed is healthy → the fresh full set is authoritative.
+ *  - `'merge'`    — a partial outage with a warm cache → keep the cached entry for
+ *                   any commodity whose feed is down, refresh the rest
+ *                   (`mergeShortageEntriesByFeedStatus`). This is the fix for the
+ *                   gap where one dead feed used to downgrade its commodities to
+ *                   baseline even though the others were fine.
+ *  - `'keep'`     — a total outage with a warm cache → preserve all prior risk and
+ *                   throttle the next retry.
+ *  - `'passthrough'` — a COLD start (no cache) under anything short of a fully
+ *                   clean refresh → return baseline but do NOT become authoritative,
+ *                   so a hydrated snapshot's supply threats are preserved by
+ *                   `supplyContributorForBase` (fail-closed). We refuse to seed the
+ *                   cache from incomplete data and clobber a known risk.
+ *
+ *  Pure + exported so the decision is unit-testable. */
+export type ShortageCacheAction = 'replace' | 'merge' | 'keep' | 'passthrough';
+export function shortageCacheAction(
+  gotAnyFeed: boolean,
+  allFeedsOk: boolean,
+  hasCache: boolean,
+): ShortageCacheAction {
+  if (allFeedsOk) return 'replace';
+  if (!hasCache) return 'passthrough';
+  return gotAnyFeed ? 'merge' : 'keep';
 }
 
-/** Returns the supply-axis shortage entries, refreshing from the live feeds
- *  only when the cache is empty or older than the TTL. On a feed outage the
- *  refresh returns an empty input map (no commodity keys); rather than downgrade
- *  a known risk to baseline we preserve the prior cache and throttle the next
- *  retry by one TTL window. `now` is injected for determinism. */
+/** Returns the supply-axis shortage entries, refreshing from the live feeds only
+ *  when the cache is empty or older than the TTL. Each feed reports its own health
+ *  (see `loadShortageInputsWithStatus`), so a partial outage keeps the cached
+ *  entries for the dead feed's commodities while refreshing the rest, and a total
+ *  outage preserves the whole prior cache — never downgrading a known risk to
+ *  baseline because a feed failed. `now` is injected for determinism. */
 async function getSupplyEntries(now: number): Promise<ShortageSummaryEntry[]> {
   if (hasShortageCache && now - cachedShortageAtMs < SHORTAGE_TTL_MS) {
     return cachedShortageEntries;
   }
-  let shortageInputs: Awaited<ReturnType<typeof loadShortageInputs>> = {};
+  let inputs: Awaited<ReturnType<typeof loadShortageInputsWithStatus>>['inputs'] = {};
+  let feedsOk: Record<ShortageFeedId, boolean> = {
+    'drought-monitor': false,
+    'power-grid-alerts': false,
+    'supply_chain': false,
+  };
   try {
-    shortageInputs = await loadShortageInputs();
-  } catch { shortageInputs = {}; }
-  const gotFeedData = Object.keys(shortageInputs).length > 0;
-  const action = shortageCacheAction(gotFeedData, hasShortageCache);
+    const res = await loadShortageInputsWithStatus();
+    inputs = res.inputs;
+    feedsOk = res.feedsOk;
+  } catch { /* leave all feeds marked failed */ }
+
+  const gotAnyFeed = feedsOk['drought-monitor'] || feedsOk['power-grid-alerts'] || feedsOk.supply_chain;
+  const allFeedsOk = feedsOk['drought-monitor'] && feedsOk['power-grid-alerts'] && feedsOk.supply_chain;
+  const action = shortageCacheAction(gotAnyFeed, allFeedsOk, hasShortageCache);
+
   if (action === 'keep') {
-    // Outage with a warm cache — preserve the known risk; throttle the next retry.
+    // Total outage with a warm cache — preserve all known risk; throttle next retry.
+    // (Skip recomputing `fresh` so the all-baseline result can't pollute trend state.)
     cachedShortageAtMs = now;
     return cachedShortageEntries;
   }
+  const fresh = computeShortageFullSet(inputs, { now });
   if (action === 'passthrough') {
-    // Cold start + no feed data: return baseline WITHOUT becoming authoritative, so
-    // `supplyContributorForBase` preserves any hydrated supply threat (fail-closed).
-    return computeShortageFullSet(shortageInputs, { now });
+    // Cold start under an incomplete refresh: return baseline WITHOUT becoming
+    // authoritative, so `supplyContributorForBase` preserves any hydrated supply
+    // threat (fail-closed). We refuse to seed the cache from partial/no data.
+    return fresh;
   }
-  // 'replace' — a real feed-backed computation becomes the authoritative cache.
-  cachedShortageEntries = computeShortageFullSet(shortageInputs, { now });
+  // 'merge' (partial outage + warm cache) keeps cached entries for the commodities
+  // whose feed is down and refreshes the rest; 'replace' (all feeds healthy) takes
+  // the fresh full set wholesale.
+  cachedShortageEntries = action === 'merge'
+    ? mergeShortageEntriesByFeedStatus(fresh, cachedShortageEntries, feedsOk)
+    : fresh;
   cachedShortageAtMs = now;
   hasShortageCache = true;
   return cachedShortageEntries;

--- a/src/services/survival/storm-posture-state.ts
+++ b/src/services/survival/storm-posture-state.ts
@@ -6,6 +6,7 @@ import { computeShortageFullSet, type ShortageSummaryEntry } from '../shortage/s
 import {
   loadShortageInputsWithStatus,
   mergeShortageEntriesByFeedStatus,
+  healthyCommodities,
   type ShortageFeedId,
 } from '../shortage/shortage-input-bridge.ts';
 import { buildSnapshot } from './world-snapshot.ts';
@@ -91,23 +92,26 @@ async function getSupplyEntries(now: number): Promise<ShortageSummaryEntry[]> {
 
   if (action === 'keep') {
     // Total outage with a warm cache — preserve all known risk; throttle next retry.
-    // (Skip recomputing `fresh` so the all-baseline result can't pollute trend state.)
+    // (Skip recomputing entirely so the all-baseline result can't pollute trend state.)
     cachedShortageAtMs = now;
     return cachedShortageEntries;
   }
-  const fresh = computeShortageFullSet(inputs, { now });
   if (action === 'passthrough') {
     // Cold start under an incomplete refresh: return baseline WITHOUT becoming
     // authoritative, so `supplyContributorForBase` preserves any hydrated supply
     // threat (fail-closed). We refuse to seed the cache from partial/no data.
-    return fresh;
+    return computeShortageFullSet(inputs, { now });
   }
-  // 'merge' (partial outage + warm cache) keeps cached entries for the commodities
-  // whose feed is down and refreshes the rest; 'replace' (all feeds healthy) takes
-  // the fresh full set wholesale.
-  cachedShortageEntries = action === 'merge'
-    ? mergeShortageEntriesByFeedStatus(fresh, cachedShortageEntries, feedsOk)
-    : fresh;
+  if (action === 'merge') {
+    // Partial outage + warm cache: recompute ONLY the healthy-feed commodities (so
+    // down-feed commodities never write a discarded baseline score into trend
+    // memory), then keep cached entries for everything whose feed is down.
+    const fresh = computeShortageFullSet(inputs, { now, only: healthyCommodities(feedsOk) });
+    cachedShortageEntries = mergeShortageEntriesByFeedStatus(fresh, cachedShortageEntries, feedsOk);
+  } else {
+    // 'replace' — every feed healthy; the fresh full set is authoritative.
+    cachedShortageEntries = computeShortageFullSet(inputs, { now });
+  }
   cachedShortageAtMs = now;
   hasShortageCache = true;
   return cachedShortageEntries;

--- a/src/services/survival/storm-posture-state.ts
+++ b/src/services/survival/storm-posture-state.ts
@@ -78,7 +78,7 @@ async function getSupplyEntries(now: number): Promise<ShortageSummaryEntry[]> {
   let feedsOk: Record<ShortageFeedId, boolean> = {
     'drought-monitor': false,
     'power-grid-alerts': false,
-    'supply_chain': false,
+    'chokepoint-status': false,
   };
   try {
     const res = await loadShortageInputsWithStatus();
@@ -86,8 +86,8 @@ async function getSupplyEntries(now: number): Promise<ShortageSummaryEntry[]> {
     feedsOk = res.feedsOk;
   } catch { /* leave all feeds marked failed */ }
 
-  const gotAnyFeed = feedsOk['drought-monitor'] || feedsOk['power-grid-alerts'] || feedsOk.supply_chain;
-  const allFeedsOk = feedsOk['drought-monitor'] && feedsOk['power-grid-alerts'] && feedsOk.supply_chain;
+  const gotAnyFeed = feedsOk['drought-monitor'] || feedsOk['power-grid-alerts'] || feedsOk['chokepoint-status'];
+  const allFeedsOk = feedsOk['drought-monitor'] && feedsOk['power-grid-alerts'] && feedsOk['chokepoint-status'];
   const action = shortageCacheAction(gotAnyFeed, allFeedsOk, hasShortageCache);
 
   if (action === 'keep') {


### PR DESCRIPTION
## What

Make the three shortage feeds signal failure honestly, then make the supply-axis
shortage cache **fail-closed at per-commodity granularity** so a partial feed
outage can no longer silently downgrade a known risk to baseline.

Mirrors the landed NWS `/api/nws-alerts` 503-on-failure pattern — the per-commodity
merge is only correct once the feeds can distinguish "feed up, no stress" from
"feed down".

### Feeds now signal failure (`dataFreshness`)
- `power-grid-alerts.ts` — records `recordError('power-grid-alerts', …)` when every RSS sub-feed fails (previously returned `[]` with no signal).
- `supply-chain/index.ts` `fetchChokepointStatus` — records `recordUpdate`/`recordError` under its **own** `'chokepoint-status'` source (hydrated, breaker, and catch paths).
- `drought-monitor.ts` already signalled correctly — unchanged.

### Per-commodity fail-closed supply cache (`storm-posture-state.ts` + bridge)
- `sourcesOk` is derived from `dataFreshness` (`lastUpdate != null && !lastError`), **not** `Promise.allSettled` fulfillment — the fetchers swallow errors and return empty fallbacks, so fulfillment is a false success signal (this is what regressed the earlier abandoned attempt).
- `COMMODITY_SOURCE_FEEDS` maps each commodity to its driving feeds; `mergeShortageEntriesByFeedStatus` keeps a commodity's prior cached entry unless **every** feed it depends on refreshed this cycle.
- 4-way `shortageCacheAction(gotAnyFeed, allFeedsOk, hasCache)`: `replace` (all healthy) / `merge` (partial + warm cache) / `keep` (total outage + warm cache) / `passthrough` (cold start under anything short of fully-clean — preserves the hydrated snapshot, never seeds the cache from incomplete data).
- Partial-outage recompute is scoped to `healthyCommodities(feedsOk)` via a new `computeShortageFullSet({ only })` so down-feed commodities never write a discarded baseline into trend memory.

## Why a dedicated `chokepoint-status` source
Codex review caught that reading the shared `'supply_chain'` source for chokepoint
health was unsafe: `loadSupplyChain()` advances `'supply_chain'` whenever shipping
or minerals have items, so a healthy shipping refresh could mask a chokepoint
outage and let rice/diesel/gasoline/wheat recompute from missing inputs. The
chokepoint feed now owns `'chokepoint-status'`; `'supply_chain'` stays the panel's
shipping/minerals aggregate.

## Test plan
- `npm run typecheck:all` — clean
- `npm run test:shortage` — 179 pass (merge truth table, `COMMODITY_SOURCE_FEEDS` exhaustiveness, partial/total/cold-start)
- `npm run test:survival` — 55 pass (3-arg `shortageCacheAction`, cold-cache hydrated preservation)
- `npm run test:datacenter` (38) + `npm run test:providers` (34) — pass (data-freshness consumers)
- eslint clean on all changed files

cross-agent review: codex — first pass flagged one P2 (shared `supply_chain` source masking chokepoint outage, fixed in b60ce239); re-review after the fix found no actionable correctness issues.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
