### PR TITLE
fix(map,globe): guard re-entrant layer adds against async races

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -5708,10 +5708,16 @@ export class DeckGLMap {
  .then((geojson) => {
  if (!this.maplibreMap || !geojson) return;
  this.countriesGeoJsonData = geojson;
+ // Guard each add: rapid basemap switches reset countryGeoJsonLoaded
+ // synchronously, so two loads can race past the entry guard and both
+ // reach here after the await — re-adding throws "already a source/layer".
+ if (!this.maplibreMap.getSource('country-boundaries')) {
  this.maplibreMap.addSource('country-boundaries', {
  type: 'geojson',
  data: geojson,
  });
+ }
+ if (!this.maplibreMap.getLayer('country-interactive')) {
  this.maplibreMap.addLayer({
  id: 'country-interactive',
  type: 'fill',
@@ -5721,6 +5727,8 @@ export class DeckGLMap {
  'fill-opacity': 0,
  },
  });
+ }
+ if (!this.maplibreMap.getLayer('country-hover-fill')) {
  this.maplibreMap.addLayer({
  id: 'country-hover-fill',
  type: 'fill',
@@ -5731,6 +5739,8 @@ export class DeckGLMap {
  },
  filter: ['==', ['get', 'name'], ''],
  });
+ }
+ if (!this.maplibreMap.getLayer('country-highlight-fill')) {
  this.maplibreMap.addLayer({
  id: 'country-highlight-fill',
  type: 'fill',
@@ -5741,6 +5751,8 @@ export class DeckGLMap {
  },
  filter: ['==', ['get', 'ISO3166-1-Alpha-2'], ''],
  });
+ }
+ if (!this.maplibreMap.getLayer('country-highlight-border')) {
  this.maplibreMap.addLayer({
  id: 'country-highlight-border',
  type: 'line',
@@ -5752,6 +5764,7 @@ export class DeckGLMap {
  },
  filter: ['==', ['get', 'ISO3166-1-Alpha-2'], ''],
  });
+ }
 
  if (!this.countryHoverSetup) this.setupCountryHover();
  this.updateCountryLayerPaint(getCurrentTheme());

--- a/src/components/GlobeDataManager.ts
+++ b/src/components/GlobeDataManager.ts
@@ -753,16 +753,20 @@ export class GlobeDataManager {
   private async loadLayer(name: string): Promise<void> {
  const layer = this.layers.get(name);
  if (!layer || layer.loaded) return;
+ // Optimistic lock: camera.changed fires checkDeferredLayers repeatedly
+ // during a pan, so claim the layer BEFORE the await — otherwise a second
+ // fire re-enters while load() is pending and adds a duplicate entity set.
+ layer.loaded = true;
  try {
  await layer.load();
- layer.loaded = true;
  const categoryColor = CLUSTER_LAYERS[name];
  if (categoryColor) {
  applyClustering(layer.source, { categoryColor });
  this.clusterableLayers.add(name);
  }
  } catch {
- // Non-fatal — other layers continue loading
+ // Load failed — release the lock so a later camera move can retry.
+ layer.loaded = false;
  }
   }
 


### PR DESCRIPTION
## Summary
Fixes two async re-entrancy bugs where a layer loader sets its re-entry guard *synchronously* but installs sources/layers only *after* an `await`, letting two rapid triggers both pass the guard and double-install.

### Problem 1 — MapLibre crash on basemap switch (scan 5 #1 CRITICAL)
`DeckGLMap.loadCountryBoundaries` sets `countryGeoJsonLoaded = true` synchronously, but `addSource`/`addLayer` run after `await getCountriesGeoJson()`. `switchBasemap` resets the guard to `false` on `style.load`, so two rapid basemap switches both reach the post-await adds — the second throws `There is already a source with this ID`, leaving layers half-installed.

**Fix:** guard each `addSource`/`addLayer` with `getSource`/`getLayer` (idiomatic MapLibre conditional-add), making the post-await pass idempotent.

### Problem 2 — Globe duplicate entities on camera move (scan 5 #2 HIGH)
`GlobeDataManager.loadLayer` sets `layer.loaded = true` only *after* `await layer.load()`. `checkDeferredLayers` fires on `camera.changed` repeatedly during a pan; a second fire while the first is awaiting sees `loaded === false`, re-enters, and adds a duplicate entity set.

**Fix:** claim `layer.loaded = true` *before* the await (optimistic lock), releasing it on failure so a later camera move can retry.

## Test
`npm run typecheck:all` — zero errors (both tsconfig.json + tsconfig.api.json).