### PR TITLE
fix: harden hypothesis-thread load + add timeouts to OREF life-safety feed

### DIFF
--- a/src/services/hypothesis-threads.ts
+++ b/src/services/hypothesis-threads.ts
@@ -58,6 +58,18 @@ const threads = new Map<string, HypothesisThread>();
 let loaded = false;
 let writtenSinceLoad = false;
 
+// Persisted threads may predate a schema change or be partially corrupt. Reject
+// any element missing a dereferenced field — otherwise a thread without
+// confidenceHistory crashes upsertThread() when it spreads the array.
+function isValidThread(t: unknown): t is HypothesisThread {
+  if (typeof t !== 'object' || t === null) return false;
+  const c = t as Partial<HypothesisThread>;
+  return typeof c.signature === 'string'
+    && Array.isArray(c.confidenceHistory)
+    && typeof c.peakRisk === 'string'
+    && typeof c.latest === 'object' && c.latest !== null;
+}
+
 function load(): void {
   if (loaded) return;
   loaded = true;
@@ -65,16 +77,18 @@ function load(): void {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw) {
-      const arr = JSON.parse(raw) as HypothesisThread[];
+      const parsed = JSON.parse(raw);
+      const arr = Array.isArray(parsed) ? parsed.filter(isValidThread) : [];
       for (const t of arr) threads.set(t.signature, t);
     }
   } catch { /* ignore */ }
   // Async IDB hydrate replaces bootstrap data with the richer store —
   // but only if nothing has been written since load() started, otherwise
   // a fresh write from a first-cycle event would be clobbered.
-  void getMemory<HypothesisThread[]>(STORAGE_KEY).then(arr => {
+  void getMemory<HypothesisThread[]>(STORAGE_KEY).then(raw => {
     if (writtenSinceLoad) return;
-    if (!arr || arr.length === 0) return;
+    const arr = Array.isArray(raw) ? raw.filter(isValidThread) : [];
+    if (arr.length === 0) return;
     threads.clear();
     for (const t of arr) threads.set(t.signature, t);
   });

--- a/src/services/oref-alerts.ts
+++ b/src/services/oref-alerts.ts
@@ -235,6 +235,7 @@ export async function fetchOrefAlerts(): Promise<OrefAlertsResponse> {
 
   try {
  const res = await fetch(getOrefApiUrl(), {
+ signal: AbortSignal.timeout(10000),
  headers: { Accept: 'application/json' },
  });
  if (!res.ok) {
@@ -265,9 +266,11 @@ export async function fetchOrefHistory(): Promise<OrefHistoryResponse> {
   await ensureLocationMapLoaded();
   try {
  const res = await fetch(getOrefApiUrl('history'), {
+ signal: AbortSignal.timeout(10000),
  headers: { Accept: 'application/json' },
  });
  if (!res.ok) {
+ dataFreshness.recordError('oref-alerts', `History HTTP ${res.status}`);
  // eslint-disable-next-line no-console -- diagnostic warning for upstream failure
  console.warn('[OREF History] HTTP', res.status);
  return { configured: false, history: [], historyCount24h: 0, timestamp: new Date().toISOString(), error: `HTTP ${res.status}` };
@@ -286,6 +289,7 @@ export async function fetchOrefHistory(): Promise<OrefHistoryResponse> {
 
  return data;
   } catch (error) {
+ dataFreshness.recordError('oref-alerts', String(error));
  return { configured: false, history: [], historyCount24h: 0, timestamp: new Date().toISOString(), error: String(error) };
   }
 }


### PR DESCRIPTION
## Problem 1 — hypothesis-threads load crash (scan 6, M3)
`src/services/hypothesis-threads.ts` cast `JSON.parse(raw)` to `HypothesisThread[]` with no per-element check. A persisted thread missing `confidenceHistory` survived into the map and crashed `upsertThread()` with a `TypeError` when it spread `undefined`.

**Fix:** added `isValidThread()` type guard (checks object, `signature: string`, `confidenceHistory: array`, `peakRisk: string`, `latest: object`) and filter parsed elements through it in **both** the synchronous localStorage bootstrap and the async IDB hydrate paths.

## Problem 2 — OREF (Israel rocket alerts) no fetch timeout (scan 2, HIGH — life-safety)
Both `fetch()` calls were bare with no `AbortSignal`. A stalled TCP connection to the alert API hung indefinitely with no error and no `recordError`.

**Fix:**
- Wrapped both fetches with `AbortSignal.timeout(10000)`.
- Added `dataFreshness.recordError('oref-alerts', ...)` to the history `!res.ok` branch (previously only `console.warn`) and to the history `catch` block — so a timeout-abort actually surfaces in feed health, matching the main path's pattern.

## Verification
`npx tsc --noEmit` → 0 errors.

---
Cross-agent review: Codex non-functional on 2026-06-17 — `codex exec review` hung indefinitely with no output on two attempts (killed after 60s each); global Codex hang being remediated in a separate session. Merge authorized by repo owner; fix verified by `npx tsc --noEmit` (0 errors). Not a clean pass — reviewer was unavailable.