### PR TITLE
security: ACLED OAuth token expiry tracking and proactive refresh (Pass 8 P2)

### DIFF
--- a/src-tauri/sidecar/acled-token-helpers.mjs
+++ b/src-tauri/sidecar/acled-token-helpers.mjs
@@ -47,7 +47,7 @@ export function updateAcledTokenState(state, oauthData, now = Date.now()) {
   const newRefreshToken = oauthData.refresh_token ?? null;
   const rotated = newRefreshToken != null && newRefreshToken !== state.refreshToken;
   return {
-    expiresAt: expiresIn != null ? now + expiresIn * 1000 : state.expiresAt,
+    expiresAt: expiresIn == null ? state.expiresAt : now + expiresIn * 1000,
     refreshToken: newRefreshToken ?? state.refreshToken,
     refreshIssuedAt: rotated ? now : state.refreshIssuedAt,
   };

--- a/src-tauri/sidecar/acled-token-helpers.mjs
+++ b/src-tauri/sidecar/acled-token-helpers.mjs
@@ -1,0 +1,54 @@
+/**
+ * Pure helper logic for ACLED OAuth token lifecycle management.
+ * Extracted here so the sidecar server and unit tests can share the same
+ * implementations without spinning up an HTTP server in tests.
+ */
+
+export const ACLED_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000; // proactive refresh 5 min before expiry
+export const ACLED_REFRESH_TOKEN_WARN_DAYS = 90; // warn when refresh token hasn't rotated in 90 days
+
+/**
+ * Returns true when the access token expires within `bufferMs` from `now`.
+ * Returns false when expiresAt is null (unknown expiry → no proactive refresh).
+ */
+export function isAcledTokenExpiringSoon(
+  expiresAt,
+  now = Date.now(),
+  bufferMs = ACLED_TOKEN_REFRESH_BUFFER_MS,
+) {
+  if (expiresAt == null) return false;
+  return now >= expiresAt - bufferMs;
+}
+
+/**
+ * Returns true when the refresh token was first seen more than `warnDays` ago.
+ * Returns false when refreshIssuedAt is null (unknown age → no warning).
+ */
+export function isRefreshTokenStale(
+  refreshIssuedAt,
+  now = Date.now(),
+  warnDays = ACLED_REFRESH_TOKEN_WARN_DAYS,
+) {
+  if (refreshIssuedAt == null) return false;
+  return now - refreshIssuedAt >= warnDays * 24 * 60 * 60 * 1000;
+}
+
+/**
+ * Merges a successful OAuth response into the in-memory token state.
+ * Resets `refreshIssuedAt` only when a genuinely new refresh_token is returned.
+ *
+ * @param {object} state - current { expiresAt, refreshToken, refreshIssuedAt }
+ * @param {object} oauthData - parsed OAuth response body
+ * @param {number} now - current timestamp (ms)
+ * @returns {object} next state (shallow-merge into caller's state object)
+ */
+export function updateAcledTokenState(state, oauthData, now = Date.now()) {
+  const expiresIn = typeof oauthData.expires_in === 'number' ? oauthData.expires_in : null;
+  const newRefreshToken = oauthData.refresh_token ?? null;
+  const rotated = newRefreshToken != null && newRefreshToken !== state.refreshToken;
+  return {
+    expiresAt: expiresIn != null ? now + expiresIn * 1000 : state.expiresAt,
+    refreshToken: newRefreshToken ?? state.refreshToken,
+    refreshIssuedAt: rotated ? now : state.refreshIssuedAt,
+  };
+}

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -7206,7 +7206,8 @@ async function dispatch(requestUrl, req, routes, context) {
  // Proactively refresh the access token when it's within 5 min of expiry.
  let tokenRefreshed = false;
  if (isAcledTokenExpiringSoon(acledTokenState.expiresAt)) {
- const rt = acledTokenState.refreshToken || process.env.ACLED_REFRESH_TOKEN;
+ // Prefer process.env so settings-flow updates (via /api/local-env-update) are always honoured.
+ const rt = process.env.ACLED_REFRESH_TOKEN || acledTokenState.refreshToken;
  if (rt) {
  try {
  const refreshResp = await fetchWithTimeout(
@@ -13101,6 +13102,8 @@ async function dispatch(requestUrl, req, routes, context) {
  context.logger.log(`[local-api] env set: ${key}`);
  }
  if (key === 'AISSTREAM_API_KEY') aisOnKeyChanged(value || null);
+ if (key === 'ACLED_REFRESH_TOKEN') acledTokenState.refreshToken = value || null;
+ if (key === 'ACLED_ACCESS_TOKEN') acledTokenState.expiresAt = null; // expiry unknown after manual key update
  if (key === 'S2U_XMPP_JID' || key === 'S2U_XMPP_SECRET') {
  s2uXmppApplyCreds().catch((error) => {
  context.logger.log(`[s2u-xmpp] reapply creds failed: ${error?.message ?? error}`);

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -30,7 +30,6 @@ import {
   isAcledTokenExpiringSoon,
   isRefreshTokenStale,
   updateAcledTokenState,
-  ACLED_TOKEN_REFRESH_BUFFER_MS,
   ACLED_REFRESH_TOKEN_WARN_DAYS,
 } from './acled-token-helpers.mjs';
 import { fetchWithFallback } from './feed-resilience.mjs';
@@ -7092,11 +7091,16 @@ async function dispatch(requestUrl, req, routes, context) {
  if (!data.access_token) return json({ error: 'No access token in refresh response' }, 401);
  // Update in-memory state and warn if the refresh token hasn't rotated recently.
  const nowRefresh = Date.now();
+ // The caller-supplied refresh token just succeeded, so it is known-valid. Seed it
+ // as the baseline when in-memory state has none (e.g. after a sidecar restart);
+ // otherwise a non-rotating provider response would leave acledTokenState.refreshToken
+ // empty and silently disable proactive refresh in /api/acled-events.
+ if (!acledTokenState.refreshToken) acledTokenState.refreshToken = refreshToken;
  const wasStale = isRefreshTokenStale(acledTokenState.refreshIssuedAt, nowRefresh);
  const refreshedState = updateAcledTokenState(acledTokenState, data, nowRefresh);
  Object.assign(acledTokenState, refreshedState);
  process.env.ACLED_ACCESS_TOKEN = data.access_token;
- if (data.refresh_token) process.env.ACLED_REFRESH_TOKEN = data.refresh_token;
+ process.env.ACLED_REFRESH_TOKEN = data.refresh_token ?? refreshToken;
  return json({
  accessToken: data.access_token,
  refreshToken: data.refresh_token ?? refreshToken,

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -26,6 +26,13 @@ import {
   expireAlerts,
 } from './ipaws-aggregate.mjs';
 import { loadEnvFile } from './env-local-loader.mjs';
+import {
+  isAcledTokenExpiringSoon,
+  isRefreshTokenStale,
+  updateAcledTokenState,
+  ACLED_TOKEN_REFRESH_BUFFER_MS,
+  ACLED_REFRESH_TOKEN_WARN_DAYS,
+} from './acled-token-helpers.mjs';
 import { fetchWithFallback } from './feed-resilience.mjs';
 import { trackSuccess, trackFailure, getAllFeedStatuses, getFeedStatus } from './feed-health-tracker.mjs';
 import { fetchAllTfrs, tfrColor } from './faa-tfrs.mjs';
@@ -265,6 +272,16 @@ function warnUnauthorizedOnce(context, pathname) {
   context.logger.warn(`[local-api] unauthorized request to ${pathname} (token race at startup/rotation)${extra}`);
 }
 const SIDECAR_START_MS = Date.now();
+
+// ── ACLED OAuth token state (in-memory) ──────────────────────────────────
+// Seeded from process.env at startup; updated by /api/acled/connect and
+// /api/acled/refresh calls so the /api/acled-events handler can proactively
+// refresh the access token before it expires.
+const acledTokenState = {
+  expiresAt: null,         // ms timestamp when the current access token expires
+  refreshToken: process.env.ACLED_REFRESH_TOKEN ?? null,
+  refreshIssuedAt: null,   // ms timestamp when we first saw the current refresh token
+};
 const wmHostStats = new Map(); // host → { ok, fail, lastStatus, lastOkAt, lastFailAt, lastError }
 const WM_HOST_STATS_CAP = 100;
 const wmHostFailures = new Map(); // host → { count, lastError, lastAt }
@@ -1133,7 +1150,7 @@ globalThis.fetch = async function wmInstrumentedFetch(input, init) {
 const ALLOWED_ENV_KEYS = new Set([
   'CRYSTALBALL_API_KEY',
   'ANTHROPIC_API_KEY', 'GROQ_API_KEY', 'OPENROUTER_API_KEY', 'FRED_API_KEY', 'EIA_API_KEY',
-  'CLOUDFLARE_API_TOKEN', 'ACLED_ACCESS_TOKEN', 'ACLED_EMAIL', 'URLHAUS_AUTH_KEY',
+  'CLOUDFLARE_API_TOKEN', 'ACLED_ACCESS_TOKEN', 'ACLED_EMAIL', 'ACLED_REFRESH_TOKEN', 'URLHAUS_AUTH_KEY',
   'OTX_API_KEY', 'ABUSEIPDB_API_KEY', 'WINGBITS_API_KEY', 'WS_RELAY_URL',
   'VITE_OPENSKY_RELAY_URL', 'OPENSKY_CLIENT_ID', 'OPENSKY_CLIENT_SECRET',
   'AISSTREAM_API_KEY', 'VITE_WS_RELAY_URL', 'FINNHUB_API_KEY', 'NASA_FIRMS_API_KEY', 'AIRNOW_API_KEY', 'PURPLEAIR_API_KEY',
@@ -7041,6 +7058,14 @@ async function dispatch(requestUrl, req, routes, context) {
  if (!resp.ok) return json({ error: `ACLED auth failed (${resp.status})` }, resp.status);
  const data = await resp.json();
  if (!data.access_token) return json({ error: data.error_description ?? 'No access token returned' }, 401);
+ // Seed in-memory token state so /api/acled-events can proactively refresh.
+ const nowConnect = Date.now();
+ const nextState = updateAcledTokenState({ expiresAt: null, refreshToken: null, refreshIssuedAt: null }, data, nowConnect);
+ acledTokenState.expiresAt = nextState.expiresAt;
+ acledTokenState.refreshToken = nextState.refreshToken;
+ acledTokenState.refreshIssuedAt = nowConnect; // fresh connect → treat refresh token as newly issued
+ process.env.ACLED_ACCESS_TOKEN = data.access_token;
+ if (data.refresh_token) process.env.ACLED_REFRESH_TOKEN = data.refresh_token;
  return json({ accessToken: data.access_token, refreshToken: data.refresh_token ?? null, email });
  } catch {
  return json({ error: 'Request failed' }, 500);
@@ -7065,10 +7090,42 @@ async function dispatch(requestUrl, req, routes, context) {
  if (!resp.ok) return json({ error: `Token refresh failed (${resp.status})` }, resp.status);
  const data = await resp.json();
  if (!data.access_token) return json({ error: 'No access token in refresh response' }, 401);
- return json({ accessToken: data.access_token, refreshToken: data.refresh_token ?? refreshToken });
+ // Update in-memory state and warn if the refresh token hasn't rotated recently.
+ const nowRefresh = Date.now();
+ const wasStale = isRefreshTokenStale(acledTokenState.refreshIssuedAt, nowRefresh);
+ const refreshedState = updateAcledTokenState(acledTokenState, data, nowRefresh);
+ Object.assign(acledTokenState, refreshedState);
+ process.env.ACLED_ACCESS_TOKEN = data.access_token;
+ if (data.refresh_token) process.env.ACLED_REFRESH_TOKEN = data.refresh_token;
+ return json({
+ accessToken: data.access_token,
+ refreshToken: data.refresh_token ?? refreshToken,
+ ...(wasStale ? {
+ rotateRefreshTokenWarning: `Refresh token is over ${ACLED_REFRESH_TOKEN_WARN_DAYS} days old — re-authenticate via /api/acled/connect to rotate it`,
+ } : {}),
+ });
  } catch {
  return json({ error: 'Request failed' }, 500);
  }
+  }
+
+  // ── ACLED token status ─────────────────────────────────────────────────────
+  if (requestUrl.pathname === '/api/acled/token-status') {
+ const nowStatus = Date.now();
+ const expiresInSeconds = acledTokenState.expiresAt != null
+ ? Math.floor((acledTokenState.expiresAt - nowStatus) / 1000)
+ : null;
+ const refreshTokenAgeDays = acledTokenState.refreshIssuedAt != null
+ ? Math.floor((nowStatus - acledTokenState.refreshIssuedAt) / (24 * 60 * 60 * 1000))
+ : null;
+ return json({
+ hasAccessToken: Boolean(process.env.ACLED_ACCESS_TOKEN),
+ expiresInSeconds,
+ expiringSoon: isAcledTokenExpiringSoon(acledTokenState.expiresAt, nowStatus),
+ hasRefreshToken: Boolean(acledTokenState.refreshToken || process.env.ACLED_REFRESH_TOKEN),
+ refreshTokenAgeDays,
+ refreshTokenStale: isRefreshTokenStale(acledTokenState.refreshIssuedAt, nowStatus),
+ });
   }
 
   // ── OREF (Israel Home Front Command) alerts ──────────────────────────────
@@ -7142,11 +7199,39 @@ async function dispatch(requestUrl, req, routes, context) {
 
   // ACLED air strikes & drone events (last 30 days)
   if (requestUrl.pathname === '/api/acled-events') {
- const key = process.env.ACLED_ACCESS_TOKEN;
  const email = process.env.ACLED_EMAIL;
- if (!key || !email) {
+ if (!process.env.ACLED_ACCESS_TOKEN || !email) {
  return json({ events: [], error: 'ACLED_ACCESS_TOKEN and ACLED_EMAIL are required' });
  }
+ // Proactively refresh the access token when it's within 5 min of expiry.
+ let tokenRefreshed = false;
+ if (isAcledTokenExpiringSoon(acledTokenState.expiresAt)) {
+ const rt = acledTokenState.refreshToken || process.env.ACLED_REFRESH_TOKEN;
+ if (rt) {
+ try {
+ const refreshResp = await fetchWithTimeout(
+ 'https://acleddata.com/oauth/token',
+ {
+ method: 'POST',
+ headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': CHROME_UA },
+ body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token: rt, client_id: 'acled' }).toString(),
+ },
+ 15_000,
+ );
+ if (refreshResp.ok) {
+ const refreshData = await refreshResp.json();
+ if (refreshData.access_token) {
+ const updatedState = updateAcledTokenState(acledTokenState, refreshData);
+ Object.assign(acledTokenState, updatedState);
+ process.env.ACLED_ACCESS_TOKEN = refreshData.access_token;
+ if (refreshData.refresh_token) process.env.ACLED_REFRESH_TOKEN = refreshData.refresh_token;
+ tokenRefreshed = true;
+ }
+ }
+ } catch { /* auto-refresh is best-effort; continue with existing token */ }
+ }
+ }
+ const key = process.env.ACLED_ACCESS_TOKEN;
  const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
  const today = new Date().toISOString().slice(0, 10);
  const fields = 'event_id_cnty|event_date|event_type|sub_event_type|actor1|actor2|country|admin1|location|latitude|longitude|fatalities|notes';
@@ -7157,7 +7242,7 @@ async function dispatch(requestUrl, req, routes, context) {
  return json({ events: [], error: `ACLED error: ${resp.status}` });
  }
  const data = await resp.json();
- return json({ events: data.data ?? [] });
+ return json({ events: data.data ?? [], ...(tokenRefreshed ? { tokenRefreshed: true } : {}) });
  } catch (error) {
  return json({ events: [], error: String(error.message ?? error) });
  }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -81,6 +81,7 @@
       "sidecar/feed-health-tracker.mjs",
       "sidecar/recent-changes.mjs",
       "sidecar/env-local-loader.mjs",
+      "sidecar/acled-token-helpers.mjs",
       "sidecar/watchboard-engine.mjs",
       "sidecar/sms-command-parser.mjs",
       "sidecar/sms-security.mjs",

--- a/tests/acled-token-rotation.test.mjs
+++ b/tests/acled-token-rotation.test.mjs
@@ -1,0 +1,174 @@
+/**
+ * ACLED OAuth token lifecycle — unit tests for the pure helper functions.
+ *
+ * Tests are offline and stateless: no HTTP, no sidecar process needed.
+ *
+ * Covers:
+ *   - isAcledTokenExpiringSoon: null / fresh / expiring / expired
+ *   - isRefreshTokenStale:      null / fresh / threshold / over-threshold
+ *   - updateAcledTokenState:    expires_in capture / refresh token rotation / identity
+ *   - exported constants
+ */
+
+import { strict as assert } from 'node:assert';
+import test, { describe } from 'node:test';
+
+import {
+  isAcledTokenExpiringSoon,
+  isRefreshTokenStale,
+  updateAcledTokenState,
+  ACLED_TOKEN_REFRESH_BUFFER_MS,
+  ACLED_REFRESH_TOKEN_WARN_DAYS,
+} from '../src-tauri/sidecar/acled-token-helpers.mjs';
+
+const MIN_MS = 60_000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = 1_780_000_000_000; // fixed reference timestamp
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+describe('exported constants', () => {
+  test('ACLED_TOKEN_REFRESH_BUFFER_MS is 5 minutes', () => {
+    assert.equal(ACLED_TOKEN_REFRESH_BUFFER_MS, 5 * MIN_MS);
+  });
+
+  test('ACLED_REFRESH_TOKEN_WARN_DAYS is 90', () => {
+    assert.equal(ACLED_REFRESH_TOKEN_WARN_DAYS, 90);
+  });
+});
+
+// ── isAcledTokenExpiringSoon ──────────────────────────────────────────────────
+
+describe('isAcledTokenExpiringSoon', () => {
+  test('returns false when expiresAt is null (unknown expiry)', () => {
+    assert.equal(isAcledTokenExpiringSoon(null, NOW), false);
+  });
+
+  test('returns false when expiresAt is undefined', () => {
+    assert.equal(isAcledTokenExpiringSoon(undefined, NOW), false);
+  });
+
+  test('returns false when token expires well after the buffer window', () => {
+    const expiresAt = NOW + 60 * MIN_MS; // 60 min from now
+    assert.equal(isAcledTokenExpiringSoon(expiresAt, NOW), false);
+  });
+
+  test('returns true when token expires exactly at the buffer boundary', () => {
+    const expiresAt = NOW + ACLED_TOKEN_REFRESH_BUFFER_MS; // now + 5 min
+    assert.equal(isAcledTokenExpiringSoon(expiresAt, NOW), true);
+  });
+
+  test('returns true when token expires within the buffer window', () => {
+    const expiresAt = NOW + 3 * MIN_MS; // 3 min → inside 5-min buffer
+    assert.equal(isAcledTokenExpiringSoon(expiresAt, NOW), true);
+  });
+
+  test('returns true when token has already expired', () => {
+    const expiresAt = NOW - MIN_MS; // 1 min ago
+    assert.equal(isAcledTokenExpiringSoon(expiresAt, NOW), true);
+  });
+
+  test('respects a custom bufferMs argument', () => {
+    const expiresAt = NOW + 2 * MIN_MS;
+    assert.equal(isAcledTokenExpiringSoon(expiresAt, NOW, MIN_MS), false);   // 2 min left > 1 min buffer
+    assert.equal(isAcledTokenExpiringSoon(expiresAt, NOW, 3 * MIN_MS), true); // 2 min left < 3 min buffer
+  });
+});
+
+// ── isRefreshTokenStale ───────────────────────────────────────────────────────
+
+describe('isRefreshTokenStale', () => {
+  test('returns false when refreshIssuedAt is null (age unknown)', () => {
+    assert.equal(isRefreshTokenStale(null, NOW), false);
+  });
+
+  test('returns false when refreshIssuedAt is undefined', () => {
+    assert.equal(isRefreshTokenStale(undefined, NOW), false);
+  });
+
+  test('returns false when token is freshly issued (0 days)', () => {
+    assert.equal(isRefreshTokenStale(NOW, NOW), false);
+  });
+
+  test('returns false when token is 89 days old', () => {
+    const issuedAt = NOW - 89 * DAY_MS;
+    assert.equal(isRefreshTokenStale(issuedAt, NOW), false);
+  });
+
+  test('returns true when token is exactly 90 days old', () => {
+    const issuedAt = NOW - 90 * DAY_MS;
+    assert.equal(isRefreshTokenStale(issuedAt, NOW), true);
+  });
+
+  test('returns true when token is 180 days old', () => {
+    const issuedAt = NOW - 180 * DAY_MS;
+    assert.equal(isRefreshTokenStale(issuedAt, NOW), true);
+  });
+
+  test('respects a custom warnDays argument', () => {
+    const issuedAt = NOW - 30 * DAY_MS;
+    assert.equal(isRefreshTokenStale(issuedAt, NOW, 60), false); // 30d < 60d threshold
+    assert.equal(isRefreshTokenStale(issuedAt, NOW, 20), true);  // 30d > 20d threshold
+  });
+});
+
+// ── updateAcledTokenState ────────────────────────────────────────────────────
+
+describe('updateAcledTokenState', () => {
+  const emptyState = { expiresAt: null, refreshToken: null, refreshIssuedAt: null };
+
+  test('captures expiresAt from expires_in', () => {
+    const result = updateAcledTokenState(emptyState, { access_token: 'tok', expires_in: 3600 }, NOW);
+    assert.equal(result.expiresAt, NOW + 3600 * 1000);
+  });
+
+  test('preserves existing expiresAt when expires_in is absent', () => {
+    const state = { ...emptyState, expiresAt: NOW + 1000 };
+    const result = updateAcledTokenState(state, { access_token: 'tok' }, NOW);
+    assert.equal(result.expiresAt, NOW + 1000);
+  });
+
+  test('preserves existing expiresAt when expires_in is non-numeric', () => {
+    const state = { ...emptyState, expiresAt: NOW + 5000 };
+    const result = updateAcledTokenState(state, { access_token: 'tok', expires_in: 'not-a-number' }, NOW);
+    assert.equal(result.expiresAt, NOW + 5000);
+  });
+
+  test('stores a new refresh token from the response', () => {
+    const result = updateAcledTokenState(emptyState, { access_token: 'tok', refresh_token: 'rt-new' }, NOW);
+    assert.equal(result.refreshToken, 'rt-new');
+  });
+
+  test('resets refreshIssuedAt when a new refresh_token is returned', () => {
+    const state = { ...emptyState, refreshToken: 'rt-old', refreshIssuedAt: NOW - DAY_MS };
+    const result = updateAcledTokenState(state, { access_token: 'tok', refresh_token: 'rt-new' }, NOW);
+    assert.equal(result.refreshIssuedAt, NOW);
+  });
+
+  test('preserves refreshIssuedAt when the same refresh_token is returned', () => {
+    const originalIssuedAt = NOW - 10 * DAY_MS;
+    const state = { ...emptyState, refreshToken: 'rt-same', refreshIssuedAt: originalIssuedAt };
+    const result = updateAcledTokenState(state, { access_token: 'tok', refresh_token: 'rt-same' }, NOW);
+    assert.equal(result.refreshIssuedAt, originalIssuedAt);
+  });
+
+  test('preserves refreshIssuedAt when no refresh_token is in the response', () => {
+    const originalIssuedAt = NOW - 5 * DAY_MS;
+    const state = { ...emptyState, refreshToken: 'rt-existing', refreshIssuedAt: originalIssuedAt };
+    const result = updateAcledTokenState(state, { access_token: 'tok' }, NOW);
+    assert.equal(result.refreshIssuedAt, originalIssuedAt);
+  });
+
+  test('does not mutate the input state object', () => {
+    const state = { expiresAt: NOW + 1000, refreshToken: 'rt', refreshIssuedAt: NOW };
+    updateAcledTokenState(state, { access_token: 'tok', expires_in: 7200, refresh_token: 'rt-new' }, NOW);
+    assert.equal(state.expiresAt, NOW + 1000);
+    assert.equal(state.refreshToken, 'rt');
+    assert.equal(state.refreshIssuedAt, NOW);
+  });
+
+  test('handles zero expires_in as a valid expiry (already expired)', () => {
+    const result = updateAcledTokenState(emptyState, { access_token: 'tok', expires_in: 0 }, NOW);
+    assert.equal(result.expiresAt, NOW);
+  });
+});


### PR DESCRIPTION
## Summary

Security hardening fix for Pass 8 P2 finding: ACLED refresh token was long-lived with no rotation or expiry tracking.

## Changes

### `src-tauri/sidecar/acled-token-helpers.mjs` (new)

Pure helper module extracted for testability:
- `isAcledTokenExpiringSoon(expiresAt, now, bufferMs)` — returns true when access token expires within 5 min
- `isRefreshTokenStale(refreshIssuedAt, now, warnDays)` — returns true when refresh token hasn't rotated in >90 days
- `updateAcledTokenState(state, oauthData, now)` — merges OAuth response into token state; resets `refreshIssuedAt` only on genuine token rotation

### `src-tauri/sidecar/local-api-server.mjs`

- **Module-level `acledTokenState`** — tracks `expiresAt`, `refreshToken`, `refreshIssuedAt` across requests
- **`/api/acled/connect`** — now captures `expires_in` and seeds token state; marks refresh token as newly issued
- **`/api/acled/refresh`** — now updates token state and returns `rotateRefreshTokenWarning` when refresh token is >90 days old
- **`/api/acled-events`** — proactively refreshes access token when within 5 min of expiry before the API call; returns `tokenRefreshed: true` so renderer can persist new tokens to keychain; prefers `process.env.ACLED_REFRESH_TOKEN` over stale in-memory state
- **`/api/acled/token-status`** — new diagnostic endpoint exposing `expiresInSeconds`, `expiringSoon`, `refreshTokenAgeDays`, `refreshTokenStale`
- **`ALLOWED_ENV_KEYS`** — added `ACLED_REFRESH_TOKEN` so renderer can push rotated tokens at runtime via `/api/set-env`
- **`/api/local-env-update`** — syncs `acledTokenState` when `ACLED_REFRESH_TOKEN` or `ACLED_ACCESS_TOKEN` is updated via settings flow, consistent with the existing AISSTREAM_API_KEY pattern

### `tests/acled-token-rotation.test.mjs` (new)

25 unit tests covering all three helper functions and their edge cases.

## Security impact

| Before | After |
|--------|-------|
| Refresh token stored but never checked for age | Warns after 90 days without rotation |
| Access token used raw with no expiry awareness | Proactively refreshed 5 min before expiry |
| Token 401s on every request after expiry | Silent auto-refresh before API call |
| `ACLED_REFRESH_TOKEN` not in `ALLOWED_ENV_KEYS` | Can be updated at runtime after rotation |
| Settings-flow key updates ignored by in-memory state | State synced in `/api/local-env-update` handler |

## Cross-agent review

Codex reviewed — P2 state-sync finding fixed in follow-up commit 8e93a549.

Cross-agent review: Codex reviewed on 2026-06-15; outcome: issues fixed (P2 — /api/acled/refresh now seeds the known-valid caller refresh token so a non-rotating provider response can't disable proactive refresh)