### PR TITLE
fix(ui): keep staleness banners inside content area, not over sidebar

### DIFF
--- a/src/components/NotificationStack.ts
+++ b/src/components/NotificationStack.ts
@@ -25,7 +25,9 @@ export class NotificationStack {
     Object.assign(el.style, {
       position: 'fixed',
       top: 'var(--eew-bar-h, 32px)',
-      left: '0',
+      // Defaults to the viewport edge; desktop chrome overrides the var to the
+      // sidebar width so banners stay inside the content area, not over the nav.
+      left: 'var(--cb-notification-stack-left, 0px)',
       right: '0',
       zIndex: '9001',
       display: 'flex',

--- a/src/styles/macos-native.css
+++ b/src/styles/macos-native.css
@@ -19,6 +19,11 @@ body.is-desktop-macos {
      use this value, not --eew-bar-h. */
   --below-eew: var(--mac-toolbar-height);
 
+  /* The fixed NotificationStack starts at the viewport edge by default; on
+     desktop it must begin after the sidebar so banners (staleness/offline)
+     live inside the content area instead of overlapping the nav. */
+  --cb-notification-stack-left: var(--mac-sidebar-width);
+
   /* Dark-mode macOS system colors (approximated) */
   --mac-window-bg: #1c1c1e;
   --mac-sidebar-bg: rgba(44, 44, 46, 0.72);
@@ -112,12 +117,6 @@ body.is-desktop-macos .mac-sidebar {
   height: var(--mac-traffic-lights-height);
   flex-shrink: 0;
   cursor: default;
-}
-
-/* When a staleness banner is fixed at the top of content, push the sidebar
-   nav down by the same amount so it isn't hidden under the banner. */
-body.has-staleness-banner .mac-sidebar-nav {
-  padding-top: var(--notification-stack-h);
 }
 
 /* Sidebar scrollable nav */

--- a/src/styles/macos-native.css
+++ b/src/styles/macos-native.css
@@ -738,6 +738,12 @@ body.is-desktop-macos.sidebar-collapsed .mac-sidebar {
   overflow: hidden;
 }
 
+/* Sidebar collapsed → content spans the full window, so the notification
+   stack must follow the content edge instead of the (now 0-width) sidebar. */
+body.is-desktop-macos.sidebar-collapsed {
+  --cb-notification-stack-left: 0px;
+}
+
 /* Floating re-open tab — visible only when collapsed */
 .mac-sidebar-collapse-tab {
   display: none;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -15015,18 +15015,21 @@ body.has-critical-banner .panels-grid {
   background: rgba(255, 255, 255, 0.3);
 }
 
+/* Matches .cb-offline-staleness-banner's .cb-osb-btn — same "Reset cache"
+   action lives in both sibling banners, so they share one button language. */
 .staleness-reset {
   background: rgba(255, 255, 255, 0.15);
-  border: 1px solid rgba(255, 255, 255, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.2);
   color: inherit;
   padding: 3px 10px;
-  border-radius: 4px;
+  border-radius: 5px;
   cursor: pointer;
-  font-size: 11px;
-  font-weight: 600;
+  font: 600 11px/1.4 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
+  white-space: nowrap;
   flex-shrink: 0;
+  transition: background 0.12s;
 }
-.staleness-reset:hover { background: rgba(255, 255, 255, 0.3); }
+.staleness-reset:hover { background: rgba(255, 255, 255, 0.25); }
 .staleness-reset:disabled { opacity: 0.6; cursor: wait; }
 
 .reg-profile-explainer {


### PR DESCRIPTION
## Problem
The "Data feeds paused — viewing cached data…" staleness banner (and its offline sibling) overlapped the macOS left sidebar — the **Reset cache** button rendered on top of the nav, and the button styling looked out of place.

## Root cause
`NotificationStack` is `position: fixed; left: 0; right: 0`, so it spans the entire viewport including the 155px sidebar. The previous workaround pushed the sidebar nav down rather than constraining the banner.

## Fix
- `NotificationStack` left edge now reads an inherited CSS var `--cb-notification-stack-left` (default `0px`); desktop chrome sets it to `--mac-sidebar-width`, so both banners stay inside the content area.
- Removed the now-obsolete `body.has-staleness-banner .mac-sidebar-nav` padding push.
- Unified `.staleness-reset` with its sibling banner's `.cb-osb-btn` button language (radius, font, transition). On desktop the existing `body.is-desktop-macos button` rule already applies the native font + 7px radius.

## Verification
- `npm run typecheck:all` — clean (both tsconfigs)
- Pure CSS/layout change scoped to the banner container; no behavior change.

---

cross-agent review: codex

Ran `codex exec review --base origin/main`. One finding:

- [P2] Banner inset not reset when the desktop sidebar is collapsed (`.mac-sidebar` → `width: 0`) — banners would stay inset ~155px while content goes full-width. **Resolved** in `ab7d701a` by resetting `--cb-notification-stack-left: 0px` under `body.is-desktop-macos.sidebar-collapsed`.

No outstanding issues.
