### PR TITLE
fix: refund LLM budget on failed cloud call + catch briefing-scheduler errors

### DIFF
--- a/src/services/intelligence/briefing-scheduler.ts
+++ b/src/services/intelligence/briefing-scheduler.ts
@@ -1,5 +1,6 @@
 import { isDesktopRuntime } from '../runtime';
 import { invokeTauri } from '../tauri-bridge';
+import { logDebug } from '../reasoning-debug';
 
 export interface BriefingSchedule {
   enabled: boolean;
@@ -149,6 +150,14 @@ export class BriefingScheduler {
       }
       this.schedule.lastGeneratedAt = Date.now();
       saveSchedule(this.schedule);
+    } catch (error) {
+      // Swallow the failure here so the rejected promise from `void this.fire()`
+      // doesn't surface as an unhandled rejection. The finally below still
+      // schedules the next run at its normal time rather than retrying in a
+      // tight loop.
+      logDebug({ level: 'error', category: 'forecast', source: 'briefing-scheduler',
+        message: 'briefing generation failed',
+        data: { error: error instanceof Error ? error.message : String(error) } });
     } finally {
       this.reschedule();
     }

--- a/src/services/llm-adapter.ts
+++ b/src/services/llm-adapter.ts
@@ -18,7 +18,7 @@
 import { runClaudeAgent } from './claude-agent';
 import { getApiBaseUrl, isDesktopRuntime } from './runtime';
 import { getRuntimeConfigSnapshot } from './runtime-config';
-import { recordCall, reserveCloudCall } from './llm-budget';
+import { recordCall, refundCloudCall, reserveCloudCall } from './llm-budget';
 import { logDebug } from './reasoning-debug';
 import { recordLatency, incrementCounter } from './reasoning-metrics';
 import { isLocalModelOnly, isLlmEgressDisclosed } from './ai-flow-settings';
@@ -207,9 +207,17 @@ export async function generateText(prompt: string, options: LlmOptions = {}): Pr
   // Atomically reserve a cloud-call slot before issuing the request.
   // If reserveCloudCall returns false, the cap is already hit; fail soft.
   if (!reserveCloudCall('cloud-agent')) return { text: '', provider: 'none' };
-  const cloud = await tryCloudAgent(prompt, options);
-  if (cloud) return cloud; // already counted by reserveCloudCall
-  return { text: '', provider: 'none' };
+  let cloud: LlmResult | null = null;
+  try {
+    cloud = await tryCloudAgent(prompt, options);
+    if (cloud) return cloud; // already counted by reserveCloudCall
+    return { text: '', provider: 'none' };
+  } finally {
+    // The call never produced a usable result, so the reserved slot was
+    // never actually spent — release it so a failed attempt doesn't
+    // permanently burn budget.
+    if (!cloud) refundCloudCall('cloud-agent');
+  }
 }
 
 /**

--- a/src/services/llm-budget.ts
+++ b/src/services/llm-budget.ts
@@ -158,8 +158,10 @@ export function canSpend(provider: LlmProvider): boolean {
  * cloud request so that N parallel callers (e.g. the multi-persona
  * ensemble) cannot all race past canSpend() and overshoot the cap.
  *
- * If the call later fails, the slot is NOT refunded — the call was
- * still attempted, and conservative accounting is the safer default.
+ * If the call never actually issues (the provider returned nothing or
+ * threw before spending a real slot), the caller must release the
+ * reservation via refundCloudCall() — typically from a finally block —
+ * so a failed attempt doesn't permanently burn budget.
  */
 export function reserveCloudCall(provider: LlmProvider): boolean {
   if (provider === 'local' || provider === 'none') return true;
@@ -173,6 +175,23 @@ export function reserveCloudCall(provider: LlmProvider): boolean {
   save();
   document.dispatchEvent(new CustomEvent<BudgetStatus>(EVENT_NAME, { detail: getBudgetStatus() }));
   return true;
+}
+
+/**
+ * Release a slot previously taken by reserveCloudCall() when the cloud
+ * call did not actually happen (empty result or thrown error). The
+ * counter is clamped at zero so a stray refund can never drive the
+ * budget negative.
+ */
+export function refundCloudCall(provider: LlmProvider): void {
+  if (provider === 'local' || provider === 'none') return;
+  load();
+  rolloverIfNeeded();
+  if (provider === 'cloud-agent') state.cloudAgent = Math.max(0, state.cloudAgent - 1);
+  else if (provider === 'cloud-chat') state.cloudChat = Math.max(0, state.cloudChat - 1);
+  else return;
+  save();
+  document.dispatchEvent(new CustomEvent<BudgetStatus>(EVENT_NAME, { detail: getBudgetStatus() }));
 }
 
 /**


### PR DESCRIPTION
## Two bug fixes

### BUG 1 — LLM budget never refunded on failed cloud call
`reserveCloudCall()` increments the daily cloud-call counter before the request is issued (race-safe reservation). But when the call produced no usable result — `tryCloudAgent` returns `null` on an empty response or a thrown error — the reserved slot was never released. Repeated failures permanently drained the daily cap even though no real call landed.

- Added `refundCloudCall(provider)` to `llm-budget.ts` (inverse of `reserveCloudCall`, clamped at zero so a stray refund can't drive the counter negative).
- `generateText` now wraps `tryCloudAgent` in try/finally and calls `refundCloudCall('cloud-agent')` whenever there's no result.
- Updated the misleading doc comment that previously claimed slots are intentionally not refunded.

**Dual-store atomicity note:** `save()` writes localStorage (sync) + IDB via `putMemory` (async). These two stores cannot share a single IDB transaction, and `putMemory` is already a single-key atomic transaction on its side, so no further change was needed there.

### BUG 2 — briefing-scheduler unhandled rejection
`BriefingScheduler.fire()` had `try/finally` but no `catch`. A throw from generation propagated out of `void this.fire()` as an unhandled promise rejection. Added a `catch` that logs via `logDebug`; the existing `finally` still calls `reschedule()`, which computes the normal next-day delay rather than retrying immediately.

## Verification
`tsc --noEmit` passes with zero errors. Changes are service-layer only (no browser-observable surface).