### PR TITLE
fix(idb): close shared crystalball_db connections on versionchange

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -61,11 +61,20 @@ function eventSeverityScore(label) {
 // the gap is observable without flooding the sidecar log on a persistent fault.
 const _eventStoreWriteWarnAt = new Map();
 function warnEventStoreWriteFailure(kind, err) {
+  const message = String(err?.message ?? err);
+  // A duplicate event id is an idempotent re-append (same observation/situation
+  // seen again on a later refresh), not a failure — the append-only invariant
+  // already preserved the original row. Log at debug so known duplicates don't
+  // light up the error badge on every boot / refresh cycle.
+  if (message.includes('append-only violation')) {
+    console.debug(`[sidecar] event-store ${kind} duplicate id skipped (idempotent)`);
+    return;
+  }
   const now = Date.now();
   const last = _eventStoreWriteWarnAt.get(kind) ?? 0;
   if (now - last < 60_000) return;
   _eventStoreWriteWarnAt.set(kind, now);
-  console.warn(`[sidecar] event-store ${kind} append failed: ${String(err?.message ?? err)}`);
+  console.warn(`[sidecar] event-store ${kind} append failed: ${message}`);
 }
 
 // ── Event-store payload redaction ──────────────────────────────────────────

--- a/src/services/notifications/notification-history-service.ts
+++ b/src/services/notifications/notification-history-service.ts
@@ -228,6 +228,13 @@ function openDb(): Promise<IDBDatabase> {
     req.addEventListener('success', () => {
       const db = req.result;
       db.addEventListener('close', () => { _dbPromise = null; });
+      // Yield to another module (reasoning-memory / alert-store) bumping the
+      // shared crystalball_db version — otherwise this open connection blocks
+      // their upgrade. Reopened lazily on the next openDb() call.
+      db.addEventListener('versionchange', () => {
+        db.close();
+        _dbPromise = null;
+      });
       resolve(db);
     });
     req.addEventListener('blocked', () => {

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -23,9 +23,17 @@ export async function initDB(): Promise<IDBDatabase> {
  request.onerror = () => reject(request.error);
 
  request.onsuccess = () => {
- db = request.result;
- db.addEventListener('close', () => { db = null; });
- resolve(db);
+ const conn = request.result;
+ db = conn;
+ conn.addEventListener('close', () => { db = null; });
+ // Another module (reasoning-memory / alert-store) bumping the shared
+ // crystalball_db version fires `versionchange` here. Close so the upgrade
+ // isn't blocked; the next initDB() reopens at the new version.
+ conn.addEventListener('versionchange', () => {
+ conn.close();
+ db = null;
+ });
+ resolve(conn);
  };
 
  request.onupgradeneeded = (event) => {


### PR DESCRIPTION
## Problem
On fresh install / version bump, the debug overlay lit up with ~18 "upgrade blocked by another connection" errors. Modules sharing `crystalball_db` held open connections without a `versionchange` handler, blocking the version bumps other modules request.

## Fix
- **`versionchange` close handlers** on the two readers that lacked them (`storage.ts`, `notification-history-service.ts`), so they yield instead of blocking an upgrade.
- **Probe-then-bump** open pattern (never pin a fixed version → no `VersionError` after another module bumps higher).
- **Blocked-upgrade handling** so a held connection can't hang `initDB()` forever, and a rejected `_dbPromise` is cleared (no session-long poisoning).
- **Single shared schema authority** (`crystalball-db-stores.ts`): every upgrader (storage, alert-store, reasoning-memory, notification-history) now creates the *complete* store set, so whichever module wins a version-bump race yields a DB with all stores present — eliminating the `NotFoundError` race for all four.
- **Sidecar**: a duplicate event id is an idempotent re-append, not a failure — downgraded the caller-side log from `warn` to `debug`. The append-only throw and its guarding test are preserved.

## Verification
- `npm run typecheck:all` — zero errors (both tsconfigs)
- `event-store.test.mjs` — 6/6 pass (incl. "duplicate event id throws and preserves the original row")
- `node --check` on sidecar files — OK

## Review
Reviewed across 6 Codex rounds; each surfaced a real follow-on issue (VersionError, store-missing race, peer-store gaps, blocked-upgrade hang, cache poisoning), all addressed. Final round: no actionable correctness issues.

cross-agent review: codex