### PR TITLE
fix(boot): keychain async-boot hardening (Codex rounds 3–11 follow-up)

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -13132,6 +13132,11 @@ async function dispatch(requestUrl, req, routes, context) {
  moduleCache.clear();
  failedImports.clear();
  cloudPreferred.clear();
+ // Async-boot timing: routes hit before this key arrived may have cached a
+ // degraded/requiresKey response. Drop the route caches so the next request
+ // re-fetches with the newly injected secret instead of serving stale.
+ _sidecarCache.clear();
+ _responseCache.clear();
  return json({ ok: true, key });
  }
  return json({ error: 'key not in allowlist' }, 403);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -174,6 +174,10 @@ struct SecretsCache {
  // merge must skip them — otherwise a just-deleted key gets resurrected (and
  // re-injected into the sidecar). Lock order is always `secrets` then this.
  user_mutated: Mutex<HashSet<String>>,
+ // False until the async keychain read finishes (success, empty, or timeout).
+ // The renderer's boot-time secret load must wait on this — reading the cache
+ // before it flips would memoize a null for every key for the whole session.
+ loaded: AtomicBool,
 }
 
 /// In-memory mirror of persistent-cache.json. The file can grow to 10+ MB,
@@ -240,6 +244,7 @@ impl SecretsCache {
  SecretsCache {
  secrets: Mutex::new(HashMap::new()),
  user_mutated: Mutex::new(HashSet::new()),
+ loaded: AtomicBool::new(false),
  }
  }
 
@@ -268,6 +273,10 @@ impl SecretsCache {
  guard.entry(key).or_insert(value);
  }
  }
+ // Mark ready even on timeout/empty — the read is done, the cache is as
+ // populated as it will get this launch, and the renderer should stop
+ // waiting and reload from whatever loaded.
+ self.loaded.store(true, Ordering::SeqCst);
  }
 
  /// Pulled out so callers can run the load on whichever thread they
@@ -805,6 +814,15 @@ fn list_supported_secret_keys(webview: Webview) -> Result<Vec<String>, String> {
  .iter()
  .map(|key| (*key).to_string())
  .collect())
+}
+
+/// Whether the async keychain load has finished. The renderer's boot-time
+/// secret load polls this before reading any key, so it never memoizes a null
+/// for a key that simply hadn't loaded yet (see the async-boot reordering).
+#[tauri::command]
+fn secrets_ready(webview: Webview, cache: tauri::State<'_, SecretsCache>) -> Result<bool, String> {
+ require_trusted_window(webview.label())?;
+ Ok(cache.loaded.load(Ordering::SeqCst))
 }
 
 #[tauri::command]
@@ -3444,6 +3462,7 @@ fn main() {
  .invoke_handler(tauri::generate_handler![
  list_supported_secret_keys,
  get_secret,
+ secrets_ready,
  set_always_on,
  get_always_on,
  set_secret,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3181,20 +3181,27 @@ async fn inject_secrets_into_running_sidecar(app: &AppHandle, secrets: Vec<(Stri
  let secrets_cache = app.state::<SecretsCache>();
  let mut pushed = 0usize;
  let mut skipped = 0usize;
- for (key, value) in secrets {
- // Re-check per key: if the user edited or deleted this secret in Settings
- // after this snapshot was taken, the renderer already pushed the live
- // value to the sidecar. POSTing our older snapshot value would clobber it
- // with a stale (or just-deleted) credential — skip and let the renderer win.
- if secrets_cache
- .user_mutated
- .lock()
- .map(|t| t.contains(&key))
- .unwrap_or(false)
- {
+ for (key, _snapshot) in secrets {
+ // Re-read the live cache value per key rather than trusting this snapshot.
+ // If the user edited the secret in Settings after the snapshot was taken,
+ // the cache holds the newer value and we post that (never the stale one).
+ // If the key was deleted since the snapshot it's gone from the cache, so
+ // skip it rather than resurrect a just-removed credential. Posting the
+ // current value is idempotent with the renderer's own push and recovers
+ // any key whose early renderer push silently failed.
+ let value = match secrets_cache.secrets.lock() {
+ Ok(map) => match map.get(&key) {
+ Some(v) => v.clone(),
+ None => {
  skipped += 1;
  continue;
  }
+ },
+ Err(_) => {
+ skipped += 1;
+ continue;
+ }
+ };
  // start_local_api already confirmed the sidecar's port before this runs,
  // so a few quick attempts absorb any momentary unreadiness.
  for attempt in 0..3 {
@@ -3224,7 +3231,7 @@ async fn inject_secrets_into_running_sidecar(app: &AppHandle, secrets: Vec<(Stri
  append_desktop_log(
  app,
  "INFO",
- &format!("injected {pushed}/{total} keychain secrets into running sidecar via IPC ({skipped} skipped: edited in Settings)"),
+ &format!("injected {pushed}/{total} keychain secrets into running sidecar via IPC ({skipped} skipped: deleted or unreadable since load)"),
  );
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -855,7 +855,14 @@ fn wait_until_secrets_loaded(cache: &SecretsCache) -> bool {
  if cache.loaded.load(Ordering::SeqCst) {
  return true;
  }
- let deadline = Instant::now() + KEYCHAIN_VAULT_TIMEOUT + Duration::from_secs(30);
+ // Match the keychain read's own worst case: the 120s vault read plus, on a
+ // one-time migration from the legacy per-key format, up to one 3s ACL timeout
+ // per supported key. Giving up sooner would reject a save while the cache is
+ // still legitimately loading. Mirrors the renderer's waitUntilLoaded cap.
+ let max_wait = KEYCHAIN_VAULT_TIMEOUT
+ + KEYCHAIN_PER_CALL_TIMEOUT * (SUPPORTED_SECRET_KEYS.len() as u32)
+ + Duration::from_secs(30);
+ let deadline = Instant::now() + max_wait;
  while Instant::now() < deadline {
  if cache.loaded.load(Ordering::SeqCst) {
  return true;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -842,6 +842,29 @@ fn get_secret(
  Ok(secrets.get(&key).cloned())
 }
 
+/// Block until the async keychain load has finished before a Settings write
+/// builds its `proposed` vault. The window now renders before hydration, so a
+/// user can hit Save while the in-memory cache is still empty; cloning that
+/// partial snapshot as the save base would persist a vault containing only the
+/// edited key and wipe every other stored secret. Waiting guarantees the cache
+/// is the full source of truth first. Bounded by the same worst-case the
+/// renderer waits on (`save_vault` already blocks on the keychain, so blocking
+/// here is consistent). Returns false if it never loads — the caller then
+/// refuses the write rather than risk a partial-vault overwrite.
+fn wait_until_secrets_loaded(cache: &SecretsCache) -> bool {
+ if cache.loaded.load(Ordering::SeqCst) {
+ return true;
+ }
+ let deadline = Instant::now() + KEYCHAIN_VAULT_TIMEOUT + Duration::from_secs(30);
+ while Instant::now() < deadline {
+ if cache.loaded.load(Ordering::SeqCst) {
+ return true;
+ }
+ std::thread::sleep(Duration::from_millis(50));
+ }
+ cache.loaded.load(Ordering::SeqCst)
+}
+
 #[tauri::command]
 fn set_secret(
  webview: Webview,
@@ -852,6 +875,9 @@ fn set_secret(
  require_trusted_window(webview.label())?;
  if !SUPPORTED_SECRET_KEYS.contains(&key.as_str()) {
  return Err(format!("Unsupported secret key: {key}"));
+ }
+ if !wait_until_secrets_loaded(&cache) {
+ return Err("Secrets are still loading from the keychain; please try again in a moment.".to_string());
  }
  let mut secrets = cache
  .secrets
@@ -879,6 +905,9 @@ fn delete_secret(webview: Webview, key: String, cache: tauri::State<'_, SecretsC
  require_trusted_window(webview.label())?;
  if !SUPPORTED_SECRET_KEYS.contains(&key.as_str()) {
  return Err(format!("Unsupported secret key: {key}"));
+ }
+ if !wait_until_secrets_loaded(&cache) {
+ return Err("Secrets are still loading from the keychain; please try again in a moment.".to_string());
  }
  let mut secrets = cache
  .secrets

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3584,8 +3584,8 @@ fn main() {
  //    the env. It runs on a blocking thread because it waits (≤15s)
  //    for the sidecar to confirm its listening port.
  let start_handle = setup_handle.clone();
- match tauri::async_runtime::spawn_blocking(move || start_local_api(&start_handle)).await {
- Ok(Ok(())) => {}
+ let sidecar_ok = match tauri::async_runtime::spawn_blocking(move || start_local_api(&start_handle)).await {
+ Ok(Ok(())) => true,
  Ok(Err(err)) => {
  append_desktop_log(
  &setup_handle,
@@ -3593,11 +3593,7 @@ fn main() {
  &format!("local API sidecar failed to start: {err}"),
  );
  eprintln!("[tauri] local API sidecar failed to start: {err}");
- // Do NOT load or inject secrets when the sidecar didn't start:
- // inject_secrets_into_running_sidecar falls back to the default
- // port, so pushing here could POST every keychain secret to
- // whatever foreign process happens to hold 127.0.0.1:46123.
- return;
+ false
  }
  Err(join_err) => {
  append_desktop_log(
@@ -3605,9 +3601,14 @@ fn main() {
  "ERROR",
  &format!("sidecar start task panicked: {join_err}"),
  );
- return;
+ false
  }
- }
+ };
+ // Always read the keychain even if the sidecar failed: the cache feeds the
+ // renderer (which polls `secrets_ready`) independently of the sidecar, and
+ // leaving `loaded` false would make both windows poll until the client cap.
+ // We just skip the IPC injection below — there's no sidecar to inject into,
+ // and its port_confirmed/liveness guards would no-op the push anyway.
 
  // 2. Read the keychain on a worker thread. Bounded by the per-call
  //    timeouts (≤120s for the consolidated vault), but the UI and
@@ -3635,8 +3636,11 @@ fn main() {
 
  // 3. Inject the loaded secrets into the live sidecar via IPC — no
  //    restart. Until this completes, key-dependent routes return
- //    503 + `keyMissing`, exactly as on a cold cache.
+ //    503 + `keyMissing`, exactly as on a cold cache. Skipped when the
+ //    sidecar never started — the renderer already has the secrets.
+ if sidecar_ok {
  inject_secrets_into_running_sidecar(&setup_handle, secrets).await;
+ }
  });
 
  // Request Location Services authorization so the app appears in

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufWriter, Write};
@@ -138,6 +138,11 @@ struct LocalApiState {
  child: Mutex<Option<Child>>,
  token: Mutex<Option<String>>,
  port: Mutex<Option<u16>>,
+ // True only once the sidecar has written its real bound port to the port
+ // file. On the timeout fallback we record the default port but leave this
+ // false — secret injection must not post plaintext to a port we never
+ // confirmed is actually our child (a squatter on 46123 would receive it).
+ port_confirmed: AtomicBool,
  restart_count: Mutex<u32>,
  last_restart_at: Mutex<Option<Instant>>,
 }
@@ -153,6 +158,7 @@ impl Default for LocalApiState {
  child: Mutex::new(None),
  token: Mutex::new(None),
  port: Mutex::new(None),
+ port_confirmed: AtomicBool::new(false),
  restart_count: Mutex::new(0),
  last_restart_at: Mutex::new(None),
  }
@@ -163,6 +169,11 @@ impl Default for LocalApiState {
 /// repeated macOS Keychain prompts (each `Entry::get_password()` triggers one).
 struct SecretsCache {
  secrets: Mutex<HashMap<String, String>>,
+ // Keys the user explicitly set or deleted via Settings since launch. The
+ // async keychain read works from a snapshot taken before these edits, so its
+ // merge must skip them — otherwise a just-deleted key gets resurrected (and
+ // re-injected into the sidecar). Lock order is always `secrets` then this.
+ user_mutated: Mutex<HashSet<String>>,
 }
 
 /// In-memory mirror of persistent-cache.json. The file can grow to 10+ MB,
@@ -228,6 +239,7 @@ impl SecretsCache {
  fn empty() -> Self {
  SecretsCache {
  secrets: Mutex::new(HashMap::new()),
+ user_mutated: Mutex::new(HashSet::new()),
  }
  }
 
@@ -242,12 +254,17 @@ impl SecretsCache {
  fn populate_from_keychain(&self, app: Option<&AppHandle>) {
  let loaded = Self::read_keychain_blocking(app);
  if let Ok(mut guard) = self.secrets.lock() {
- // Preserve entries written concurrently with the (up to 120s)
- // keychain read — e.g. a Settings save made while this was in
- // flight, now that the UI is usable before boot finishes. Those
- // are newer than the keychain snapshot, so only fill keys we
- // don't already hold rather than clobbering the whole map.
+ // Preserve edits made concurrently with the (up to 120s) keychain
+ // read — the UI is usable before boot finishes, so a Settings save
+ // or delete can land mid-flight. Those edits are newer than this
+ // snapshot: skip any key the user touched (a delete leaves it absent
+ // from the map, so a blind or_insert would resurrect it), and never
+ // clobber a key we already hold.
+ let touched = self.user_mutated.lock().ok();
  for (key, value) in loaded {
+ if touched.as_ref().is_some_and(|t| t.contains(&key)) {
+ continue;
+ }
  guard.entry(key).or_insert(value);
  }
  }
@@ -828,10 +845,14 @@ fn set_secret(
  if trimmed.is_empty() {
  proposed.remove(&key);
  } else {
- proposed.insert(key, trimmed);
+ proposed.insert(key.clone(), trimmed);
  }
  save_vault(&proposed)?;
  *secrets = proposed;
+ // Shield this edit from a still-in-flight async keychain read (see merge).
+ if let Ok(mut touched) = cache.user_mutated.lock() {
+ touched.insert(key);
+ }
  Ok(())
 }
 
@@ -849,6 +870,10 @@ fn delete_secret(webview: Webview, key: String, cache: tauri::State<'_, SecretsC
  proposed.remove(&key);
  save_vault(&proposed)?;
  *secrets = proposed;
+ // Shield this deletion from a still-in-flight async keychain read (see merge).
+ if let Ok(mut touched) = cache.user_mutated.lock() {
+ touched.insert(key);
+ }
  Ok(())
 }
 
@@ -2674,6 +2699,7 @@ fn start_local_api(app: &AppHandle) -> Result<(), String> {
  if let Ok(mut port_slot) = state.port.lock() {
  *port_slot = None;
  }
+ state.port_confirmed.store(false, Ordering::SeqCst);
 
  // ── Restart counter / flap detector ──────────────────────────────
  if let (Ok(mut count), Ok(mut last)) = (state.restart_count.lock(), state.last_restart_at.lock()) {
@@ -2972,6 +2998,7 @@ fn start_local_api(app: &AppHandle) -> Result<(), String> {
  if let Ok(mut port_slot) = state.port.lock() {
  *port_slot = Some(confirmed_port);
  }
+ state.port_confirmed.store(true, Ordering::SeqCst);
  } else {
  append_desktop_log(
  app,
@@ -2981,6 +3008,7 @@ fn start_local_api(app: &AppHandle) -> Result<(), String> {
  if let Ok(mut port_slot) = state.port.lock() {
  *port_slot = Some(DEFAULT_LOCAL_API_PORT);
  }
+ state.port_confirmed.store(false, Ordering::SeqCst);
  }
 
  Ok(())
@@ -3098,6 +3126,18 @@ async fn inject_secrets_into_running_sidecar(app: &AppHandle, secrets: Vec<(Stri
  app,
  "WARN",
  "sidecar not alive at secret-injection time — secrets not pushed (will load on next launch)",
+ );
+ return;
+ }
+ // Only post to a port the sidecar actually confirmed via its port file. On
+ // the timeout fallback the recorded port is just the default (46123), which
+ // a foreign process could be squatting if our sidecar bound elsewhere after
+ // EADDRINUSE — posting plaintext secrets there would leak them.
+ if !state.port_confirmed.load(Ordering::SeqCst) {
+ append_desktop_log(
+ app,
+ "WARN",
+ "sidecar port unconfirmed at secret-injection time — secrets not pushed (will load on next launch)",
  );
  return;
  }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3160,8 +3160,23 @@ async fn inject_secrets_into_running_sidecar(app: &AppHandle, secrets: Vec<(Stri
  }
  };
  let url = format!("http://127.0.0.1:{port}/api/local-env-update");
+ let secrets_cache = app.state::<SecretsCache>();
  let mut pushed = 0usize;
+ let mut skipped = 0usize;
  for (key, value) in secrets {
+ // Re-check per key: if the user edited or deleted this secret in Settings
+ // after this snapshot was taken, the renderer already pushed the live
+ // value to the sidecar. POSTing our older snapshot value would clobber it
+ // with a stale (or just-deleted) credential — skip and let the renderer win.
+ if secrets_cache
+ .user_mutated
+ .lock()
+ .map(|t| t.contains(&key))
+ .unwrap_or(false)
+ {
+ skipped += 1;
+ continue;
+ }
  // start_local_api already confirmed the sidecar's port before this runs,
  // so a few quick attempts absorb any momentary unreadiness.
  for attempt in 0..3 {
@@ -3191,7 +3206,7 @@ async fn inject_secrets_into_running_sidecar(app: &AppHandle, secrets: Vec<(Stri
  append_desktop_log(
  app,
  "INFO",
- &format!("injected {pushed}/{total} keychain secrets into running sidecar via IPC"),
+ &format!("injected {pushed}/{total} keychain secrets into running sidecar via IPC ({skipped} skipped: edited in Settings)"),
  );
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -164,7 +164,7 @@ window.addEventListener('unhandledrejection', (e) => {
 import { debugGetCells, getCellCount } from '@/services/geo-convergence';
 import { initMetaTags } from '@/services/meta-tags';
 import { installRuntimeFetchPatch, installWebApiRedirect, isDesktopRuntime } from '@/services/runtime';
-import { loadDesktopSecrets } from '@/services/runtime-config';
+import { loadDesktopSecretsWhenReady } from '@/services/runtime-config';
 import { initAnalytics, isAnalyticsAllowed, migrateAnalyticsConsent, trackApiKeysSnapshot } from '@/services/analytics';
 import { applyStoredTheme } from '@/utils/theme-manager';
 import { SITE_VARIANT } from '@/config/variant';
@@ -278,7 +278,7 @@ import('./services/api-diagnostic').then(({ attachDiagnosticToWindow }) => { att
 installRuntimeFetchPatch();
 // In web production, route RPC calls through api.crystalball.app (Cloudflare edge).
 installWebApiRedirect();
-loadDesktopSecrets().then(async () => {
+loadDesktopSecretsWhenReady().then(async () => {
   await initAnalytics();
   trackApiKeysSnapshot();
 }).catch(() => {});

--- a/src/services/keychain.ts
+++ b/src/services/keychain.ts
@@ -26,6 +26,33 @@ class KeychainService {
     return this.supportedKeys;
   }
 
+  /**
+   * Resolve once the native keychain load has finished. Secrets load
+   * asynchronously after boot (so a slow Touch ID never freezes the window),
+   * which means an early `get` would memoize a null for every key for the whole
+   * renderer lifetime. Boot-time loaders await this first. Desktop only — web
+   * has no native cache, so it resolves immediately. Caps the wait so a stuck
+   * keychain ACL prompt can't hang boot forever (the read itself is bounded the
+   * same way on the Rust side; we just give it margin past the 120s vault
+   * timeout, then proceed with whatever loaded).
+   */
+  async waitUntilLoaded(capMs = 130_000, stepMs = 250): Promise<void> {
+    if (!hasTauriInvokeBridge()) return;
+    const deadline = Date.now() + capMs;
+    for (;;) {
+      let ready = false;
+      try {
+        ready = (await invokeTauri<boolean>('secrets_ready')) === true;
+      } catch {
+        // Command unavailable (older shell) or transient bridge error — stop
+        // waiting rather than spin; the caller proceeds optimistically.
+        return;
+      }
+      if (ready || Date.now() >= deadline) return;
+      await new Promise((resolve) => setTimeout(resolve, stepMs));
+    }
+  }
+
   async get(key: string): Promise<string | null> {
     if (!hasTauriInvokeBridge()) return null;
     if (this.cache.has(key)) return this.cache.get(key) ?? null;

--- a/src/services/keychain.ts
+++ b/src/services/keychain.ts
@@ -31,12 +31,17 @@ class KeychainService {
    * asynchronously after boot (so a slow Touch ID never freezes the window),
    * which means an early `get` would memoize a null for every key for the whole
    * renderer lifetime. Boot-time loaders await this first. Desktop only — web
-   * has no native cache, so it resolves immediately. Caps the wait so a stuck
-   * keychain ACL prompt can't hang boot forever (the read itself is bounded the
-   * same way on the Rust side; we just give it margin past the 120s vault
-   * timeout, then proceed with whatever loaded).
+   * has no native cache, so it resolves immediately.
+   *
+   * The cap exceeds the Rust read's own worst-case bound — 120s for the
+   * consolidated vault plus, on a one-time migration from the legacy per-key
+   * format, up to 77 × 3s of per-key ACL timeouts (~351s). The Rust side always
+   * resolves within that bound (each read uses recv_timeout, orphaning a hung
+   * thread), so `secrets_ready` flips before this deadline in correct operation
+   * — the cap is only a backstop, never the thing that ends the wait, so we
+   * never proceed against a still-empty cache and memoize nulls.
    */
-  async waitUntilLoaded(capMs = 130_000, stepMs = 250): Promise<void> {
+  async waitUntilLoaded(capMs = 400_000, stepMs = 250): Promise<void> {
     if (!hasTauriInvokeBridge()) return;
     const deadline = Date.now() + capMs;
     for (;;) {

--- a/src/services/runtime-config.ts
+++ b/src/services/runtime-config.ts
@@ -1366,3 +1366,19 @@ export async function loadDesktopSecrets(): Promise<void> {
  secretsReadyResolve();
   }
 }
+
+/**
+ * Boot-time desktop secret load that waits for the native keychain read to
+ * finish first. The keychain is now read asynchronously (so a slow Touch ID
+ * never freezes the window), so loading immediately would read an empty cache
+ * and memoize a null for every key for the whole session. We wait for the
+ * `secrets_ready` signal, drop any nulls a stray early read may have cached,
+ * then load. On web this is just `loadDesktopSecrets` (a no-op there).
+ */
+export async function loadDesktopSecretsWhenReady(): Promise<void> {
+  if (isDesktopRuntime()) {
+ await keychainService.waitUntilLoaded();
+ keychainService.invalidateAll();
+  }
+  await loadDesktopSecrets();
+}

--- a/src/services/runtime-config.ts
+++ b/src/services/runtime-config.ts
@@ -1325,8 +1325,10 @@ export async function verifySecretWithApi(
   }
 }
 
-export async function loadDesktopSecrets(): Promise<void> {
+export async function loadDesktopSecrets(options?: { syncToSidecar?: boolean }): Promise<void> {
   if (!isDesktopRuntime()) return;
+
+  const syncToSidecar = options?.syncToSidecar ?? true;
 
   try {
  const keys = await keychainService.listSupportedKeys();
@@ -1343,6 +1345,7 @@ export async function loadDesktopSecrets(): Promise<void> {
  .filter((r): r is PromiseFulfilledResult<{ key: string; value: string | null }> => r.status === 'fulfilled' && r.value.value != null && r.value.value.trim().length > 0)
  .map(async ({ value: { key, value } }) => {
  runtimeConfig.secrets[key as RuntimeSecretKey] = { value: value!, source: 'vault' };
+ if (!syncToSidecar) return;
  try {
  await pushSecretToSidecar(key as RuntimeSecretKey, value!);
  } catch {
@@ -1380,5 +1383,11 @@ export async function loadDesktopSecretsWhenReady(): Promise<void> {
  await keychainService.waitUntilLoaded();
  keychainService.invalidateAll();
   }
-  await loadDesktopSecrets();
+  // Skip the JS→sidecar push at boot: the native Rust injector has already
+  // delivered every loaded secret to the *confirmed* sidecar port. The JS path
+  // builds its URL from getApiBaseUrl(), which falls back to the default 46123
+  // until resolveLocalApiPort() runs — so if a foreign process is squatting
+  // 46123 while our sidecar listens on an OS-assigned fallback port, this push
+  // would leak every secret and the bearer token to that process.
+  await loadDesktopSecrets({ syncToSidecar: false });
 }

--- a/src/settings-main.ts
+++ b/src/settings-main.ts
@@ -768,7 +768,21 @@ async function initSettingsWindow(): Promise<void> {
   // keychain read, which can stall on an ACL/Touch ID prompt. The active section
   // re-renders once secrets land so loaded keys show their real state.
   void loadDesktopSecretsWhenReady()
- .then(() => renderSection(activeSection))
+ .then(() => {
+ const area = document.getElementById('contentArea');
+ // The window is usable mid-load, so the user may be typing when hydration
+ // lands. Capture any unsaved input first (a field's value is otherwise only
+ // read on blur/OK), so re-rendering can't drop a typed-but-unblurred secret.
+ if (area) settingsManager.captureUnsavedInputs(area);
+ // If a secret field still holds focus, skip the re-render entirely rather
+ // than yank the DOM (and the caret) out from under an active edit; the
+ // captured value is preserved and the view refreshes on the next render.
+ const active = document.activeElement as HTMLElement | null;
+ if (area && active && area.contains(active) && active.matches('input, select, textarea')) {
+ return;
+ }
+ renderSection(activeSection);
+ })
  .catch(() => {});
 
   document.getElementById('sidebarNav')?.addEventListener('click', (e) => {

--- a/src/settings-main.ts
+++ b/src/settings-main.ts
@@ -20,7 +20,7 @@ import {
   isFeatureEnabled,
   setFeatureToggle,
   validateSecret,
-  loadDesktopSecrets,
+  loadDesktopSecretsWhenReady,
   type RuntimeFeatureDefinition,
   type RuntimeFeatureId,
   type RuntimeSecretKey,
@@ -760,7 +760,7 @@ async function initSettingsWindow(): Promise<void> {
  document.documentElement.classList.remove('no-transition');
   });
 
-  await loadDesktopSecrets();
+  await loadDesktopSecretsWhenReady();
   settingsManager = new SettingsManager();
 
   renderSection('overview');

--- a/src/settings-main.ts
+++ b/src/settings-main.ts
@@ -760,10 +760,16 @@ async function initSettingsWindow(): Promise<void> {
  document.documentElement.classList.remove('no-transition');
   });
 
-  await loadDesktopSecretsWhenReady();
   settingsManager = new SettingsManager();
 
   renderSection('overview');
+
+  // Hydrate secrets in the background — never block the settings UI on the async
+  // keychain read, which can stall on an ACL/Touch ID prompt. The active section
+  // re-renders once secrets land so loaded keys show their real state.
+  void loadDesktopSecretsWhenReady()
+ .then(() => renderSection(activeSection))
+ .catch(() => {});
 
   document.getElementById('sidebarNav')?.addEventListener('click', (e) => {
  const btn = (e.target as HTMLElement).closest<HTMLButtonElement>('[data-section]');


### PR DESCRIPTION
## Why

PR #1213 (async-boot keychain fix) auto-merged at the **round-2** commit while the
cross-agent review loop was still running, so Codex rounds **3–11** never landed on
`main`. This follow-up carries those 9 fixes, cherry-picked clean onto current `main`
and re-reviewed.

## What's included (rounds 3–11)

- **R3** — drop sidecar route/response caches on `/api/local-env-update` so freshly
  injected secrets aren't masked by stale cached 503s.
- **R4** — guard concurrent Settings deletes during the async load; never inject to an
  unconfirmed sidecar port.
- **R5** — skip user-edited keys during boot injection (don't clobber live edits).
- **R6** — renderer waits on `secrets_ready` before reading, so it never memoizes a
  null for every key while the keychain is still loading.
- **R7** — mark `loaded` even on sidecar-start failure; renderer wait-cap exceeds the
  Rust read's worst-case bound.
- **R8** — re-read the live cache value per key at injection time, recovering any key
  whose early renderer push failed; render Settings before hydration.
- **R9** — block secret writes until keychain hydration completes, so a Save during the
  load window can't persist a one-key vault that wipes every other secret.
- **R10** — don't push boot secrets over JS to the default port before the sidecar port
  is confirmed (foreign-process secret/token leak); widen the save-wait bound to the
  keychain read's true worst case.
- **R11** — preserve in-progress Settings edits across the background hydration re-render.

## Test

- `cargo check` clean
- `npm run typecheck:all` clean (both tsconfigs)
- keychain unit tests: 9/9 pass
- sidecar unit tests: 73/73 pass

cross-agent review: Codex