### PR TITLE
fix(deps): bump @babel/core 7.29.0 → 7.29.7 (GHSA-4x5r-pxfx-6jf8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -253,7 +253,8 @@
     "serialize-javascript": "^7.0.5",
     "protobufjs": "^7.5.6",
     "dompurify": "^3.4.0",
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "@babel/core": "^7.29.7"
   },
   "engines": {
     "node": ">=22.0.0 <23.0.0"


### PR DESCRIPTION
## Summary

Pins `@babel/core` from 7.29.0 (vulnerable) to 7.29.7 (patched) via:
- `package.json` `overrides` entry (`^7.29.7`) to persist the pin across future `npm install` runs
- `package-lock.json` lockfile entry bumped to 7.29.7 for `npm ci` in CI

**Advisory**: [GHSA-4x5r-pxfx-6jf8](https://github.com/advisories/GHSA-4x5r-pxfx-6jf8) — Arbitrary file read via `sourceMappingURL` comment. Affects `@babel/core <=7.29.0`.

`@babel/core` is a transitive devDependency (not used in production bundles). Risk is limited to dev/build environments.

Cross-agent review: Codex reviewed on 2026-06-15; outcome: pass