### PR TITLE
fix(storage): point quota eviction at real cache keys + split LS/IDB latch

### DIFF
--- a/src/services/offline-alert-cache.ts
+++ b/src/services/offline-alert-cache.ts
@@ -15,6 +15,8 @@
  * const alerts = await withOfflineCache('nws-alerts', fetchNwsAlerts, 4 * 3600_000);
  */
 
+import { safeSetItem } from '@/utils/safe-storage';
+
 export interface CachedSnapshot<T> {
   data: T;
   cachedAt: number; // unix ms
@@ -56,7 +58,7 @@ function writeEntry<T>(serviceId: string, data: T): void {
  cachedAt: Date.now(),
  version: CACHE_VERSION,
  };
- localStorage.setItem(storageKey(serviceId), JSON.stringify(entry));
+ safeSetItem(storageKey(serviceId), JSON.stringify(entry));
   } catch {
  // localStorage might be full — fail silently
   }

--- a/src/services/persistent-cache.ts
+++ b/src/services/persistent-cache.ts
@@ -1,6 +1,6 @@
 import { isDesktopRuntime } from './runtime';
 import { invokeTauri } from './tauri-bridge';
-import { isStorageQuotaExceeded, isQuotaError, markStorageQuotaExceeded, safeSetItem } from '@/utils';
+import { isStorageQuotaExceeded, isIndexedDbQuotaExceeded, isQuotaError, markIndexedDbQuotaExceeded, safeSetItem } from '@/utils';
 
 interface CacheEnvelope<T> {
   key: string;
@@ -108,12 +108,12 @@ export async function setPersistentCache<T>(key: string, data: T, ttlMs?: number
  }
   }
 
-  if (isIndexedDbAvailable() && !isStorageQuotaExceeded()) {
+  if (isIndexedDbAvailable() && !isIndexedDbQuotaExceeded()) {
  try {
  await setInIndexedDb(payload);
  return;
  } catch (error) {
- if (isQuotaError(error)) markStorageQuotaExceeded();
+ if (isQuotaError(error)) markIndexedDbQuotaExceeded();
  else console.warn('[persistent-cache] IndexedDB write failed; falling back to localStorage', error);
  cacheDbPromise = null;
  }

--- a/src/utils/__tests__/safe-storage.test.mts
+++ b/src/utils/__tests__/safe-storage.test.mts
@@ -33,7 +33,7 @@ function totalBytes(skipKey?: string): number {
 const { safeSetItem, EVICTABLE_CACHE_PREFIXES, _resetQuotaLatchForTest } =
   await import('../safe-storage.ts');
 
-const { isStorageQuotaExceeded } = await import('../storage-quota.ts');
+const { isStorageQuotaExceeded, isIndexedDbQuotaExceeded } = await import('../storage-quota.ts');
 
 beforeEach(() => {
   store.clear();
@@ -101,10 +101,17 @@ describe('safeSetItem — fail-closed', () => {
     assert.equal(result, false);
   });
 
-  it('trips the shared quota latch so other writers can bail early', () => {
+  it('trips the localStorage quota latch so other writers can bail early', () => {
     budget = 5;
     safeSetItem('wm-too-big', 'x'.repeat(50));
     assert.equal(isStorageQuotaExceeded(), true);
+  });
+
+  it('does NOT trip the IndexedDB latch — a full localStorage must not disable healthy IDB writes', () => {
+    budget = 5;
+    safeSetItem('wm-too-big', 'x'.repeat(50));
+    assert.equal(isStorageQuotaExceeded(), true);
+    assert.equal(isIndexedDbQuotaExceeded(), false);
   });
 
   it('swallows non-quota errors and returns false without evicting', () => {
@@ -131,8 +138,13 @@ describe('safeSetItem — fail-closed', () => {
 
 describe('EVICTABLE_CACHE_PREFIXES', () => {
   it('covers the known disposable cache namespaces', () => {
+    // `crystalball-persistent-cache:` also covers proxy `api-response:` entries —
+    // proxy.ts writes them through setPersistentCache, which nests them under this
+    // prefix rather than storing a raw top-level `api-response:` key.
     assert.ok(EVICTABLE_CACHE_PREFIXES.includes('crystalball-persistent-cache:'));
-    assert.ok(EVICTABLE_CACHE_PREFIXES.includes('api-response:'));
+    // offline-alert-cache.ts last-known snapshots (saved-place-weather, place-briefs,
+    // local-logistics, …) all write under the `wm_offline_<serviceId>` prefix.
+    assert.ok(EVICTABLE_CACHE_PREFIXES.includes('wm_offline_'));
   });
 
   it('covers the high-frequency / rolling-buffer log-spam sources', () => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -115,8 +115,10 @@ export function loadFromStorage<T>(key: string, defaultValue: T): T {
 
 export {
   isStorageQuotaExceeded,
+  isIndexedDbQuotaExceeded,
   isQuotaError,
   markStorageQuotaExceeded,
+  markIndexedDbQuotaExceeded,
   _resetStorageQuotaForTest,
 } from './storage-quota';
 export { safeSetItem, EVICTABLE_CACHE_PREFIXES } from './safe-storage';

--- a/src/utils/safe-storage.ts
+++ b/src/utils/safe-storage.ts
@@ -25,12 +25,15 @@ import { isQuotaError, markStorageQuotaExceeded, _resetStorageQuotaForTest } fro
  */
 export const EVICTABLE_CACHE_PREFIXES: readonly string[] = [
   // Re-fetchable derived caches (largest byte-hogs — most reclaimed per delete).
+  // `crystalball-persistent-cache:` also covers proxy `api-response:` entries,
+  // which are nested under it (setPersistentCache re-prefixes the key) rather
+  // than stored raw.
   'crystalball-persistent-cache:',   // persistent-cache.ts localStorage fallback
-  'api-response:',                   // utils/proxy.ts cached proxy responses
-  'saved-place-weather',             // saved-place-weather.ts
-  'saved-place-brief',               // place-briefs.ts
-  'local-logistics',                 // local-logistics.ts
   'crystalball-market-stale-',       // market/index.ts stale fallback
+  // offline-alert-cache.ts last-known snapshots — saved-place-weather,
+  // place-briefs, local-logistics and every other offline-cached service write
+  // under the `wm_offline_<serviceId>` prefix, not their raw service names.
+  'wm_offline_',
   // High-frequency writers + loss-tolerant rolling buffers (the log-spam sources).
   'wm-analytics-offline-queue',      // analytics.ts offline event queue
   'crystalball-pressure-history-v1', // pressure-history.ts sparkline samples

--- a/src/utils/storage-quota.ts
+++ b/src/utils/storage-quota.ts
@@ -1,14 +1,26 @@
 /**
- * Session-scoped localStorage quota state + classifier.
+ * Session-scoped storage-quota state + classifier.
  *
  * Kept in its own dependency-free module (no DOM, no i18n, no barrel) so the
  * quota-safe storage layer and its unit tests can import it under plain Node.
+ *
+ * localStorage (~5 MB) and IndexedDB (hundreds of MB) have INDEPENDENT quotas,
+ * so they get independent latches. Conflating them lets a full localStorage
+ * disable otherwise-healthy IndexedDB writes — exactly the failure
+ * `setPersistentCache` must avoid when it decides whether to skip IndexedDB.
  */
 
-let _storageQuotaExceeded = false;
+let _localStorageQuotaExceeded = false;
+let _indexedDbQuotaExceeded = false;
 
+/** True once a localStorage write has exhausted quota even after eviction. */
 export function isStorageQuotaExceeded(): boolean {
-  return _storageQuotaExceeded;
+  return _localStorageQuotaExceeded;
+}
+
+/** True once an IndexedDB write has thrown QuotaExceededError. */
+export function isIndexedDbQuotaExceeded(): boolean {
+  return _indexedDbQuotaExceeded;
 }
 
 export function isQuotaError(e: unknown): boolean {
@@ -16,10 +28,15 @@ export function isQuotaError(e: unknown): boolean {
 }
 
 export function markStorageQuotaExceeded(): void {
-  _storageQuotaExceeded = true;
+  _localStorageQuotaExceeded = true;
 }
 
-/** Test-only: clear the session quota latch between cases. */
+export function markIndexedDbQuotaExceeded(): void {
+  _indexedDbQuotaExceeded = true;
+}
+
+/** Test-only: clear both session quota latches between cases. */
 export function _resetStorageQuotaForTest(): void {
-  _storageQuotaExceeded = false;
+  _localStorageQuotaExceeded = false;
+  _indexedDbQuotaExceeded = false;
 }


### PR DESCRIPTION
Follow-up to #1214. Two corrections to the quota-safe storage layer.

## 1. Eviction allowlist matched zero real keys
`evictLargestCache` named prefixes that never appear as top-level `localStorage` keys:
- `api-response:` is written via `setPersistentCache` (proxy.ts:67), which nests it under `crystalball-persistent-cache:` — no raw top-level key exists.
- `saved-place-weather` / `saved-place-brief` / `local-logistics` are written by `offline-alert-cache.ts` under `wm_offline_<serviceId>`, not their raw names.

So under quota pressure the eviction pass found nothing to free for those namespaces and failed closed prematurely. Replaced the dead prefixes with `wm_offline_` (the real offline-cache namespace; `crystalball-persistent-cache:` already covers the nested api-response entries) and routed `offline-alert-cache.ts` writes through `safeSetItem` so the largest byte-hogs are actually reclaimable.

## 2. Shared LS/IDB quota latch disabled healthy IndexedDB
`localStorage` (~5 MB) and IndexedDB (hundreds of MB) shared one quota latch. Routing the localStorage-only offline cache through `safeSetItem` let a full localStorage trip the latch that `setPersistentCache` reads to **skip IndexedDB** — disabling otherwise-healthy IDB writes for the rest of the session. Split into independent localStorage / IndexedDB latches; `setPersistentCache` now gates the IDB-skip on the IDB latch only.

## Verification
- `npx tsx --test src/utils/__tests__/safe-storage.test.mts` — 12/12 pass (added a regression test pinning the latch separation).
- `npm run typecheck:all` — clean.

Cross-agent review: Codex reviewed on 2026-06-16; outcome: pass (first pass flagged the shared-latch P2, fixed in this same commit; re-review found no blocking bug).