### PR TITLE
sec: wire on_navigation guard into main window builder

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1762,7 +1762,8 @@ fn is_trusted_window_navigation(url: &Url) -> bool {
 /// The main window holds all trusted-window IPC privileges. Unlike auxiliary
 /// windows (live-channels) it never needs to navigate to a local HTTP service,
 /// so the allowed set is stricter:
-/// - Production: `tauri://` bundled content only.
+/// - Production: `tauri://` bundled content, plus the `tauri.localhost`
+///   WebView2 workaround origin that serves bundled app content on Windows.
 /// - Debug builds: also `localhost` (the Vite dev server at `devUrl`).
 ///
 /// `127.0.0.1` at any port is intentionally excluded — a compromised renderer
@@ -1770,6 +1771,15 @@ fn is_trusted_window_navigation(url: &Url) -> bool {
 /// `require_trusted_window` privileges.
 fn is_main_window_navigation(url: &Url) -> bool {
  if url.scheme() == "tauri" {
+  return true;
+ }
+ // Windows production builds serve bundled `WebviewUrl::App` content through
+ // the WebView2 workaround origin `http(s)://tauri.localhost` rather than the
+ // `tauri://` scheme. That host resolves to the bundled app itself — not a
+ // real loopback service — so it carries the same trust as `tauri://` and must
+ // be allowed; otherwise same-origin `window.location.reload()` after
+ // settings / API-key changes is canceled on Windows.
+ if matches!(url.scheme(), "http" | "https") && url.host_str() == Some("tauri.localhost") {
   return true;
  }
  // Dev server only; compile-gated so the loopback escape hatch is absent
@@ -3544,4 +3554,62 @@ fn main() {
  _ => {}
  }
  });
+}
+
+#[cfg(test)]
+mod navigation_guard_tests {
+ use super::{is_main_window_navigation, is_trusted_window_navigation, Url};
+
+ fn url(s: &str) -> Url {
+  Url::parse(s).expect("valid test url")
+ }
+
+ // ── main-window guard ────────────────────────────────────────────────────
+
+ #[test]
+ fn main_window_allows_tauri_scheme() {
+  assert!(is_main_window_navigation(&url("tauri://localhost/index.html")));
+ }
+
+ #[test]
+ fn main_window_allows_windows_app_origin() {
+  // WebView2 serves bundled app content from this host on Windows production
+  // builds; same-origin reloads must not be canceled there.
+  assert!(is_main_window_navigation(&url("http://tauri.localhost/index.html")));
+  assert!(is_main_window_navigation(&url("https://tauri.localhost/settings")));
+ }
+
+ #[test]
+ fn main_window_rejects_loopback_service() {
+  // A compromised renderer must not redirect `main` to a sibling loopback
+  // service and inherit trusted-window IPC privileges.
+  assert!(!is_main_window_navigation(&url("http://127.0.0.1:46123/api/analyst-state")));
+  assert!(!is_main_window_navigation(&url("https://127.0.0.1/anything")));
+ }
+
+ #[test]
+ fn main_window_rejects_external_origin() {
+  assert!(!is_main_window_navigation(&url("https://evil.example.com/")));
+  // A look-alike host that merely ends in the trusted suffix must not pass.
+  assert!(!is_main_window_navigation(&url("https://tauri.localhost.evil.com/")));
+ }
+
+ #[cfg(debug_assertions)]
+ #[test]
+ fn main_window_allows_localhost_dev_only_in_debug() {
+  assert!(is_main_window_navigation(&url("http://localhost:3001/")));
+ }
+
+ // ── trusted-window (aux) guard ───────────────────────────────────────────
+
+ #[test]
+ fn trusted_window_allows_tauri_and_loopback() {
+  assert!(is_trusted_window_navigation(&url("tauri://localhost/index.html")));
+  assert!(is_trusted_window_navigation(&url("http://127.0.0.1:46123/live-channels.html")));
+ }
+
+ #[test]
+ fn trusted_window_rejects_external_origin() {
+  assert!(!is_trusted_window_navigation(&url("https://evil.example.com/")));
+ }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1757,6 +1757,30 @@ fn is_trusted_window_navigation(url: &Url) -> bool {
  url.scheme() == "tauri" || url.host_str() == Some("127.0.0.1")
 }
 
+/// Tighter navigation guard for the main window only.
+///
+/// The main window holds all trusted-window IPC privileges. Unlike auxiliary
+/// windows (live-channels) it never needs to navigate to a local HTTP service,
+/// so the allowed set is stricter:
+/// - Production: `tauri://` bundled content only.
+/// - Debug builds: also `localhost` (the Vite dev server at `devUrl`).
+///
+/// `127.0.0.1` at any port is intentionally excluded — a compromised renderer
+/// that redirected `main` to a sibling service on loopback would inherit all
+/// `require_trusted_window` privileges.
+fn is_main_window_navigation(url: &Url) -> bool {
+ if url.scheme() == "tauri" {
+  return true;
+ }
+ // Dev server only; compile-gated so the loopback escape hatch is absent
+ // from release builds.
+ #[cfg(debug_assertions)]
+ if url.host_str() == Some("localhost") {
+  return true;
+ }
+ false
+}
+
 fn open_live_channels_window(app: &AppHandle, base_url: Option<String>) -> Result<(), String> {
  if let Some(window) = app.get_webview_window("live-channels") {
  let _ = window.show();
@@ -3313,7 +3337,7 @@ fn main() {
   .resizable(true)
   .transparent(true)
   .background_color(tauri::webview::Color(0, 0, 0, 0))
-  .on_navigation(is_trusted_window_navigation);
+  .on_navigation(is_main_window_navigation);
  #[cfg(target_os = "macos")]
  {
   main_builder = main_builder

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -19,7 +19,7 @@ use sha2::{Digest, Sha256};
 use serde::Serialize;
 use serde_json::{Map, Value};
 use tauri::menu::{AboutMetadata, Menu, MenuItemKind, MenuItem, PredefinedMenuItem, Submenu};
-use tauri::{AppHandle, Manager, RunEvent, Webview, WebviewUrl, WebviewWindowBuilder, WindowEvent};
+use tauri::{AppHandle, Manager, RunEvent, TitleBarStyle, Webview, WebviewUrl, WebviewWindowBuilder, WindowEvent};
 use tauri_plugin_biometry;
 
 mod corelocation;
@@ -3301,6 +3301,26 @@ fn main() {
  if let Ok(data_dir) = app.handle().path().app_data_dir() {
  exclude_app_data_from_backup(&data_dir);
  }
+
+ // Create the main window programmatically so on_navigation can be attached
+ // before the window exists — the callback is builder-only in Tauri 2.
+ // macOSPrivateApi: true in tauri.conf.json enables transparent + vibrancy.
+ #[allow(unused_mut)]
+ let mut main_builder = WebviewWindowBuilder::new(app, "main", WebviewUrl::App("index.html".into()))
+  .title("Crystal Ball")
+  .inner_size(1440.0, 960.0)
+  .min_inner_size(1200.0, 720.0)
+  .resizable(true)
+  .transparent(true)
+  .background_color(tauri::webview::Color(0, 0, 0, 0))
+  .on_navigation(is_trusted_window_navigation);
+ #[cfg(target_os = "macos")]
+ {
+  main_builder = main_builder
+   .title_bar_style(TitleBarStyle::Overlay)
+   .hidden_title(true);
+ }
+ main_builder.build().expect("failed to create main window");
 
  // Apply native macOS vibrancy (HudWindow material, 12pt rounded corners).
  // Pairs with `transparent: true` + `macOSPrivateApi: true` in tauri.conf.json

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,26 +12,6 @@
   },
   "app": {
     "macOSPrivateApi": true,
-    "windows": [
-      {
-        "title": "Crystal Ball",
-        "width": 1440,
-        "height": 960,
-        "minWidth": 1200,
-        "minHeight": 720,
-        "resizable": true,
-        "fullscreen": false,
-        "titleBarStyle": "Overlay",
-        "hiddenTitle": true,
-        "transparent": true,
-        "backgroundColor": [
-          0,
-          0,
-          0,
-          0
-        ]
-      }
-    ],
     "security": {
       "csp": "default-src 'self'; connect-src 'self' http://127.0.0.1:46123 http://127.0.0.1:11434 http://127.0.0.1:1234 http://localhost:11434 http://localhost:1234 https://*.open-meteo.com https://*.rainviewer.com https://*.basemaps.cartocdn.com https://*.tile.opentopomap.org https://*.arcgisonline.com https://*.nesdis.noaa.gov https://*.mapbox.com https://*.cesium.com https://*.virtualearth.net https://*.posthog.com https://api.weather.gov https://api.avalanche.org https://api.bgpview.io https://api.reliefweb.int https://api.safecast.org https://api.spaceflightnewsapi.net https://api.tidesandcurrents.noaa.gov https://api.unhcr.org https://api.usaspending.gov https://api.worldbank.org https://api.maptiler.com https://api.anthropic.com https://api.groq.com https://aviationweather.gov https://banks.data.fdic.gov https://cdn.jsdelivr.net https://celestrak.org https://crystalball.app https://*.crystalball.app https://disease.sh https://droughtmonitor.unl.edu https://earthquake.usgs.gov https://emergency.copernicus.eu https://eonet.gsfc.nasa.gov https://gamma-api.polymarket.com https://gibs.earthdata.nasa.gov https://github.com https://api.github.com https://*.githubusercontent.com https://habsos.noaa.gov https://incidentnews.noaa.gov https://ioda.inetintel.cc.gatech.edu https://ll.thespacedevs.com https://map.blitzortung.org https://maps.googleapis.com https://mesonet.agron.iastate.edu https://msi.nga.mil https://nominatim.openstreetmap.org https://openrouter.ai https://router.project-osrm.org https://services.faa.gov https://services.swpc.noaa.gov https://tile.googleapis.com https://tile.openstreetmap.org https://valhalla1.openstreetmap.de https://waterwatch.usgs.gov https://www.cloudflarestatus.com https://www.fastlystatus.com https://www.federalregister.gov https://www.fema.gov https://www.gdacs.org https://www.ipcinfo.org https://www.ndbc.noaa.gov https://www.nhc.noaa.gov https://www.spc.noaa.gov https://www.who.int https://www.wpc.ncep.noaa.gov https://en.wikipedia.org https://restcountries.com wss://stream.aisstream.io; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; worker-src 'self' blob:; font-src 'self' data: https:; media-src 'self' data: blob: https:; frame-src 'self' http://127.0.0.1:46123 https://crystalball.app https://www.youtube.com https://www.youtube-nocookie.com; object-src 'none'; base-uri 'self'; form-action 'self';"
     }


### PR DESCRIPTION
## Summary

Moves the main window from `tauri.conf.json` static config into the `setup` hook as a programmatic `WebviewWindowBuilder` call, enabling `on_navigation(is_trusted_window_navigation)` to be attached.

### Why this matters

`on_navigation` is a builder-only callback in Tauri 2. Config-defined windows have no hook — any XSS that triggers a top-level navigation would redirect the main window to an attacker-controlled URL without any Rust-side guard. This PR closes that gap for the primary window.

### Changes

- **`tauri.conf.json`**: Remove the `windows` array. Window creation moves to Rust.
- **`src-tauri/src/main.rs`**: Add `WebviewWindowBuilder` in `setup` hook with `on_navigation(is_trusted_window_navigation)`. macOS-only builder methods (`title_bar_style`, `hidden_title`) are gated with `#[cfg(target_os = "macos")]`. All other properties (size, transparent, background_color) match the previous config exactly.

### Settings window

Investigated — the settings "window" is the `UnifiedSettings` in-page modal overlay inside the main window, not a separate OS window. No builder exists; no guard can be added. `TRUSTED_WINDOWS["settings"]` and `close_settings_window` are dead stubs from a previously-planned separate window that was never shipped.

### Verification

`cargo check` passes.


Cross-agent review: Codex reviewed on 2026-06-15; outcome: issues fixed (P2 — main-window navigation guard now allows the Windows `tauri.localhost` WebView2 app origin so same-origin reloads work in production; fixed in d68b7091)
