### PR TITLE
fix: XSS in economic panel, dossier hydrate race, USGS dup ingestion

### DIFF
--- a/src-tauri/sidecar/event-store.mjs
+++ b/src-tauri/sidecar/event-store.mjs
@@ -95,6 +95,18 @@ export class EventStore {
         (id, event_type, occurred_at, domain, entity_ids, source_id, severity, payload, partition_key)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
+    this._existsById = this.db.prepare('SELECT 1 FROM events WHERE id = ? LIMIT 1');
+  }
+
+  /**
+   * True when an event with this id already exists. Lets ingestion callers do
+   * an idempotent insert (check-then-append) instead of hitting the append-only
+   * throw on every re-seen record — e.g. USGS earthquakes that reappear in the
+   * feed on each poll keep their stable id and should be inserted only once.
+   */
+  hasEvent(id) {
+    if (typeof id !== 'string' || id.length === 0) return false;
+    return this._existsById.get(id) != null;
   }
 
   journalMode() {

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -129,10 +129,16 @@ export function appendObservationToEventStore(store, obs) {
     const occurredAt = typeof obs?.timestamp === 'number' && obs.timestamp > 0
       ? new Date(obs.timestamp).toISOString()
       : new Date().toISOString();
+    // Stable id for records that carry one (e.g. USGS earthquakes reappear in
+    // the feed every poll). Check-then-append makes re-ingestion idempotent so
+    // we don't keep re-inserting an already-stored event. Records without a
+    // stable id get a fresh UUID and are always genuinely new.
+    const id = (typeof obs?.id === 'string' && obs.id)
+      ? `${obs.sourceId || obs.domain || 'obs'}:${obs.id}`
+      : randomUUID();
+    if (typeof store.hasEvent === 'function' && store.hasEvent(id)) return;
     store.appendEvent({
-      id: (typeof obs?.id === 'string' && obs.id)
-        ? `${obs.sourceId || obs.domain || 'obs'}:${obs.id}`
-        : randomUUID(),
+      id,
       event_type: 'observation',
       occurred_at: occurredAt,
       domain: typeof obs?.domain === 'string' && obs.domain ? obs.domain : null,

--- a/src/components/EconomicStressPanel.ts
+++ b/src/components/EconomicStressPanel.ts
@@ -67,10 +67,6 @@ export class EconomicStressPanel extends Panel {
 
  const ts = new Date(data.updatedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 
- const wsbText = snapshots.length > 0
- ? snapshots.slice(0, 3).map(s => `${s.ticker} ${s.sentiment >= 0 ? '+' : ''}${s.sentiment.toFixed(2)}`).join(' · ')
- : '';
-
  el.innerHTML = `
 <div style="padding:0.8rem;display:flex;flex-direction:column;gap:0.7rem;">
   <div>
@@ -89,8 +85,18 @@ export class EconomicStressPanel extends Panel {
   <div style="padding:0.4rem 0.55rem;background:rgba(255,255,255,0.04);border-radius:5px;font-size:0.7rem;opacity:0.75;">
  Global Food Security: <strong style="color:${fsColor};">${fsVal} / 100</strong> — ${fsLabel}
   </div>
-  ${wsbText ? `<div style="padding:0.4rem 0.55rem;background:rgba(255,255,255,0.04);border-radius:5px;font-size:0.7rem;opacity:0.75;">WSB Retail: ${wsbText}</div>` : ''}
 </div>`;
+
+ // WSB ticker symbols are external/untrusted data — render as text, never
+ // as markup, so a crafted symbol can't inject script.
+ if (snapshots.length > 0) {
+ const wsbRow = document.createElement('div');
+ wsbRow.style.cssText = 'padding:0.4rem 0.55rem;background:rgba(255,255,255,0.04);border-radius:5px;font-size:0.7rem;opacity:0.75;';
+ wsbRow.textContent = 'WSB Retail: ' + snapshots.slice(0, 3)
+ .map(s => `${s.ticker} ${s.sentiment >= 0 ? '+' : ''}${s.sentiment.toFixed(2)}`)
+ .join(' · ');
+ el.firstElementChild?.appendChild(wsbRow);
+ }
   }
 
   private _renderKeyRequired(): void {

--- a/src/services/cognition/entity-dossier.ts
+++ b/src/services/cognition/entity-dossier.ts
@@ -187,6 +187,13 @@ const COOLING_RATIO_THRESHOLD = 0.67;
 const dossiers = new Map<string, EntityDossier>();
 let loaded = false;
 let writtenSinceLoad = false;
+/**
+ * Monotonic counter bumped on every in-memory mutation (each save()). The async
+ * IDB hydrate captures this at read-start and only commits if it hasn't moved —
+ * so a hydrate whose async read began before a fresh ingest can't clobber the
+ * newer in-memory data with the stale snapshot it read.
+ */
+let mutationVersion = 0;
 
 // Injected overrides (populated via configure() for tests).
 let _storage: DossierStorageLike | null | undefined = undefined;
@@ -206,6 +213,7 @@ export function configure(opts: EntityDossierOptions): void {
   _putMemoryOverride = opts.putMemoryFn ?? null;
   _nowFn = opts.now ?? Date.now;
   dossiers.clear();
+  mutationVersion++;
   // Mark as already loaded so subsequent reads do NOT reload from the injected
   // storage (which may still contain data from a prior test run). Tests that
   // want to pre-seed the store should do so via ingestFromHypotheses() after
@@ -264,14 +272,18 @@ function load(): void {
     _getMemoryOverride
       ? (key) => (_getMemoryOverride as (k: string) => Promise<EntityDossier[] | null>)(key)
       : (key) => { lazyLoadIdb(); return _getMemory!<EntityDossier[]>(key); };
+  const versionAtReadStart = mutationVersion;
   void getMemFn(STORAGE_KEY).then((arr) => {
-    if (writtenSinceLoad) return;
+    // If any write landed while this async read was in flight, the in-memory
+    // state is fresher than the snapshot we just read — don't clobber it.
+    if (writtenSinceLoad || mutationVersion !== versionAtReadStart) return;
     applyLoaded(arr);
   });
 }
 
 function save(): void {
   writtenSinceLoad = true;
+  mutationVersion++;
   const arr = [...dossiers.values()];
   const stor = resolveStorage();
   if (stor) {
@@ -573,6 +585,7 @@ export function resetEntityDossiers(): void {
   dossiers.clear();
   loaded = false;
   writtenSinceLoad = false;
+  mutationVersion++;
 }
 
 /** Export all dossiers as an array (for testing / diagnostics). */


### PR DESCRIPTION
Three independent bugfixes:

## BUG 1 — XSS (security)
`EconomicStressPanel` interpolated WSB ticker symbols (external/untrusted, Reddit-derived) into `el.innerHTML`. A crafted symbol could inject markup/script. The WSB row is now built with `textContent` and appended to the rendered container — no external data flows into `innerHTML`.

## BUG 2 — entity-dossier hydrate race
The async IDB hydrate in `load()` guarded only on the coarse `writtenSinceLoad` boolean, so a hydrate whose async read began *before* a fresh `ingestFromHypotheses` could overwrite the newer in-memory dossiers with the stale snapshot it read. Added a monotonic `mutationVersion` captured at read-start; the hydrate only commits if the version hasn't advanced (and bumps on save/configure/reset).

## BUG 3 — USGS earthquake duplicate ingestion
USGS earthquakes reappear in the feed on each poll with a stable id, so `appendObservationToEventStore` kept re-attempting an append-only insert for already-stored records. Added `EventStore.hasEvent(id)` and made the appender check-then-append (idempotent) — each record is inserted only once. The append-only invariant on `appendEvent` itself is unchanged (its guarding test still passes).

## Verification
- `tsc --noEmit` (both tsconfig.json + tsconfig.api.json) — zero errors
- `node --check` on both sidecar files — OK
- `event-store.test.mjs` — 6/6 pass (append-only invariant intact)