### PR TITLE
fix(memory): remove HUD keydown listener in destroy()

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -617,6 +617,7 @@ export class PanelLayoutManager implements AppModule {
   private analystHud: AnalystHUD | null = null;
   private _onAnalystHudKey: ((e: KeyboardEvent) => void) | null = null;
   private _onBriefExportKey: ((e: KeyboardEvent) => void) | null = null;
+  private _onStatusOverlayKey: ((e: KeyboardEvent) => void) | null = null;
   private readonly applyTimeRangeFilterDebounced: () => void;
   private readonly _onUpdateState = () => { this.renderSidebarUpdateBtn(); };
 
@@ -694,6 +695,7 @@ export class PanelLayoutManager implements AppModule {
  if (this.analystHud) { this.analystHud.destroy(); this.analystHud = null; }
  if (this._onAnalystHudKey) { document.removeEventListener('keydown', this._onAnalystHudKey); this._onAnalystHudKey = null; }
  if (this._onBriefExportKey) { document.removeEventListener('keydown', this._onBriefExportKey); this._onBriefExportKey = null; }
+ if (this._onStatusOverlayKey) { document.removeEventListener('keydown', this._onStatusOverlayKey); this._onStatusOverlayKey = null; }
  // Clean up datacenter strip + saved-places subscription
  if (this.unsubDcPlaces) { this.unsubDcPlaces(); this.unsubDcPlaces = null; }
  if (this.dcStrip) { this.dcStrip.destroy(); this.dcStrip = null; }
@@ -996,12 +998,13 @@ export class PanelLayoutManager implements AppModule {
  document.addEventListener('cb:toggle-status', () => statusOverlay.toggle());
  const shiftCard = new ShiftHandoffCard(); shiftCard.mount(document.body);
  const replayScrubber = new AlertReplayScrubber(); replayScrubber.mount(document.body);
- document.addEventListener('keydown', (ev) => {
+ this._onStatusOverlayKey = (ev: KeyboardEvent) => {
    if (ev.metaKey && ev.shiftKey && (ev.key === 'S' || ev.key === 's')) {
      ev.preventDefault();
      statusOverlay.toggle();
    }
- });
+ };
+ document.addEventListener('keydown', this._onStatusOverlayKey);
  startBlackoutSignature();
  const digestOverlay = new DigestOverlay();
  digestOverlay.mount(document.body);


### PR DESCRIPTION
## Remove the last anonymous keydown listener leak in `panel-layout.ts`

`PanelLayoutManager.createPanels()` registered the **⌘⇧S** (status-overlay) shortcut as an **anonymous** `document.addEventListener('keydown', …)`, which `destroy()` never removed. On each re-init that stacks a duplicate handler — a listener leak plus double-fire of `statusOverlay.toggle()`.

### Fix
Follows the pattern already used in this file for the other two keydown shortcuts (`_onAnalystHudKey` ⌘⇧A, `_onBriefExportKey` ⌘⇧H):
- New named-handler field `_onStatusOverlayKey`.
- Register `document.addEventListener('keydown', this._onStatusOverlayKey)`.
- `removeEventListener` + null it in `destroy()`.

No behavior change (same keys, same guard, same `statusOverlay.toggle()`). This was the **last anonymous keydown listener** in the file — `grep "addEventListener('keydown', ("` now returns nothing.

### Noted (not in this PR)
`createPanels()` also has ~14 anonymous `document.addEventListener('cb:*'/'wm:*', …)` custom-event listeners that `destroy()` doesn't remove (same re-init-stacking class). The maintainer-established cleanup so far covers only the keydown shortcuts; converting the `cb:*`/`wm:*` set is a larger, separate change (an `AbortController`-per-method would fit that volume better than 14 named fields) and is left as a follow-up.

### Verification
`typecheck:all` 0 errors, ESLint clean on the file. (No unit test: `PanelLayoutManager` is a DOM-lifecycle class requiring a full `AppContext` + jsdom + dozens of side-effectful `start*()`/panel constructors to instantiate — not unit-testable in isolation, consistent with the existing two keydown fixes which also have none.)

### Cross-agent review
Cross-agent review: Codex reviewed on 2026-06-16; outcome: pass.
