### PR TITLE
Fix notification + signup-link Tauri command names

### DIFF
--- a/src/components/KeyDashboard.ts
+++ b/src/components/KeyDashboard.ts
@@ -176,7 +176,7 @@ export class KeyDashboard {
       a.addEventListener('click', (ev) => {
         ev.preventDefault();
         void (async () => {
-          try { await invokeTauri('plugin:shell|open', { path: signupUrl }); }
+          try { await invokeTauri('open_url', { url: signupUrl }); }
           catch { window.open(signupUrl, '_blank', 'noopener,noreferrer'); }
         })();
       });

--- a/src/components/SetupWizard.ts
+++ b/src/components/SetupWizard.ts
@@ -135,7 +135,7 @@ export class SetupWizard {
       a.addEventListener('click', (ev) => {
         ev.preventDefault();
         void (async () => {
-          try { await invokeTauri('plugin:shell|open', { path: signup }); }
+          try { await invokeTauri('open_url', { url: signup }); }
           catch { window.open(signup, '_blank', 'noopener,noreferrer'); }
         })();
       });

--- a/src/services/notification-router.ts
+++ b/src/services/notification-router.ts
@@ -134,7 +134,7 @@ async function defaultSendNativeNotification(
  ) => Promise<unknown>;
  };
  if (typeof mod.tryInvokeTauri === 'function') {
- await mod.tryInvokeTauri('plugin:crystalball|send_notification', {
+ await mod.tryInvokeTauri('send_notification', {
  title,
  body,
  });
@@ -202,6 +202,7 @@ function defaultDeps(): RouterDeps {
 // ── Core delivery ──────────────────────────────────────────────────────
 
 let activeDeps: RouterDeps | null = null;
+let routerStarted = false;
 
 function alertToUnified(alert: ReactorAlert): UnifiedAlert {
   const { threat, relevance, alertId, createdAt } = alert;
@@ -311,6 +312,8 @@ const NOOP = (): void => {
 };
 
 export function startNotificationRouter(deps?: RouterDeps): () => void {
+  if (routerStarted) return NOOP;
+  routerStarted = true;
   const resolved = deps ?? defaultDeps();
   activeDeps = resolved;
 
@@ -346,4 +349,5 @@ export function __resetForTesting(): void {
   lastNotifiedBySeverity.clear();
   config = { ...DEFAULT_CONFIG };
   activeDeps = null;
+  routerStarted = false;
 }


### PR DESCRIPTION
## What

Three call-site fixes for Tauri commands that targeted plugins that aren't registered:

1. `notification-router.ts` — `plugin:crystalball|send_notification` → `send_notification` (the registered command; the crystalball plugin namespace doesn't exist).
2. `SetupWizard.ts` + `KeyDashboard.ts` — `plugin:shell|open` `{path}` → `open_url` `{url}` (the shell plugin isn't registered; `open_url` is the real command).
3. `startNotificationRouter()` — added an idempotency guard. `App.ts` and `panel-layout.ts` both call it at boot, so without the guard the router subscribed twice. Returns the no-op cleanup on the duplicate call; `__resetForTesting` clears the flag.

## Verification

- `tsc --noEmit` clean on both tsconfig.json and tsconfig.api.json.
- notification-router test suite: 7/7 pass.

Verified `send_notification` and `open_url` exist and are registered in `src-tauri/src/main.rs` (invoke_handler at lines 3528/3534).