### PR TITLE
fix(vault): never block the unlock gate on a late Tauri bridge

### DIFF
--- a/src/app/vault-intro.ts
+++ b/src/app/vault-intro.ts
@@ -38,6 +38,11 @@ const NS = 'http://www.w3.org/2000/svg';
 const BIOMETRY_ENABLED_KEY = 'cb:vault-biometry-enabled';
 const CRASH_SENTINEL_KEY = 'cb:vault-biometry-crash-sentinel';
 const FAKE_AUTH_DELAY_MS = 600;
+// Hard ceiling on the native biometry call. The tauri-plugin-biometry
+// authenticate path can wedge (not crash, not resolve) when its keychain
+// item is in a bad state, which would otherwise freeze the vault door
+// forever. Bound it so a wedged prompt becomes a recoverable error.
+const BIOMETRY_NATIVE_TIMEOUT_MS = 30_000;
 
 function safeGetItem(key: string): string | null {
   try { return localStorage.getItem(key); } catch { return null; }
@@ -78,9 +83,18 @@ async function attemptAuth(): Promise<AuthOutcome> {
     await new Promise<void>(r => setTimeout(r, FAKE_AUTH_DELAY_MS));
     return 'success';
   }
+  // Only the native path needs the Tauri invoke bridge. On a cold first
+  // launch the bridge can lag behind the tauri:// location that already
+  // marks us as a desktop runtime, so wait for it here (not before the
+  // bridge-free fake path) and degrade to a recoverable error if it never
+  // shows rather than dead-ending the whole gate.
+  if (!(await waitForBridge())) return 'error';
   safeSetItem(CRASH_SENTINEL_KEY, String(Date.now()));
   try {
-    await invokeTauri<void>(CMD, { reason: REASON, options: { allowDeviceCredential: true } });
+    await Promise.race([
+      invokeTauri<void>(CMD, { reason: REASON, options: { allowDeviceCredential: true } }),
+      sleep(BIOMETRY_NATIVE_TIMEOUT_MS).then(() => { throw new Error('biometry-timeout'); }),
+    ]);
     safeRemoveItem(CRASH_SENTINEL_KEY);
     return 'success';
   } catch (error) {
@@ -1117,18 +1131,15 @@ async function runBiometricFlow(
  if (settled || inFlight) return;
  inFlight = true;
 
- const ready = await waitForBridge();
- if (!ready || settled) { inFlight = false; return; }
-
  if (!manual) {
  setScannerWarmup(refs);
  await sleep(700);
- if (settled) return;
+ if (settled) { inFlight = false; return; }
  }
 
  setScannerPeak(refs);
  await sleep(600);
- if (settled) return;
+ if (settled) { inFlight = false; return; }
 
  // Native biometry is opt-in (see BIOMETRY_ENABLED_KEY comment up top).
  // When disabled — current default while the plugin's keychain item is


### PR DESCRIPTION
## Problem

The vault door froze on **cold first launch** (subsequent launches worked). Root cause:

- `detectDesktopRuntime()` marks the window as desktop from the `tauri://` scheme **before** `__TAURI__.core.invoke` is injected (its own comment notes this).
- `waitForBridge()` at the top of `tryAuth` has a 2500ms cap. On a slow cold start the bridge lands after the window, so it returns `false`.
- On that failure `tryAuth` did `{ inFlight = false; return; }` — a **silent dead-end**: never resolved the flow, never showed a retry, never rescheduled. The overlay is removed only when the flow resolves, so the login screen froze forever.
- It also gated the **bridge-free** fake-success path (biometry disabled, the current default — confirmed: neither `cb:vault-biometry-enabled` nor the crash sentinel exists in localStorage), so even the no-native-call path couldn't open until the bridge appeared.

## Fix (`src/app/vault-intro.ts`)

1. Move the bridge wait **out of `tryAuth`** and into `attemptAuth`'s native branch only — the fake-success path no longer depends on the bridge.
2. Bound the native `plugin:biometry|authenticate` call with `Promise.race([..., 30s timeout])`; a bridge miss returns a recoverable `'error'` ("TAP TO RETRY") instead of dead-ending.
3. Reset `inFlight` on the settled-bail branches so manual retry always works.

Net: the gate is now guaranteed to resolve in every config — fake-success opens regardless of bridge timing, and the real biometry path degrades to a visible retry instead of an infinite await.

## Verification

- `tsc --noEmit` clean (exit 0).
- Not browser-previewable (Tauri desktop boot gate only).