### PR TITLE
fix(idb): stop opening shared crystalball_db at a pinned version 1

### DIFF
--- a/src/services/notifications/notification-history-service.ts
+++ b/src/services/notifications/notification-history-service.ts
@@ -202,7 +202,6 @@ export function __reset(): void {
 // ── IndexedDB persistence ─────────────────────────────────────────────────
 
 const DB_NAME = 'crystalball_db';
-const DB_VERSION = 1;
 const STORE = 'kv';
 
 let _dbPromise: Promise<IDBDatabase> | null = null;
@@ -217,16 +216,7 @@ function openDb(): Promise<IDBDatabase> {
   if (!isIndexedDbAvailable()) return Promise.reject(new Error('IndexedDB unavailable'));
   if (_dbPromise) return _dbPromise;
   _dbPromise = new Promise((resolve, reject) => {
-    const req = indexedDB.open(DB_NAME, DB_VERSION);
-    req.addEventListener('error', () => reject(req.error ?? new Error('Failed to open IndexedDB')));
-    req.addEventListener('upgradeneeded', () => {
-      const db = req.result;
-      if (!db.objectStoreNames.contains(STORE)) {
-        db.createObjectStore(STORE);
-      }
-    });
-    req.addEventListener('success', () => {
-      const db = req.result;
+    const attach = (db: IDBDatabase): void => {
       db.addEventListener('close', () => { _dbPromise = null; });
       // Yield to another module (reasoning-memory / alert-store) bumping the
       // shared crystalball_db version — otherwise this open connection blocks
@@ -236,11 +226,34 @@ function openDb(): Promise<IDBDatabase> {
         _dbPromise = null;
       });
       resolve(db);
+    };
+
+    const openWithUpgrade = (currentVersion: number): void => {
+      const up = indexedDB.open(DB_NAME, currentVersion + 1);
+      up.addEventListener('error', () => reject(up.error ?? new Error('Failed to upgrade IndexedDB')));
+      up.addEventListener('blocked', () => reject(new Error('IndexedDB upgrade blocked')));
+      up.addEventListener('upgradeneeded', () => {
+        if (!up.result.objectStoreNames.contains(STORE)) up.result.createObjectStore(STORE);
+      });
+      up.addEventListener('success', () => attach(up.result));
+    };
+
+    // Open without a version first so we never request a version *lower* than
+    // what alert-store / reasoning-memory may have already bumped the shared
+    // crystalball_db to (which throws a VersionError and silently disabled
+    // notification-history persistence on already-upgraded databases).
+    const probe = indexedDB.open(DB_NAME);
+    probe.addEventListener('error', () => reject(probe.error ?? new Error('Failed to open IndexedDB')));
+    // Fires only when the DB does not exist yet — create our store in the fresh v1.
+    probe.addEventListener('upgradeneeded', () => {
+      if (!probe.result.objectStoreNames.contains(STORE)) probe.result.createObjectStore(STORE);
     });
-    req.addEventListener('blocked', () => {
-      // Another connection is preventing the upgrade — fall through
-      // gracefully so the panel doesn't block on a stuck DB.
-      reject(new Error('IndexedDB upgrade blocked'));
+    probe.addEventListener('success', () => {
+      const db = probe.result;
+      if (db.objectStoreNames.contains(STORE)) { attach(db); return; }
+      const currentVersion = db.version;
+      db.close();
+      openWithUpgrade(currentVersion);
     });
   });
   return _dbPromise;

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -1,7 +1,6 @@
 import type { ReplayWatchSummary } from '@/services/replay-narrative';
 
 const DB_NAME = 'crystalball_db';
-const DB_VERSION = 1;
 
 interface BaselineEntry {
   key: string;
@@ -14,39 +13,74 @@ interface BaselineEntry {
 
 let db: IDBDatabase | null = null;
 
+function createStores(database: IDBDatabase): void {
+  if (!database.objectStoreNames.contains('baselines')) {
+ database.createObjectStore('baselines', { keyPath: 'key' });
+  }
+
+  if (!database.objectStoreNames.contains('snapshots')) {
+ const store = database.createObjectStore('snapshots', { keyPath: 'timestamp' });
+ store.createIndex('by_time', 'timestamp');
+  }
+}
+
+function attachConn(conn: IDBDatabase, resolve: (database: IDBDatabase) => void): void {
+  db = conn;
+  conn.addEventListener('close', () => { db = null; });
+  // Another module (reasoning-memory / alert-store) bumping the shared
+  // crystalball_db version fires `versionchange` here. Close so the upgrade
+  // isn't blocked; the next initDB() reopens at the new version.
+  conn.addEventListener('versionchange', () => {
+ conn.close();
+ db = null;
+  });
+  resolve(conn);
+}
+
+function openWithUpgrade(currentVersion: number): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+ const request = indexedDB.open(DB_NAME, currentVersion + 1);
+ request.onerror = () => reject(request.error);
+ request.onupgradeneeded = (event) => {
+ createStores((event.target as IDBOpenDBRequest).result);
+ };
+ request.onsuccess = () => attachConn(request.result, resolve);
+  });
+}
+
 export async function initDB(): Promise<IDBDatabase> {
   if (db) return db;
 
   return new Promise((resolve, reject) => {
- const request = indexedDB.open(DB_NAME, DB_VERSION);
+ // Open without a version first so we never request a version *lower* than
+ // what alert-store / reasoning-memory may have already bumped the shared
+ // crystalball_db to. Requesting a lower version throws "open ... using a
+ // lower version than the existing version", which rejected initDB() and
+ // broke every baseline/snapshot caller on boot.
+ const probe = indexedDB.open(DB_NAME);
 
- request.onerror = () => reject(request.error);
+ probe.onerror = () => reject(probe.error);
 
- request.onsuccess = () => {
- const conn = request.result;
- db = conn;
- conn.addEventListener('close', () => { db = null; });
- // Another module (reasoning-memory / alert-store) bumping the shared
- // crystalball_db version fires `versionchange` here. Close so the upgrade
- // isn't blocked; the next initDB() reopens at the new version.
- conn.addEventListener('versionchange', () => {
- conn.close();
- db = null;
- });
- resolve(conn);
+ // Fires only when the DB does not exist yet (fresh DB created at v1) —
+ // seed our stores immediately.
+ probe.onupgradeneeded = (event) => {
+ createStores((event.target as IDBOpenDBRequest).result);
  };
 
- request.onupgradeneeded = (event) => {
- const database = (event.target as IDBOpenDBRequest).result;
-
- if (!database.objectStoreNames.contains('baselines')) {
- database.createObjectStore('baselines', { keyPath: 'key' });
+ probe.onsuccess = () => {
+ const conn = probe.result;
+ if (
+ conn.objectStoreNames.contains('baselines') &&
+ conn.objectStoreNames.contains('snapshots')
+ ) {
+ attachConn(conn, resolve);
+ return;
  }
-
- if (!database.objectStoreNames.contains('snapshots')) {
- const store = database.createObjectStore('snapshots', { keyPath: 'timestamp' });
- store.createIndex('by_time', 'timestamp');
- }
+ // Stores missing on an existing (possibly already-bumped) DB — reopen
+ // one version higher to add them, never requesting a lower version.
+ const currentVersion = conn.version;
+ conn.close();
+ openWithUpgrade(currentVersion).then(resolve, reject);
  };
   });
 }


### PR DESCRIPTION
## Root cause (the real boot freeze)

`desktop.log` showed every boot session logging:
`console.error: An attempt was made to open a database using a lower version than the existing version` — then the app exits / is force-quit and relaunches in a loop.

Four modules open the **shared** `crystalball_db`:

| File | Strategy |
|---|---|
| `alert-store.ts` | probe → open at `currentVersion + 1` ✅ |
| `reasoning-memory.ts` | probe → open at `currentVersion + 1` ✅ |
| `storage.ts` | **hardcoded `open(name, 1)`** ❌ |
| `notifications/notification-history-service.ts` | **hardcoded `open(name, 1)`** ❌ |

`alert-store` / `reasoning-memory` bump the on-disk DB to v2/v3/… as they create their stores. Once bumped, the v1-pinned openers throw a `VersionError`. `storage.ts`'s `initDB()` **rejected**, propagating to every baseline/snapshot caller in the data-load path and stalling boot (frozen behind the vault overlay). `notification-history` swallowed the same error, silently disabling its persistence.

This is why the prior vault-intro fix didn't help — the hang was never in the biometric gate.

## Fix

Both pinned openers now use the same **probe-then-bump** pattern as `alert-store`:
1. `open(name)` with no version → read current on-disk version.
2. Reuse the connection if the store already exists.
3. Otherwise reopen at `currentVersion + 1` to create the store.

Never requests a version below what's on disk. Self-heals on already-upgraded DBs — no data loss, no DB reset. The other `crystalball_db` consumers (web-secret-store, episodic-memory) delegate to `reasoning-memory`; survival/snapshot-store uses a separate DB.

## Verification
- `tsc --noEmit` clean (exit 0).
- Confirmed no remaining version-pinned opener of `crystalball_db`.
- Not browser-previewable (Tauri desktop boot path).