### PR TITLE
fix: route precious localStorage writes through safeSetItem

### DIFF
--- a/src/components/FamilyTrackerPanel.ts
+++ b/src/components/FamilyTrackerPanel.ts
@@ -18,6 +18,7 @@ import {
   distanceKm,
 } from '@/services/family-tracker';
 import type { FamilyMember, FamilyStatus } from '@/services/family-tracker';
+import { safeSetItem } from '@/utils/safe-storage';
 
 const ICON_OPTIONS = ['👨', '👩', '👧', '👦', '🐕', '👴', '👵', '🧑', '👶'];
 
@@ -287,7 +288,7 @@ export class FamilyTrackerPanel extends Panel {
  member.lastUpdate = Date.now();
  member.status = status;
  if (battery != null) member.battery = battery;
- localStorage.setItem('wm-family-members-v1', JSON.stringify(members));
+ safeSetItem('wm-family-members-v1', JSON.stringify(members));
 
  resultEl.style.display = 'block';
  resultEl.textContent = `Updated ${member.icon} ${member.name}: ${lat.toFixed(4)}, ${lon.toFixed(4)} — ${STATUS_LABELS[status]}${battery != null ? ` — ${battery}%` : ''}`;

--- a/src/services/family-tracker.ts
+++ b/src/services/family-tracker.ts
@@ -8,6 +8,7 @@
  */
 
 import { locationService } from '@/services/location';
+import { safeSetItem } from '@/utils/safe-storage';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -74,7 +75,7 @@ function load(): FamilyMember[] {
 }
 
 function save(members: FamilyMember[]): void {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(members));
+  safeSetItem(STORAGE_KEY, JSON.stringify(members));
   notify();
 }
 

--- a/src/services/globe-waypoints.ts
+++ b/src/services/globe-waypoints.ts
@@ -1,5 +1,6 @@
 import { Cartesian3, Math as CesiumMath, type Viewer } from 'cesium';
 import type { CameraBookmark } from './camera-bookmarks';
+import { safeSetItem } from '../utils/safe-storage';
 
 const STORAGE_KEY = 'crystalball-waypoints';
 
@@ -17,12 +18,12 @@ export function loadWaypoints(): Waypoint[] {
 export function saveWaypoint(wp: Waypoint): void {
   const all = loadWaypoints().filter(w => w.id !== wp.id);
   all.push(wp);
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
+  safeSetItem(STORAGE_KEY, JSON.stringify(all));
 }
 
 export function deleteWaypoint(id: string): void {
   const all = loadWaypoints().filter(w => w.id !== id);
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
+  safeSetItem(STORAGE_KEY, JSON.stringify(all));
 }
 
 export class WaypointTour {

--- a/src/services/registration-profile.ts
+++ b/src/services/registration-profile.ts
@@ -1,3 +1,5 @@
+import { safeSetItem } from '../utils/safe-storage';
+
 export interface RegistrationProfile {
   firstName: string;
   lastName: string;
@@ -15,7 +17,7 @@ export function getRegistrationProfile(): RegistrationProfile | null {
 }
 
 export function saveRegistrationProfile(profile: RegistrationProfile): void {
-  localStorage.setItem(PROFILE_KEY, JSON.stringify(profile));
+  safeSetItem(PROFILE_KEY, JSON.stringify(profile));
 }
 
 export function clearRegistrationProfile(): void {

--- a/src/services/runtime-config.ts
+++ b/src/services/runtime-config.ts
@@ -1,6 +1,7 @@
 import { getApiBaseUrl, isDesktopRuntime } from './runtime';
 import { invokeTauri } from './tauri-bridge';
 import { keychainService } from './keychain';
+import { safeSetItem } from '../utils/safe-storage';
 import {
   isVaultUnlocked as isWebVaultUnlocked,
   listSecrets as listWebVaultSecrets,
@@ -1103,7 +1104,7 @@ export function getEffectiveSecrets(feature: RuntimeFeatureDefinition): RuntimeS
 
 export function setFeatureToggle(featureId: RuntimeFeatureId, enabled: boolean): void {
   runtimeConfig.featureToggles[featureId] = enabled;
-  localStorage.setItem(TOGGLES_STORAGE_KEY, JSON.stringify(runtimeConfig.featureToggles));
+  safeSetItem(TOGGLES_STORAGE_KEY, JSON.stringify(runtimeConfig.featureToggles));
   notifyConfigChanged();
 }
 

--- a/src/services/saved-places.ts
+++ b/src/services/saved-places.ts
@@ -1,4 +1,5 @@
 import { loadProximityConfig } from './proximity-filter';
+import { safeSetItem } from '../utils/safe-storage';
 
 export type SavedPlaceSource = 'manual' | 'gps' | 'search' | 'migrated-proximity';
 export type SavedPlaceTag = 'home' | 'work' | 'family' | 'bugout' | 'travel' | 'medical' | 'supply' | 'concern' | 'school' | 'shelter' | 'critical' | 'data_center';
@@ -209,7 +210,15 @@ function persistPlaces(storage: SavedPlacesStorageLike | null, places: SavedPlac
  storage.removeItem?.(STORAGE_KEY);
  return;
   }
-  storage.setItem(STORAGE_KEY, JSON.stringify(places));
+  const serialized = JSON.stringify(places);
+  // Route the real localStorage through the quota-safe wrapper so a
+  // QuotaExceededError can't seize the renderer; an injected custom storage
+  // (e.g. tests) keeps its own setItem.
+  if (typeof localStorage !== 'undefined' && storage === localStorage) {
+ safeSetItem(STORAGE_KEY, serialized);
+  } else {
+ storage.setItem(STORAGE_KEY, serialized);
+  }
 }
 
 function emitSavedPlacesChanged(places: SavedPlace[]): void {

--- a/src/services/watchlist-locations.ts
+++ b/src/services/watchlist-locations.ts
@@ -6,6 +6,8 @@
  * `crystalball-user-location` localStorage key.
  */
 
+import { safeSetItem } from '../utils/safe-storage';
+
 const STORAGE_KEY = 'wm-watched-locations-v1';
 const LEGACY_LOCATION_KEY = 'crystalball-user-location';
 const LEGACY_SAVED_PLACES_KEY = 'crystalball-saved-places';
@@ -202,7 +204,7 @@ class WatchlistLocations {
   }
 
   private save(): void {
- localStorage.setItem(STORAGE_KEY, JSON.stringify(this.locations));
+ safeSetItem(STORAGE_KEY, JSON.stringify(this.locations));
   }
 
   private notify(): void {

--- a/src/services/webcam-sources.ts
+++ b/src/services/webcam-sources.ts
@@ -1,5 +1,6 @@
 import { getApiBaseUrl } from '@/services/runtime';
 import { dataFreshness } from '@/services/data-freshness';
+import { safeSetItem } from '@/utils/safe-storage';
 
 export type WebcamSource = 'windy' | 'youtube' | 'dot' | 'custom';
 export type WebcamRegion = 'iran' | 'middle-east' | 'europe' | 'asia' | 'americas';
@@ -201,12 +202,12 @@ export function addCustomWebcam(url: string, title: string, city: string, countr
     lastVerified: Date.now(),
     sourceId: url,
   };
-  localStorage.setItem(CUSTOM_WEBCAMS_KEY, JSON.stringify([...existing, feed]));
+  safeSetItem(CUSTOM_WEBCAMS_KEY, JSON.stringify([...existing, feed]));
 }
 
 export function removeCustomWebcam(id: string): void {
   const existing = getCustomWebcams();
-  localStorage.setItem(CUSTOM_WEBCAMS_KEY, JSON.stringify(existing.filter(f => f.id !== id)));
+  safeSetItem(CUSTOM_WEBCAMS_KEY, JSON.stringify(existing.filter(f => f.id !== id)));
 }
 
 export async function getWebcamFeeds(region?: WebcamRegion, limit = 24): Promise<WebcamFeed[]> {


### PR DESCRIPTION
## Problem (C1, bug scan 6)

Seven files persist precious user data with a bare `localStorage.setItem`. A `QuotaExceededError` from any of them propagates up and freezes the renderer thread mid-tick (observed: multi-hundred-second refreshes when storage fills).

## Fix

Route each write through `safeSetItem` from `src/utils/safe-storage.ts`, which evicts disposable cache largest-first and **fails closed (returns `false`) instead of throwing**:

- `watchlist-locations.ts` — `save()` (watched locations)
- `family-tracker.ts` — `save()` (family members)
- `FamilyTrackerPanel.ts` — direct family-member writer
- `saved-places.ts` — `persistPlaces()` — routes only the **real** `localStorage` through the wrapper; an injected custom storage (tests) keeps its own `setItem`
- `registration-profile.ts` — profile write
- `runtime-config.ts` — `setFeatureToggle`
- `globe-waypoints.ts` — save + delete waypoint
- `webcam-sources.ts` — add + remove custom webcam

## Verification

- `npm run typecheck:all` — clean (both tsconfigs)
- `tests/saved-places.test.mts` — 10/10 pass (storage abstraction preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)