### PR TITLE
fix(components): clean up leaked listeners on panel teardown

### DIFF
--- a/src/components/CountryTimeline.ts
+++ b/src/components/CountryTimeline.ts
@@ -36,6 +36,7 @@ export class CountryTimeline {
   private tooltip: HTMLDivElement | null = null;
   private resizeObserver: ResizeObserver | null = null;
   private currentEvents: TimelineEvent[] = [];
+  private readonly onThemeChange: () => void;
 
   constructor(container: HTMLElement) {
  this.container = container;
@@ -45,7 +46,7 @@ export class CountryTimeline {
  });
  this.resizeObserver.observe(this.container);
 
- window.addEventListener('theme-changed', () => {
+ this.onThemeChange = () => {
  // Re-create tooltip with new theme colors
  if (this.tooltip) {
  this.tooltip.remove();
@@ -54,7 +55,8 @@ export class CountryTimeline {
  this.createTooltip();
  // Re-render chart with new colors
  if (this.currentEvents.length > 0) this.render(this.currentEvents);
- });
+ };
+ window.addEventListener('theme-changed', this.onThemeChange);
   }
 
   private createTooltip(): void {
@@ -268,6 +270,7 @@ export class CountryTimeline {
   }
 
   destroy(): void {
+ window.removeEventListener('theme-changed', this.onThemeChange);
  if (this.resizeObserver) {
  this.resizeObserver.disconnect();
  this.resizeObserver = null;

--- a/src/components/CountryTimeline.ts
+++ b/src/components/CountryTimeline.ts
@@ -173,7 +173,7 @@ export class CountryTimeline {
  .attr('fill', (d: TimelineEvent['lane']) => LANE_COLORS[d])
  .attr('font-size', '11px')
  .attr('font-weight', '500')
- .text((d: TimelineEvent['lane']) => laneLabels[d] || d);
+ .text((d: TimelineEvent['lane']) => laneLabels[d] ?? d);
   }
 
   private drawNowMarker(

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -162,6 +162,10 @@ export class MapComponent {
   private lastRenderTime = 0;
   private readonly MIN_RENDER_INTERVAL_MS = 100;
   private healthCheckIntervalId: ReturnType<typeof setInterval> | null = null;
+  private boundThemeChange!: () => void;
+  private boundPanMouseMove: ((e: MouseEvent) => void) | null = null;
+  private boundPanMouseUp: (() => void) | null = null;
+  private inertiaRaf = 0;
 
   constructor(container: HTMLElement, initialState: MapState) {
  this.container = container;
@@ -204,10 +208,11 @@ export class MapComponent {
  this.loadMapData();
  this.setupResizeObserver();
 
- window.addEventListener('theme-changed', () => {
+ this.boundThemeChange = () => {
  this.baseRendered = false;
  this.render();
- });
+ };
+ window.addEventListener('theme-changed', this.boundThemeChange);
   }
 
   private setupResizeObserver(): void {
@@ -245,6 +250,16 @@ export class MapComponent {
 
   public destroy(): void {
  document.removeEventListener('visibilitychange', this.boundVisibilityHandler);
+ window.removeEventListener('theme-changed', this.boundThemeChange);
+ if (this.boundPanMouseMove) {
+ document.removeEventListener('mousemove', this.boundPanMouseMove);
+ this.boundPanMouseMove = null;
+ }
+ if (this.boundPanMouseUp) {
+ document.removeEventListener('mouseup', this.boundPanMouseUp);
+ this.boundPanMouseUp = null;
+ }
+ cancelAnimationFrame(this.inertiaRaf);
  if (this.healthCheckIntervalId) {
  clearInterval(this.healthCheckIntervalId);
  this.healthCheckIntervalId = null;
@@ -700,7 +715,7 @@ export class MapComponent {
  }
  });
 
- const onPanMouseMove = rafSchedule((e: MouseEvent) => {
+ this.boundPanMouseMove = rafSchedule((e: MouseEvent) => {
  if (!isDragging) return;
 
  const dx = e.clientX - lastPos.x;
@@ -713,25 +728,25 @@ export class MapComponent {
  lastPos = { x: e.clientX, y: e.clientY };
  this.applyTransform();
  });
- document.addEventListener('mousemove', onPanMouseMove);
+ document.addEventListener('mousemove', this.boundPanMouseMove);
 
- document.addEventListener('mouseup', () => {
+ this.boundPanMouseUp = () => {
  if (isDragging) {
  isDragging = false;
  this.container.style.cursor = 'grab';
  }
- });
+ };
+ document.addEventListener('mouseup', this.boundPanMouseUp);
 
  let touchStartPos = { x: 0, y: 0 };
  let touchDragActive = false;
  let lastDragEndTime = 0;
  const TOUCH_DRAG_THRESHOLD = 8;
  const touchHistory: { x: number; y: number; t: number }[] = [];
- let inertiaRaf = 0;
 
  this.container.addEventListener('touchstart', (e) => {
  if (shouldIgnoreInteractionStart(e.target)) return;
- cancelAnimationFrame(inertiaRaf);
+ cancelAnimationFrame(this.inertiaRaf);
  const touch1 = e.touches[0];
  const touch2 = e.touches[1];
 
@@ -824,9 +839,9 @@ export class MapComponent {
  this.state.pan.x += (vx / 60) * panSpeed;
  this.state.pan.y += (vy / 60) * panSpeed;
  this.applyTransform();
- inertiaRaf = requestAnimationFrame(animate);
+ this.inertiaRaf = requestAnimationFrame(animate);
  };
- inertiaRaf = requestAnimationFrame(animate);
+ this.inertiaRaf = requestAnimationFrame(animate);
  }
  }
  isDragging = false;

--- a/src/components/NeoTrackerPanel.ts
+++ b/src/components/NeoTrackerPanel.ts
@@ -41,8 +41,9 @@ export class NeoTrackerPanel extends Panel {
     }
   }
 
-  public dispose(): void {
+  public override destroy(): void {
     this.fetchAbort?.abort();
+    super.destroy();
   }
 
   private render(): void {


### PR DESCRIPTION
## Summary
Fixes three accumulating event-listener / RAF leaks in component teardown (scan 3 findings P1/P2).

- **CountryTimeline** (P1, true accumulating leak): the constructor's anonymous `window.addEventListener('theme-changed', …)` was never removed in `destroy()`. Since `CountryTimeline` is recreated on every country-brief open, each open permanently added another listener — instances couldn't be GC'd and every theme toggle fired render methods on dead instances. Now bound to `this.onThemeChange` and removed in `destroy()`.
- **NeoTrackerPanel** (P2): defined `dispose()`, but the panel teardown system calls `destroy()` (from `Panel`), which it never overrode — so in-flight NEO fetches resolved into a torn-down panel. Renamed to `public override destroy()` that aborts the fetch and calls `super.destroy()`.
- **Map** (P2): `document` `mousemove`/`mouseup` pan handlers, the `theme-changed` window listener, and the inertia RAF were never cleaned up in `destroy()`. All three handlers are now stored as instance fields and removed in `destroy()`, and `inertiaRaf` is cancelled.

## Testing
- `tsc --noEmit` on both `tsconfig.json` and `tsconfig.api.json` — 0 errors.

## Cross-agent review
Branch is `claude/*`; requires a Codex review per repo policy.