### PR TITLE
fix: clear eslint debt in oref-alerts + hypothesis-threads (follow-up to #1222)

### DIFF
--- a/src/services/hypothesis-threads.ts
+++ b/src/services/hypothesis-threads.ts
@@ -63,7 +63,7 @@ let writtenSinceLoad = false;
 // confidenceHistory crashes upsertThread() when it spreads the array.
 function isValidThread(t: unknown): t is HypothesisThread {
   if (typeof t !== 'object' || t === null) return false;
-  const c = t as Partial<HypothesisThread>;
+  const c = t as Record<string, unknown>;
   return typeof c.signature === 'string'
     && Array.isArray(c.confidenceHistory)
     && typeof c.peakRisk === 'string'
@@ -77,8 +77,8 @@ function load(): void {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw) {
-      const parsed = JSON.parse(raw);
-      const arr = Array.isArray(parsed) ? parsed.filter(isValidThread) : [];
+      const parsed: unknown = JSON.parse(raw);
+      const arr = (Array.isArray(parsed) ? parsed : []).filter((t): t is HypothesisThread => isValidThread(t));
       for (const t of arr) threads.set(t.signature, t);
     }
   } catch { /* ignore */ }
@@ -87,7 +87,7 @@ function load(): void {
   // a fresh write from a first-cycle event would be clobbered.
   void getMemory<HypothesisThread[]>(STORAGE_KEY).then(raw => {
     if (writtenSinceLoad) return;
-    const arr = Array.isArray(raw) ? raw.filter(isValidThread) : [];
+    const arr = Array.isArray(raw) ? raw.filter(t => isValidThread(t)) : [];
     if (arr.length === 0) return;
     threads.clear();
     for (const t of arr) threads.set(t.signature, t);

--- a/src/services/oref-alerts.ts
+++ b/src/services/oref-alerts.ts
@@ -235,7 +235,7 @@ export async function fetchOrefAlerts(): Promise<OrefAlertsResponse> {
 
   try {
  const res = await fetch(getOrefApiUrl(), {
- signal: AbortSignal.timeout(10000),
+ signal: AbortSignal.timeout(10_000),
  headers: { Accept: 'application/json' },
  });
  if (!res.ok) {
@@ -266,7 +266,7 @@ export async function fetchOrefHistory(): Promise<OrefHistoryResponse> {
   await ensureLocationMapLoaded();
   try {
  const res = await fetch(getOrefApiUrl('history'), {
- signal: AbortSignal.timeout(10000),
+ signal: AbortSignal.timeout(10_000),
  headers: { Accept: 'application/json' },
  });
  if (!res.ok) {
@@ -303,9 +303,11 @@ export function onOrefAlertsUpdate(cb: (data: OrefAlertsResponse) => void): void
 
 export function startOrefPolling(): void {
   if (pollingInterval) return;
-  pollingInterval = setInterval(async () => {
+  pollingInterval = setInterval(() => {
+ void (async () => {
  const data = await fetchOrefAlerts();
  for (const cb of updateCallbacks) cb(data);
+ })();
   }, 120_000);
 }
 


### PR DESCRIPTION
Follow-up to #1222, which auto-merged on its required checks before this lint cleanup synced (ESLint is a non-blocking check, so the merge raced ahead).

#1222 shipped the functional fixes (hypothesis-thread load hardening + OREF fetch timeouts) but `lint:ci` lints **whole changed files**, so the next contributor to touch these two files inherits 7 ESLint errors — 4 introduced by #1222, 3 pre-existing/dormant.

This PR makes both files lint-clean with no behavior change:
- `hypothesis-threads.ts`: cast parsed value to `Record<string, unknown>` (so `!== null` is meaningful, not always-true); type `JSON.parse` result as `unknown`; wrap `isValidThread` in arrow callbacks for `.filter()`.
- `oref-alerts.ts`: `10000` → `10_000` numeric separators; `void`-wrap the pre-existing async `setInterval` poll callback (`no-misused-promises`).

## Verification
`npx eslint <both files>` → 0 errors. `npx tsc --noEmit` → 0 errors.

Cross-agent review: Codex non-functional on 2026-06-17 — `codex exec review` hung indefinitely (killed after 60s on multiple attempts; global Codex hang remediated separately). Pure lint refactor, no behavior change; verified by eslint + tsc. Not a clean reviewed pass — reviewer was unavailable.