### PR TITLE
fix(notifications): error-aware staleness banner + stable weather alert dedupe

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -339,6 +339,22 @@ const PROTO_TO_CLIENT_LEVEL: Record<ProtoThreatLevel, ClientThreatLevel> = {
   THREAT_LEVEL_CRITICAL: 'critical',
 };
 
+// Stable dedupe key for an NWS alert. Prefers the official alert id (unique
+// per issuance — an updated/re-issued warning gets a fresh id and re-notifies);
+// falls back to a hash of headline+area when the id is missing so a long-lived
+// warning still maps to one stable key across refreshes.
+function weatherAlertDedupeKey(alert: { id?: string; headline?: string; event?: string; areaDesc?: string }): string {
+  if (alert.id) return `nws-${alert.id}`;
+  const basis = `${alert.headline ?? alert.event ?? ''}|${alert.areaDesc ?? ''}`;
+  let hash = 5381;
+  for (const ch of basis) hash = (hash * 33 + (ch.codePointAt(0) ?? 0)) % 2_147_483_647;
+  return `nws-h${hash.toString(36)}`;
+}
+
+// A long-lived NWS warning keeps reappearing in every fetch. Re-notify at most
+// once per this window so the user gets a periodic reminder, not spam each cycle.
+const WEATHER_NOTIFY_DEDUPE_WINDOW_MS = 60 * 60 * 1000;
+
 function protoItemToNewsItem(p: ProtoNewsItem): NewsItem {
   const level = PROTO_TO_CLIENT_LEVEL[p.threat?.level ?? 'THREAT_LEVEL_UNSPECIFIED'];
   return {
@@ -1664,13 +1680,28 @@ export class DataLoaderManager implements AppModule {
    continue;
  }
  pipelineTrace.record(alert.id, 'weather', { stage: 'evaluated', detail: { isBigEvent: true, tier: bigEventResult.tier } });
+ // Dedupe: a stable per-alert key lets us detect a warning we already
+ // notified for. The trace candidateId stays unique per occurrence (the
+ // registry rejects duplicate ids), while situationId groups occurrences
+ // of the same alert so dedupeMatch can fire on a recent prior dispatch.
+ const dispatchAt = Date.now();
+ const dedupeKey = weatherAlertDedupeKey(alert);
+ const dedupeMatch = registry
+   .bySituation(dedupeKey)
+   .some((e) => {
+     if (e.decision !== 'dispatched') return false;
+     const lastAt = e.events[e.events.length - 1]?.at ?? e.candidate.createdAt;
+     return dispatchAt - lastAt < WEATHER_NOTIFY_DEDUPE_WINDOW_MS;
+   });
  const decision = routeBigEventToLadder(registry, bigEventResult, ladderInput, {
+ candidateId: `${dedupeKey}-${dispatchAt}`,
+ situationId: dedupeKey,
  domain: 'weather',
  headline: alert.headline || alert.event,
  summary: alert.areaDesc ? `${alert.event} — ${alert.areaDesc}` : alert.event,
  quietHoursActive: false,
  quietHoursBypassEnabled: true,
- dedupeMatch: false,
+ dedupeMatch,
  });
  pipelineTrace.record(alert.id, 'weather', { stage: 'routed', detail: { rung: decision.rung, dispatched: decision.dispatched } });
  const action = RUNG_ACTION[decision.rung] ?? null;

--- a/src/services/data-freshness.ts
+++ b/src/services/data-freshness.ts
@@ -136,6 +136,7 @@ export interface DataSourceState {
   name: string;
   lastUpdate: Date | null;
   lastError: string | null;
+  lastErrorAt: number | null;
   itemCount: number;
   enabled: boolean;
   status: FreshnessStatus;
@@ -299,6 +300,7 @@ class DataFreshnessTracker {
  name: meta.name,
  lastUpdate: null,
  lastError: null,
+ lastErrorAt: null,
  itemCount: 0,
  enabled: true, // Assume enabled by default
  status: 'no_data',
@@ -316,6 +318,7 @@ class DataFreshnessTracker {
  source.lastUpdate = new Date();
  source.itemCount += itemCount;
  source.lastError = null;
+ source.lastErrorAt = null;
  source.status = this.calculateStatus(source);
  this.notifyListeners();
  }
@@ -328,9 +331,28 @@ class DataFreshnessTracker {
  const source = this.sources.get(sourceId);
  if (source) {
  source.lastError = error;
+ source.lastErrorAt = Date.now();
  source.status = 'error';
  this.notifyListeners();
  }
+  }
+
+  /**
+ * True when any source recorded an error within the given window.
+ * Used by the offline-staleness banner so a feed that is actively
+ * failing surfaces as stale even when other feeds are refreshing
+ * successfully (a failing feed stops writing cb-source-updates, so
+ * the age-only check alone reports false-fresh).
+ */
+  hasRecentError(windowMs = 10 * 60 * 1000): boolean {
+ const now = Date.now();
+ for (const source of this.sources.values()) {
+ if (!source.enabled) continue;
+ if (source.lastError && source.lastErrorAt !== null && now - source.lastErrorAt <= windowMs) {
+ return true;
+ }
+ }
+ return false;
   }
 
   /**

--- a/src/services/offline-staleness.ts
+++ b/src/services/offline-staleness.ts
@@ -12,6 +12,8 @@
  * "current" — always with an explicit age.
  */
 
+import { dataFreshness } from './data-freshness';
+
 export type OfflineStatus = 'fresh' | 'stale' | 'very-stale' | 'offline';
 
 export interface OfflineState {
@@ -92,10 +94,18 @@ function formatAge(ms: number): string {
   return `${Math.floor(hrs / 24)}d ago`;
 }
 
+// A feed that is actively erroring stops writing cb-source-updates, so the
+// age-only check below can report "fresh" while a source is silently failing.
+// Consult the freshness tracker's error state so the banner reflects reality.
+function feedHasRecentError(): boolean {
+  try { return dataFreshness.hasRecentError(); } catch { return false; }
+}
+
 export function getOfflineState(): OfflineState {
   const isOnline = typeof navigator === 'undefined' ? true : navigator.onLine !== false;
   const offlineDurationMs = isOnline ? 0 : Math.max(0, Date.now() - lastOnlineAt);
   const oldestAge = oldestCachedAge();
+  const feedError = feedHasRecentError();
 
   let status: OfflineStatus = 'fresh';
   if (!isOnline && offlineDurationMs > OFFLINE_GRACE_MS) {
@@ -104,7 +114,7 @@ export function getOfflineState(): OfflineState {
     status = 'very-stale';
   } else if (oldestAge > STALE_MS || (!isOnline && offlineDurationMs > 0)) {
     status = 'stale';
-  } else if (oldestAge > FRESH_MS) {
+  } else if (oldestAge > FRESH_MS || feedError) {
     status = 'stale';
   }
 
@@ -117,6 +127,9 @@ export function getOfflineState(): OfflineState {
   } else if (status === 'very-stale') {
     bannerLabel = 'Data is very old';
     bannerSubtext = `Last updated ${ageLabel} \u2014 verify before use`;
+  } else if (status === 'stale' && feedError && oldestAge <= STALE_MS) {
+    bannerLabel = 'A data feed is not updating';
+    bannerSubtext = `Some sources may be out of date — last refresh ${ageLabel}`;
   } else if (status === 'stale') {
     bannerLabel = 'Viewing cached data';
     bannerSubtext = `Last updated ${ageLabel}`;


### PR DESCRIPTION
## Summary
Two HIGH findings from security scan round 5.

### Problem 1 — staleness banner false-fresh while a feed errors (#3)
`offline-staleness.ts` derived status only from `oldestCachedAge()` over `cb-source-updates`, which is written **only on successful refresh**. A failing feed stops updating its entry; if siblings succeed, the banner stays "fresh" and the failing feed is invisible.

- `data-freshness.ts`: track `lastErrorAt` per source + add `hasRecentError(windowMs = 10min)`.
- `offline-staleness.ts`: consult `hasRecentError()`; bump status to ≥`stale` and show a "A data feed is not updating" banner when a feed errored recently.

### Problem 2 — weather alert re-notifies every refresh (#4)
The ladder dispatch hardcoded `dedupeMatch: false` and omitted `candidateId`, so the dedupe stage never fired and a long-lived NWS warning re-notified every fetch cycle.

- `data-loader.ts`: derive a stable per-alert key (`nws-${alert.id}`, hash fallback) used as the ladder `situationId`; compute `dedupeMatch` from a recent prior dispatch (60-min window) so the ladder's dedupe stage suppresses repeats. The trace `candidateId` stays unique per occurrence so the registry's duplicate-id guard isn't tripped.

## Testing
- `npm run typecheck:all` — clean (both tsconfigs).
- `notification-trace` + `notification-ladder` suites pass (28 tests).

## Notes
- Out of scope but observed: `NotificationTraceRegistry.trim()` is never called in production, so the trace registry grows unbounded (pre-existing; this change doesn't worsen it).