### PR TITLE
fix(feeds): add fetch timeouts to prevent hung data feeds

### DIFF
--- a/src/services/emsc-seismic.ts
+++ b/src/services/emsc-seismic.ts
@@ -18,13 +18,15 @@ export interface EmscEvent {
 export async function fetchEmscSeismic(): Promise<EmscEvent[]> {
   if (!isFeatureAvailable('emscSeismic')) return [];
   try {
- const res = await fetch(`${getApiBaseUrl()}/api/emsc-seismic`, { signal: AbortSignal.timeout(10000) });
+ const res = await fetch(`${getApiBaseUrl()}/api/emsc-seismic`, { signal: AbortSignal.timeout(10_000) });
  if (!res.ok) {
+ // eslint-disable-next-line no-console -- surface nuclear-test feed degradation, never swallow
  console.warn(`[emsc-seismic] feed returned HTTP ${res.status}`);
  return [];
  }
  return (await res.json()) as EmscEvent[];
   } catch (error) {
+ // eslint-disable-next-line no-console -- surface nuclear-test feed degradation, never swallow
  console.warn('[emsc-seismic] feed fetch failed (timeout or network):', error);
  return [];
   }

--- a/src/services/emsc-seismic.ts
+++ b/src/services/emsc-seismic.ts
@@ -18,10 +18,14 @@ export interface EmscEvent {
 export async function fetchEmscSeismic(): Promise<EmscEvent[]> {
   if (!isFeatureAvailable('emscSeismic')) return [];
   try {
- const res = await fetch(`${getApiBaseUrl()}/api/emsc-seismic`);
- if (!res.ok) return [];
+ const res = await fetch(`${getApiBaseUrl()}/api/emsc-seismic`, { signal: AbortSignal.timeout(10000) });
+ if (!res.ok) {
+ console.warn(`[emsc-seismic] feed returned HTTP ${res.status}`);
+ return [];
+ }
  return (await res.json()) as EmscEvent[];
-  } catch {
+  } catch (error) {
+ console.warn('[emsc-seismic] feed fetch failed (timeout or network):', error);
  return [];
   }
 }

--- a/src/services/gdacs.ts
+++ b/src/services/gdacs.ts
@@ -57,7 +57,8 @@ const EVENT_TYPE_NAMES: Record<string, string> = {
 export async function fetchGDACSEvents(): Promise<GDACSEvent[]> {
   return breaker.execute(async () => {
  const response = await fetch(GDACS_API, {
- headers: { 'Accept': 'application/json' }
+ headers: { 'Accept': 'application/json' },
+ signal: AbortSignal.timeout(10000),
  });
 
  if (!response.ok) throw new Error(`HTTP ${response.status}`);

--- a/src/services/gdacs.ts
+++ b/src/services/gdacs.ts
@@ -58,7 +58,7 @@ export async function fetchGDACSEvents(): Promise<GDACSEvent[]> {
   return breaker.execute(async () => {
  const response = await fetch(GDACS_API, {
  headers: { 'Accept': 'application/json' },
- signal: AbortSignal.timeout(10000),
+ signal: AbortSignal.timeout(10_000),
  });
 
  if (!response.ok) throw new Error(`HTTP ${response.status}`);

--- a/src/services/runtime.ts
+++ b/src/services/runtime.ts
@@ -291,7 +291,7 @@ export function installRuntimeFetchPatch(): void {
  // signal would abort the fallback immediately and break it.
  const callerSignal = init?.signal;
  const withTimeout = (base?: RequestInit): RequestInit =>
- callerSignal ? { ...base } : { ...base, signal: AbortSignal.timeout(15000) };
+ callerSignal ? { ...base } : { ...base, signal: AbortSignal.timeout(15_000) };
  const target = getApiTargetFromRequestInput(input);
  const debug = localStorage.getItem('wm-debug-log') === '1';
 

--- a/src/services/runtime.ts
+++ b/src/services/runtime.ts
@@ -285,8 +285,13 @@ export function installRuntimeFetchPatch(): void {
   window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
  // Default timeout: ~100 data feeds route through this patched fetch with no
  // timeout of their own, so a hung connection would otherwise stall forever.
- // Only apply when the caller hasn't supplied its own AbortSignal.
- if (!init?.signal) init = { ...init, signal: AbortSignal.timeout(15000) };
+ // Honor a caller-supplied signal; otherwise give EACH fetch attempt its own
+ // fresh 15s timeout. We must not share one AbortSignal across the local
+ // attempt and the cloud fallback — once the local timeout fires, a reused
+ // signal would abort the fallback immediately and break it.
+ const callerSignal = init?.signal;
+ const withTimeout = (base?: RequestInit): RequestInit =>
+ callerSignal ? { ...base } : { ...base, signal: AbortSignal.timeout(15000) };
  const target = getApiTargetFromRequestInput(input);
  const debug = localStorage.getItem('wm-debug-log') === '1';
 
@@ -295,7 +300,7 @@ export function installRuntimeFetchPatch(): void {
  const raw = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
  console.log(`[fetch] passthrough → ${raw.slice(0, 120)}`);
  }
- return nativeFetch(input, init);
+ return nativeFetch(input, withTimeout(init));
  }
 
  // Resolve dynamic sidecar port on first API call
@@ -312,7 +317,7 @@ export function installRuntimeFetchPatch(): void {
  if (localApiToken) {
  headers.set('Authorization', `Bearer ${localApiToken}`);
  }
- const localInit = { ...init, headers };
+ const localInit = withTimeout({ ...init, headers });
 
  const localUrl = `${getApiBaseUrl()}${target}`;
  if (debug) console.log(`[fetch] intercept → ${target}`);
@@ -333,7 +338,7 @@ export function installRuntimeFetchPatch(): void {
  });
  }
  cloudHeaders.set('X-CrystalBall-Key', cloudApiKey);
- return nativeFetch(cloudUrl, { ...init, headers: cloudHeaders });
+ return nativeFetch(cloudUrl, withTimeout({ ...init, headers: cloudHeaders }));
  };
 
  try {
@@ -351,7 +356,7 @@ export function installRuntimeFetchPatch(): void {
  if (localApiToken) {
  const retryHeaders = new Headers(init?.headers);
  retryHeaders.set('Authorization', `Bearer ${localApiToken}`);
- response = await fetchLocalWithStartupRetry(nativeFetch, localUrl, { ...init, headers: retryHeaders });
+ response = await fetchLocalWithStartupRetry(nativeFetch, localUrl, withTimeout({ ...init, headers: retryHeaders }));
  if (debug) console.log(`[fetch] retry ${target} → ${response.status}`);
  }
  }

--- a/src/services/runtime.ts
+++ b/src/services/runtime.ts
@@ -283,6 +283,10 @@ export function installRuntimeFetchPatch(): void {
   }
 
   window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+ // Default timeout: ~100 data feeds route through this patched fetch with no
+ // timeout of their own, so a hung connection would otherwise stall forever.
+ // Only apply when the caller hasn't supplied its own AbortSignal.
+ if (!init?.signal) init = { ...init, signal: AbortSignal.timeout(15000) };
  const target = getApiTargetFromRequestInput(input);
  const debug = localStorage.getItem('wm-debug-log') === '1';
 


### PR DESCRIPTION
## Summary
Three data feeds could hang indefinitely on a stalled connection because their `fetch()` calls had no timeout. A hung socket would never reject, stalling the feed (and any caller awaiting it) forever.

### BUG 1 — `emsc-seismic.ts` (nuclear-test monitoring feed)
Bare `fetch()` with a silent `catch {}`. Added `AbortSignal.timeout(10000)` and replaced the silent swallow with `console.warn` on both non-ok HTTP status and thrown errors — failures of a nuclear-test monitoring feed should never be invisible.

### BUG 2 — `gdacs.ts`
Bare `fetch()` inside the circuit breaker. Added `AbortSignal.timeout(10000)`; the existing circuit breaker already records the resulting error.

### BUG 3 — `runtime.ts` `installRuntimeFetchPatch()`
The global fetch patch applied no default timeout, leaving ~100 feeds that route through it unprotected. Added a default 15s timeout at the top of the patched wrapper, applied only when the caller supplies no `signal` of its own (so explicit per-call signals — including the 10s ones above — are preserved). Covers both the passthrough and `/api/` branches.

## Test
`npx tsc --noEmit` — exit 0 (zero errors).