### PR TITLE
fix(ui): scope staleness banner to content area + refine button style

### DIFF
--- a/src/components/OfflineStalenessBanner.ts
+++ b/src/components/OfflineStalenessBanner.ts
@@ -78,17 +78,19 @@ const STYLE_CSS = `
   flex-shrink: 0;
 }
 .cb-osb-btn {
-  background: rgba(255, 255, 255, 0.15);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.16);
+  border: 0.5px solid rgba(255, 255, 255, 0.28);
   color: inherit;
-  padding: 3px 10px;
-  border-radius: 5px;
-  font: 600 11px/1.4 -apple-system, sans-serif;
+  padding: 4px 11px;
+  border-radius: 6px;
+  font: 600 12px/1.4 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
+  letter-spacing: -0.01em;
   cursor: pointer;
   white-space: nowrap;
-  transition: background 0.12s;
+  transition: background 0.12s ease, border-color 0.12s ease;
 }
-.cb-osb-btn:hover { background: rgba(255, 255, 255, 0.25); }
+.cb-osb-btn:hover { background: rgba(255, 255, 255, 0.26); border-color: rgba(255, 255, 255, 0.4); }
+.cb-osb-btn:active { background: rgba(255, 255, 255, 0.34); }
 .cb-osb-dismiss {
   background: none;
   border: none;

--- a/src/styles/macos-native.css
+++ b/src/styles/macos-native.css
@@ -840,6 +840,18 @@ body.is-desktop-macos.sidebar-collapsed .mac-content-toolbar {
   padding-left: 80px;
 }
 
+/* Notification stack (staleness / offline / "Reset cache" banners) must start
+   where the sidebar ends so its banners stay scoped to the content area and
+   don't overlap the sidebar. Mirrors the .replay-scrubber treatment. The stack
+   anchors left:0 via inline styles, so !important is required to override.
+   When the sidebar is collapsed the content fills the window, so reset to 0. */
+body.is-desktop-macos #cb-notification-stack {
+  left: var(--mac-sidebar-width) !important;
+}
+body.is-desktop-macos.sidebar-collapsed #cb-notification-stack {
+  left: 0 !important;
+}
+
 /* Toolbar overflow controls — shown when sidebar is collapsed */
 .mac-toolbar-sidebar-overflow {
   display: none;


### PR DESCRIPTION
## Problem
The "Data feeds paused — viewing cached data" banner (with **Reset cache** / dismiss buttons) spanned the full window width and overlapped the left sidebar. The button styling also looked out of place against the app's macOS-native design language.

## Fix
- **Layout**: Offset `#cb-notification-stack` to start at the sidebar edge on desktop chrome (`left: var(--mac-sidebar-width)`), mirroring the existing `.replay-scrubber` treatment. Resets to full width when the sidebar is collapsed.
- **Button**: Aligned the Reset cache button with the app's native button language — hairline 0.5px border, 6px radius, 12px system font, added `:active` state.

## Verification
- `npm run typecheck:all` passes (zero errors).
- Change is pure CSS scoped to the desktop chrome + a self-contained banner component; follows the established sidebar-offset precedent.

---
cross-agent review: Codex — ran `codex exec review --base origin/main`; no discrete correctness issues found. CSS override correctly scopes the notification stack to the content area without breaking the fixed left/right sizing.